### PR TITLE
axi_adapter/shim: no need to have the fixed burst type

### DIFF
--- a/src/axi_adapter.sv
+++ b/src/axi_adapter.sv
@@ -17,332 +17,332 @@
 //import std_cache_pkg::*;
 
 module axi_adapter #(
-    parameter int unsigned DATA_WIDTH            = 256,
-    parameter logic        CRITICAL_WORD_FIRST   = 0, // the AXI subsystem needs to support wrapping reads for this feature
-    parameter int unsigned AXI_ID_WIDTH          = 10,
-    parameter int unsigned CACHELINE_BYTE_OFFSET = 8
+  parameter int unsigned DATA_WIDTH            = 256,
+  parameter logic        CRITICAL_WORD_FIRST   = 0, // the AXI subsystem needs to support wrapping reads for this feature
+  parameter int unsigned AXI_ID_WIDTH          = 10,
+  parameter int unsigned CACHELINE_BYTE_OFFSET = 8
 )(
-    input  logic                                        clk_i,  // Clock
-    input  logic                                        rst_ni, // Asynchronous reset active low
+  input  logic                             clk_i,  // Clock
+  input  logic                             rst_ni, // Asynchronous reset active low
 
-    input  logic                                        req_i,
-    input  ariane_axi::ad_req_t                         type_i,
-    output logic                                        gnt_o,
-    output logic [AXI_ID_WIDTH-1:0]                     gnt_id_o,
-    input  logic [63:0]                                 addr_i,
-    input  logic                                        we_i,
-    input  logic [(DATA_WIDTH/64)-1:0][63:0]            wdata_i,
-    input  logic [(DATA_WIDTH/64)-1:0][7:0]             be_i,
-    input  logic [1:0]                                  size_i,
-    input  logic [AXI_ID_WIDTH-1:0]                     id_i,
-    // read port
-    output logic                                        valid_o,
-    output logic [(DATA_WIDTH/64)-1:0][63:0]            rdata_o,
-    output logic [AXI_ID_WIDTH-1:0]                     id_o,
-    // critical word - read port
-    output logic [63:0]                                 critical_word_o,
-    output logic                                        critical_word_valid_o,
-    // AXI port
-    output ariane_axi::req_t                            axi_req_o,
-    input  ariane_axi::resp_t                           axi_resp_i
+  input  logic                             req_i,
+  input  ariane_axi::ad_req_t              type_i,
+  output logic                             gnt_o,
+  output logic [AXI_ID_WIDTH-1:0]          gnt_id_o,
+  input  logic [63:0]                      addr_i,
+  input  logic                             we_i,
+  input  logic [(DATA_WIDTH/64)-1:0][63:0] wdata_i,
+  input  logic [(DATA_WIDTH/64)-1:0][7:0]  be_i,
+  input  logic [1:0]                       size_i,
+  input  logic [AXI_ID_WIDTH-1:0]          id_i,
+  // read port
+  output logic                             valid_o,
+  output logic [(DATA_WIDTH/64)-1:0][63:0] rdata_o,
+  output logic [AXI_ID_WIDTH-1:0]          id_o,
+  // critical word - read port
+  output logic [63:0]                      critical_word_o,
+  output logic                             critical_word_valid_o,
+  // AXI port
+  output ariane_axi::req_t                 axi_req_o,
+  input  ariane_axi::resp_t                axi_resp_i
 );
-    localparam BURST_SIZE = DATA_WIDTH/64-1;
-    localparam ADDR_INDEX = ($clog2(DATA_WIDTH/64) > 0) ? $clog2(DATA_WIDTH/64) : 1;
+  localparam BURST_SIZE = DATA_WIDTH/64-1;
+  localparam ADDR_INDEX = ($clog2(DATA_WIDTH/64) > 0) ? $clog2(DATA_WIDTH/64) : 1;
 
-    enum logic [3:0] {
-        IDLE, WAIT_B_VALID, WAIT_AW_READY, WAIT_LAST_W_READY, WAIT_LAST_W_READY_AW_READY, WAIT_AW_READY_BURST,
-        WAIT_R_VALID, WAIT_R_VALID_MULTIPLE, COMPLETE_READ
-    } state_q, state_d;
+  enum logic [3:0] {
+    IDLE, WAIT_B_VALID, WAIT_AW_READY, WAIT_LAST_W_READY, WAIT_LAST_W_READY_AW_READY, WAIT_AW_READY_BURST,
+    WAIT_R_VALID, WAIT_R_VALID_MULTIPLE, COMPLETE_READ
+  } state_q, state_d;
 
-    // counter for AXI transfers
-    logic [ADDR_INDEX-1:0] cnt_d, cnt_q;
-    logic [(DATA_WIDTH/64)-1:0][63:0] cache_line_d, cache_line_q;
-    // save the address for a read, as we allow for non-cacheline aligned accesses
-    logic [(DATA_WIDTH/64)-1:0] addr_offset_d, addr_offset_q;
-    logic [AXI_ID_WIDTH-1:0]    id_d, id_q;
-    logic [ADDR_INDEX-1:0]      index;
+  // counter for AXI transfers
+  logic [ADDR_INDEX-1:0] cnt_d, cnt_q;
+  logic [(DATA_WIDTH/64)-1:0][63:0] cache_line_d, cache_line_q;
+  // save the address for a read, as we allow for non-cacheline aligned accesses
+  logic [(DATA_WIDTH/64)-1:0] addr_offset_d, addr_offset_q;
+  logic [AXI_ID_WIDTH-1:0]    id_d, id_q;
+  logic [ADDR_INDEX-1:0]      index;
 
