### PR TITLE
Fixed a typo in ariane_tb.cpp

### DIFF
--- a/tb/ariane_tb.cpp
+++ b/tb/ariane_tb.cpp
@@ -320,7 +320,7 @@ done_processing:
 
   // Preload memory.
   size_t mem_size = 0x100000;
-  memif.read(0x80000000, mem_size, (void *) top->ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk2__DOT__i_ram__DOT__Mem_DP);
+  memif.read(0x80000000, mem_size, (void *) top->ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk1__DOT__i_ram__DOT__Mem_DP);
 
 #ifndef DROMAJO
   while (!dtm->done() && !jtag->done()) {


### PR DESCRIPTION
The old line causes the following compilation problem with `make verilate DEBUG=1`:
 ```
 ../tb/ariane_tb.cpp:323:50: error: no member named 'ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk2__DOT__i_ram__DOT__Mem_DP' in 'Variane_testharness'; did you mean 'ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk1__DOT__i_ram__DOT__Mem_DP'?

memif.read(0x80000000, mem_size, (void *) top->ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk2__DOT__i_ram__DOT__Mem_DP);
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                 ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk1__DOT__i_ram__DOT__Mem_DP
./Variane_testharness.h:4308:27: note: 'ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk1__DOT__i_ram__DOT__Mem_DP' declared here
            QData/*63:0*/ ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk1__DOT__i_ram__DOT__Mem_DP[33554432];
                          ^
1 warning and 1 error generated. 
```