### PR TITLE
src/ariane.sv: Verilator: change single-letter string to byte

### DIFF
--- a/src/ariane.sv
+++ b/src/ariane.sv
@@ -860,7 +860,7 @@ module ariane import ariane_pkg::*; #(
     if (~rst_ni) begin
       cycles <= 0;
     end else begin
-      string mode = "";
+      byte mode = "";
       if (debug_mode) mode = "D";
       else begin
         case (priv_lvl)


### PR DESCRIPTION
The string in this block is restrained to one letter. Using a byte (also displayable using `%s`) instead makes some tools' life easier, and makes it arguably more readable.