### PR TITLE
Added fixes for Errors/Warnings for compiling with xcelium on CVA6

### DIFF
--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -485,7 +485,7 @@ package ariane_pkg;
             EQ, NE, LTS, GES, LTU, GEU: return 1'b1;
             default                   : return 1'b0; // all other ops
         endcase
-    endfunction;
+    endfunction
 
     // -------------------------------
     // Extract Src/Dst FP Reg from Op
@@ -505,7 +505,7 @@ package ariane_pkg;
             endcase
         end else
             return 1'b0;
-    endfunction;
+    endfunction
 
     function automatic logic is_rs2_fpr (input fu_op op);
         if (FP_PRESENT) begin // makes function static for non-fp case
@@ -521,7 +521,7 @@ package ariane_pkg;
             endcase
         end else
             return 1'b0;
-    endfunction;
+    endfunction
 
     // ternary operations encode the rs3 address in the imm field, also add/sub
     function automatic logic is_imm_fpr (input fu_op op);
@@ -534,7 +534,7 @@ package ariane_pkg;
             endcase
         end else
             return 1'b0;
-    endfunction;
+    endfunction
 
     function automatic logic is_rd_fpr (input fu_op op);
         if (FP_PRESENT) begin // makes function static for non-fp case
@@ -551,7 +551,7 @@ package ariane_pkg;
             endcase
         end else
             return 1'b0;
-    endfunction;
+    endfunction
 
     function automatic logic is_amo (fu_op op);
         case (op) inside

--- a/include/riscv_pkg.sv
+++ b/include/riscv_pkg.sv
@@ -39,8 +39,8 @@ package riscv;
     localparam ModeW      = (XLEN == 32) ? 1 : 4;
     localparam ASIDW      = (XLEN == 32) ? 9 : 16;
     localparam PPNW       = (XLEN == 32) ? 22 : 44;
-    localparam logic [ModeW-1:0] MODE_SV = (XLEN == 32) ? ModeSv32[ModeW-1:0] : ModeSv39[ModeW-1:0];
-    localparam SV         = (MODE_SV == ModeSv32[ModeW-1:0]) ? 32 : 39;
+    localparam logic [3:0] MODE_SV = (XLEN == 32) ? ModeSv32 : ModeSv39;
+    localparam SV         = (MODE_SV == ModeSv32) ? 32 : 39;
     localparam VPN2       = (riscv::VLEN-31 < 8) ? riscv::VLEN-31 : 8;
 
     typedef logic [riscv::XLEN-1:0] xlen_t;

--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -494,7 +494,7 @@ module csr_regfile import ariane_pkg::*; #(
                         // only make ASID_LEN - 1 bit stick, that way software can figure out how many ASID bits are supported
                         satp.asid = satp.asid & {{(riscv::ASIDW-AsidWidth){1'b0}}, {AsidWidth{1'b1}}};
                         // only update if we actually support this mode
-                        if (satp.mode == riscv::ModeOff[riscv::ModeW-1:0] || satp.mode == riscv::MODE_SV) satp_d = satp;
+                        if (satp.mode == riscv::ModeOff || satp.mode == riscv::MODE_SV) satp_d = satp;
                     end
                     // changing the mode can have side-effects on address translation (e.g.: other instructions), re-fetch
                     // the next instruction by executing a flush

--- a/src/pmp/src/pmp.sv
+++ b/src/pmp/src/pmp.sv
@@ -32,13 +32,18 @@ module pmp #(
         logic [NR_ENTRIES-1:0] match;
 
         for (genvar i = 0; i < NR_ENTRIES; i++) begin
+
+            logic [PMP_LEN-1:0] conf_addr_prev;
+	
+            assign conf_addr_prev = (i == 0) ? '0 : conf_addr_i[i-1];
+
             pmp_entry #(
                 .PLEN    ( PLEN    ),
                 .PMP_LEN ( PMP_LEN )
             ) i_pmp_entry(
                 .addr_i           ( addr_i                         ),
                 .conf_addr_i      ( conf_addr_i[i]                 ),
-                .conf_addr_prev_i ( i == 0 ? '0 : conf_addr_i[i-1] ),
+                .conf_addr_prev_i ( conf_addr_prev                 ),
                 .conf_addr_mode_i ( conf_i[i].addr_mode            ),
                 .match_o          ( match[i]                       )
             );


### PR DESCRIPTION
**List of Error Fixed for xrun command:**
* In `ariane_pkg.sv` and `riscv_pkg.sv` the slicing of an enumeration constant is illegal for xcelium. The size of `MODE_SV` has been fixed to the size of `vm_mode_t` which removes the need for slicing;
* In `pmp.sv` assigning the port `conf_addr_prev_i ` of `pmp_entry` with a ternary operator caused an error. The assignment has been done outside the `pmp_entry` module.

**Warnings:**
* In `ariane_pkg.sv` removed extra semicolons at the end of endfunctions.

Signed-off-by: Gianmarco Ottavi <gianmarco@openhwgroup.org>