### PR TITLE
Fix the lint warnings which create errors in ASIC synthesis tool

### DIFF
--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -87,8 +87,8 @@ module ariane import ariane_pkg::*; #(
   // --------------
   // ISSUE <-> EX
   // --------------
-   logic [63:0] rs1_forwarding_id_ex; // unregistered version of fu_data_o.operanda
-   logic [63:0] rs2_forwarding_id_ex; // unregistered version of fu_data_o.operandb
+   logic [riscv::VLEN-1:0] rs1_forwarding_id_ex; // unregistered version of fu_data_o.operanda
+   logic [riscv::VLEN-1:0] rs2_forwarding_id_ex; // unregistered version of fu_data_o.operandb
 
   fu_data_t                 fu_data_id_ex;
   logic [riscv::VLEN-1:0]   pc_id_ex;
@@ -185,7 +185,7 @@ module ariane import ariane_pkg::*; #(
   logic                     debug_mode;
   logic                     single_step_csr_commit;
   riscv::pmpcfg_t [15:0]    pmpcfg;
-  logic [15:0][53:0]        pmpaddr;
+  logic [15:0][riscv::PLEN-3:0] pmpaddr;
   // ----------------------------
   // Performance Counters <-> *
   // ----------------------------
@@ -245,7 +245,7 @@ module ariane import ariane_pkg::*; #(
     .flush_i             ( flush_ctrl_if                 ), // not entirely correct
     .flush_bp_i          ( 1'b0                          ),
     .debug_mode_i        ( debug_mode                    ),
-    .boot_addr_i         ( boot_addr_i[riscv::XLEN-1:0]  ),
+    .boot_addr_i         ( boot_addr_i[riscv::VLEN-1:0]  ),
     .icache_dreq_i       ( icache_dreq_cache_if          ),
     .icache_dreq_o       ( icache_dreq_if_cache          ),
     .resolved_branch_i   ( resolved_branch               ),
@@ -500,7 +500,7 @@ module ariane import ariane_pkg::*; #(
     .halt_csr_o             ( halt_csr_ctrl                 ),
     .commit_instr_i         ( commit_instr_id_commit        ),
     .commit_ack_i           ( commit_ack                    ),
-    .boot_addr_i            ( boot_addr_i[riscv::XLEN-1:0]  ),
+    .boot_addr_i            ( boot_addr_i[riscv::VLEN-1:0]  ),
     .hart_id_i              ( hart_id_i[riscv::XLEN-1:0]    ),
     .ex_i                   ( ex_commit                     ),
     .csr_op_i               ( csr_op_commit_csr             ),

--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -29,7 +29,7 @@ module csr_regfile import ariane_pkg::*; #(
     input  scoreboard_entry_t [NrCommitPorts-1:0] commit_instr_i, // the instruction we want to commit
     input  logic [NrCommitPorts-1:0]              commit_ack_i,   // Commit acknowledged a instruction -> increase instret CSR
     // Core and Cluster ID
-    input  logic[riscv::XLEN-1:0] boot_addr_i,                // Address from which to start booting, mtvec is set to the same address
+    input  logic[riscv::VLEN-1:0] boot_addr_i,                // Address from which to start booting, mtvec is set to the same address
     input  logic[riscv::XLEN-1:0] hart_id_i,                  // Hart id in a multicore environment (reflected in a CSR)
     // we are taking an exception
     input exception_t             ex_i,                       // We've got an exception from the commit stage, take it
@@ -85,7 +85,7 @@ module csr_regfile import ariane_pkg::*; #(
     output logic                  perf_we_o,
     // PMPs
     output riscv::pmpcfg_t [15:0] pmpcfg_o,   // PMP configuration containing pmpcfg for max 16 PMPs
-    output logic [15:0][53:0]     pmpaddr_o   // PMP addresses
+    output logic [15:0][riscv::PLEN-3:0] pmpaddr_o            // PMP addresses
 );
     // internal signal to keep track of access exceptions
     logic        read_access_exception, update_access_exception, privilege_violation;
@@ -361,7 +361,7 @@ module csr_regfile import ariane_pkg::*; #(
         // boot_addr_i will be assigned a constant
         // on the top-level.
         if (mtvec_rst_load_q) begin
