### PR TITLE
wt_cache: Fix unknown assertion condition

### DIFF
--- a/src/cache_subsystem/wt_cache_subsystem.sv
+++ b/src/cache_subsystem/wt_cache_subsystem.sv
@@ -184,7 +184,7 @@ module wt_cache_subsystem import ariane_pkg::*; import wt_cache_pkg::*; #(
 
   for (genvar j=0; j<2; j++) begin : gen_assertion
     a_invalid_read_data: assert property (
-      @(posedge clk_i) disable iff (!rst_ni) dcache_req_ports_o[j].data_rvalid |-> (|dcache_req_ports_o[j].data_rdata) !== 1'hX)
+      @(posedge clk_i) disable iff (!rst_ni) dcache_req_ports_o[j].data_rvalid && ~dcache_req_ports_i[j].kill_req |-> (|dcache_req_ports_o[j].data_rdata) !== 1'hX)
     else $warning(1,"[l1 dcache] reading invalid data on port %01d: data=%016X",
       j, dcache_req_ports_o[j].data_rdata);
   end


### PR DESCRIPTION
If the tag request is being killed it might be the case that the
cache's SRAM macros return an unkown value. As the value will never be
saved anywhere the assertion triggering just produces noise.