### PR TITLE
fix modelsim flow

### DIFF
--- a/include/riscv_pkg.sv
+++ b/include/riscv_pkg.sv
@@ -39,7 +39,7 @@ package riscv;
     localparam ModeW      = (XLEN == 32) ? 1 : 4;
     localparam ASIDW      = (XLEN == 32) ? 9 : 16;
     localparam PPNW       = (XLEN == 32) ? 22 : 44;
-    localparam logic [3:0] MODE_SV = (XLEN == 32) ? ModeSv32 : ModeSv39;
+    localparam vm_mode_t MODE_SV = (XLEN == 32) ? ModeSv32 : ModeSv39;
     localparam SV         = (MODE_SV == ModeSv32) ? 32 : 39;
     localparam VPN2       = (riscv::VLEN-31 < 8) ? riscv::VLEN-31 : 8;
 

--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -494,7 +494,8 @@ module csr_regfile import ariane_pkg::*; #(
                         // only make ASID_LEN - 1 bit stick, that way software can figure out how many ASID bits are supported
                         satp.asid = satp.asid & {{(riscv::ASIDW-AsidWidth){1'b0}}, {AsidWidth{1'b1}}};
                         // only update if we actually support this mode
-                        if (satp.mode == riscv::ModeOff || satp.mode == riscv::MODE_SV) satp_d = satp;
+                        if (riscv::vm_mode_t'(satp.mode) == riscv::ModeOff ||
+                            riscv::vm_mode_t'(satp.mode) == riscv::MODE_SV) satp_d = satp;
                     end
                     // changing the mode can have side-effects on address translation (e.g.: other instructions), re-fetch
                     // the next instruction by executing a flush
@@ -800,7 +801,7 @@ module csr_regfile import ariane_pkg::*; #(
         // ------------------------------
         // Set the address translation at which the load and stores should occur
         // we can use the previous values since changing the address translation will always involve a pipeline flush
-        if (mprv && satp_q.mode == riscv::MODE_SV && (mstatus_q.mpp != riscv::PRIV_LVL_M))
+        if (mprv && riscv::vm_mode_t'(satp_q.mode) == riscv::MODE_SV && (mstatus_q.mpp != riscv::PRIV_LVL_M))
             en_ld_st_translation_d = 1'b1;
         else // otherwise we go with the regular settings
             en_ld_st_translation_d = en_translation_o;
@@ -1036,7 +1037,8 @@ module csr_regfile import ariane_pkg::*; #(
     assign asid_o           = satp_q.asid[AsidWidth-1:0];
     assign sum_o            = mstatus_q.sum;
     // we support bare memory addressing and SV39
-    assign en_translation_o = (satp_q.mode == riscv::MODE_SV && priv_lvl_o != riscv::PRIV_LVL_M)
+    assign en_translation_o = (riscv::vm_mode_t'(satp_q.mode) == riscv::MODE_SV &&
+                               priv_lvl_o != riscv::PRIV_LVL_M)
                               ? 1'b1
                               : 1'b0;
     assign mxr_o            = mstatus_q.mxr;

--- a/tb/ariane_testharness.sv
+++ b/tb/ariane_testharness.sv
@@ -281,7 +281,7 @@ module ariane_testharness #(
     .clk_i                 ( clk_i                     ),
     .rst_ni                ( rst_ni                    ),
     .req_i                 ( dm_master_req             ),
-    .type_i                ( ariane_axi_soc::SINGLE_REQ    ),
+    .type_i                ( ariane_axi::SINGLE_REQ    ),
     .gnt_o                 ( dm_master_gnt             ),
     .gnt_id_o              (                           ),
     .addr_i                ( dm_master_add             ),


### PR DESCRIPTION
fixes issues with the modelsim flow introduced by recent commits.
* `riscv_pkg`, `csr_regfile`: explicit typecast of `satp.mode` to `vm_mode_t`
* `ariane_testharness`: `axi_adapter.type_i` is of type `ariane_axi::ad_req_t`