### PR TITLE
Remove unnecessary ariane_soc_pkg dependency

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,6 @@ sources:
     - src/register_interface/src/reg_intf.sv
     - src/register_interface/src/reg_intf_pkg.sv
     - include/axi_intf.sv
-    - tb/ariane_soc_pkg.sv
     - include/ariane_axi_pkg.sv
     - src/fpu/src/fpnew_pkg.sv
     - src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
@@ -196,6 +195,8 @@ sources:
     - src/tech_cells_generic/src/pulp_clock_mux2.sv
     - target: test
       files:
+      - tb/ariane_soc_pkg.sv
+      - tb/ariane_axi_soc_pkg.sv
       - tb/ariane_testharness.sv
       - tb/ariane_peripherals.sv
       - tb/common/uart.sv

--- a/Flist.ariane
+++ b/Flist.ariane
@@ -58,9 +58,10 @@ src/fpu/src/fpnew_rounding.sv
 src/fpu/src/fpnew_top.sv
 src/axi/src/axi_pkg.sv
 tb/ariane_soc_pkg.sv
+tb/ariane_axi_soc_pkg.sv
 include/ariane_axi_pkg.sv
 include/wt_cache_pkg.sv
-//include/std_cache_pkg.sv
+include/std_cache_pkg.sv
 include/axi_intf.sv
 include/instr_tracer_pkg.sv
 src/util/instr_tracer_if.sv

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ ariane_pkg := include/riscv_pkg.sv                          \
               src/register_interface/src/reg_intf_pkg.sv    \
               include/axi_intf.sv                           \
               tb/ariane_soc_pkg.sv                          \
+              tb/ariane_axi_soc_pkg.sv                      \
               include/ariane_axi_pkg.sv                     \
               src/fpu/src/fpnew_pkg.sv                      \
               src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv

--- a/tb/ariane_axi_soc_pkg.sv
+++ b/tb/ariane_axi_soc_pkg.sv
@@ -8,25 +8,25 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  *
- * File:   ariane_axi_pkg.sv
+ * File:   ariane_axi_soc_pkg.sv
  * Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
  * Date:   17.8.2018
  *
- * Description: Contains Ariane's AXI ports, does not contain user ports
+ * Description: Contains Ariane's AXI ports on SoC, does not contain user ports
  */
 
-package ariane_axi;
+package ariane_axi_soc;
 
     // used in axi_adapter.sv
     typedef enum logic { SINGLE_REQ, CACHE_LINE_REQ } ad_req_t;
 
-    localparam IdWidth   = 4; // Recommended by AXI standard
     localparam UserWidth = 1;
     localparam AddrWidth = 64;
     localparam DataWidth = 64;
     localparam StrbWidth = DataWidth / 8;
 
-    typedef logic   [IdWidth-1:0]   id_t;
+    typedef logic [ariane_soc::IdWidth-1:0]      id_t;
+    typedef logic [ariane_soc::IdWidthSlave-1:0] id_slv_t;
     typedef logic [AddrWidth-1:0] addr_t;
     typedef logic [DataWidth-1:0] data_t;
     typedef logic [StrbWidth-1:0] strb_t;
@@ -48,6 +48,22 @@ package ariane_axi;
         user_t            user;
     } aw_chan_t;
 
+    // AW Channel - Slave
+    typedef struct packed {
+        id_slv_t          id;
+        addr_t            addr;
+        axi_pkg::len_t    len;
+        axi_pkg::size_t   size;
+        axi_pkg::burst_t  burst;
+        logic             lock;
+        axi_pkg::cache_t  cache;
+        axi_pkg::prot_t   prot;
+        axi_pkg::qos_t    qos;
+        axi_pkg::region_t region;
+        axi_pkg::atop_t   atop;
+        user_t            user;
+    } aw_chan_slv_t;
+
     // W Channel - AXI4 doesn't define a wid
     typedef struct packed {
         data_t data;
@@ -62,6 +78,13 @@ package ariane_axi;
         axi_pkg::resp_t resp;
         user_t          user;
     } b_chan_t;
+
+    // B Channel - Slave
+    typedef struct packed {
+        id_slv_t        id;
+        axi_pkg::resp_t resp;
+        user_t          user;
+    } b_chan_slv_t;
 
     // AR Channel
     typedef struct packed {
@@ -78,6 +101,21 @@ package ariane_axi;
         user_t            user;
     } ar_chan_t;
 
