### PR TITLE
According to IEEE 1800-2017 (9.2.2.4 Sequential logic always_ff proce…

### DIFF
--- a/src/dromajo_ram.sv
+++ b/src/dromajo_ram.sv
@@ -71,7 +71,7 @@ module dromajo_ram
     end
   end
 
-  always_ff @(posedge Clk_CI) begin
+  always @(posedge Clk_CI) begin
     if(CSel_SI) begin
       if(WrEn_SI) begin
         if(BEn_SI[0]) Mem_DP[Addr_DI][7:0]   <= WrData_DI[7:0];


### PR DESCRIPTION
…dure)

"Variables on the left-hand side of assignments within an always_ff procedure, including variables from the contents of a called function, shall not be written to by any other process."
Thus there is a proposal of changing always_ff with always because Mem_DP is driven by two processes: initial and always_ff what is forbidden.