### PR TITLE
instr_queue.sv: propagate INSTR_ACCESS_FAULT

### DIFF
--- a/src/frontend/instr_queue.sv
+++ b/src/frontend/instr_queue.sv
@@ -222,12 +222,12 @@ module instr_queue (
     fetch_entry_o.branch_predict.cf = ariane_pkg::NoCF;
     // output mux select
     for (int unsigned i = 0; i < ariane_pkg::INSTR_PER_FETCH; i++) begin
-      if (instr_data_out[i].ex == ariane_pkg::FE_INSTR_ACCESS_FAULT) begin
-          fetch_entry_o.ex.cause = riscv::INSTR_ACCESS_FAULT;
-      end else begin
-          fetch_entry_o.ex.cause = riscv::INSTR_PAGE_FAULT;
-      end
       if (idx_ds_q[i]) begin
+        if (instr_data_out[i].ex == ariane_pkg::FE_INSTR_ACCESS_FAULT) begin
+            fetch_entry_o.ex.cause = riscv::INSTR_ACCESS_FAULT;
+        end else begin
+            fetch_entry_o.ex.cause = riscv::INSTR_PAGE_FAULT;
+        end
         fetch_entry_o.instruction = instr_data_out[i].instr;
         fetch_entry_o.ex.valid = instr_data_out[i].ex != ariane_pkg::FE_NONE;
         // TODO(zarubaf,moschn): Might need some fixes with illegal access exceptions


### PR DESCRIPTION
This prevents an INSTR_ACCESS_FAULT to retire as an INSTR_PAGE_FAULT if `idx_ds_q=2'b01`.