### PR TITLE
DROMAJO SV sources filtered out if DROMAJO is not activated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,12 @@ src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
         tb/common/SimDTM.sv                                                    \
         tb/common/SimJTAG.sv
 
+# filter dromajo stuff if dromajo is not activated
+ifndef DROMAJO
+	src :=  $(filter-out src/dromajo_ram.sv, $(src))
+	src :=  $(filter-out bootrom/dromajo_bootrom.sv, $(src))
+endif
+
 src := $(addprefix $(root-dir), $(src))
 
 uart_src := $(wildcard fpga/src/apb_uart/src/*.vhd)


### PR DESCRIPTION
(cherry picked from commit 5302f2e65b493419ec43f829f9e1dbd6f61fc276)

Signed-off-by: pawelkudlakaldec <pawel.kudlak@aldec.com.pl>