+    // AR Channel - Slave
+    typedef struct packed {
+        id_slv_t          id;
+        addr_t            addr;
+        axi_pkg::len_t    len;
+        axi_pkg::size_t   size;
+        axi_pkg::burst_t  burst;
+        logic             lock;
+        axi_pkg::cache_t  cache;
+        axi_pkg::prot_t   prot;
+        axi_pkg::qos_t    qos;
+        axi_pkg::region_t region;
+        user_t            user;
+    } ar_chan_slv_t;
+
     // R Channel
     typedef struct packed {
         id_t            id;
@@ -86,6 +124,15 @@ package ariane_axi;
         logic           last;
         user_t          user;
     } r_chan_t;
+
+    // R Channel - Slave
+    typedef struct packed {
+        id_slv_t        id;
+        data_t          data;
+        axi_pkg::resp_t resp;
+        logic           last;
+        user_t          user;
+    } r_chan_slv_t;
 
     // Request/Response structs
     typedef struct packed {
@@ -108,5 +155,26 @@ package ariane_axi;
         logic     r_valid;
         r_chan_t  r;
     } resp_t;
+
+    typedef struct packed {
+        aw_chan_slv_t aw;
+        logic         aw_valid;
+        w_chan_t      w;
+        logic         w_valid;
+        logic         b_ready;
+        ar_chan_slv_t ar;
+        logic         ar_valid;
+        logic         r_ready;
+    } req_slv_t;
+
+    typedef struct packed {
+        logic         aw_ready;
+        logic         ar_ready;
+        logic         w_ready;
+        logic         b_valid;
+        b_chan_slv_t  b;
+        logic         r_valid;
+        r_chan_slv_t  r;
+    } resp_slv_t;
 
 endpackage

--- a/tb/ariane_testharness.sv
+++ b/tb/ariane_testharness.sv
@@ -195,8 +195,8 @@ module ariane_testharness #(
     end
   end
 
-  ariane_axi::req_t    dm_axi_m_req;
-  ariane_axi::resp_t   dm_axi_m_resp;
+  ariane_axi_soc::req_t    dm_axi_m_req;
+  ariane_axi_soc::resp_t   dm_axi_m_resp;
 
   logic                dm_slave_req;
   logic                dm_slave_we;
@@ -281,7 +281,7 @@ module ariane_testharness #(
     .clk_i                 ( clk_i                     ),
     .rst_ni                ( rst_ni                    ),
     .req_i                 ( dm_master_req             ),
-    .type_i                ( ariane_axi::SINGLE_REQ    ),
+    .type_i                ( ariane_axi_soc::SINGLE_REQ    ),
     .gnt_o                 ( dm_master_gnt             ),
     .gnt_id_o              (                           ),
     .addr_i                ( dm_master_add             ),
@@ -377,23 +377,23 @@ module ariane_testharness #(
     .AXI_USER_WIDTH ( AXI_USER_WIDTH           )
   ) dram_delayed();
 
-  ariane_axi::aw_chan_slv_t aw_chan_i;
-  ariane_axi::w_chan_t      w_chan_i;
-  ariane_axi::b_chan_slv_t  b_chan_o;
-  ariane_axi::ar_chan_slv_t ar_chan_i;
-  ariane_axi::r_chan_slv_t  r_chan_o;
-  ariane_axi::aw_chan_slv_t aw_chan_o;
-  ariane_axi::w_chan_t      w_chan_o;
-  ariane_axi::b_chan_slv_t  b_chan_i;
-  ariane_axi::ar_chan_slv_t ar_chan_o;
-  ariane_axi::r_chan_slv_t  r_chan_i;
+  ariane_axi_soc::aw_chan_slv_t aw_chan_i;
+  ariane_axi_soc::w_chan_t      w_chan_i;
+  ariane_axi_soc::b_chan_slv_t  b_chan_o;
+  ariane_axi_soc::ar_chan_slv_t ar_chan_i;
+  ariane_axi_soc::r_chan_slv_t  r_chan_o;
+  ariane_axi_soc::aw_chan_slv_t aw_chan_o;
+  ariane_axi_soc::w_chan_t      w_chan_o;
+  ariane_axi_soc::b_chan_slv_t  b_chan_i;
+  ariane_axi_soc::ar_chan_slv_t ar_chan_o;
+  ariane_axi_soc::r_chan_slv_t  r_chan_i;
 
   axi_delayer #(
