### PR TITLE
Add RVFI to Ariane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ else
 endif
 
 generate-trace:
-	cat trace_ip.dasm | sed 's/^.*core/core/'| $(SPIKE_ROOT)/bin/spike-dasm
+	cat trace_rvfi_hart_00.dasm | sed 's/^.*core/core/'| $(SPIKE_ROOT)/bin/spike-dasm
 
 # Build the TB and module using QuestaSim
 build: $(library) $(library)/.build-srcs $(library)/.build-tb $(dpi-library)/ariane_dpi.so

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,12 @@ ifdef spike-tandem
     CFLAGS += -Itb/riscv-isa-sim/install/include/spike
 endif
 
+ifeq ($(findstring 32, $(variant)),32)
+    CVA6=-DCV32A6
+else
+    CVA6=""
+endif
+
 # this list contains the standalone components
 src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
         $(filter-out src/fpu/src/fpnew_pkg.sv, $(wildcard src/fpu/src/*.sv))   \
@@ -408,6 +414,8 @@ verilate_command := $(verilator)                                                
                     -Wno-UNOPTFLAT                                                                               \
                     -Wno-BLKANDNBLK                                                                              \
                     -Wno-style                                                                                   \
+                    $(if ($(PRELOAD)!=""), -DPRELOAD=1,)                                                         \
+                    $(CVA6)                                                                                      \
                     $(if $(DROMAJO), -DDROMAJO=1,)                                                               \
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
                     $(if $(DEBUG),--trace --trace-structs,)                                                      \

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ ariane_pkg := include/riscv_pkg.sv                          \
               src/register_interface/src/reg_intf.sv        \
               src/register_interface/src/reg_intf_pkg.sv    \
               include/axi_intf.sv                           \
+              include/rvfi_tracer_pkg.sv                    \
               tb/ariane_soc_pkg.sv                          \
               include/ariane_axi_pkg.sv                     \
               src/fpu/src/fpnew_pkg.sv                      \
@@ -205,6 +206,7 @@ src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
         src/tech_cells_generic/src/pulp_clock_mux2.sv                          \
         tb/ariane_testharness.sv                                               \
         tb/ariane_peripherals.sv                                               \
+        tb/rvfi_tracer.sv                                                      \
         tb/common/uart.sv                                                      \
         tb/common/SimDTM.sv                                                    \
         tb/common/SimJTAG.sv

--- a/Makefile
+++ b/Makefile
@@ -277,6 +277,9 @@ else
 	questa-cmd += +jtag_rbb_enable=0
 endif
 
+generate-trace:
+	cat trace_ip.dasm | sed 's/^.*core/core/'| $(SPIKE_ROOT)/bin/spike-dasm
+
 # Build the TB and module using QuestaSim
 build: $(library) $(library)/.build-srcs $(library)/.build-tb $(dpi-library)/ariane_dpi.so
 	# Optimize top level
@@ -478,6 +481,10 @@ verilate: $(if $(DROMAJO), dromajo,)
 	@echo "[Verilator] Building Model$(if $(PROFILE), for Profiling,)"
 	$(verilate_command)
 	cd $(ver-library) && $(MAKE) -j${NUM_JOBS} -f Variane_testharness.mk
+
+generate-trace-verilator:
+	make sim-verilator
+	make generate-trace
 
 sim-verilator: verilate
 	$(ver-library)/Variane_testharness $(elf-bin)

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -235,9 +235,6 @@ package ariane_pkg;
     // enables a commit log which matches spikes commit log format for easier trace comparison
     localparam bit ENABLE_SPIKE_COMMIT_LOG = 1'b1;
 
-    //enable RFVI to generate RVFI trace
-    `define RVFI_TRACE
-
 
     // ------------- Dangerouse -------------
     // if set to zero a flush will not invalidate the cache-lines, in a single core environment

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -235,6 +235,10 @@ package ariane_pkg;
     // enables a commit log which matches spikes commit log format for easier trace comparison
     localparam bit ENABLE_SPIKE_COMMIT_LOG = 1'b1;
 
+    //enable RFVI to generate RVFI trace
+    `define RVFI_TRACE
+
+
     // ------------- Dangerouse -------------
     // if set to zero a flush will not invalidate the cache-lines, in a single core environment
     // where coherence is not necessary this can improve performance. This needs to be switched on

--- a/include/riscv_pkg.sv
+++ b/include/riscv_pkg.sv
@@ -28,7 +28,11 @@ package riscv;
        ModeSv64 = 11
     } vm_mode_t;
 
+`ifdef CV32A6
+    localparam XLEN = 32;
+`else
     localparam XLEN = 64;
+`endif
 
     // Warning: When using STD_CACHE, configuration must be PLEN=56 and VLEN=64
     // Warning: VLEN must be superior or equal to PLEN

--- a/include/rvfi_tracer_pkg.sv
+++ b/include/rvfi_tracer_pkg.sv
@@ -1,24 +1,16 @@
-//#############################################################################
-//#
-//# Copyright 2020 Thales DIS design services SAS
-//#
-//# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-//# you may not use this file except in compliance with the License.
-//# You may obtain a copy of the License at
-//#
-//#     https://solderpad.org/licenses/
-//#
-//# Unless required by applicable law or agreed to in writing, software
-//# distributed under the License is distributed on an "AS IS" BASIS,
-//# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//# See the License for the specific language governing permissions and
-//# limitations under the License.
-//#
-//#############################################################################
-//#
-//# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
-//#
-//#############################################################################
+// Copyright 2020 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
 
 package rvfi_tracer_pkg;
 

--- a/include/rvfi_tracer_pkg.sv
+++ b/include/rvfi_tracer_pkg.sv
@@ -1,0 +1,56 @@
+//#############################################################################
+//#
+//# Copyright 2020 Thales DIS design services SAS
+//#
+//# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+//# you may not use this file except in compliance with the License.
+//# You may obtain a copy of the License at
+//#
+//#     https://solderpad.org/licenses/
+//#
+//# Unless required by applicable law or agreed to in writing, software
+//# distributed under the License is distributed on an "AS IS" BASIS,
+//# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//# See the License for the specific language governing permissions and
+//# limitations under the License.
+//#
+//#############################################################################
+//#
+//# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
+//#
+//#############################################################################
+
+package rvfi_tracer_pkg;
+
+  localparam NRET = 1;
+  localparam ILEN = 32;
+
+  typedef struct packed {
+    logic [NRET-1:0]                 rvfi_valid;
+    logic [NRET*63:0]                rvfi_order;
+    logic [NRET*ILEN-1:0]            rvfi_insn;
+    logic [NRET-1:0]                 rvfi_trap;
+    logic [NRET-1:0]                 rvfi_halt;
+    logic [NRET-1:0]                 rvfi_intr;
+    logic [NRET*2-1:0]               rvfi_mode;
+    logic [NRET*2-1:0]               rvfi_ixl;
+    logic [NRET*5-1:0]               rvfi_rs1_addr;
+    logic [NRET*5-1:0]               rvfi_rs2_addr;
+    logic [NRET*riscv::XLEN-1:0]     rvfi_rs1_rdata;
+    logic [NRET*riscv::XLEN-1:0]     rvfi_rs2_rdata;
+    logic [NRET*5-1:0]               rvfi_rd_addr;
+    logic [NRET*riscv::XLEN-1:0]     rvfi_rd_wdata;
+
+    logic [NRET*riscv::XLEN-1:0]     rvfi_pc_rdata;
+    logic [NRET*riscv::XLEN-1:0]     rvfi_pc_wdata;
+
+    logic [NRET*riscv::XLEN-1:0]     rvfi_mem_addr;
+    logic [NRET*(riscv::XLEN/8)-1:0] rvfi_mem_rmask;
+    logic [NRET*(riscv::XLEN/8)-1:0] rvfi_mem_wmask;
+    logic [NRET*riscv::XLEN-1:0]     rvfi_mem_rdata;
+    logic [NRET*riscv::XLEN-1:0]     rvfi_mem_wdata;
+  } rvfi_instr_t;
+
+  typedef rvfi_instr_t [ariane_pkg::NR_COMMIT_PORTS-1:0] rvfi_port_t;
+
+endpackage

--- a/include/rvfi_tracer_pkg.sv
+++ b/include/rvfi_tracer_pkg.sv
@@ -4,11 +4,6 @@
 // you may not use this file except in compliance with the License.
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 // You may obtain a copy of the License at https://solderpad.org/licenses/
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 // Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
 
@@ -18,29 +13,29 @@ package rvfi_tracer_pkg;
   localparam ILEN = 32;
 
   typedef struct packed {
-    logic [NRET-1:0]                 rvfi_valid;
-    logic [NRET*63:0]                rvfi_order;
-    logic [NRET*ILEN-1:0]            rvfi_insn;
-    logic [NRET-1:0]                 rvfi_trap;
-    logic [NRET-1:0]                 rvfi_halt;
-    logic [NRET-1:0]                 rvfi_intr;
-    logic [NRET*2-1:0]               rvfi_mode;
-    logic [NRET*2-1:0]               rvfi_ixl;
-    logic [NRET*5-1:0]               rvfi_rs1_addr;
-    logic [NRET*5-1:0]               rvfi_rs2_addr;
-    logic [NRET*riscv::XLEN-1:0]     rvfi_rs1_rdata;
-    logic [NRET*riscv::XLEN-1:0]     rvfi_rs2_rdata;
-    logic [NRET*5-1:0]               rvfi_rd_addr;
-    logic [NRET*riscv::XLEN-1:0]     rvfi_rd_wdata;
+    logic [NRET-1:0]                 valid;
+    logic [NRET*63:0]                order;
+    logic [NRET*ILEN-1:0]            insn;
+    logic [NRET-1:0]                 trap;
+    logic [NRET-1:0]                 halt;
+    logic [NRET-1:0]                 intr;
+    logic [NRET*2-1:0]               mode;
+    logic [NRET*2-1:0]               ixl;
+    logic [NRET*5-1:0]               rs1_addr;
+    logic [NRET*5-1:0]               rs2_addr;
+    logic [NRET*riscv::XLEN-1:0]     rs1_rdata;
+    logic [NRET*riscv::XLEN-1:0]     rs2_rdata;
+    logic [NRET*5-1:0]               rd_addr;
+    logic [NRET*riscv::XLEN-1:0]     rd_wdata;
 
-    logic [NRET*riscv::XLEN-1:0]     rvfi_pc_rdata;
-    logic [NRET*riscv::XLEN-1:0]     rvfi_pc_wdata;
+    logic [NRET*riscv::XLEN-1:0]     pc_rdata;
+    logic [NRET*riscv::XLEN-1:0]     pc_wdata;
 
-    logic [NRET*riscv::XLEN-1:0]     rvfi_mem_addr;
-    logic [NRET*(riscv::XLEN/8)-1:0] rvfi_mem_rmask;
-    logic [NRET*(riscv::XLEN/8)-1:0] rvfi_mem_wmask;
-    logic [NRET*riscv::XLEN-1:0]     rvfi_mem_rdata;
-    logic [NRET*riscv::XLEN-1:0]     rvfi_mem_wdata;
+    logic [NRET*riscv::XLEN-1:0]     mem_addr;
+    logic [NRET*(riscv::XLEN/8)-1:0] mem_rmask;
+    logic [NRET*(riscv::XLEN/8)-1:0] mem_wmask;
+    logic [NRET*riscv::XLEN-1:0]     mem_rdata;
+    logic [NRET*riscv::XLEN-1:0]     mem_wdata;
   } rvfi_instr_t;
 
   typedef rvfi_instr_t [ariane_pkg::NR_COMMIT_PORTS-1:0] rvfi_port_t;

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -42,7 +42,9 @@ module ariane import ariane_pkg::*; #(
   // firesim trace port
   output traced_instr_pkg::trace_port_t trace_o,
 `endif
-  // Risc-V Format Interface port
+  // RISC-V formal interface port (`rvfi`):
+  // Can be left open when formal tracing is not needed.
+  // The `rvfi_tracer` module can be connected to dump the trace content into a file.
   output rvfi_tracer_pkg::rvfi_port_t  rvfi_o,
 `ifdef PITON_ARIANE
   // L15 (memory side)

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -915,20 +915,20 @@ module ariane import ariane_pkg::*; #(
          commit_instr_id_commit[i].ex.cause == riscv::LOAD_PAGE_FAULT ||
          commit_instr_id_commit[i].ex.cause == riscv::STORE_PAGE_FAULT);
       // when rvfi_valid, the instruction is executed
-      rvfi_o[i].rvfi_valid    = (commit_ack[i] && !commit_instr_id_commit[i].ex.valid) ||
+      rvfi_o[i].valid    = (commit_ack[i] && !commit_instr_id_commit[i].ex.valid) ||
         (exception && (commit_instr_id_commit[i].ex.cause == riscv::ENV_CALL_MMODE ||
                   commit_instr_id_commit[i].ex.cause == riscv::ENV_CALL_SMODE ||
                   commit_instr_id_commit[i].ex.cause == riscv::ENV_CALL_UMODE));
-      rvfi_o[i].rvfi_insn     = commit_instr_id_commit[i].ex.tval[31:0];
-      // when rvfi_trap, the instruction is not executed
-      rvfi_o[i].rvfi_trap     = mem_exception;
-      rvfi_o[i].rvfi_mode     = debug_mode ? 2'b10 : priv_lvl;
-      rvfi_o[i].rvfi_ixl      = riscv::XLEN == 64 ? 2 : 1;
-      rvfi_o[i].rvfi_rs1_addr = commit_instr_id_commit[i].rs1;
-      rvfi_o[i].rvfi_rs2_addr = commit_instr_id_commit[i].rs2;
-      rvfi_o[i].rvfi_rd_addr  = commit_instr_id_commit[i].rd;
-      rvfi_o[i].rvfi_rd_wdata = ariane_pkg::is_rd_fpr(commit_instr_id_commit[i].op) == 0 ? wdata_commit_id[i] : commit_instr_id_commit[i].result;
-      rvfi_o[i].rvfi_pc_rdata = commit_instr_id_commit[i].pc;
+      rvfi_o[i].insn     = commit_instr_id_commit[i].ex.tval[31:0];
+      // when trap, the instruction is not executed
+      rvfi_o[i].trap     = mem_exception;
+      rvfi_o[i].mode     = debug_mode ? 2'b10 : priv_lvl;
+      rvfi_o[i].ixl      = riscv::XLEN == 64 ? 2 : 1;
+      rvfi_o[i].rs1_addr = commit_instr_id_commit[i].rs1;
+      rvfi_o[i].rs2_addr = commit_instr_id_commit[i].rs2;
+      rvfi_o[i].rd_addr  = commit_instr_id_commit[i].rd;
+      rvfi_o[i].rd_wdata = ariane_pkg::is_rd_fpr(commit_instr_id_commit[i].op) == 0 ? wdata_commit_id[i] : commit_instr_id_commit[i].result;
+      rvfi_o[i].pc_rdata = commit_instr_id_commit[i].pc;
     end
 `endif
 

--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -42,10 +42,8 @@ module ariane import ariane_pkg::*; #(
   // firesim trace port
   output traced_instr_pkg::trace_port_t trace_o,
 `endif
-`ifdef RVFI_TRACE
   // Risc-V Format Interface port
   output rvfi_tracer_pkg::rvfi_port_t  rvfi_o,
-`endif
 `ifdef PITON_ARIANE
   // L15 (memory side)
   output wt_cache_pkg::l15_req_t       l15_req_o,
@@ -898,7 +896,6 @@ module ariane import ariane_pkg::*; #(
 `endif // VERILATOR
 //pragma translate_on
 
-`ifdef RVFI_TRACE
   always_comb
     for (int i = 0; i < NR_COMMIT_PORTS; i++) begin
       logic exception, mem_exception;
@@ -930,6 +927,5 @@ module ariane import ariane_pkg::*; #(
       rvfi_o[i].rd_wdata = ariane_pkg::is_rd_fpr(commit_instr_id_commit[i].op) == 0 ? wdata_commit_id[i] : commit_instr_id_commit[i].result;
       rvfi_o[i].pc_rdata = commit_instr_id_commit[i].pc;
     end
-`endif
 
 endmodule // ariane

--- a/tb/ariane_testharness.sv
+++ b/tb/ariane_testharness.sv
@@ -32,6 +32,8 @@ module ariane_testharness #(
   output logic [31:0]                    exit_o
 );
 
+  localparam [7:0] hart_id = '0;
+
   // disable test-enable
   logic        test_en;
   logic        ndmreset;
@@ -686,7 +688,7 @@ module ariane_testharness #(
     .clk_i                ( clk_i               ),
     .rst_ni               ( ndmreset_n          ),
     .boot_addr_i          ( ariane_soc::ROMBase ), // start fetching from ROM
-    .hart_id_i            ( '0                  ),
+    .hart_id_i            ( {56'h0, hart_id}    ),
     .irq_i                ( irqs                ),
     .ipi_i                ( ipi                 ),
     .time_irq_i           ( timer_irq           ),
@@ -735,6 +737,7 @@ module ariane_testharness #(
 
   rvfi_tracer  #(
     .SIM_FINISH(2000000),
+    .HART_ID(hart_id),
     .DEBUG_START(0),
     .DEBUG_STOP(0)
   ) rvfi_tracer_i (

--- a/tb/ariane_testharness.sv
+++ b/tb/ariane_testharness.sv
@@ -690,9 +690,7 @@ module ariane_testharness #(
     .irq_i                ( irqs                ),
     .ipi_i                ( ipi                 ),
     .time_irq_i           ( timer_irq           ),
-`ifdef RVFI_TRACE
     .rvfi_o               ( rvfi                ),
-`endif
 // Disable Debug when simulating with Spike
 `ifdef SPIKE_TANDEM
     .debug_req_i          ( 1'b0                ),

--- a/tb/rvfi_tracer.sv
+++ b/tb/rvfi_tracer.sv
@@ -4,17 +4,10 @@
 // you may not use this file except in compliance with the License.
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 // You may obtain a copy of the License at https://solderpad.org/licenses/
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 // Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
 
-import ariane_pkg::*;
-
-module rvfi_tracer #(
+module rvfi_tracer import ariane_pkg::*; #(
   parameter int unsigned SIM_FINISH = 1000000,
   parameter int unsigned DEBUG_START = 0,
   parameter int unsigned DEBUG_STOP  = 0

--- a/tb/rvfi_tracer.sv
+++ b/tb/rvfi_tracer.sv
@@ -27,20 +27,20 @@ module rvfi_tracer #(
   initial f = $fopen("trace_ip.dasm", "w");
   final $fclose(f);
 
-  //Generate the trace based on RVFI
+  // Generate the trace based on RVFI
   logic [63:0] pc64;
   always_ff @(posedge i_ariane.clk_i) begin
     for (int i = 0; i < NR_COMMIT_PORTS; i++) begin
       pc64 = {{riscv::XLEN-riscv::VLEN{rvfi_i[i].rvfi_pc_rdata[riscv::VLEN-1]}}, rvfi_i[i].rvfi_pc_rdata};
-      //print instruction information if is valid or is trapped
+      // print the instruction information if the instruction is valid or a trap is taken
       if (rvfi_i[i].rvfi_valid) begin
-        //Instruction information
+        // Instruction information
         $fwrite(f, "core   0: 0x%h (0x%h) DASM(%h)\n",
           pc64, rvfi_i[i].rvfi_insn, rvfi_i[i].rvfi_insn);
-        //Destination register information
+        // Destination register information
         $fwrite(f, "%h 0x%h (0x%h)",
           rvfi_i[i].rvfi_mode, pc64, rvfi_i[i].rvfi_insn);
-        //Decode instruction to know if destination register is FP register
+        // Decode instruction to know if destination register is FP register
         if ( rvfi_i[i].rvfi_insn[6:0] == 7'b1001111 ||
              rvfi_i[i].rvfi_insn[6:0] == 7'b1001011 ||
              rvfi_i[i].rvfi_insn[6:0] == 7'b1000111 ||
@@ -62,16 +62,14 @@ module rvfi_tracer #(
     if (cycles > SIM_FINISH) $finish(1);
   end
 
-  //Trace custom signals
-  //Define signals to be traced by adding them into debug and name arrays
+  // Trace any custom signals
+  // Define signals to be traced by adding them into debug and name arrays
   string name[0:10];
   logic[63:0] debug[0:10], debug_previous[0:10];
-  //assign debug[0] = i_ariane.csr_regfile_i.dscratch1_q;
-  //assign  name[0] = "i_ariane.csr_regfile_i.dscratch1_q";
 
   always_ff @(posedge i_ariane.clk_i) begin
     if (cycles > DEBUG_START && cycles < DEBUG_STOP)
-      for (int index=0; index<100; index=index+1)
+      for (int index = 0; index < 100; index++)
         if (debug_previous[index] != debug[index])
           $fwrite(f, "%d %s %x\n", cycles, name[index], debug[index]);
     debug_previous <= debug;

--- a/tb/rvfi_tracer.sv
+++ b/tb/rvfi_tracer.sv
@@ -8,7 +8,8 @@
 // Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
 
 module rvfi_tracer import ariane_pkg::*; #(
-  parameter int unsigned SIM_FINISH = 1000000,
+  parameter int unsigned SIM_FINISH  = 1000000,
+  parameter logic [7:0] HART_ID      = '0,
   parameter int unsigned DEBUG_START = 0,
   parameter int unsigned DEBUG_STOP  = 0
 )(
@@ -17,7 +18,7 @@ module rvfi_tracer import ariane_pkg::*; #(
 );
 
   int f;
-  initial f = $fopen("trace_ip.dasm", "w");
+  initial f = $fopen($sformatf("trace_rvfi_hart_%h.dasm", HART_ID), "w");
   final $fclose(f);
 
   // Generate the trace based on RVFI

--- a/tb/rvfi_tracer.sv
+++ b/tb/rvfi_tracer.sv
@@ -1,0 +1,88 @@
+//#############################################################################
+//#
+//# Copyright 2020 Thales DIS design services SAS
+//#
+//# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+//# you may not use this file except in compliance with the License.
+//# You may obtain a copy of the License at
+//#
+//#     https://solderpad.org/licenses/
+//#
+//# Unless required by applicable law or agreed to in writing, software
+//# distributed under the License is distributed on an "AS IS" BASIS,
+//# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//# See the License for the specific language governing permissions and
+//# limitations under the License.
+//#
+//#############################################################################
+//#
+//# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
+//#
+//#############################################################################
+
+import ariane_pkg::*;
+
+module rvfi_tracer #(
+  parameter int unsigned SIM_FINISH = 1000000,
+  parameter int unsigned DEBUG_START = 0,
+  parameter int unsigned DEBUG_STOP  = 0
+)(
+  input logic [31:0]                    cycles,
+  input rvfi_tracer_pkg::rvfi_port_t    rvfi_i
+);
+
+  int f;
+  initial f = $fopen("trace_ip.dasm", "w");
+  final $fclose(f);
+
+  //Generate the trace based on RVFI
+  logic [63:0] pc64;
+  always_ff @(posedge i_ariane.clk_i) begin
+    for (int i = 0; i < NR_COMMIT_PORTS; i++) begin
+      pc64 = {{riscv::XLEN-riscv::VLEN{rvfi_i[i].rvfi_pc_rdata[riscv::VLEN-1]}}, rvfi_i[i].rvfi_pc_rdata};
+      //print instruction information if is valid or is trapped
+      if (rvfi_i[i].rvfi_valid) begin
+        //Instruction information
+        $fwrite(f, "core   0: 0x%h (0x%h) DASM(%h)\n",
+          pc64, rvfi_i[i].rvfi_insn, rvfi_i[i].rvfi_insn);
+        //Destination register information
+        $fwrite(f, "%h 0x%h (0x%h)",
+          rvfi_i[i].rvfi_mode, pc64, rvfi_i[i].rvfi_insn);
+        //Decode instruction to know if destination register is FP register
+        if ( rvfi_i[i].rvfi_insn[6:0] == 7'b1001111 ||
+             rvfi_i[i].rvfi_insn[6:0] == 7'b1001011 ||
+             rvfi_i[i].rvfi_insn[6:0] == 7'b1000111 ||
+             rvfi_i[i].rvfi_insn[6:0] == 7'b1000011 ||
+             rvfi_i[i].rvfi_insn[6:0] == 7'b0000111 ||
+            (rvfi_i[i].rvfi_insn[6:0] == 7'b1010011
+                        && rvfi_i[i].rvfi_insn[31:26] != 6'b111000
+                        && rvfi_i[i].rvfi_insn[31:26] != 6'b101000
+                        && rvfi_i[i].rvfi_insn[31:26] != 6'b110000) )
+          $fwrite(f, " f%d 0x%h\n",
+            rvfi_i[i].rvfi_rd_addr, rvfi_i[i].rvfi_rd_wdata);
+        else if (rvfi_i[i].rvfi_rd_addr != 0)
+          $fwrite(f, " x%d 0x%h\n",
+            rvfi_i[i].rvfi_rd_addr, rvfi_i[i].rvfi_rd_wdata);
+        else $fwrite(f, "\n");
+      end else if (rvfi_i[i].rvfi_trap)
+        $fwrite(f, "exception : 0x%h\n", pc64);
+    end
+    if (cycles > SIM_FINISH) $finish(1);
+  end
+
+  //Trace custom signals
+  //Define signals to be traced by adding them into debug and name arrays
+  string name[0:10];
+  logic[63:0] debug[0:10], debug_previous[0:10];
+  //assign debug[0] = i_ariane.csr_regfile_i.dscratch1_q;
+  //assign  name[0] = "i_ariane.csr_regfile_i.dscratch1_q";
+
+  always_ff @(posedge i_ariane.clk_i) begin
+    if (cycles > DEBUG_START && cycles < DEBUG_STOP)
+      for (int index=0; index<100; index=index+1)
+        if (debug_previous[index] != debug[index])
+          $fwrite(f, "%d %s %x\n", cycles, name[index], debug[index]);
+    debug_previous <= debug;
+  end
+
+endmodule // rvfi_tracer

--- a/tb/rvfi_tracer.sv
+++ b/tb/rvfi_tracer.sv
@@ -24,32 +24,31 @@ module rvfi_tracer import ariane_pkg::*; #(
   logic [63:0] pc64;
   always_ff @(posedge i_ariane.clk_i) begin
     for (int i = 0; i < NR_COMMIT_PORTS; i++) begin
-      pc64 = {{riscv::XLEN-riscv::VLEN{rvfi_i[i].rvfi_pc_rdata[riscv::VLEN-1]}}, rvfi_i[i].rvfi_pc_rdata};
+      pc64 = {{riscv::XLEN-riscv::VLEN{rvfi_i[i].pc_rdata[riscv::VLEN-1]}}, rvfi_i[i].pc_rdata};
       // print the instruction information if the instruction is valid or a trap is taken
-      if (rvfi_i[i].rvfi_valid) begin
+      if (rvfi_i[i].valid) begin
         // Instruction information
         $fwrite(f, "core   0: 0x%h (0x%h) DASM(%h)\n",
-          pc64, rvfi_i[i].rvfi_insn, rvfi_i[i].rvfi_insn);
+          pc64, rvfi_i[i].insn, rvfi_i[i].insn);
         // Destination register information
         $fwrite(f, "%h 0x%h (0x%h)",
-          rvfi_i[i].rvfi_mode, pc64, rvfi_i[i].rvfi_insn);
+          rvfi_i[i].mode, pc64, rvfi_i[i].insn);
         // Decode instruction to know if destination register is FP register
-        if ( rvfi_i[i].rvfi_insn[6:0] == 7'b1001111 ||
-             rvfi_i[i].rvfi_insn[6:0] == 7'b1001011 ||
-             rvfi_i[i].rvfi_insn[6:0] == 7'b1000111 ||
-             rvfi_i[i].rvfi_insn[6:0] == 7'b1000011 ||
-             rvfi_i[i].rvfi_insn[6:0] == 7'b0000111 ||
-            (rvfi_i[i].rvfi_insn[6:0] == 7'b1010011
-                        && rvfi_i[i].rvfi_insn[31:26] != 6'b111000
-                        && rvfi_i[i].rvfi_insn[31:26] != 6'b101000
-                        && rvfi_i[i].rvfi_insn[31:26] != 6'b110000) )
+        if ( rvfi_i[i].insn[6:0] == 7'b1001111 ||
+             rvfi_i[i].insn[6:0] == 7'b1001011 ||
+             rvfi_i[i].insn[6:0] == 7'b1000111 ||
+             rvfi_i[i].insn[6:0] == 7'b1000011 ||
+             rvfi_i[i].insn[6:0] == 7'b0000111 ||
+            (rvfi_i[i].insn[6:0] == 7'b1010011 && rvfi_i[i].insn[31:26] != 6'b111000
+                                               && rvfi_i[i].insn[31:26] != 6'b101000
+                                               && rvfi_i[i].insn[31:26] != 6'b110000) )
           $fwrite(f, " f%d 0x%h\n",
-            rvfi_i[i].rvfi_rd_addr, rvfi_i[i].rvfi_rd_wdata);
-        else if (rvfi_i[i].rvfi_rd_addr != 0)
+            rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
+        else if (rvfi_i[i].rd_addr != 0)
           $fwrite(f, " x%d 0x%h\n",
-            rvfi_i[i].rvfi_rd_addr, rvfi_i[i].rvfi_rd_wdata);
+            rvfi_i[i].rd_addr, rvfi_i[i].rd_wdata);
         else $fwrite(f, "\n");
-      end else if (rvfi_i[i].rvfi_trap)
+      end else if (rvfi_i[i].trap)
         $fwrite(f, "exception : 0x%h\n", pc64);
     end
     if (cycles > SIM_FINISH) $finish(1);

--- a/tb/rvfi_tracer.sv
+++ b/tb/rvfi_tracer.sv
@@ -1,24 +1,16 @@
-//#############################################################################
-//#
-//# Copyright 2020 Thales DIS design services SAS
-//#
-//# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-//# you may not use this file except in compliance with the License.
-//# You may obtain a copy of the License at
-//#
-//#     https://solderpad.org/licenses/
-//#
-//# Unless required by applicable law or agreed to in writing, software
-//# distributed under the License is distributed on an "AS IS" BASIS,
-//# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//# See the License for the specific language governing permissions and
-//# limitations under the License.
-//#
-//#############################################################################
-//#
-//# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
-//#
-//#############################################################################
+// Copyright 2020 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
 
 import ariane_pkg::*;
 


### PR DESCRIPTION
The RVFI has been implemented to generate execution trace. This RFVI implementation is synthetizable which is convenient to keep the trace functionility in gate simulation. Only the signals useful to generate instruction execution trace have been implemented. In the near future, our goal is to implement all the signals.

Makefile, rvfi_tracer_pck.sv, ariane.sv, ariane_testharness.sv :
    - rvfi_tracer.sv: add RVFI tracer and debug support. rvfi_tracer is a module added in ariane-testharness.sv.
    - RVFI ports are added to ariane module and connected to rvfi_tracer module
    - RVFI_TRACE enables RVFI trace generation
