### PR TITLE
instr_queue: Prevent latch inference in always_comb

### DIFF
--- a/src/frontend/instr_queue.sv
+++ b/src/frontend/instr_queue.sv
@@ -219,6 +219,7 @@ module instr_queue (
     fetch_entry_o.instruction = '0;
     fetch_entry_o.address = pc_q;
     fetch_entry_o.ex.valid = 1'b0;
+    fetch_entry_o.ex.cause = '0;
 
     fetch_entry_o.ex.tval = '0;
     fetch_entry_o.branch_predict.predict_address = address_out;


### PR DESCRIPTION
Using CVA6 as an IP in Vivado 2018.2, a latch was inferred durring OOC synthesis.

Signed-off-by: Luca Zulberti <zulberti.luca@gmail.com>