### PR TITLE
peripherals: assign default value to unused interrupts

### DIFF
--- a/fpga/src/ariane_peripherals_xilinx.sv
+++ b/fpga/src/ariane_peripherals_xilinx.sv
@@ -63,6 +63,9 @@ module ariane_peripherals #(
     // ---------------
     logic [ariane_soc::NumSources-1:0] irq_sources;
 
+    // Unused interrupt sources
+    assign irq_sources[ariane_soc::NumSources-1:7] = '0;
+
     REG_BUS #(
         .ADDR_WIDTH ( 32 ),
         .DATA_WIDTH ( 32 )

--- a/tb/ariane_peripherals.sv
+++ b/tb/ariane_peripherals.sv
@@ -56,6 +56,9 @@ module ariane_peripherals #(
     // ---------------
     logic [ariane_soc::NumSources-1:0] irq_sources;
 
+    // Unused interrupt sources
+    assign irq_sources[ariane_soc::NumSources-1:7] = '0;
+
     REG_BUS #(
         .ADDR_WIDTH ( 32 ),
         .DATA_WIDTH ( 32 )


### PR DESCRIPTION
Otherwise, the PLIC registers will be poisoned.