### PR TITLE
Performance Counters Fix

### DIFF
--- a/src/perf_counters.sv
+++ b/src/perf_counters.sv
@@ -67,7 +67,7 @@ module perf_counters import ariane_pkg::*; (
         perf_counter_d[riscv::CSR_MDTLB_MISS] = perf_counter_q[riscv::CSR_MDTLB_MISS] + 1'b1;
 
       // instruction related perf counters
-      for (int unsigned i = 0; i < NR_COMMIT_PORTS-1; i++) begin
+      for (int unsigned i = 0; i < NR_COMMIT_PORTS; i++) begin
         if (commit_ack_i[i]) begin
           if (commit_instr_i[i].fu == LOAD)
             perf_counter_d[riscv::CSR_MLOAD] = perf_counter_q[riscv::CSR_MLOAD] + 1'b1;
@@ -80,12 +80,12 @@ module perf_counters import ariane_pkg::*; (
 
           // The standard software calling convention uses register x1 to hold the return address on a call
           // the unconditional jump is decoded as ADD op
-          if (commit_instr_i[i].fu == CTRL_FLOW && commit_instr_i[i].op == '0
-                                                && (commit_instr_i[i].rd == 'd1 || commit_instr_i[i].rd == 'd1))
+          if (commit_instr_i[i].fu == CTRL_FLOW && commit_instr_i[i].op == '0 && (commit_instr_i[i].rd == 'd1 || commit_instr_i[i].rd == 'd5) ||
+             (commit_instr_i[i].op == JALR && (commit_instr_i[i].rd == 'd1 || commit_instr_i[i].rd == 'd5)) )
             perf_counter_d[riscv::CSR_MCALL] = perf_counter_q[riscv::CSR_MCALL] + 1'b1;
 
           // Return from call
-          if (commit_instr_i[i].op == JALR && (commit_instr_i[i].rd == 'd1 || commit_instr_i[i].rd == 'd1))
+          if (commit_instr_i[i].op == JALR && (commit_instr_i[i].rd == 'd0))
             perf_counter_d[riscv::CSR_MRET] = perf_counter_q[riscv::CSR_MRET] + 1'b1;
         end
       end


### PR DESCRIPTION
## Performance counter fix
* Fixed the for loop exit condition, now both commit ports are properly tracked;
* Added JALR to calls counter and modified the typo for the second destination register from x1 to x5 (AFAIK it can be used as alternate register to store the return address);
* For returns from call we only check if the instruction is a JALR and the destination register is x0.

Signed-off-by: Gianmarco Ottavi <gianmarco@openhwgroup.org>