### PR TITLE
vcs: Compatibility improvements

### DIFF
--- a/include/riscv_pkg.sv
+++ b/include/riscv_pkg.sv
@@ -671,7 +671,6 @@ package riscv;
             return $sformatf("%d 0x%h %s\n", priv_lvl, pc, instr_word);
         end
     endfunction
-    // pragma translate_on
 
     typedef struct {
         byte priv;
@@ -682,5 +681,6 @@ package riscv;
         int unsigned instr;
         byte was_exception;
     } commit_log_t;
+    // pragma translate_on
 
 endpackage

--- a/src/pmp/src/pmp.sv
+++ b/src/pmp/src/pmp.sv
@@ -32,9 +32,8 @@ module pmp #(
         logic [NR_ENTRIES-1:0] match;
 
         for (genvar i = 0; i < NR_ENTRIES; i++) begin
-
             logic [PMP_LEN-1:0] conf_addr_prev;
-	
+
             assign conf_addr_prev = (i == 0) ? '0 : conf_addr_i[i-1];
 
             pmp_entry #(
@@ -51,7 +50,7 @@ module pmp #(
 
         always_comb begin
             int i;
-            
+
             allow_o = 1'b0;
             for (i = 0; i < NR_ENTRIES; i++) begin
                 // either we are in S or U mode or the config is locked in which
@@ -82,7 +81,7 @@ module pmp #(
                     no_locked &= 1'b0;
                 end else no_locked &= 1'b1;
             end
-            
+
             if (no_locked == 1'b1) assert(allow_o == 1'b1);
         end
     end

--- a/src/scoreboard.sv
+++ b/src/scoreboard.sv
@@ -65,11 +65,12 @@ module scoreboard #(
   localparam int unsigned BITS_ENTRIES = $clog2(NR_ENTRIES);
 
   // this is the FIFO struct of the issue queue
-  struct packed {
+  typedef struct packed {
     logic                          issued;         // this bit indicates whether we issued this instruction e.g.: if it is valid
     logic                          is_rd_fpr_flag; // redundant meta info, added for speed
     ariane_pkg::scoreboard_entry_t sbe;            // this is the score board entry we will send to ex
-  } mem_q [NR_ENTRIES-1:0], mem_n [NR_ENTRIES-1:0];
+  } sb_mem_t;
+  sb_mem_t [NR_ENTRIES-1:0] mem_q, mem_n;
 
   logic                    issue_full, issue_en;
   logic [BITS_ENTRIES-1:0] issue_cnt_n,      issue_cnt_q;
@@ -353,7 +354,7 @@ module scoreboard #(
   // sequential process
   always_ff @(posedge clk_i or negedge rst_ni) begin : regs
     if(!rst_ni) begin
-      mem_q                 <= '{default: 0};
+      mem_q                 <= '{default: sb_mem_t'(0)};
       issue_cnt_q           <= '0;
       commit_pointer_q      <= '0;
       issue_pointer_q       <= '0;

--- a/src/util/instr_tracer.sv
+++ b/src/util/instr_tracer.sv
@@ -14,8 +14,6 @@
 
 `ifndef VERILATOR
 //pragma translate_off
-import uvm_pkg::*;
-`include "uvm_macros.svh"
 `include "ex_trace_item.svh"
 `include "instr_trace_item.svh"
 //pragma translate_on
@@ -197,14 +195,12 @@ module instr_tracer (
     if (ariane_pkg::ENABLE_SPIKE_COMMIT_LOG && !debug_mode) begin
       $fwrite(commit_log, riscv::spikeCommitLog(sbe.pc, priv_lvl, instr, sbe.rd, result, ariane_pkg::is_rd_fpr(sbe.op)));
     end
-    uvm_report_info( "Tracer",  print_instr, UVM_HIGH);
     $fwrite(f, {print_instr, "\n"});
   endfunction
 
   function void printException(logic [riscv::VLEN-1:0] pc, logic [63:0] cause, logic [63:0] tval);
     automatic ex_trace_item eti = new (pc, cause, tval);
     automatic string print_ex = eti.printException();
-    uvm_report_info( "Tracer",  print_ex, UVM_HIGH);
     $fwrite(f, {print_ex, "\n"});
   endfunction
 


### PR DESCRIPTION
- The PMP generation was causing troubles.
- The UVM tracer information isn't really needed
- Make `mem_q` in the scoreboard a proper type