-    .aw_t              ( ariane_axi::aw_chan_slv_t ),
-    .w_t               ( ariane_axi::w_chan_t      ),
-    .b_t               ( ariane_axi::b_chan_slv_t  ),
-    .ar_t              ( ariane_axi::ar_chan_slv_t ),
-    .r_t               ( ariane_axi::r_chan_slv_t  ),
+    .aw_t              ( ariane_axi_soc::aw_chan_slv_t ),
+    .w_t               ( ariane_axi_soc::w_chan_t      ),
+    .b_t               ( ariane_axi_soc::b_chan_slv_t  ),
+    .ar_t              ( ariane_axi_soc::ar_chan_slv_t ),
+    .r_t               ( ariane_axi_soc::r_chan_slv_t  ),
     .StallRandomOutput ( StallRandomOutput         ),
     .StallRandomInput  ( StallRandomInput          ),
     .FixedDelayInput   ( 0                         ),
@@ -596,8 +596,8 @@ module ariane_testharness #(
   logic ipi;
   logic timer_irq;
 
-  ariane_axi::req_t    axi_clint_req;
-  ariane_axi::resp_t   axi_clint_resp;
+  ariane_axi_soc::req_t    axi_clint_req;
+  ariane_axi_soc::resp_t   axi_clint_resp;
 
   clint #(
     .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH        ),
@@ -676,8 +676,8 @@ module ariane_testharness #(
   // ---------------
   // Core
   // ---------------
-  ariane_axi::req_t    axi_ariane_req;
-  ariane_axi::resp_t   axi_ariane_resp;
+  ariane_axi_soc::req_t    axi_ariane_req;
+  ariane_axi_soc::resp_t   axi_ariane_resp;
 
   ariane #(
     .ArianeCfg  ( ariane_soc::ArianeSocCfg )
@@ -726,15 +726,15 @@ module ariane_testharness #(
   // AXI 4 Assertion IP integration - You will need to get your own copy of this IP if you want
   // to use it
   Axi4PC #(
-    .DATA_WIDTH(ariane_axi::DataWidth),
+    .DATA_WIDTH(ariane_axi_soc::DataWidth),
     .WID_WIDTH(ariane_soc::IdWidthSlave),
     .RID_WIDTH(ariane_soc::IdWidthSlave),
-    .AWUSER_WIDTH(ariane_axi::UserWidth),
-    .WUSER_WIDTH(ariane_axi::UserWidth),
-    .BUSER_WIDTH(ariane_axi::UserWidth),
-    .ARUSER_WIDTH(ariane_axi::UserWidth),
-    .RUSER_WIDTH(ariane_axi::UserWidth),
-    .ADDR_WIDTH(ariane_axi::AddrWidth)
+    .AWUSER_WIDTH(ariane_axi_soc::UserWidth),
+    .WUSER_WIDTH(ariane_axi_soc::UserWidth),
+    .BUSER_WIDTH(ariane_axi_soc::UserWidth),
+    .ARUSER_WIDTH(ariane_axi_soc::UserWidth),
+    .RUSER_WIDTH(ariane_axi_soc::UserWidth),
+    .ADDR_WIDTH(ariane_axi_soc::AddrWidth)
   ) i_Axi4PC (
     .ACLK(clk_i),
     .ARESETn(ndmreset_n),

--- a/tb/tb_wb_dcache/tb.list
+++ b/tb/tb_wb_dcache/tb.list
@@ -13,6 +13,7 @@
 ../../src/axi/src/axi_test.sv
 ../../include/ariane_pkg.sv
 ../ariane_soc_pkg.sv
+../ariane_axi_soc_pkg.sv
 ../../include/ariane_axi_pkg.sv
 ../../include/std_cache_pkg.sv
 ../../src/fpga-support/rtl/SyncSpRamBeNx64.sv


### PR DESCRIPTION
With my work, I had the necessity to remove the dependency of ariane_soc package from the CVA6 core.
It was straightforward because *_slv_t types are needed only in ariane_testharness.

I'm not familiar with your build system (Bender, etc..) and I'm not sure this is the best solution to be maintained.
If you are interested in isolating better the code of CVA6 from the SoC where it is instantiated, this patch aims to obtain this result.

Draft until interested and improved.
