### PR TITLE
Verilator: Dot reference compilation issue (fix #583)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It has configurable size, separate TLBs, a hardware PTW and branch-prediction (b
 If you use CVA6 in your academic work you can cite us:
 
 ```
-@article{8777130,
+@article{zaruba2019cost,
    author={F. {Zaruba} and L. {Benini}},
    journal={IEEE Transactions on Very Large Scale Integration (VLSI) Systems},
    title={The Cost of Application-Class Processing: Energy and Performance Analysis of a Linux-Ready 1.7-GHz 64-Bit RISC-V Core in 22-nm FDSOI Technology},
@@ -49,6 +49,13 @@ Table of Contents
    * [Acknowledgements](#acknowledgements)
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
+
+## Tool Requirements
+
+* `verilator >= 4.002`
+
+> There is currently a known issue with version 4.106 and 4.108. 4.106 does not
+> compile and 4.108 hangs after a couple of cycles simulation time.
 
 ## Getting Started
 

--- a/tb/ariane_tb.cpp
+++ b/tb/ariane_tb.cpp
@@ -320,7 +320,7 @@ done_processing:
 
   // Preload memory.
   size_t mem_size = 0x100000;
-  memif.read(0x80000000, mem_size, (void *) top->ariane_testharness__DOT__i_sram__DOT__genblk1__BRA__0__KET____DOT__genblk2__DOT__i_ram__DOT__Mem_DP);
+  memif.read(0x80000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_ram__DOT__Mem_DP);
 
 #ifndef DROMAJO
   while (!dtm->done() && !jtag->done()) {


### PR DESCRIPTION
Theoretically fixes #583, but I can't bring the simulation to run for both `verilator-4.106` and `verilator-4.108/9`. I've noted this in the `README.md`. At this stage, I believe this is a problem with Verilator and I would prefer to wait for a couple more releases until investigating for a fix in the RTL. 

@TarekIbnZiad I can confirm successful compilation and simulation with `verilator-4.104`, does that work for you?