### PR TITLE
Makefile: Fix whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ generate-trace-vsim:
 	make generate-trace
 
 sim: build
-    vsim${questa_version} +permissive $(questa-flags) $(questa-cmd) -lib $(library) +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) \
+	vsim${questa_version} +permissive $(questa-flags) $(questa-cmd) -lib $(library) +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) \
 	+BASEDIR=$(riscv-test-dir) $(uvm-flags) $(QUESTASIM_FLAGS) -gblso $(SPIKE_ROOT)/lib/libfesvr.so -sv_lib $(dpi-library)/ariane_dpi  \
 	${top_level}_optimized +permissive-off ++$(elf-bin) ++$(target-options) | tee sim.log
 


### PR DESCRIPTION
There was a typo in https://github.com/openhwgroup/cva6/commit/4abae602c57045a2c89147a2c9c2cc47eab8fc14 which indents the Makefile with spaces instead of tabs. Sorry for the spam.