### PR TITLE
Add mcs file generation for kc705 board

### DIFF
--- a/fpga/scripts/write_cfgmem.tcl
+++ b/fpga/scripts/write_cfgmem.tcl
@@ -30,6 +30,8 @@ if {$::env(BOARD) eq "genesys2"} {
     write_cfgmem -format mcs -interface SPIx4 -size 256  -loadbit "up 0x0 $bitfile" -file $mcsfile -force
 } elseif {$::env(BOARD) eq "vc707"} {
     write_cfgmem -format mcs -interface bpix16 -size 128 -loadbit "up 0x0 $bitfile" -file $mcsfile -force
+} elseif {$::env(BOARD) eq "kc705"} {
+    write_cfgmem -format mcs -interface SPIx4 -size 128  -loadbit "up 0x0 $bitfile" -file $mcsfile -force
 } else {
       exit 1
 }


### PR DESCRIPTION
write_cfgmem.tcl misses the creation of the mcs file if the kc705 board is selected. This patch adds this functionality.