-    always_comb begin : axi_fsm
-        // Default assignments
-        axi_req_o.aw_valid  = 1'b0;
-        axi_req_o.aw.addr   = addr_i;
-        axi_req_o.aw.prot   = 3'b0;
-        axi_req_o.aw.region = 4'b0;
-        axi_req_o.aw.len    = 8'b0;
-        axi_req_o.aw.size   = {1'b0, size_i}; // 1, 2, 4 or 8 bytes
-        axi_req_o.aw.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
-        axi_req_o.aw.lock   = 1'b0;
-        axi_req_o.aw.cache  = 4'b0;
-        axi_req_o.aw.qos    = 4'b0;
-        axi_req_o.aw.id     = id_i;
-        axi_req_o.aw.atop   = '0; // currently not used
-        axi_req_o.aw.user   = '0;
+  always_comb begin : axi_fsm
+    // Default assignments
+    axi_req_o.aw_valid  = 1'b0;
+    axi_req_o.aw.addr   = addr_i;
+    axi_req_o.aw.prot   = 3'b0;
+    axi_req_o.aw.region = 4'b0;
+    axi_req_o.aw.len    = 8'b0;
+    axi_req_o.aw.size   = {1'b0, size_i}; // 1, 2, 4 or 8 bytes
+    axi_req_o.aw.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
+    axi_req_o.aw.lock   = 1'b0;
+    axi_req_o.aw.cache  = 4'b0;
+    axi_req_o.aw.qos    = 4'b0;
+    axi_req_o.aw.id     = id_i;
+    axi_req_o.aw.atop   = '0; // currently not used
+    axi_req_o.aw.user   = '0;
 
-        axi_req_o.ar_valid  = 1'b0;
-        // in case of a single request or wrapping transfer we can simply begin at the address, if we want to request a cache-line
-        // with an incremental transfer we need to output the corresponding base address of the cache line
-        axi_req_o.ar.addr   = (CRITICAL_WORD_FIRST || type_i == ariane_axi::SINGLE_REQ) ? addr_i : { addr_i[63:CACHELINE_BYTE_OFFSET], {{CACHELINE_BYTE_OFFSET}{1'b0}}};
-        axi_req_o.ar.prot   = 3'b0;
-        axi_req_o.ar.region = 4'b0;
-        axi_req_o.ar.len    = 8'b0;
-        axi_req_o.ar.size   = {1'b0, size_i}; // 1, 2, 4 or 8 bytes
-        axi_req_o.ar.burst  = (CRITICAL_WORD_FIRST ? axi_pkg::BURST_WRAP : axi_pkg::BURST_INCR); // wrapping transfer in case of a critical word first strategy
-        axi_req_o.ar.lock   = 1'b0;
-        axi_req_o.ar.cache  = 4'b0;
-        axi_req_o.ar.qos    = 4'b0;
-        axi_req_o.ar.id     = id_i;
-        axi_req_o.ar.user   = '0;
+    axi_req_o.ar_valid  = 1'b0;
+    // in case of a single request or wrapping transfer we can simply begin at the address, if we want to request a cache-line
+    // with an incremental transfer we need to output the corresponding base address of the cache line
+    axi_req_o.ar.addr   = (CRITICAL_WORD_FIRST || type_i == ariane_axi::SINGLE_REQ) ? addr_i : { addr_i[63:CACHELINE_BYTE_OFFSET], {{CACHELINE_BYTE_OFFSET}{1'b0}}};
+    axi_req_o.ar.prot   = 3'b0;
+    axi_req_o.ar.region = 4'b0;
+    axi_req_o.ar.len    = 8'b0;
+    axi_req_o.ar.size   = {1'b0, size_i}; // 1, 2, 4 or 8 bytes
+    axi_req_o.ar.burst  = (CRITICAL_WORD_FIRST ? axi_pkg::BURST_WRAP : axi_pkg::BURST_INCR); // wrapping transfer in case of a critical word first strategy
+    axi_req_o.ar.lock   = 1'b0;
+    axi_req_o.ar.cache  = 4'b0;
+    axi_req_o.ar.qos    = 4'b0;
+    axi_req_o.ar.id     = id_i;
+    axi_req_o.ar.user   = '0;
 
-        axi_req_o.w_valid   = 1'b0;
-        axi_req_o.w.data    = wdata_i[0];
-        axi_req_o.w.strb    = be_i[0];
-        axi_req_o.w.last    = 1'b0;
-        axi_req_o.w.user    = '0;
+    axi_req_o.w_valid   = 1'b0;
+    axi_req_o.w.data    = wdata_i[0];
+    axi_req_o.w.strb    = be_i[0];
+    axi_req_o.w.last    = 1'b0;
+    axi_req_o.w.user    = '0;
 
-        axi_req_o.b_ready   = 1'b0;
-        axi_req_o.r_ready   = 1'b0;
+    axi_req_o.b_ready   = 1'b0;
+    axi_req_o.r_ready   = 1'b0;
 
-        gnt_o         = 1'b0;
-        gnt_id_o      = id_i;
-        valid_o       = 1'b0;
-        id_o          = axi_resp_i.r.id;
+    gnt_o    = 1'b0;
+    gnt_id_o = id_i;
+    valid_o  = 1'b0;
+    id_o     = axi_resp_i.r.id;
 
-        critical_word_o         = axi_resp_i.r.data;
-        critical_word_valid_o   = 1'b0;
-        rdata_o                 = cache_line_q;
+    critical_word_o       = axi_resp_i.r.data;
+    critical_word_valid_o = 1'b0;
+    rdata_o               = cache_line_q;
 
-        state_d                 = state_q;
-        cnt_d                   = cnt_q;
-        cache_line_d            = cache_line_q;
-        addr_offset_d           = addr_offset_q;
-        id_d                    = id_q;
-        index                   = '0;
+    state_d       = state_q;
+    cnt_d         = cnt_q;
+    cache_line_d  = cache_line_q;
+    addr_offset_d = addr_offset_q;
+    id_d          = id_q;
+    index         = '0;
 
-        case (state_q)
+    case (state_q)
 
-            IDLE: begin
-                cnt_d = '0;
-                // we have an incoming request
-                if (req_i) begin
-                    // is this a read or write?
-                    // write
-                    if (we_i) begin
-                        // the data is valid
-                        axi_req_o.aw_valid = 1'b1;
-                        axi_req_o.w_valid  = 1'b1;
-                        // its a single write
-                        if (type_i == ariane_axi::SINGLE_REQ) begin
-                            // only a single write so the data is already the last one
-                            axi_req_o.w.last   = 1'b1;
-                            // single req can be granted here
-                            gnt_o = axi_resp_i.aw_ready & axi_resp_i.w_ready;
-                            case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
-                                2'b11: state_d = WAIT_B_VALID;
-                                2'b01: state_d = WAIT_AW_READY;
-                                2'b10: state_d = WAIT_LAST_W_READY;
-                                default: state_d = IDLE;
-                            endcase
+      IDLE: begin
+        cnt_d = '0;
+        // we have an incoming request
+        if (req_i) begin
+          // is this a read or write?
+          // write
+          if (we_i) begin
+            // the data is valid
+            axi_req_o.aw_valid = 1'b1;
+            axi_req_o.w_valid  = 1'b1;
+            // its a single write
+            if (type_i == ariane_axi::SINGLE_REQ) begin
+              // only a single write so the data is already the last one
+              axi_req_o.w.last   = 1'b1;
+              // single req can be granted here
+              gnt_o = axi_resp_i.aw_ready & axi_resp_i.w_ready;
+              case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
+                2'b11: state_d = WAIT_B_VALID;
+                2'b01: state_d = WAIT_AW_READY;
+                2'b10: state_d = WAIT_LAST_W_READY;
+                default: state_d = IDLE;
+              endcase
 
-                        // its a request for the whole cache line
-                        end else begin
-                            axi_req_o.aw.len = BURST_SIZE; // number of bursts to do
-                            axi_req_o.w.data = wdata_i[0];
-                            axi_req_o.w.strb = be_i[0];
+            // its a request for the whole cache line
+            end else begin
+              axi_req_o.aw.len = BURST_SIZE; // number of bursts to do
+              axi_req_o.w.data = wdata_i[0];
+              axi_req_o.w.strb = be_i[0];
 
-                            if (axi_resp_i.w_ready)
-                                cnt_d = BURST_SIZE - 1;
-                            else
-                                cnt_d = BURST_SIZE;
+              if (axi_resp_i.w_ready)
+                cnt_d = BURST_SIZE - 1;
+              else
+                cnt_d = BURST_SIZE;
 
-                            case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
-                                2'b11: state_d = WAIT_LAST_W_READY;
-                                2'b01: state_d = WAIT_LAST_W_READY_AW_READY;
-                                2'b10: state_d = WAIT_LAST_W_READY;
-                                default:;
-                            endcase
-                        end
-                    // read
-                    end else begin
+              case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
+                2'b11: state_d = WAIT_LAST_W_READY;
+                2'b01: state_d = WAIT_LAST_W_READY_AW_READY;
+                2'b10: state_d = WAIT_LAST_W_READY;
+                default:;
+              endcase
+            end
+          // read
+          end else begin
 
-                        axi_req_o.ar_valid = 1'b1;
-                        gnt_o = axi_resp_i.ar_ready;
-                        if (type_i != ariane_axi::SINGLE_REQ) begin
-                            axi_req_o.ar.len = BURST_SIZE;
-                            cnt_d = BURST_SIZE;
-                        end
-
-                        if (axi_resp_i.ar_ready) begin
-                            state_d = (type_i == ariane_axi::SINGLE_REQ) ? WAIT_R_VALID : WAIT_R_VALID_MULTIPLE;
-                            addr_offset_d = addr_i[ADDR_INDEX-1+3:3];
-                        end
-                    end
-                end
+            axi_req_o.ar_valid = 1'b1;
+            gnt_o = axi_resp_i.ar_ready;
+            if (type_i != ariane_axi::SINGLE_REQ) begin
+              axi_req_o.ar.len = BURST_SIZE;
+              cnt_d = BURST_SIZE;
             end
 
-            // ~> from single write
-            WAIT_AW_READY: begin
-                axi_req_o.aw_valid = 1'b1;
-
-                if (axi_resp_i.aw_ready) begin
-                    gnt_o   = 1'b1;
-                    state_d = WAIT_B_VALID;
-                end
+            if (axi_resp_i.ar_ready) begin
+              state_d = (type_i == ariane_axi::SINGLE_REQ) ? WAIT_R_VALID : WAIT_R_VALID_MULTIPLE;
+              addr_offset_d = addr_i[ADDR_INDEX-1+3:3];
             end
-
-            // ~> we need to wait for an aw_ready and there is at least one outstanding write
-            WAIT_LAST_W_READY_AW_READY: begin
-                axi_req_o.w_valid  = 1'b1;
-                axi_req_o.w.last   = (cnt_q == '0);
-                if (type_i == ariane_axi::SINGLE_REQ) begin
-                    axi_req_o.w.data   = wdata_i[0];
-                    axi_req_o.w.strb   = be_i[0];
-                end else begin
-                    axi_req_o.w.data   = wdata_i[BURST_SIZE-cnt_q];
-                    axi_req_o.w.strb   = be_i[BURST_SIZE-cnt_q];
-                end
-                axi_req_o.aw_valid = 1'b1;
-                // we are here because we want to write a cache line
-                axi_req_o.aw.len   = BURST_SIZE;
-                // we got an aw_ready
-                case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
-                    // we got an aw ready
-                    2'b01: begin
-                        // are there any outstanding transactions?
-                        if (cnt_q == 0)
-                            state_d = WAIT_AW_READY_BURST;
-                        else // yes, so reduce the count and stay here
-                            cnt_d = cnt_q - 1;
-                    end
-                    2'b10: state_d = WAIT_LAST_W_READY;
-                    2'b11: begin
-                        // we are finished
-                        if (cnt_q == 0) begin
-                            state_d  = WAIT_B_VALID;
-                            gnt_o    = 1'b1;
-                        // there are outstanding transactions
-                        end else begin
-                            state_d = WAIT_LAST_W_READY;
-                            cnt_d = cnt_q - 1;
-                        end
-                    end
-                    default:;
-               endcase
-
-            end
-
-            // ~> all data has already been sent, we are only waiting for the aw_ready
-            WAIT_AW_READY_BURST: begin
-                axi_req_o.aw_valid = 1'b1;
-                axi_req_o.aw.len   = BURST_SIZE;
-
-                if (axi_resp_i.aw_ready) begin
-                    state_d  = WAIT_B_VALID;
-                    gnt_o    = 1'b1;
-                end
-            end
-
-            // ~> from write, there is an outstanding write
-            WAIT_LAST_W_READY: begin
-                axi_req_o.w_valid = 1'b1;
-
-                if (type_i != ariane_axi::SINGLE_REQ) begin
-                    axi_req_o.w.data   = wdata_i[BURST_SIZE-cnt_q];
-                    axi_req_o.w.strb   = be_i[BURST_SIZE-cnt_q];
-                end
-
-                // this is the last write
-                if (cnt_q == '0) begin
-                    axi_req_o.w.last = 1'b1;
-                    if (axi_resp_i.w_ready) begin
-                        state_d  = WAIT_B_VALID;
-                        gnt_o    = 1'b1;
-                    end
-                end else if (axi_resp_i.w_ready) begin
-                    cnt_d = cnt_q - 1;
-                end
-            end
-
-            // ~> finish write transaction
-            WAIT_B_VALID: begin
-                axi_req_o.b_ready = 1'b1;
-                id_o = axi_resp_i.b.id;
-
-                // Write is valid
-                if (axi_resp_i.b_valid) begin
-                    state_d = IDLE;
-                    valid_o = 1'b1;
-                end
-            end
-
-            // ~> cacheline read, single read
-            WAIT_R_VALID_MULTIPLE, WAIT_R_VALID: begin
-                if (CRITICAL_WORD_FIRST)
-                    index = addr_offset_q + (BURST_SIZE-cnt_q);
-                else
-                    index = BURST_SIZE-cnt_q;
-
-                // reads are always wrapping here
-                axi_req_o.r_ready = 1'b1;
-                // this is the first read a.k.a the critical word
-                if (axi_resp_i.r_valid) begin
-                    if (CRITICAL_WORD_FIRST) begin
-                        // this is the first word of a cacheline read, e.g.: the word which was causing the miss
-                        if (state_q == WAIT_R_VALID_MULTIPLE && cnt_q == BURST_SIZE) begin
-                            critical_word_valid_o = 1'b1;
-                            critical_word_o       = axi_resp_i.r.data;
-                        end
-                    end else begin
-                        // check if the address offset matches - then we are getting the critical word
-                        if (index == addr_offset_q) begin
-                            critical_word_valid_o = 1'b1;
-                            critical_word_o       = axi_resp_i.r.data;
-                        end
-                    end
-
-                    // this is the last read
-                    if (axi_resp_i.r.last) begin
-                        id_d    = axi_resp_i.r.id;
-                        state_d = COMPLETE_READ;
-                    end
-
-                    // save the word
-                    if (state_q == WAIT_R_VALID_MULTIPLE) begin
-                        cache_line_d[index] = axi_resp_i.r.data;
-
-                    end else
-                        cache_line_d[0] = axi_resp_i.r.data;
-
-                    // Decrease the counter
-                    cnt_d = cnt_q - 1;
-                end
-            end
-            // ~> read is complete
-            COMPLETE_READ: begin
-                valid_o = 1'b1;
-                state_d = IDLE;
-                id_o    = id_q;
-            end
-        endcase
-    end
-
-    // ----------------
-    // Registers
-    // ----------------
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-            // start in flushing state and initialize the memory
-            state_q       <= IDLE;
-            cnt_q         <= '0;
-            cache_line_q  <= '0;
-            addr_offset_q <= '0;
-            id_q          <= '0;
-        end else begin
-            state_q       <= state_d;
-            cnt_q         <= cnt_d;
-            cache_line_q  <= cache_line_d;
-            addr_offset_q <= addr_offset_d;
-            id_q          <= id_d;
+          end
         end
+      end
+
+      // ~> from single write
+      WAIT_AW_READY: begin
+        axi_req_o.aw_valid = 1'b1;
+
+        if (axi_resp_i.aw_ready) begin
+          gnt_o   = 1'b1;
+          state_d = WAIT_B_VALID;
+        end
+      end
+
+      // ~> we need to wait for an aw_ready and there is at least one outstanding write
+      WAIT_LAST_W_READY_AW_READY: begin
+        axi_req_o.w_valid  = 1'b1;
+        axi_req_o.w.last   = (cnt_q == '0);
+        if (type_i == ariane_axi::SINGLE_REQ) begin
+          axi_req_o.w.data = wdata_i[0];
+          axi_req_o.w.strb = be_i[0];
+        end else begin
+          axi_req_o.w.data = wdata_i[BURST_SIZE-cnt_q];
+          axi_req_o.w.strb = be_i[BURST_SIZE-cnt_q];
+        end
+        axi_req_o.aw_valid = 1'b1;
+        // we are here because we want to write a cache line
+        axi_req_o.aw.len   = BURST_SIZE;
+        // we got an aw_ready
+        case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
+          // we got an aw ready
+          2'b01: begin
+            // are there any outstanding transactions?
+            if (cnt_q == 0)
+              state_d = WAIT_AW_READY_BURST;
+            else // yes, so reduce the count and stay here
+              cnt_d = cnt_q - 1;
+          end
+          2'b10: state_d = WAIT_LAST_W_READY;
+          2'b11: begin
+            // we are finished
+            if (cnt_q == 0) begin
+              state_d = WAIT_B_VALID;
+              gnt_o   = 1'b1;
+            // there are outstanding transactions
+            end else begin
+              state_d = WAIT_LAST_W_READY;
+              cnt_d   = cnt_q - 1;
+            end
+          end
+          default:;
+         endcase
+
+      end
+
+      // ~> all data has already been sent, we are only waiting for the aw_ready
+      WAIT_AW_READY_BURST: begin
+        axi_req_o.aw_valid = 1'b1;
+        axi_req_o.aw.len   = BURST_SIZE;
+
+        if (axi_resp_i.aw_ready) begin
+          state_d  = WAIT_B_VALID;
+          gnt_o    = 1'b1;
+        end
+      end
+
+      // ~> from write, there is an outstanding write
+      WAIT_LAST_W_READY: begin
+        axi_req_o.w_valid = 1'b1;
+
+        if (type_i != ariane_axi::SINGLE_REQ) begin
+          axi_req_o.w.data = wdata_i[BURST_SIZE-cnt_q];
+          axi_req_o.w.strb = be_i[BURST_SIZE-cnt_q];
+        end
+
+        // this is the last write
+        if (cnt_q == '0) begin
+          axi_req_o.w.last = 1'b1;
+          if (axi_resp_i.w_ready) begin
+            state_d = WAIT_B_VALID;
+            gnt_o   = 1'b1;
+          end
+        end else if (axi_resp_i.w_ready) begin
+          cnt_d = cnt_q - 1;
+        end
+      end
+
+      // ~> finish write transaction
+      WAIT_B_VALID: begin
+        axi_req_o.b_ready = 1'b1;
+        id_o = axi_resp_i.b.id;
+
+        // Write is valid
+        if (axi_resp_i.b_valid) begin
+          state_d = IDLE;
+          valid_o = 1'b1;
+        end
+      end
+
+      // ~> cacheline read, single read
+      WAIT_R_VALID_MULTIPLE, WAIT_R_VALID: begin
+        if (CRITICAL_WORD_FIRST)
+          index = addr_offset_q + (BURST_SIZE-cnt_q);
+        else
+          index = BURST_SIZE-cnt_q;
+
+        // reads are always wrapping here
+        axi_req_o.r_ready = 1'b1;
+        // this is the first read a.k.a the critical word
+        if (axi_resp_i.r_valid) begin
+          if (CRITICAL_WORD_FIRST) begin
+            // this is the first word of a cacheline read, e.g.: the word which was causing the miss
+            if (state_q == WAIT_R_VALID_MULTIPLE && cnt_q == BURST_SIZE) begin
+              critical_word_valid_o = 1'b1;
+              critical_word_o       = axi_resp_i.r.data;
+            end
+          end else begin
+            // check if the address offset matches - then we are getting the critical word
+            if (index == addr_offset_q) begin
+              critical_word_valid_o = 1'b1;
+              critical_word_o       = axi_resp_i.r.data;
+            end
+          end
+
+          // this is the last read
+          if (axi_resp_i.r.last) begin
+            id_d    = axi_resp_i.r.id;
+            state_d = COMPLETE_READ;
+          end
+
+          // save the word
+          if (state_q == WAIT_R_VALID_MULTIPLE) begin
+            cache_line_d[index] = axi_resp_i.r.data;
+
+          end else
+            cache_line_d[0] = axi_resp_i.r.data;
+
+          // Decrease the counter
+          cnt_d = cnt_q - 1;
+        end
+      end
+      // ~> read is complete
+      COMPLETE_READ: begin
+        valid_o = 1'b1;
+        state_d = IDLE;
+        id_o    = id_q;
+      end
+    endcase
+  end
+
+  // ----------------
+  // Registers
+  // ----------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      // start in flushing state and initialize the memory
+      state_q       <= IDLE;
+      cnt_q         <= '0;
+      cache_line_q  <= '0;
+      addr_offset_q <= '0;
+      id_q          <= '0;
+    end else begin
+      state_q       <= state_d;
+      cnt_q         <= cnt_d;
+      cache_line_q  <= cache_line_d;
+      addr_offset_q <= addr_offset_d;
+      id_q          <= id_d;
     end
+  end
 
 endmodule

--- a/src/axi_adapter.sv
+++ b/src/axi_adapter.sv
@@ -70,7 +70,7 @@ module axi_adapter #(
         axi_req_o.aw.region = 4'b0;
         axi_req_o.aw.len    = 8'b0;
         axi_req_o.aw.size   = {1'b0, size_i};
-        axi_req_o.aw.burst  = (type_i == ariane_axi::SINGLE_REQ) ? 2'b00 :  2'b01;  // fixed size for single request and incremental transfer for everything else
+        axi_req_o.aw.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
         axi_req_o.aw.lock   = 1'b0;
         axi_req_o.aw.cache  = 4'b0;
         axi_req_o.aw.qos    = 4'b0;
@@ -86,7 +86,7 @@ module axi_adapter #(
         axi_req_o.ar.region = 4'b0;
         axi_req_o.ar.len    = 8'b0;
         axi_req_o.ar.size   = {1'b0, size_i}; // 8 bytes
-        axi_req_o.ar.burst  = (type_i == ariane_axi::SINGLE_REQ) ? 2'b00 : (CRITICAL_WORD_FIRST ? 2'b10 : 2'b01);  // wrapping transfer in case of a critical word first strategy
+        axi_req_o.ar.burst  = (CRITICAL_WORD_FIRST ? axi_pkg::BURST_WRAP : axi_pkg::BURST_INCR); // wrapping transfer in case of a critical word first strategy
         axi_req_o.ar.lock   = 1'b0;
         axi_req_o.ar.cache  = 4'b0;
         axi_req_o.ar.qos    = 4'b0;

--- a/src/axi_adapter.sv
+++ b/src/axi_adapter.sv
@@ -69,7 +69,7 @@ module axi_adapter #(
         axi_req_o.aw.prot   = 3'b0;
         axi_req_o.aw.region = 4'b0;
         axi_req_o.aw.len    = 8'b0;
-        axi_req_o.aw.size   = {1'b0, size_i};
+        axi_req_o.aw.size   = {1'b0, size_i}; // 1, 2, 4 or 8 bytes
         axi_req_o.aw.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
         axi_req_o.aw.lock   = 1'b0;
         axi_req_o.aw.cache  = 4'b0;
@@ -85,7 +85,7 @@ module axi_adapter #(
         axi_req_o.ar.prot   = 3'b0;
         axi_req_o.ar.region = 4'b0;
         axi_req_o.ar.len    = 8'b0;
-        axi_req_o.ar.size   = {1'b0, size_i}; // 8 bytes
+        axi_req_o.ar.size   = {1'b0, size_i}; // 1, 2, 4 or 8 bytes
         axi_req_o.ar.burst  = (CRITICAL_WORD_FIRST ? axi_pkg::BURST_WRAP : axi_pkg::BURST_INCR); // wrapping transfer in case of a critical word first strategy
         axi_req_o.ar.lock   = 1'b0;
         axi_req_o.ar.cache  = 4'b0;

--- a/src/axi_shim.sv
+++ b/src/axi_shim.sv
@@ -15,7 +15,7 @@
  *
  * Description: Manages communication with the AXI Bus. Note that this unit does not
  *              buffer requests and register the signals.
- * 
+ *
  */
 
 
@@ -74,7 +74,7 @@ module axi_shim #(
     // AXI tx counter
     logic [AddrIndex-1:0] wr_cnt_d, wr_cnt_q;
     logic wr_single_req, wr_cnt_done, wr_cnt_clr, wr_cnt_en;
-    
+
     assign wr_single_req       = (wr_blen_i == 0);
 
     // address
@@ -88,7 +88,7 @@ module axi_shim #(
     assign axi_req_o.aw.lock   = wr_lock_i;
     assign axi_req_o.aw.cache  = 4'b0;
     assign axi_req_o.aw.qos    = 4'b0;
-    assign axi_req_o.aw.atop   = wr_atop_i; 
+    assign axi_req_o.aw.atop   = wr_atop_i;
     // data
     assign axi_req_o.w.data    = wr_data_i[wr_cnt_q];
     assign axi_req_o.w.strb    = wr_be_i[wr_cnt_q];
@@ -255,9 +255,9 @@ module axi_shim #(
     assign rd_last_o           = axi_resp_i.r.last;
     assign rd_valid_o          = axi_resp_i.r_valid;
     assign rd_id_o             = axi_resp_i.r.id;
-    assign rd_exokay_o         = (axi_resp_i.r.resp == axi_pkg::RESP_EXOKAY);        
-    
-    
+    assign rd_exokay_o         = (axi_resp_i.r.resp == axi_pkg::RESP_EXOKAY);
+
+
     // ----------------
     // Registers
     // ----------------

--- a/src/axi_shim.sv
+++ b/src/axi_shim.sv
@@ -20,257 +20,257 @@
 
 
 module axi_shim #(
-    parameter int unsigned AxiNumWords       = 4, // data width in dwords, this is also the maximum burst length, must be >=2
-    parameter int unsigned AxiIdWidth        = 4  // stick to the spec
+  parameter int unsigned AxiNumWords = 4, // data width in dwords, this is also the maximum burst length, must be >=2
+  parameter int unsigned AxiIdWidth  = 4  // stick to the spec
 ) (
-    input  logic                            clk_i,  // Clock
-    input  logic                            rst_ni, // Asynchronous reset active low
-    // read channel
-    // request
-    input  logic                            rd_req_i,
-    output logic                            rd_gnt_o,
-    input  logic [63:0]                     rd_addr_i,
-    input  logic [$clog2(AxiNumWords)-1:0]  rd_blen_i, // axi convention: LEN-1
-    input  logic [1:0]                      rd_size_i,
-    input  logic [AxiIdWidth-1:0]           rd_id_i,   // use same ID for reads, or make sure you only have one outstanding read tx
-    input  logic                            rd_lock_i,
-    // read response (we have to unconditionally sink the response)
-    input  logic                            rd_rdy_i,
-    output logic                            rd_last_o,
-    output logic                            rd_valid_o,
-    output logic [63:0]                     rd_data_o,
-    output logic [AxiIdWidth-1:0]           rd_id_o,
-    output logic                            rd_exokay_o, // indicates whether exclusive tx succeeded
-    // write channel
-    input  logic                            wr_req_i,
-    output logic                            wr_gnt_o,
-    input  logic [63:0]                     wr_addr_i,
-    input  logic [AxiNumWords-1:0][63:0]    wr_data_i,
-    input  logic [AxiNumWords-1:0][7:0]     wr_be_i,
-    input  logic [$clog2(AxiNumWords)-1:0]  wr_blen_i, // axi convention: LEN-1
-    input  logic [1:0]                      wr_size_i,
-    input  logic [AxiIdWidth-1:0]           wr_id_i,
-    input  logic                            wr_lock_i,
-    input  logic [5:0]                      wr_atop_i,
-    // write response
-    input  logic                            wr_rdy_i,
-    output logic                            wr_valid_o,
-    output logic [AxiIdWidth-1:0]           wr_id_o,
-    output logic                            wr_exokay_o, // indicates whether exclusive tx succeeded
-    // AXI port
-    output ariane_axi::req_t                axi_req_o,
-    input  ariane_axi::resp_t               axi_resp_i
+  input  logic                            clk_i,  // Clock
+  input  logic                            rst_ni, // Asynchronous reset active low
+  // read channel
+  // request
+  input  logic                            rd_req_i,
+  output logic                            rd_gnt_o,
+  input  logic [63:0]                     rd_addr_i,
+  input  logic [$clog2(AxiNumWords)-1:0]  rd_blen_i, // axi convention: LEN-1
+  input  logic [1:0]                      rd_size_i,
+  input  logic [AxiIdWidth-1:0]           rd_id_i,   // use same ID for reads, or make sure you only have one outstanding read tx
+  input  logic                            rd_lock_i,
+  // read response (we have to unconditionally sink the response)
+  input  logic                            rd_rdy_i,
+  output logic                            rd_last_o,
+  output logic                            rd_valid_o,
+  output logic [63:0]                     rd_data_o,
+  output logic [AxiIdWidth-1:0]           rd_id_o,
+  output logic                            rd_exokay_o, // indicates whether exclusive tx succeeded
+  // write channel
+  input  logic                            wr_req_i,
+  output logic                            wr_gnt_o,
+  input  logic [63:0]                     wr_addr_i,
+  input  logic [AxiNumWords-1:0][63:0]    wr_data_i,
+  input  logic [AxiNumWords-1:0][7:0]     wr_be_i,
+  input  logic [$clog2(AxiNumWords)-1:0]  wr_blen_i, // axi convention: LEN-1
+  input  logic [1:0]                      wr_size_i,
+  input  logic [AxiIdWidth-1:0]           wr_id_i,
+  input  logic                            wr_lock_i,
+  input  logic [5:0]                      wr_atop_i,
+  // write response
+  input  logic                            wr_rdy_i,
+  output logic                            wr_valid_o,
+  output logic [AxiIdWidth-1:0]           wr_id_o,
+  output logic                            wr_exokay_o, // indicates whether exclusive tx succeeded
+  // AXI port
+  output ariane_axi::req_t                axi_req_o,
+  input  ariane_axi::resp_t               axi_resp_i
 );
-    localparam AddrIndex = ($clog2(AxiNumWords) > 0) ? $clog2(AxiNumWords) : 1;
+  localparam AddrIndex = ($clog2(AxiNumWords) > 0) ? $clog2(AxiNumWords) : 1;
 
 ///////////////////////////////////////////////////////
 // write channel
 ///////////////////////////////////////////////////////
 
-    enum logic [3:0] {
-        IDLE, WAIT_AW_READY, WAIT_LAST_W_READY, WAIT_LAST_W_READY_AW_READY, WAIT_AW_READY_BURST
-    } wr_state_q, wr_state_d;
+  enum logic [3:0] {
+    IDLE, WAIT_AW_READY, WAIT_LAST_W_READY, WAIT_LAST_W_READY_AW_READY, WAIT_AW_READY_BURST
+  } wr_state_q, wr_state_d;
 
-    // AXI tx counter
-    logic [AddrIndex-1:0] wr_cnt_d, wr_cnt_q;
-    logic wr_single_req, wr_cnt_done, wr_cnt_clr, wr_cnt_en;
+  // AXI tx counter
+  logic [AddrIndex-1:0] wr_cnt_d, wr_cnt_q;
+  logic wr_single_req, wr_cnt_done, wr_cnt_clr, wr_cnt_en;
 
-    assign wr_single_req       = (wr_blen_i == 0);
+  assign wr_single_req = (wr_blen_i == 0);
 
-    // address
-    assign axi_req_o.aw.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
-    assign axi_req_o.aw.addr   = wr_addr_i;
-    assign axi_req_o.aw.size   = wr_size_i;
-    assign axi_req_o.aw.len    = wr_blen_i;
-    assign axi_req_o.aw.id     = wr_id_i;
-    assign axi_req_o.aw.prot   = 3'b0;
-    assign axi_req_o.aw.region = 4'b0;
-    assign axi_req_o.aw.lock   = wr_lock_i;
-    assign axi_req_o.aw.cache  = 4'b0;
-    assign axi_req_o.aw.qos    = 4'b0;
-    assign axi_req_o.aw.atop   = wr_atop_i;
-    // data
-    assign axi_req_o.w.data    = wr_data_i[wr_cnt_q];
-    assign axi_req_o.w.strb    = wr_be_i[wr_cnt_q];
-    assign axi_req_o.w.last    = wr_cnt_done;
+  // address
+  assign axi_req_o.aw.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
+  assign axi_req_o.aw.addr   = wr_addr_i;
+  assign axi_req_o.aw.size   = wr_size_i;
+  assign axi_req_o.aw.len    = wr_blen_i;
+  assign axi_req_o.aw.id     = wr_id_i;
+  assign axi_req_o.aw.prot   = 3'b0;
+  assign axi_req_o.aw.region = 4'b0;
+  assign axi_req_o.aw.lock   = wr_lock_i;
+  assign axi_req_o.aw.cache  = 4'b0;
+  assign axi_req_o.aw.qos    = 4'b0;
+  assign axi_req_o.aw.atop   = wr_atop_i;
+  // data
+  assign axi_req_o.w.data    = wr_data_i[wr_cnt_q];
+  assign axi_req_o.w.strb    = wr_be_i[wr_cnt_q];
+  assign axi_req_o.w.last    = wr_cnt_done;
 
-    // write response
-    assign wr_exokay_o         = (axi_resp_i.b.resp == axi_pkg::RESP_EXOKAY);
-    assign axi_req_o.b_ready   = wr_rdy_i;
-    assign wr_valid_o          = axi_resp_i.b_valid;
-    assign wr_id_o             = axi_resp_i.b.id;
+  // write response
+  assign wr_exokay_o         = (axi_resp_i.b.resp == axi_pkg::RESP_EXOKAY);
+  assign axi_req_o.b_ready   = wr_rdy_i;
+  assign wr_valid_o          = axi_resp_i.b_valid;
+  assign wr_id_o             = axi_resp_i.b.id;
 
-    // tx counter
-    assign wr_cnt_done         = (wr_cnt_q == wr_blen_i);
-    assign wr_cnt_d            = (wr_cnt_clr) ? '0         :
-                                 (wr_cnt_en)  ? wr_cnt_q+1 :
-                                                wr_cnt_q;
+  // tx counter
+  assign wr_cnt_done = (wr_cnt_q == wr_blen_i);
+  assign wr_cnt_d    = (wr_cnt_clr) ?
+                          '0 : (wr_cnt_en) ?
+                                  wr_cnt_q+1 : wr_cnt_q;
 
-    always_comb begin : p_axi_write_fsm
-        // default
-        wr_state_d          = wr_state_q;
+  always_comb begin : p_axi_write_fsm
+    // default
+    wr_state_d         = wr_state_q;
 
-        axi_req_o.aw_valid  = 1'b0;
-        axi_req_o.w_valid   = 1'b0;
-        wr_gnt_o            = 1'b0;
+    axi_req_o.aw_valid = 1'b0;
+    axi_req_o.w_valid  = 1'b0;
+    wr_gnt_o           = 1'b0;
 
-        wr_cnt_en           = 1'b0;
-        wr_cnt_clr          = 1'b0;
+    wr_cnt_en          = 1'b0;
+    wr_cnt_clr         = 1'b0;
 
-        case (wr_state_q)
-            ///////////////////////////////////
-            IDLE: begin
-                // we have an incoming request
-                if (wr_req_i) begin
-                    // is this a read or write?
-                    axi_req_o.aw_valid = 1'b1;
-                    axi_req_o.w_valid  = 1'b1;
+    case (wr_state_q)
+      ///////////////////////////////////
+      IDLE: begin
+        // we have an incoming request
+        if (wr_req_i) begin
+          // is this a read or write?
+          axi_req_o.aw_valid = 1'b1;
+          axi_req_o.w_valid  = 1'b1;
 
-                    // its a single write
-                    if (wr_single_req) begin
-                        wr_cnt_clr = 1'b1;
-                        // single req can be granted here
-                        wr_gnt_o = axi_resp_i.aw_ready & axi_resp_i.w_ready;
-                        case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
-                            2'b01: wr_state_d   = WAIT_AW_READY;
-                            2'b10: wr_state_d   = WAIT_LAST_W_READY;
-                            default: wr_state_d = IDLE;
-                        endcase
-                    // its a request for the whole cache line
-                    end else begin
-                        wr_cnt_en = axi_resp_i.w_ready;
+          // its a single write
+          if (wr_single_req) begin
+            wr_cnt_clr = 1'b1;
+            // single req can be granted here
+            wr_gnt_o = axi_resp_i.aw_ready & axi_resp_i.w_ready;
+            case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
+              2'b01: wr_state_d   = WAIT_AW_READY;
+              2'b10: wr_state_d   = WAIT_LAST_W_READY;
+              default: wr_state_d = IDLE;
+            endcase
+          // its a request for the whole cache line
+          end else begin
+            wr_cnt_en = axi_resp_i.w_ready;
 
-                        case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
-                            2'b11: wr_state_d = WAIT_LAST_W_READY;
-                            2'b01: wr_state_d = WAIT_LAST_W_READY_AW_READY;
-                            2'b10: wr_state_d = WAIT_LAST_W_READY;
-                            default:;
-                        endcase
-                    end
-                end
+            case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
+              2'b11: wr_state_d = WAIT_LAST_W_READY;
+              2'b01: wr_state_d = WAIT_LAST_W_READY_AW_READY;
+              2'b10: wr_state_d = WAIT_LAST_W_READY;
+              default:;
+            endcase
+          end
+        end
+      end
+      ///////////////////////////////////
+      // ~> from single write
+      WAIT_AW_READY: begin
+        axi_req_o.aw_valid = 1'b1;
+
+        if (axi_resp_i.aw_ready) begin
+          wr_state_d = IDLE;
+          wr_gnt_o   = 1'b1;
+        end
+      end
+      ///////////////////////////////////
+      // ~> we need to wait for an aw_ready and there is at least one outstanding write
+      WAIT_LAST_W_READY_AW_READY: begin
+        axi_req_o.w_valid  = 1'b1;
+        axi_req_o.aw_valid = 1'b1;
+        // we got an aw_ready
+        case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
+          // we got an aw ready
+          2'b01: begin
+            // are there any outstanding transactions?
+            if (wr_cnt_done) begin
+              wr_state_d = WAIT_AW_READY_BURST;
+              wr_cnt_clr = 1'b1;
+            end else begin
+            // yes, so reduce the count and stay here
+              wr_cnt_en = 1'b1;
             end
-            ///////////////////////////////////
-            // ~> from single write
-            WAIT_AW_READY: begin
-                axi_req_o.aw_valid = 1'b1;
+          end
+          2'b10: wr_state_d = WAIT_LAST_W_READY;
+          2'b11: begin
+            // we are finished
+            if (wr_cnt_done) begin
+              wr_state_d = IDLE;
+              wr_gnt_o   = 1'b1;
+              wr_cnt_clr = 1'b1;
+            // there are outstanding transactions
+            end else begin
+              wr_state_d = WAIT_LAST_W_READY;
+              wr_cnt_en  = 1'b1;
+            end
+          end
+          default:;
+         endcase
+      end
+      ///////////////////////////////////
+      // ~> all data has already been sent, we are only waiting for the aw_ready
+      WAIT_AW_READY_BURST: begin
+        axi_req_o.aw_valid = 1'b1;
 
-                if (axi_resp_i.aw_ready) begin
-                    wr_state_d = IDLE;
-                    wr_gnt_o   = 1'b1;
-                end
-            end
-            ///////////////////////////////////
-            // ~> we need to wait for an aw_ready and there is at least one outstanding write
-            WAIT_LAST_W_READY_AW_READY: begin
-                axi_req_o.w_valid  = 1'b1;
-                axi_req_o.aw_valid = 1'b1;
-                // we got an aw_ready
-                case ({axi_resp_i.aw_ready, axi_resp_i.w_ready})
-                    // we got an aw ready
-                    2'b01: begin
-                        // are there any outstanding transactions?
-                        if (wr_cnt_done) begin
-                            wr_state_d = WAIT_AW_READY_BURST;
-                            wr_cnt_clr = 1'b1;
-                        end else begin
-                        // yes, so reduce the count and stay here
-                            wr_cnt_en = 1'b1;
-                        end
-                    end
-                    2'b10: wr_state_d = WAIT_LAST_W_READY;
-                    2'b11: begin
-                        // we are finished
-                        if (wr_cnt_done) begin
-                            wr_state_d = IDLE;
-                            wr_gnt_o   = 1'b1;
-                            wr_cnt_clr = 1'b1;
-                        // there are outstanding transactions
-                        end else begin
-                            wr_state_d = WAIT_LAST_W_READY;
-                            wr_cnt_en  = 1'b1;
-                        end
-                    end
-                    default:;
-               endcase
-            end
-            ///////////////////////////////////
-            // ~> all data has already been sent, we are only waiting for the aw_ready
-            WAIT_AW_READY_BURST: begin
-                axi_req_o.aw_valid = 1'b1;
+        if (axi_resp_i.aw_ready) begin
+          wr_state_d = IDLE;
+          wr_gnt_o   = 1'b1;
+        end
+      end
+      ///////////////////////////////////
+      // ~> from write, there is an outstanding write
+      WAIT_LAST_W_READY: begin
+        axi_req_o.w_valid = 1'b1;
 
-                if (axi_resp_i.aw_ready) begin
-                    wr_state_d  = IDLE;
-                    wr_gnt_o    = 1'b1;
-                end
-            end
-            ///////////////////////////////////
-            // ~> from write, there is an outstanding write
-            WAIT_LAST_W_READY: begin
-                axi_req_o.w_valid = 1'b1;
-
-                // this is the last write
-                if (wr_cnt_done) begin
-                    if (axi_resp_i.w_ready) begin
-                        wr_state_d  = IDLE;
-                        wr_cnt_clr  = 1'b1;
-                        wr_gnt_o    = 1'b1;
-                    end
-                end else if (axi_resp_i.w_ready) begin
-                    wr_cnt_en = 1'b1;
-                end
-            end
-            ///////////////////////////////////
-            default: begin
-                wr_state_d = IDLE;
-            end
-        endcase
-    end
+        // this is the last write
+        if (wr_cnt_done) begin
+          if (axi_resp_i.w_ready) begin
+            wr_state_d = IDLE;
+            wr_cnt_clr = 1'b1;
+            wr_gnt_o   = 1'b1;
+          end
+        end else if (axi_resp_i.w_ready) begin
+          wr_cnt_en = 1'b1;
+        end
+      end
+      ///////////////////////////////////
+      default: begin
+        wr_state_d = IDLE;
+      end
+    endcase
+  end
 
 
 ///////////////////////////////////////////////////////
 // read channel
 ///////////////////////////////////////////////////////
 
-    // address
-    // in case of a wrapping transfer we can simply begin at the address, if we want to request a cache-line
-    // with an incremental transfer we need to output the corresponding base address of the cache line
-    assign axi_req_o.ar.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
-    assign axi_req_o.ar.addr   = rd_addr_i;
-    assign axi_req_o.ar.size   = rd_size_i;
-    assign axi_req_o.ar.len    = rd_blen_i;
-    assign axi_req_o.ar.id     = rd_id_i;
-    assign axi_req_o.ar.prot   = 3'b0;
-    assign axi_req_o.ar.region = 4'b0;
-    assign axi_req_o.ar.lock   = rd_lock_i;
-    assign axi_req_o.ar.cache  = 4'b0;
-    assign axi_req_o.ar.qos    = 4'b0;
+  // address
+  // in case of a wrapping transfer we can simply begin at the address, if we want to request a cache-line
+  // with an incremental transfer we need to output the corresponding base address of the cache line
+  assign axi_req_o.ar.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
+  assign axi_req_o.ar.addr   = rd_addr_i;
+  assign axi_req_o.ar.size   = rd_size_i;
+  assign axi_req_o.ar.len    = rd_blen_i;
+  assign axi_req_o.ar.id     = rd_id_i;
+  assign axi_req_o.ar.prot   = 3'b0;
+  assign axi_req_o.ar.region = 4'b0;
+  assign axi_req_o.ar.lock   = rd_lock_i;
+  assign axi_req_o.ar.cache  = 4'b0;
+  assign axi_req_o.ar.qos    = 4'b0;
 
-    // make the read request
-    assign axi_req_o.ar_valid  = rd_req_i;
-    assign rd_gnt_o            = rd_req_i & axi_resp_i.ar_ready;
+  // make the read request
+  assign axi_req_o.ar_valid  = rd_req_i;
+  assign rd_gnt_o            = rd_req_i & axi_resp_i.ar_ready;
 
-    // return path
-    assign axi_req_o.r_ready   = rd_rdy_i;
-    assign rd_data_o           = axi_resp_i.r.data;
-    assign rd_last_o           = axi_resp_i.r.last;
-    assign rd_valid_o          = axi_resp_i.r_valid;
-    assign rd_id_o             = axi_resp_i.r.id;
-    assign rd_exokay_o         = (axi_resp_i.r.resp == axi_pkg::RESP_EXOKAY);
+  // return path
+  assign axi_req_o.r_ready   = rd_rdy_i;
+  assign rd_data_o           = axi_resp_i.r.data;
+  assign rd_last_o           = axi_resp_i.r.last;
+  assign rd_valid_o          = axi_resp_i.r_valid;
+  assign rd_id_o             = axi_resp_i.r.id;
+  assign rd_exokay_o         = (axi_resp_i.r.resp == axi_pkg::RESP_EXOKAY);
 
 
-    // ----------------
-    // Registers
-    // ----------------
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-            // start in flushing state and initialize the memory
-            wr_state_q    <= IDLE;
-            wr_cnt_q      <= '0;
-        end else begin
-            wr_state_q    <= wr_state_d;
-            wr_cnt_q      <= wr_cnt_d;
-        end
+  // ----------------
+  // Registers
+  // ----------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      // start in flushing state and initialize the memory
+      wr_state_q <= IDLE;
+      wr_cnt_q   <= '0;
+    end else begin
+      wr_state_q <= wr_state_d;
+      wr_cnt_q   <= wr_cnt_d;
     end
+  end
 
 // ----------------
 // Assertions
@@ -279,8 +279,8 @@ module axi_shim #(
 //pragma translate_off
 `ifndef VERILATOR
    initial begin
-      assert (AxiNumWords >= 1) else
-         $fatal(1,"[axi adapter] AxiNumWords must be >= 1");
+    assert (AxiNumWords >= 1) else
+     $fatal(1,"[axi adapter] AxiNumWords must be >= 1");
    end
 `endif
 //pragma translate_on

--- a/src/axi_shim.sv
+++ b/src/axi_shim.sv
@@ -78,7 +78,7 @@ module axi_shim #(
     assign wr_single_req       = (wr_blen_i == 0);
 
     // address
-    assign axi_req_o.aw.burst  = (wr_single_req) ? 2'b00 : 2'b01;  // fixed size for single request and incremental transfer for everything else
+    assign axi_req_o.aw.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
     assign axi_req_o.aw.addr   = wr_addr_i;
     assign axi_req_o.aw.size   = wr_size_i;
     assign axi_req_o.aw.len    = wr_blen_i;
@@ -232,10 +232,9 @@ module axi_shim #(
 ///////////////////////////////////////////////////////
 
     // address
-    // in case of a single request or wrapping transfer we can simply begin at the address, if we want to request a cache-line
+    // in case of a wrapping transfer we can simply begin at the address, if we want to request a cache-line
     // with an incremental transfer we need to output the corresponding base address of the cache line
-    assign axi_req_o.ar.burst  = (rd_blen_i == 0)      ? 2'b00 :
-                                                         2'b01;  
+    assign axi_req_o.ar.burst  = axi_pkg::BURST_INCR; // Use BURST_INCR for AXI regular transaction
     assign axi_req_o.ar.addr   = rd_addr_i;
     assign axi_req_o.ar.size   = rd_size_i;
     assign axi_req_o.ar.len    = rd_blen_i;


### PR DESCRIPTION
The AXI transactions can be _regular_ as stated in AXI specification section A3.4.3.

It seems there is no need to perform FIXED transactions, am I wrong?
This patch makes the CPU compliant also with _AXI Regular Transactions_. For example, now it is compatible with the AXI SmartConnect IP of Vivado.

I have created a draft PR since I have not tested this patch a lot. Do you have any concerns about this change?