### PR TITLE
Added rules for compiling and running tests on xcelium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ work-dpi/
 tb/riscv-isa-sim/
 work-*/*
 install/
+xrun_results/


### PR DESCRIPTION
Added rules for compiling and running tests on xcelium following similar pattern to Questasim rules.

Signed-off-by: Gianmarco Ottavi <gianmarco@openhwgroup.org>