### PR TITLE
Fixed tval of misaligned 32-bit instr's page fault

### DIFF
--- a/src/frontend/frontend.sv
+++ b/src/frontend/frontend.sv
@@ -418,6 +418,7 @@ module frontend import ariane_pkg::*; #(
       .instr_i             ( instr                ), // from re-aligner
       .addr_i              ( addr                 ), // from re-aligner
       .exception_i         ( icache_ex_valid_q    ), // from I$
+      .exception_addr_i    ( icache_vaddr_q       ),
       .predict_address_i   ( predict_address      ),
       .cf_type_i           ( cf_type              ),
       .valid_i             ( instruction_valid    ), // from re-aligner


### PR DESCRIPTION
Fixed wrong tval for instruction page fault exception when fetching the second half of a 4-byte instruction split across two pages.
This PR fixes issue #470 