### PR TITLE
pmp.sv: change XLEN (64 bits) to PLEN (56 bits)

### DIFF
--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -35,14 +35,14 @@ module mmu #(
     // in the LSU as we distinguish load and stores, what we do here is simple address translation
     input  exception_t                      misaligned_ex_i,
     input  logic                            lsu_req_i,        // request address translation
-    input  logic [63:0]                     lsu_vaddr_i,      // virtual address in
+    input  logic [riscv::VLEN-1:0]          lsu_vaddr_i,      // virtual address in
     input  logic                            lsu_is_store_i,   // the translation is requested by a store
     // if we need to walk the page table we can't grant in the same cycle
     // Cycle 0
     output logic                            lsu_dtlb_hit_o,   // sent in the same cycle as the request if translation hits in the DTLB
     // Cycle 1
     output logic                            lsu_valid_o,      // translation is valid
-    output logic [63:0]                     lsu_paddr_o,      // translated address
+    output logic [riscv::PLEN-1:0]          lsu_paddr_o,      // translated address
     output exception_t                      lsu_exception_o,  // address translation threw an exception
     // General control signals
     input riscv::priv_lvl_t                 priv_lvl_i,
@@ -64,13 +64,13 @@ module mmu #(
     input  logic [ArianeCfg.NrPMPEntries-1:0][53:0]     pmpaddr_i
 );
 
-    logic        iaccess_err;   // insufficient privilege to access this instruction page
-    logic        daccess_err;   // insufficient privilege to access this data page
-    logic        ptw_active;    // PTW is currently walking a page table
-    logic        walking_instr; // PTW is walking because of an ITLB miss
-    logic        ptw_error;     // PTW threw an exception
-    logic        ptw_access_exception; // PTW threw an access exception (PMPs)
-    logic [63:0] ptw_bad_paddr; // PTW PMP exception bad physical addr
+    logic                   iaccess_err;   // insufficient privilege to access this instruction page
+    logic                   daccess_err;   // insufficient privilege to access this data page
+    logic                   ptw_active;    // PTW is currently walking a page table
+    logic                   walking_instr; // PTW is walking because of an ITLB miss
+    logic                   ptw_error;     // PTW threw an exception
+    logic                   ptw_access_exception; // PTW threw an access exception (PMPs)
+    logic [riscv::PLEN-1:0] ptw_bad_paddr; // PTW PMP exception bad physical addr
 
     logic [riscv::VLEN-1:0] update_vaddr;
     tlb_update_t update_ptw_itlb, update_ptw_dtlb;
@@ -264,8 +264,8 @@ module mmu #(
 
     // Instruction fetch
     pmp #(
-        .XLEN       ( 64                     ),
-        .PMP_LEN    ( 54                     ),
+        .PLEN       ( riscv::PLEN            ),
+        .PMP_LEN    ( riscv::PLEN - 2        ),
         .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
     ) i_pmp_if (
         .addr_i        ( icache_areq_o.fetch_paddr ),
@@ -403,8 +403,8 @@ module mmu #(
 
     // Load/store PMP check
     pmp #(
-        .XLEN       ( 64                     ),
-        .PMP_LEN    ( 54                     ),
+        .PLEN       ( riscv::PLEN            ),
+        .PMP_LEN    ( riscv::PLEN - 2        ),
         .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
     ) i_pmp_data (
         .addr_i        ( lsu_paddr_o         ),

--- a/src/pmp/src/pmp.sv
+++ b/src/pmp/src/pmp.sv
@@ -13,12 +13,12 @@
 // Description: purely combinatorial PMP unit (with extraction for more complex configs such as NAPOT)
 
 module pmp #(
-    parameter int unsigned XLEN = 32,       // rv64: 64
+    parameter int unsigned PLEN = 34,       // rv64: 56
     parameter int unsigned PMP_LEN = 32,    // rv64: 54
     parameter int unsigned NR_ENTRIES = 4
 ) (
     // Input
-    input logic [XLEN-1:0] addr_i,
+    input logic [PLEN-1:0] addr_i,
     input riscv::pmp_access_t access_type_i,
     input riscv::priv_lvl_t priv_lvl_i,
     // Configuration
@@ -33,7 +33,7 @@ module pmp #(
 
         for (genvar i = 0; i < NR_ENTRIES; i++) begin
             pmp_entry #(
-                .XLEN    ( XLEN    ),
+                .PLEN    ( PLEN    ),
                 .PMP_LEN ( PMP_LEN )
             ) i_pmp_entry(
                 .addr_i           ( addr_i                         ),

--- a/src/pmp/src/pmp_entry.sv
+++ b/src/pmp/src/pmp_entry.sv
@@ -13,11 +13,11 @@
 // Description: single PMP entry
 
 module pmp_entry #(
-    parameter int unsigned XLEN = 64,
+    parameter int unsigned PLEN = 56,
     parameter int unsigned PMP_LEN = 54
 ) (
     // Input
-    input logic [XLEN-1:0] addr_i,
+    input logic [PLEN-1:0] addr_i,
 
     // Configuration
     input logic [PMP_LEN-1:0] conf_addr_i,
@@ -27,10 +27,10 @@ module pmp_entry #(
     // Output
     output logic match_o
 );
-    logic [XLEN-1:0] conf_addr_n;
-    logic [$clog2(XLEN)-1:0] trail_ones;
+    logic [PLEN-1:0] conf_addr_n;
+    logic [$clog2(PLEN)-1:0] trail_ones;
     assign conf_addr_n = ~conf_addr_i;
-    lzc #(.WIDTH(XLEN), .MODE(1'b0)) i_lzc(
+    lzc #(.WIDTH(PLEN), .MODE(1'b0)) i_lzc(
         .in_i    ( conf_addr_n ),
         .cnt_o   ( trail_ones  ),
         .empty_o (             )
@@ -54,8 +54,8 @@ module pmp_entry #(
                 `endif
             end
             riscv::NA4, riscv::NAPOT:   begin
-                logic [XLEN-1:0] base;
-                logic [XLEN-1:0] mask;
+                logic [PLEN-1:0] base;
+                logic [PLEN-1:0] mask;
                 int unsigned size;
 
                 if (conf_addr_mode_i == riscv::NA4) size = 2;
@@ -81,7 +81,7 @@ module pmp_entry #(
                     end
                 end
 
-                if (size < XLEN-1) begin
+                if (size < PLEN-1) begin
                     if (base + 2**size > base) begin // check for overflow
                         if (match_o == 0) begin
                             assert(addr_i >= base + 2**size || addr_i < base);


### PR DESCRIPTION
Currently, the PMP module works with 64-bit instead of 56-bit physical addresses. This results in undriven signals.