### PR TITLE
Fix lint

### DIFF
--- a/src/frontend/frontend.sv
+++ b/src/frontend/frontend.sv
@@ -49,7 +49,7 @@ module frontend import ariane_pkg::*; #(
     logic [FETCH_WIDTH-1:0] icache_data_q;
     logic                   icache_valid_q;
     ariane_pkg::frontend_exception_t icache_ex_valid_q;
-    logic [63:0]            icache_vaddr_q;
+    logic [riscv::VLEN-1:0] icache_vaddr_q;
     logic                   instr_queue_ready;
     logic [ariane_pkg::INSTR_PER_FETCH-1:0] instr_queue_consumed;
     // upper-most branch-prediction from last cycle

--- a/src/issue_stage.sv
+++ b/src/issue_stage.sv
@@ -31,8 +31,8 @@ module issue_stage import ariane_pkg::*; #(
     input  logic                                     is_ctrl_flow_i,
     output logic                                     decoded_instr_ack_o,
     // to EX
-    output [63:0]                                    rs1_forwarding_o,  // unregistered version of fu_data_o.operanda
-    output [63:0]                                    rs2_forwarding_o, // unregistered version of fu_data_o.operandb
+    output [riscv::VLEN-1:0]                         rs1_forwarding_o,  // unregistered version of fu_data_o.operanda
+    output [riscv::VLEN-1:0]                         rs2_forwarding_o, // unregistered version of fu_data_o.operandb
     output fu_data_t                                 fu_data_o,
     output logic [riscv::VLEN-1:0]                   pc_o,
     output logic                                     is_compressed_instr_o,

--- a/src/load_store_unit.sv
+++ b/src/load_store_unit.sv
@@ -55,7 +55,7 @@ module load_store_unit import ariane_pkg::*; #(
     input  logic [riscv::PPNW-1:0]   satp_ppn_i,               // From CSR register file
     input  logic [ASID_WIDTH-1:0]    asid_i,                   // From CSR register file
     input  logic [ASID_WIDTH-1:0]    asid_to_be_flushed_i,
-    input  logic [63:0]              vaddr_to_be_flushed_i,
+    input  logic [riscv::VLEN-1:0]   vaddr_to_be_flushed_i,
     input  logic                     flush_tlb_i,
     // Performance counters
     output logic                     itlb_miss_o,
@@ -111,7 +111,7 @@ module load_store_unit import ariane_pkg::*; #(
     logic [riscv::PLEN-1:0]   mmu_paddr;
     exception_t               mmu_exception;
     logic                     dtlb_hit;
-    logic [riscv::PLEN-13:0]  dtlb_ppn;
+    logic [riscv::PPNW-1:0]   dtlb_ppn;
 
     logic                     ld_valid;
     logic [TRANS_ID_BITS-1:0] ld_trans_id;

--- a/src/load_unit.sv
+++ b/src/load_unit.sv
@@ -34,7 +34,7 @@ module load_unit import ariane_pkg::*; #(
     input  logic [riscv::PLEN-1:0]   paddr_i,             // physical address in
     input  exception_t               ex_i,                // exception which may has happened earlier. for example: mis-aligned exception
     input  logic                     dtlb_hit_i,          // hit on the dtlb, send in the same cycle as the request
-    input  logic [riscv::PLEN-13:0]  dtlb_ppn_i,          // ppn on the dtlb, send in the same cycle as the request
+    input  logic [riscv::PPNW-1:0]   dtlb_ppn_i,          // ppn on the dtlb, send in the same cycle as the request
     // address checker
     output logic [11:0]              page_offset_o,
     input  logic                     page_offset_matches_i,

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -39,7 +39,7 @@ module mmu import ariane_pkg::*; #(
     // if we need to walk the page table we can't grant in the same cycle
     // Cycle 0
     output logic                            lsu_dtlb_hit_o,   // sent in the same cycle as the request if translation hits in the DTLB
-    output logic [riscv::PLEN-13:0]         lsu_dtlb_ppn_o,   // ppn (send same cycle as hit)
+    output logic [riscv::PPNW-1:0]          lsu_dtlb_ppn_o,   // ppn (send same cycle as hit)
     // Cycle 1
     output logic                            lsu_valid_o,      // translation is valid
     output logic [riscv::PLEN-1:0]          lsu_paddr_o,      // translated address

--- a/src/tlb.sv
+++ b/src/tlb.sv
@@ -114,7 +114,7 @@ module tlb import ariane_pkg::*; #(
 
             vaddr_vpn0_match[i] = (vaddr_to_be_flushed_i[20:12] == tags_q[i].vpn0);
             vaddr_vpn1_match[i] = (vaddr_to_be_flushed_i[29:21] == tags_q[i].vpn1);
-            vaddr_vpn2_match[i] = (vaddr_to_be_flushed_i[38:30] == tags_q[i].vpn2);
+            vaddr_vpn2_match[i] = (vaddr_to_be_flushed_i[30+riscv::VPN2:30] == tags_q[i].vpn2);
 
             if (flush_i) begin
                 // invalidate logic


### PR DESCRIPTION
@zarubaf 

Sebastien Jack has detected some lint errors which break the FPGA generation in 32bits configuration. This PR fix some of them. 

Git logs:
load_store_unit.sv, load_unit.sv, mmu.sv, tlb.sv: fix lint warnings
issue_stage.sv: fix lint warnings on rs1_forwarding and rs2_forwarding signals
frontend.sv: fix lint error on icache_vaddr_q signal

A lint error related to PMP cannot be solved easily: PMP has been designed to be compliant to rv64, and not rv32. In 32bits, new registers (pmpconfig) need to be defined and current registers need to be reduced from 64 to 32bits. How can think we can fix these LINT errors?  Does Moritz Schneider available to adapt the PMP to 32bits, it would be great?
