### PR TITLE
Jekyll doc readme update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
-# Jekyll Doc Theme
+# Ariane RISC-V CPU (cva6) Documents
 
+Powered by Jekyll Doc Theme.
 Go to [the website](https://aksakalli.github.io/jekyll-doc-theme/) for detailed information and demo.
 
 ## Running locally
@@ -10,14 +11,13 @@ You need Ruby and gem before starting, then:
 # install bundler
 gem install bundler
 
-# clone the project
-git clone https://github.com/aksakalli/jekyll-doc-theme.git
-cd jekyll-doc-theme
+# bundle install missing dependencies
+bundle install
 
 # run jekyll with dependencies
 bundle exec jekyll serve
 ```
 
-## License
+## Jekyll Doc Theme License
 
 Released under [the MIT license](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ bundle install
 # run jekyll with dependencies
 bundle exec jekyll serve
 ```
-
+and then open URL which list in the `Server address` entry.
 ## Jekyll Doc Theme License
 
 Released under [the MIT license](LICENSE).


### PR DESCRIPTION
Because original README.md in docs folder is copied from https://github.com/aksakalli/jekyll-doc-theme. If we follow the command will build an example site provided by https://github.com/aksakalli/jekyll-doc-theme.