### PR TITLE
Fixed multithreading and optimization options for verilator target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,27 +77,27 @@ jobs:
       name: run riscv benchmarks (Write-Back Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-benchmarks-verilator defines=WB_DCACHE
+        - make run-benchmarks-verilator defines=WB_DCACHE
 
     # asm tests
     - stage: test
       name: run asm tests (Write-Back Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-asm-tests-verilator defines=WB_DCACHE
+        - make run-asm-tests-verilator defines=WB_DCACHE
 
     # rv64um-*-* tests
     - stage: test
       name: run mul tests (Write-Back Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-mul-verilator defines=WB_DCACHE
+        - make run-mul-verilator defines=WB_DCACHE
 
     - stage: test
       name: run fp tests (Write-Back Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-fp-verilator defines=WB_DCACHE
+        - make run-fp-verilator defines=WB_DCACHE
 
     # amo tests
     # rv64ua-v-* tests
@@ -105,13 +105,13 @@ jobs:
       name: run amo tests (Write-Back Cache)
       script:
         - ci/build-riscv-tests.sh
-        - travis_wait 60 make -j${NUM_JOBS} run-amo-verilator defines=WB_DCACHE
+        - travis_wait 60 make run-amo-verilator defines=WB_DCACHE
 
     - stage: test
       name: run riscv benchmarks (Write-through Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-benchmarks-verilator  defines=WT_DCACHE
+        - make run-benchmarks-verilator  defines=WT_DCACHE
 
     # asm tests
     # rv64ui-v-* tests
@@ -119,21 +119,21 @@ jobs:
       name: run asm tests (Write-through Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-asm-tests-verilator defines=WT_DCACHE
+        - make run-asm-tests-verilator defines=WT_DCACHE
 
     # rv64um-*-* tests
     - stage: test
       name: run mul tests (Write-through Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-mul-verilator defines=WT_DCACHE
+        - make run-mul-verilator defines=WT_DCACHE
 
     # rv64ud-*-* tests
     - stage: test
       name: run fp tests (Write-through Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-fp-verilator defines=WT_DCACHE
+        - make run-fp-verilator defines=WT_DCACHE
 
     # amo tests
     # rv64ua-v-* tests
@@ -141,7 +141,7 @@ jobs:
       name: run amo tests (Write-through Cache)
       script:
         - ci/build-riscv-tests.sh
-        - make -j${NUM_JOBS} run-amo-verilator defines=WT_DCACHE
+        - make run-amo-verilator defines=WT_DCACHE
 
 # extra time during long builds
 install: travis_wait

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ CFLAGS := -I$(QUESTASIM_HOME)/include         \
           -I$(RISCV)/include                  \
           -I$(SPIKE_ROOT)/include             \
           $(if $(DROMAJO), -I../tb/dromajo/src,) \
-          -std=c++11 -I../tb/dpi
+          -std=c++11 -I../tb/dpi -O3
 
 
 ifdef spike-tandem
@@ -413,7 +413,7 @@ verilate_command := $(verilator)                                                
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
                     $(if $(DEBUG),--trace --trace-structs,)                                                      \
                     -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../tb/dromajo/src -ldromajo_cosim,) -lpthread" \
-                    -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -DDROMAJO=1,) -O3 -DVL_DEBUG"   \
+                    -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -DDROMAJO=1,) -DVL_DEBUG"       \
                     -Wall --cc  --vpi                                                                            \
                     $(list_incdir) --top-module ariane_testharness                                               \
                     --Mdir $(ver-library) -O3                                                                    \

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ CFLAGS := -I$(QUESTASIM_HOME)/include         \
           -I$(RISCV)/include                  \
           -I$(SPIKE_ROOT)/include             \
           $(if $(DROMAJO), -I../tb/dromajo/src,) \
-          -std=c++11 -I../tb/dpi -O3
+          -std=c++11 -I../tb/dpi
 
 
 ifdef spike-tandem
@@ -413,7 +413,7 @@ verilate_command := $(verilator)                                                
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
                     $(if $(DEBUG),--trace --trace-structs,)                                                      \
                     -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../tb/dromajo/src -ldromajo_cosim,) -lpthread" \
-                    -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -DDROMAJO=1,) -DVL_DEBUG"       \
+                    -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -DDROMAJO=1,) -O3 -DVL_DEBUG"   \
                     -Wall --cc  --vpi                                                                            \
                     $(list_incdir) --top-module ariane_testharness                                               \
                     --Mdir $(ver-library) -O3                                                                    \


### PR DESCRIPTION
This PR primarily fixed the following problems in the verilator target:
1.  The verilator version test did not work correctly on our
    System (Ubuntu 18.04). The verilator model was always
    single-threaded before the change.
2.  From our experiments, 4 threads is a better pick than 2 threads.
    On our workstation with i7-7700, running verilator model with
    4 threads use about 60% of wall time of the case in 2 threads, and
    more threads are having diminishing returns. On our server,
    8 threads are slower than 4 threads.
3.  The original Makefile did not add optimization flags to verilator
    output. Adding the optimization flag makes building the verilator
    target significantly slower (>=10 mins) but makes the simulation
    significantly faster.
4.  The VL_DEBUG macro is added to the CFLAGS of the verilator target.
    It can assist catching buggy logic at runtime. IRCC we added
    VL_DEBUG to catch a combinational loop we acccidentally introduced
    in our modification to the processor.