### PR TITLE
fpga: Fix IP synthesis for Vivado 2020.2

### DIFF
--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -30,7 +30,7 @@ $(ips): %.xci :
 	mkdir -p $(work-dir)
 	@echo Generating $(@F)
 	@cd $(ip-dir)/$(basename $(@F)) && make clean && make
-	@cp $(ip-dir)/$(basename $(@F))/ip/$(@F) $@
+	@cp $(ip-dir)/$(basename $(@F))/$(basename $(@F)).srcs/sources_1/ip/$(basename $(@F))/$(@F) $@
 
 mcs: $(mcs)
 

--- a/fpga/scripts/run.tcl
+++ b/fpga/scripts/run.tcl
@@ -26,12 +26,14 @@ if {$::env(BOARD) eq "genesys2"} {
       exit 1
 }
 
-read_ip xilinx/xlnx_mig_7_ddr3/ip/xlnx_mig_7_ddr3.xci
-read_ip xilinx/xlnx_axi_clock_converter/ip/xlnx_axi_clock_converter.xci
-read_ip xilinx/xlnx_axi_dwidth_converter/ip/xlnx_axi_dwidth_converter.xci
-read_ip xilinx/xlnx_axi_gpio/ip/xlnx_axi_gpio.xci
-read_ip xilinx/xlnx_axi_quad_spi/ip/xlnx_axi_quad_spi.xci
-read_ip xilinx/xlnx_clk_gen/ip/xlnx_clk_gen.xci
+read_ip { \
+      "xilinx/xlnx_mig_7_ddr3/xlnx_mig_7_ddr3.srcs/sources_1/ip/xlnx_mig_7_ddr3/xlnx_mig_7_ddr3.xci" \
+      "xilinx/xlnx_axi_clock_converter/xlnx_axi_clock_converter.srcs/sources_1/ip/xlnx_axi_clock_converter/xlnx_axi_clock_converter.xci" \
+      "xilinx/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.srcs/sources_1/ip/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.xci" \
+      "xilinx/xlnx_axi_gpio/xlnx_axi_gpio.srcs/sources_1/ip/xlnx_axi_gpio/xlnx_axi_gpio.xci" \
+      "xilinx/xlnx_axi_quad_spi/xlnx_axi_quad_spi.srcs/sources_1/ip/xlnx_axi_quad_spi/xlnx_axi_quad_spi.xci" \
+      "xilinx/xlnx_clk_gen/xlnx_clk_gen.srcs/sources_1/ip/xlnx_clk_gen/xlnx_clk_gen.xci" \
+}
 # read_ip xilinx/xlnx_protocol_checker/ip/xlnx_protocol_checker.xci
 
 set_property include_dirs { "src/axi_sd_bridge/include" "../src/common_cells/include" } [current_fileset]

--- a/fpga/xilinx/common.mk
+++ b/fpga/xilinx/common.mk
@@ -1,8 +1,5 @@
 all:
 	vivado -mode batch -source tcl/run.tcl
-	mkdir -p ip
-	cp -r ${PROJECT}.srcs/sources_1/ip/${PROJECT}/* ip/.
-	cp ${PROJECT}.runs/${PROJECT}_synth_1/${PROJECT}.dcp ip/.
 
 gui:
 	vivado -mode gui -source tcl/run.tcl &


### PR DESCRIPTION
Since Vivado 2020.2 one can not relocate the `xci` files. 