-            mtvec_d             = boot_addr_i + 'h40;
+            mtvec_d             = {{riscv::XLEN-riscv::VLEN{1'b0}}, boot_addr_i} + 'h40;
         end else begin
             mtvec_d             = mtvec_q;
         end

--- a/src/ex_stage.sv
+++ b/src/ex_stage.sv
@@ -105,7 +105,7 @@ module ex_stage import ariane_pkg::*; #(
     output logic                                   dtlb_miss_o,
     // PMPs
     input  riscv::pmpcfg_t [15:0]                  pmpcfg_i,
-    input  logic[15:0][53:0]                       pmpaddr_i
+    input  logic[15:0][riscv::PLEN-3:0]            pmpaddr_i
 );
 
     // -------------------------

--- a/src/frontend/frontend.sv
+++ b/src/frontend/frontend.sv
@@ -24,7 +24,7 @@ module frontend import ariane_pkg::*; #(
   input  logic               flush_bp_i,         // flush branch prediction
   input  logic               debug_mode_i,
   // global input
-  input  logic [63:0]        boot_addr_i,
+  input  logic [riscv::VLEN-1:0]        boot_addr_i,
   // Set a new PC
   // mispredict
   input  bp_resolve_t        resolved_branch_i,  // from controller signaling a branch_predict -> update BTB
@@ -289,8 +289,8 @@ module frontend import ariane_pkg::*; #(
       // boot_addr_i will be assigned a constant
       // on the top-level.
       if (npc_rst_load_q) begin
-        npc_d         = boot_addr_i[riscv::VLEN-1:0];
-        fetch_address = boot_addr_i[riscv::VLEN-1:0];
+        npc_d         = boot_addr_i;
+        fetch_address = boot_addr_i;
       end else begin
         fetch_address    = npc_q;
         // keep stable by default

--- a/src/load_store_unit.sv
+++ b/src/load_store_unit.sv
@@ -71,7 +71,7 @@ module load_store_unit import ariane_pkg::*; #(
     input  amo_resp_t                amo_resp_i,
     // PMP
     input  riscv::pmpcfg_t [15:0]    pmpcfg_i,
-    input  logic [15:0][53:0]        pmpaddr_i
+    input  logic [15:0][riscv::PLEN-3:0] pmpaddr_i
 );
     // data is misaligned
     logic data_misaligned;

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -302,7 +302,7 @@ module mmu import ariane_pkg::*; #(
     // Wires to PMP checks
     riscv::pmp_access_t pmp_access_type;
     logic        pmp_data_allow;
-    localparam   PPNW_min = (riscv::PPNW-1 > 29) ? 29 : riscv::PPNW-1;
+    localparam   PPNWMin = (riscv::PPNW-1 > 29) ? 29 : riscv::PPNW-1;
     // The data interface is simpler and only consists of a request/response interface
     always_comb begin : data_interface
         // save request and DTLB response
@@ -341,8 +341,8 @@ module mmu import ariane_pkg::*; #(
             end
             // Giga page
             if (dtlb_is_1G_q) begin
-                lsu_paddr_o[PPNW_min:12] = lsu_vaddr_q[PPNW_min:12];
-                lsu_dtlb_ppn_o[PPNW_min:12] = lsu_vaddr_n[PPNW_min:12];
+                lsu_paddr_o[PPNWMin:12] = lsu_vaddr_q[PPNWMin:12];
+                lsu_dtlb_ppn_o[PPNWMin:12] = lsu_vaddr_n[PPNWMin:12];
             end
             // ---------
             // DTLB Hit

--- a/src/mmu.sv
+++ b/src/mmu.sv
@@ -302,6 +302,7 @@ module mmu import ariane_pkg::*; #(
     // Wires to PMP checks
     riscv::pmp_access_t pmp_access_type;
     logic        pmp_data_allow;
+    localparam   PPNW_min = (riscv::PPNW-1 > 29) ? 29 : riscv::PPNW-1;
     // The data interface is simpler and only consists of a request/response interface
     always_comb begin : data_interface
         // save request and DTLB response
@@ -340,8 +341,8 @@ module mmu import ariane_pkg::*; #(
             end
             // Giga page
             if (dtlb_is_1G_q) begin
-                lsu_paddr_o[29:12] = lsu_vaddr_q[29:12];
-                lsu_dtlb_ppn_o[29:12] = lsu_vaddr_n[29:12];
+                lsu_paddr_o[PPNW_min:12] = lsu_vaddr_q[PPNW_min:12];
+                lsu_dtlb_ppn_o[PPNW_min:12] = lsu_vaddr_n[PPNW_min:12];
             end
             // ---------
             // DTLB Hit

--- a/src/ptw.sv
+++ b/src/ptw.sv
@@ -62,7 +62,7 @@ module ptw import ariane_pkg::*; #(
     // PMP
 
     input  riscv::pmpcfg_t [15:0]   pmpcfg_i,
-    input  logic [15:0][53:0]       pmpaddr_i,
+    input  logic [15:0][riscv::PLEN-3:0] pmpaddr_i,
     output logic [riscv::PLEN-1:0]  bad_paddr_o
 
 );


### PR DESCRIPTION
Hello @zarubaf, 
The Synopsys dc_shell LINT creates errors when reading the code, modifications have been done on the following nets:
- rs1_forwarding
- rs2_forwarding
- pmp_addr
- boot_addr
- icache_vaddr
- vaddr_to_be_flushed
- dtlb_ppn
- vaddr_vpn2_match
Kind regards