### PR TITLE
cache_ctrl: remove forward reference

### DIFF
--- a/src/cache_subsystem/cache_ctrl.sv
+++ b/src/cache_subsystem/cache_ctrl.sv
@@ -83,10 +83,10 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
 
     logic [DCACHE_SET_ASSOC-1:0] hit_way_d, hit_way_q;
 
+    mem_req_t mem_req_d, mem_req_q;
+
     assign busy_o = (state_q != IDLE);
     assign tag_o  = mem_req_d.tag;
-
-    mem_req_t mem_req_d, mem_req_q;
 
     logic [DCACHE_LINE_WIDTH-1:0] cl_i;
 


### PR DESCRIPTION
DesignCompiler 2019.12 reports it as a possible error in future versions.