### PR TITLE
Tiny mistakes in wt_cache_subsystem

### DIFF
--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -684,7 +684,7 @@ package ariane_pkg;
         amo_t        amo_op;    // atomic memory operation to perform
         logic [1:0]  size;      // 2'b10 --> word operation, 2'b11 --> double word operation
         logic [63:0] operand_a; // address
-        logic [63:0] operand_b; // data as layuoted in the register
+        logic [63:0] operand_b; // data as layouted in the register
     } amo_req_t;
 
     // AMO response coming from cache.

--- a/src/cache_subsystem/wt_icache.sv
+++ b/src/cache_subsystem/wt_icache.sv
@@ -121,7 +121,7 @@ module wt_icache  #(
                          ( paddr_is_nc  & mem_data_req_o ) ? cl_offset_q[2]<<2 : // needed since we transfer 32bit over a 64bit AXI bus in this case
                                                              cl_offset_q;
     // request word address instead of cl address in case of NC access
-    assign mem_data_o.paddr = (paddr_is_nc) ? {cl_tag_d, vaddr_q[ICACHE_INDEX_WIDTH-1:3], 3'b0} :                                         // align to 32bit
+    assign mem_data_o.paddr = (paddr_is_nc) ? {cl_tag_d, vaddr_q[ICACHE_INDEX_WIDTH-1:3], 3'b0} :                                         // align to 64bit
                                               {cl_tag_d, vaddr_q[ICACHE_INDEX_WIDTH-1:ICACHE_OFFSET_WIDTH], {ICACHE_OFFSET_WIDTH{1'b0}}}; // align to cl
 end else begin : gen_piton_offset
     // icache fills are either cachelines or 4byte fills, depending on whether they go to the Piton I/O space or not.


### PR DESCRIPTION
Hello, I have reviewed the code in wt_cache_subsystem.
It seems that a few mistakes are here.
* A word misspelling
* The address is align to 64bit, but not 32bit. Seems the comment was copied from the other case.