### PR TITLE
Modelsim: Fix simulation flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,13 +101,18 @@ util := $(addprefix $(root-dir), $(util))
 # Test packages
 test_pkg := $(wildcard tb/test/*/*sequence_pkg.sv*) \
 			$(wildcard tb/test/*/*_pkg.sv*)
+
 # DPI
-dpi_list := $(patsubst tb/dpi/%.cc, ${dpi-library}/%.o, $(wildcard tb/dpi/*.cc))
+dpi := $(patsubst tb/dpi/%.cc, ${dpi-library}/%.o, $(wildcard tb/dpi/*.cc))
+
 # filter spike stuff if tandem is not activated
 ifndef spike-tandem
-    dpi = $(filter-out ${dpi-library}/spike.o ${dpi-library}/sim_spike.o, $(dpi_list))
-else
-    dpi = $(dpi_list)
+    dpi := $(filter-out ${dpi-library}/spike.o ${dpi-library}/sim_spike.o, $(dpi))
+endif
+
+# filter dromajo stuff if dromajo is not activated
+ifndef DROMAJO
+    dpi := $(filter-out ${dpi-library}/dromajo_cosim_dpi.o, $(dpi))
 endif
 
 dpi_hdr := $(wildcard tb/dpi/*.h)
@@ -159,7 +164,7 @@ src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
         src/common_cells/src/rstgen.sv                                         \
         src/common_cells/src/stream_mux.sv                                     \
         src/common_cells/src/stream_demux.sv                                   \
-	src/common_cells/src/exp_backoff.sv                                    \
+        src/common_cells/src/exp_backoff.sv                                    \
         src/util/axi_master_connect.sv                                         \
         src/util/axi_slave_connect.sv                                          \
         src/util/axi_master_connect_rev.sv                                     \
@@ -187,6 +192,7 @@ src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
         src/common_cells/src/stream_delay.sv                                   \
         src/common_cells/src/lfsr_8bit.sv                                      \
         src/common_cells/src/lfsr_16bit.sv                                     \
+        src/common_cells/src/delta_counter.sv                                  \
         src/common_cells/src/counter.sv                                        \
         src/common_cells/src/shift_reg.sv                                      \
         src/tech_cells_generic/src/pulp_clock_gating.sv                        \

--- a/tb/ariane_tb.sv
+++ b/tb/ariane_tb.sv
@@ -19,7 +19,7 @@ import uvm_pkg::*;
 
 `include "uvm_macros.svh"
 
-`define MAIN_MEM(P) dut.i_sram.genblk1[0].i_ram.Mem_DP[(``P``)]
+`define MAIN_MEM(P) dut.i_sram.genblk1[0].genblk1.i_ram.Mem_DP[(``P``)]
 
 import "DPI-C" function read_elf(input string filename);
 import "DPI-C" function byte get_section(output longint address, output longint len);


### PR DESCRIPTION
Fix the Modelsim simulation flow after the Dromajo integration (https://github.com/openhwgroup/cva6/commit/2d814452094b3e20897e2362771d70024a610651).