### PR TITLE
cache_ctrl.sv: fix two bugs in WB data cache controller

### DIFF
--- a/src/cache_subsystem/cache_ctrl.sv
+++ b/src/cache_subsystem/cache_ctrl.sv
@@ -167,7 +167,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
             // cache enabled and waiting for tag
             WAIT_TAG, WAIT_TAG_SAVED: begin
                 // check that the client really wants to do the request and that we have a valid tag
-                if (!req_port_i.kill_req && (req_port_i.tag_valid || state_q == WAIT_TAG_SAVED)) begin
+                if (!req_port_i.kill_req && (req_port_i.tag_valid || state_q == WAIT_TAG_SAVED || mem_req_q.we)) begin
                     // save tag if we didn't already save it
                     if (state_q != WAIT_TAG_SAVED) begin
                         mem_req_d.tag = req_port_i.address_tag;
@@ -334,7 +334,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
             // its for sure a miss
             WAIT_TAG_BYPASSED: begin
                 // check that the client really wants to do the request and that we have a valid tag
-                if (!req_port_i.kill_req & req_port_i.tag_valid) begin
+                if (!req_port_i.kill_req && (req_port_i.tag_valid || mem_req_q.we)) begin
                     // save tag
                     mem_req_d.tag = req_port_i.address_tag;
                     state_d = WAIT_REFILL_GNT;

--- a/src/cache_subsystem/cache_ctrl.sv
+++ b/src/cache_subsystem/cache_ctrl.sv
@@ -209,7 +209,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
 
                         // report data for a read
                         if (!mem_req_q.we) begin
-                            req_port_o.data_rvalid = 1'b1;
+                            req_port_o.data_rvalid = ~mem_req_q.killed;
                         // else this was a store so we need an extra step to handle it
                         end else begin
                             state_d = STORE_REQ;

--- a/src/cache_subsystem/cache_ctrl.sv
+++ b/src/cache_subsystem/cache_ctrl.sv
@@ -165,9 +165,9 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
             // cache enabled and waiting for tag
             WAIT_TAG, WAIT_TAG_SAVED: begin
                 // check that the client really wants to do the request and that we have a valid tag
-                if (!req_port_i.kill_req && (req_port_i.tag_valid || state_d == WAIT_TAG_SAVED)) begin
+                if (!req_port_i.kill_req && (req_port_i.tag_valid || state_q == WAIT_TAG_SAVED)) begin
                     // save tag if we didn't already save it
-                    if (state_d != WAIT_TAG_SAVED) begin
+                    if (state_q != WAIT_TAG_SAVED) begin
                         mem_req_d.tag = req_port_i.address_tag;
                     end
                     // we speculatively request another transfer

--- a/src/cache_subsystem/cache_ctrl.sv
+++ b/src/cache_subsystem/cache_ctrl.sv
@@ -252,6 +252,12 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
                         mem_req_d.bypass = 1'b1;
                         state_d = WAIT_REFILL_GNT;
                     end
+
+                // we are still waiting for a valid tag
+                end else begin
+                    // request cache line for saved index
+                    addr_o = mem_req_q.index;
+                    req_o  = '1;
                 end
             end
 


### PR DESCRIPTION
This PR resolves two bugs within the write-back data cache controller. Specifically:

#### Safely kill in-flight miss requests
If we already issued a miss request and are waiting for the critical word to arrive when receiving a kill request, we want to wait for the miss handler to complete before returning to the `IDLE` state. Hence, when a miss request might be in-flight (we are in `WAIT_REFILL_GNT` or `WAIT_CRITICAL_WORD`, do not abort immediately but remember that the request was killed, and discard the critical word after it arrives.

#### Wait for `tag_valid`
The load unit can send the tag only after it has translated the virtual address. Depending on the state of the TLB and the time it takes to walk the page table, the tag may be available many cycles after the load request was issued to the cache. Therefore, the cache needs to wait for the `req_port_i.tag_valid` signal before it can know whether we have a hit or a miss.
##### Wait for memory grant if we loose it in `WAIT_TAG`
It is possible that we loose the memory grant while we wait for a valid tag. So we introduce two more states, `WAIT_GNT` and `WAIT_GNT_SAVED`. `WAIT_GNT` is reached when the memory grant is lost while we wait for a valid tag. It returns to `WAIT_TAG` once we have a memory grant again. If the valid tag arrives while we wait for a memory grant in `WAIT_GNT`, it is saved and we continue in `WAIT_GNT_SAVED` and eventually `WAIT_TAG_SAVED`.