### PR TITLE
fix configuration issue of sram addr_i when DRAM size is larger than …

### DIFF
--- a/tb/ariane_testharness.sv
+++ b/tb/ariane_testharness.sv
@@ -524,6 +524,10 @@ module ariane_testharness #(
     .data_i ( rdata        )
   );
 
+
+  logic [AXI_ADDRESS_WIDTH-1:0] addr_sram;
+  assign addr_sram = addr - ariane_soc::DRAMBase;
+
   sram #(
     .DATA_WIDTH ( AXI_DATA_WIDTH ),
 `ifdef DROMAJO
@@ -535,7 +539,7 @@ module ariane_testharness #(
     .rst_ni     ( rst_ni                                                                      ),
     .req_i      ( req                                                                         ),
     .we_i       ( we                                                                          ),
-    .addr_i     ( addr[$clog2(NUM_WORDS)-1+$clog2(AXI_DATA_WIDTH/8):$clog2(AXI_DATA_WIDTH/8)] ),
+    .addr_i     ( addr_sram[$clog2(NUM_WORDS)-1+$clog2(AXI_DATA_WIDTH/8):$clog2(AXI_DATA_WIDTH/8)] ),
     .wdata_i    ( wdata                                                                       ),
     .be_i       ( be                                                                          ),
     .rdata_o    ( rdata                                                                       )


### PR DESCRIPTION
Addr should subtract DRAMBase before it is sent to sram. Otherwise bit select of addr will exceed the border.

e.g.  set DRAMBase=0x50000000 (2'b 0101 0000 0000 0000 0000 0000 0000 0000) and NUM_WORDS=2**26.
then addr_i=addr[28:3] , it will select bit 28 of addr, which is always equal  to1.
