### PR TITLE
Flush all state when reset is not deasserted

### DIFF
--- a/src/util/instr_tracer.sv
+++ b/src/util/instr_tracer.sv
@@ -66,7 +66,11 @@ module instr_tracer (
     forever begin
       automatic ariane_pkg::bp_resolve_t bp_instruction = '0;
       // new cycle, we are only interested if reset is de-asserted
-      @(tracer_if.pck iff tracer_if.pck.rstn);
+      @(tracer_if.pck) if (tracer_if.pck.rstn !== 1'b1) begin
+        flush();
+        continue;
+      end
+
       // increment clock tick
       clk_ticks++;
 


### PR DESCRIPTION
This PR ensures that while the CPU reset is asserted, the simulation instruction tracer flushes its internal state, so that it can resume tracing correctly once reset is deasserted. Otherwise the trace logging becomes inconsistent with the actual CPU state if the CPU is ever reset externally and then resumes execution.
