### PR TITLE
PMP fixes

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -60,6 +60,9 @@ sources:
     - src/mult.sv
     - src/load_unit.sv
     - src/issue_read_operands.sv
+    - src/pmp/src/pmp_entry.sv
+    - src/pmp/src/pmp.sv
+    - src/synopsys_sram.sv
     - src/fpu/src/fpnew_fma.sv
     - src/fpu/src/fpnew_opgroup_fmt_slice.sv
     - src/fpu/src/fpnew_divsqrt_multi.sv
@@ -161,8 +164,8 @@ sources:
     - src/common_cells/src/rstgen.sv
     - src/common_cells/src/stream_mux.sv
     - src/common_cells/src/stream_demux.sv
-    - src/common_cells/src/deprecated/stream_arbiter.sv
-    - src/common_cells/src/deprecated/stream_arbiter_flushable.sv
+    - src/common_cells/src/stream_arbiter.sv
+    - src/common_cells/src/stream_arbiter_flushable.sv
     - src/util/axi_master_connect.sv
     - src/util/axi_slave_connect.sv
     - src/util/axi_master_connect_rev.sv

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -182,8 +182,8 @@ module ariane #(
   logic                     icache_en_csr;
   logic                     debug_mode;
   logic                     single_step_csr_commit;
-  riscv::pmpcfg_t [ArianeCfg.NrPMPEntries-1:0] pmpcfg;
-  logic [ArianeCfg.NrPMPEntries-1:0][53:0]     pmpaddr;
+  riscv::pmpcfg_t [15:0]    pmpcfg;
+  logic [15:0][53:0]        pmpaddr;
   // ----------------------------
   // Performance Counters <-> *
   // ----------------------------

--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -85,8 +85,8 @@ module csr_regfile #(
     input  logic  [63:0]          perf_data_i,                // read data from performance counter module
     output logic                  perf_we_o,
     // PMPs
-    output riscv::pmpcfg_t [NrPMPEntries-1:0] pmpcfg_o,   // PMP configuration containing pmpcfg for max 16 PMPs
-    output logic [NrPMPEntries-1:0][53:0]     pmpaddr_o   // PMP addresses
+    output riscv::pmpcfg_t [15:0] pmpcfg_o,   // PMP configuration containing pmpcfg for max 16 PMPs
+    output logic [15:0][53:0]     pmpaddr_o   // PMP addresses
 );
     // internal signal to keep track of access exceptions
     logic        read_access_exception, update_access_exception, privilege_violation;
@@ -143,7 +143,7 @@ module csr_regfile #(
     logic [15:0][53:0]        pmpaddr_q,  pmpaddr_d;
 
 
-    assign pmpcfg_o = pmpcfg_q[NrPMPEntries-1:0];
+    assign pmpcfg_o = pmpcfg_q[15:0];
     assign pmpaddr_o = pmpaddr_q;
 
     riscv::fcsr_t fcsr_q, fcsr_d;

--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -1135,12 +1135,14 @@ module csr_regfile #(
             // wait for interrupt
             wfi_q                  <= wfi_d;
             // pmp
-            if (NrPMPEntries > 0) begin
-                pmpcfg_q[NrPMPEntries-1:0]  <= pmpcfg_d[NrPMPEntries-1:0];
-                pmpaddr_q[NrPMPEntries-1:0] <= pmpaddr_d[NrPMPEntries-1:0];
-            end else begin
-                pmpcfg_q <= '0;
-                pmpaddr_q <= '0;
+            for(int i = 0; i < 16; i++) begin
+                if(i < NrPMPEntries) begin
+                    pmpcfg_q[i] <= pmpcfg_d[i];
+                    pmpaddr_q[i] <= pmpaddr_d[i];
+                end else begin
+                    pmpcfg_q[i] <= '0;
+                    pmpaddr_q[i] <= '0;
+                end
             end
         end
     end

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -101,8 +101,8 @@ module ex_stage #(
     output logic                                   itlb_miss_o,
     output logic                                   dtlb_miss_o,
     // PMPs
-    input  riscv::pmpcfg_t [ArianeCfg.NrPMPEntries-1:0]  pmpcfg_i,
-    input  logic[ArianeCfg.NrPMPEntries-1:0][53:0]       pmpaddr_i
+    input  riscv::pmpcfg_t [15:0]                  pmpcfg_i,
+    input  logic[15:0][53:0]                       pmpaddr_i
 );
 
     // -------------------------

--- a/src/load_store_unit.sv
+++ b/src/load_store_unit.sv
@@ -68,8 +68,8 @@ module load_store_unit #(
     output amo_req_t                 amo_req_o,
     input  amo_resp_t                amo_resp_i,
     // PMP
-    input  riscv::pmpcfg_t [ArianeCfg.NrPMPEntries-1:0] pmpcfg_i,
-    input  logic [ArianeCfg.NrPMPEntries-1:0][53:0]     pmpaddr_i
+    input  riscv::pmpcfg_t [15:0]    pmpcfg_i,
+    input  logic [15:0][53:0]        pmpaddr_i
 );
     // data is misaligned
     logic data_misaligned;

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -60,8 +60,8 @@ module mmu #(
     input  dcache_req_o_t                   req_port_i,
     output dcache_req_i_t                   req_port_o,
     // PMP
-    input  riscv::pmpcfg_t [ArianeCfg.NrPMPEntries-1:0] pmpcfg_i,
-    input  logic [ArianeCfg.NrPMPEntries-1:0][53:0]     pmpaddr_i
+    input  riscv::pmpcfg_t [15:0]           pmpcfg_i,
+    input  logic [15:0][53:0]               pmpaddr_i
 );
 
     logic                   iaccess_err;   // insufficient privilege to access this instruction page

--- a/src/pmp/src/pmp.sv
+++ b/src/pmp/src/pmp.sv
@@ -22,8 +22,8 @@ module pmp #(
     input riscv::pmp_access_t access_type_i,
     input riscv::priv_lvl_t priv_lvl_i,
     // Configuration
-    input logic [NR_ENTRIES-1:0][PMP_LEN-1:0] conf_addr_i,
-    input riscv::pmpcfg_t [NR_ENTRIES-1:0] conf_i,
+    input logic [15:0][PMP_LEN-1:0] conf_addr_i,
+    input riscv::pmpcfg_t [15:0] conf_i,
     // Output
     output logic allow_o
 );

--- a/src/ptw.sv
+++ b/src/ptw.sv
@@ -61,8 +61,9 @@ module ptw #(
     output logic                    itlb_miss_o,
     output logic                    dtlb_miss_o,
     // PMP
-    input  riscv::pmpcfg_t [ArianeCfg.NrPMPEntries-1:0]  pmpcfg_i,
-    input  logic [ArianeCfg.NrPMPEntries-1:0][53:0]      pmpaddr_i,
+
+    input  riscv::pmpcfg_t [15:0]   pmpcfg_i,
+    input  logic [15:0][53:0]       pmpaddr_i,
     output logic [riscv::PLEN-1:0]  bad_paddr_o
 
 );


### PR DESCRIPTION
During some work with some other tools form the ASIC flow, some issues with the PMP syntax came up. This PR fixes the SV syntax so that hopefully more tools will be able to process it. The main problem was the over/underflow that happens for `pmp_conf_t[NrPMPEntries-1:0]` when `NrPMPEntries=0`.

Details:
- Always wire the full width of the PMP configuration signals through the arch
- The csr file now explicitly only sets the entries below `NrPMPEntries`
- Fix the bender file list