### PR TITLE
Compile corev_apu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,37 +79,21 @@ endif
 
 # Sources
 # Package files -> compile first
-ariane_pkg := core/include/riscv_pkg.sv                          \
-              corev_apu/riscv-dbg/src/dm_pkg.sv                   \
-              core/include/ariane_pkg.sv                         \
-              core/include/std_cache_pkg.sv                      \
-              core/include/wt_cache_pkg.sv                       \
-              corev_apu/axi/src/axi_pkg.sv                        \
-              corev_apu/register_interface/src/reg_intf.sv        \
-              corev_apu/register_interface/src/reg_intf_pkg.sv    \
-              core/include/axi_intf.sv                           \
-              corev_apu/tb/ariane_soc_pkg.sv                          \
-              corev_apu/tb/ariane_axi_soc_pkg.sv                      \
-              core/include/ariane_axi_pkg.sv                     \
-              core/fpu/src/fpnew_pkg.sv                      \
+ariane_pkg := core/include/riscv_pkg.sv                              \
+              corev_apu/riscv-dbg/src/dm_pkg.sv                      \
+              core/include/ariane_pkg.sv                             \
+              core/include/std_cache_pkg.sv                          \
+              core/include/wt_cache_pkg.sv                           \
+              corev_apu/axi/src/axi_pkg.sv                           \
+              corev_apu/register_interface/src/reg_intf.sv           \
+              corev_apu/register_interface/src/reg_intf_pkg.sv       \
+              core/include/axi_intf.sv                               \
+              corev_apu/tb/ariane_soc_pkg.sv                         \
+              corev_apu/tb/ariane_axi_soc_pkg.sv                     \
+              core/include/ariane_axi_pkg.sv                         \
+              core/fpu/src/fpnew_pkg.sv                              \
               core/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
 ariane_pkg := $(addprefix $(root-dir), $(ariane_pkg))
-
-#ariane_pkg := include/riscv_pkg.sv                          \
-#              src/riscv-dbg/src/dm_pkg.sv                   \
-#              include/ariane_pkg.sv                         \
-#              include/std_cache_pkg.sv                      \
-#              include/wt_cache_pkg.sv                       \
-#              src/axi/src/axi_pkg.sv                        \
-#              src/register_interface/src/reg_intf.sv        \
-#              src/register_interface/src/reg_intf_pkg.sv    \
-#              include/axi_intf.sv                           \
-#              tb/ariane_soc_pkg.sv                          \
-#              tb/ariane_axi_soc_pkg.sv                      \
-#              include/ariane_axi_pkg.sv                     \
-#              src/fpu/src/fpnew_pkg.sv                      \
-#              src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
-#ariane_pkg := $(addprefix $(root-dir), $(ariane_pkg))
 
 # utility modules
 util := include/instr_tracer_pkg.sv                         \

--- a/Makefile
+++ b/Makefile
@@ -79,21 +79,37 @@ endif
 
 # Sources
 # Package files -> compile first
-ariane_pkg := include/riscv_pkg.sv                          \
-              src/riscv-dbg/src/dm_pkg.sv                   \
-              include/ariane_pkg.sv                         \
-              include/std_cache_pkg.sv                      \
-              include/wt_cache_pkg.sv                       \
-              src/axi/src/axi_pkg.sv                        \
-              src/register_interface/src/reg_intf.sv        \
-              src/register_interface/src/reg_intf_pkg.sv    \
-              include/axi_intf.sv                           \
-              tb/ariane_soc_pkg.sv                          \
-              tb/ariane_axi_soc_pkg.sv                      \
-              include/ariane_axi_pkg.sv                     \
-              src/fpu/src/fpnew_pkg.sv                      \
-              src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
+ariane_pkg := core/include/riscv_pkg.sv                          \
+              corev_apu/riscv-dbg/src/dm_pkg.sv                   \
+              core/include/ariane_pkg.sv                         \
+              core/include/std_cache_pkg.sv                      \
+              core/include/wt_cache_pkg.sv                       \
+              corev_apu/axi/src/axi_pkg.sv                        \
+              corev_apu/register_interface/src/reg_intf.sv        \
+              corev_apu/register_interface/src/reg_intf_pkg.sv    \
+              core/include/axi_intf.sv                           \
+              corev_apu/tb/ariane_soc_pkg.sv                          \
+              corev_apu/tb/ariane_axi_soc_pkg.sv                      \
+              core/include/ariane_axi_pkg.sv                     \
+              core/fpu/src/fpnew_pkg.sv                      \
+              core/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
 ariane_pkg := $(addprefix $(root-dir), $(ariane_pkg))
+
+#ariane_pkg := include/riscv_pkg.sv                          \
+#              src/riscv-dbg/src/dm_pkg.sv                   \
+#              include/ariane_pkg.sv                         \
+#              include/std_cache_pkg.sv                      \
+#              include/wt_cache_pkg.sv                       \
+#              src/axi/src/axi_pkg.sv                        \
+#              src/register_interface/src/reg_intf.sv        \
+#              src/register_interface/src/reg_intf_pkg.sv    \
+#              include/axi_intf.sv                           \
+#              tb/ariane_soc_pkg.sv                          \
+#              tb/ariane_axi_soc_pkg.sv                      \
+#              include/ariane_axi_pkg.sv                     \
+#              src/fpu/src/fpnew_pkg.sv                      \
+#              src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
+#ariane_pkg := $(addprefix $(root-dir), $(ariane_pkg))
 
 # utility modules
 util := include/instr_tracer_pkg.sv                         \
@@ -130,8 +146,8 @@ dpi_hdr := $(addprefix $(root-dir), $(dpi_hdr))
 CFLAGS := -I$(QUESTASIM_HOME)/include         \
           -I$(RISCV)/include                  \
           -I$(SPIKE_ROOT)/include             \
-          $(if $(DROMAJO), -I../tb/dromajo/src,) \
-          -std=c++11 -I../tb/dpi -O3
+          $(if $(DROMAJO), -I../corev_apu/tb/dromajo/src,) \
+          -std=c++11 -I../corev_apu/tb/dpi -O3
 
 ifdef XCELIUM_HOME
 CFLAGS += -I$(XCELIUM_HOME)/tools/include
@@ -144,82 +160,82 @@ ifdef spike-tandem
 endif
 
 # this list contains the standalone components
-src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
-        $(filter-out src/fpu/src/fpnew_pkg.sv, $(wildcard src/fpu/src/*.sv))   \
-        $(filter-out src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv,    \
-        $(wildcard src/fpu/src/fpu_div_sqrt_mvp/hdl/*.sv))                     \
-        $(wildcard src/frontend/*.sv)                                          \
-        $(filter-out src/cache_subsystem/std_no_dcache.sv,                     \
-        $(wildcard src/cache_subsystem/*.sv))                                  \
-        $(wildcard bootrom/*.sv)                                               \
-        $(wildcard src/clint/*.sv)                                             \
-        $(wildcard fpga/src/axi2apb/src/*.sv)                                  \
-        $(wildcard fpga/src/apb_timer/*.sv)                                    \
-        $(wildcard fpga/src/axi_slice/src/*.sv)                                \
-        $(wildcard src/axi_node/src/*.sv)                                      \
-        $(wildcard src/axi_riscv_atomics/src/*.sv)                             \
-        $(wildcard src/axi_mem_if/src/*.sv)                                    \
-        $(wildcard src/pmp/src/*.sv)                                           \
-        src/rv_plic/rtl/rv_plic_target.sv                                      \
-        src/rv_plic/rtl/rv_plic_gateway.sv                                     \
-        src/rv_plic/rtl/plic_regmap.sv                                         \
-        src/rv_plic/rtl/plic_top.sv                                            \
-        src/riscv-dbg/src/dmi_cdc.sv                                           \
-        src/riscv-dbg/src/dmi_jtag.sv                                          \
-        src/riscv-dbg/src/dmi_jtag_tap.sv                                      \
-        src/riscv-dbg/src/dm_csrs.sv                                           \
-        src/riscv-dbg/src/dm_mem.sv                                            \
-        src/riscv-dbg/src/dm_sba.sv                                            \
-        src/riscv-dbg/src/dm_top.sv                                            \
-        src/riscv-dbg/debug_rom/debug_rom.sv                                   \
-        src/register_interface/src/apb_to_reg.sv                               \
-        src/axi/src/axi_multicut.sv                                            \
-        src/common_cells/src/deprecated/generic_fifo.sv                        \
-        src/common_cells/src/deprecated/pulp_sync.sv                           \
-        src/common_cells/src/deprecated/find_first_one.sv                      \
-        src/common_cells/src/rstgen_bypass.sv                                  \
-        src/common_cells/src/rstgen.sv                                         \
-        src/common_cells/src/stream_mux.sv                                     \
-        src/common_cells/src/stream_demux.sv                                   \
-        src/common_cells/src/exp_backoff.sv                                    \
-        src/util/axi_master_connect.sv                                         \
-        src/util/axi_slave_connect.sv                                          \
-        src/util/axi_master_connect_rev.sv                                     \
-        src/util/axi_slave_connect_rev.sv                                      \
-        src/axi/src/axi_cut.sv                                                 \
-        src/axi/src/axi_join.sv                                                \
-        src/axi/src/axi_delayer.sv                                             \
-        src/axi/src/axi_to_axi_lite.sv                                         \
-        src/fpga-support/rtl/SyncSpRamBeNx64.sv                                \
-        src/common_cells/src/unread.sv                                         \
-        src/common_cells/src/sync.sv                                           \
-        src/common_cells/src/cdc_2phase.sv                                     \
-        src/common_cells/src/spill_register.sv                                 \
-        src/common_cells/src/sync_wedge.sv                                     \
-        src/common_cells/src/edge_detect.sv                                    \
-        src/common_cells/src/stream_arbiter.sv                                 \
-        src/common_cells/src/stream_arbiter_flushable.sv                       \
-        src/common_cells/src/deprecated/fifo_v1.sv                             \
-        src/common_cells/src/deprecated/fifo_v2.sv                             \
-        src/common_cells/src/fifo_v3.sv                                        \
-        src/common_cells/src/lzc.sv                                            \
-        src/common_cells/src/popcount.sv                                       \
-        src/common_cells/src/rr_arb_tree.sv                                    \
-        src/common_cells/src/deprecated/rrarbiter.sv                           \
-        src/common_cells/src/stream_delay.sv                                   \
-        src/common_cells/src/lfsr_8bit.sv                                      \
-        src/common_cells/src/lfsr_16bit.sv                                     \
-        src/common_cells/src/delta_counter.sv                                  \
-        src/common_cells/src/counter.sv                                        \
-        src/common_cells/src/shift_reg.sv                                      \
-        src/tech_cells_generic/src/pulp_clock_gating.sv                        \
-        src/tech_cells_generic/src/cluster_clock_inverter.sv                   \
-        src/tech_cells_generic/src/pulp_clock_mux2.sv                          \
-        tb/ariane_testharness.sv                                               \
-        tb/ariane_peripherals.sv                                               \
-        tb/common/uart.sv                                                      \
-        tb/common/SimDTM.sv                                                    \
-        tb/common/SimJTAG.sv
+src :=  $(filter-out core/ariane_regfile.sv, $(wildcard core/*.sv))                  \
+        $(filter-out core/fpu/src/fpnew_pkg.sv, $(wildcard core/fpu/src/*.sv))       \
+        $(filter-out core/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv,         \
+        $(wildcard core/fpu/src/fpu_div_sqrt_mvp/hdl/*.sv))                          \
+        $(wildcard core/frontend/*.sv)                                               \
+        $(filter-out core/cache_subsystem/std_no_dcache.sv,                          \
+        $(wildcard core/cache_subsystem/*.sv))                                       \
+        $(wildcard corev_apu/bootrom/*.sv)                                           \
+        $(wildcard corev_apu/clint/*.sv)                                             \
+        $(wildcard corev_apu/fpga/src/axi2apb/src/*.sv)                              \
+        $(wildcard corev_apu/fpga/src/apb_timer/*.sv)                                \
+        $(wildcard corev_apu/fpga/src/axi_slice/src/*.sv)                            \
+        $(wildcard corev_apu/axi_node/src/*.sv)                                      \
+        $(wildcard corev_apu/src/axi_riscv_atomics/src/*.sv)                         \
+        $(wildcard corev_apu/axi_mem_if/src/*.sv)                                    \
+        $(wildcard core/pmp/src/*.sv)                                                \
+        corev_apu/rv_plic/rtl/rv_plic_target.sv                                      \
+        corev_apu/rv_plic/rtl/rv_plic_gateway.sv                                     \
+        corev_apu/rv_plic/rtl/plic_regmap.sv                                         \
+        corev_apu/rv_plic/rtl/plic_top.sv                                            \
+        corev_apu/riscv-dbg/src/dmi_cdc.sv                                           \
+        corev_apu/riscv-dbg/src/dmi_jtag.sv                                          \
+        corev_apu/riscv-dbg/src/dmi_jtag_tap.sv                                      \
+        corev_apu/riscv-dbg/src/dm_csrs.sv                                           \
+        corev_apu/riscv-dbg/src/dm_mem.sv                                            \
+        corev_apu/riscv-dbg/src/dm_sba.sv                                            \
+        corev_apu/riscv-dbg/src/dm_top.sv                                            \
+        corev_apu/riscv-dbg/debug_rom/debug_rom.sv                                   \
+        corev_apu/register_interface/src/apb_to_reg.sv                               \
+        corev_apu/axi/src/axi_multicut.sv                                            \
+        common/submodules/common_cells/src/deprecated/generic_fifo.sv                \
+        common/submodules/common_cells/src/deprecated/pulp_sync.sv                   \
+        common/submodules/common_cells/src/deprecated/find_first_one.sv              \
+        common/submodules/common_cells/src/rstgen_bypass.sv                          \
+        common/submodules/common_cells/src/rstgen.sv                                 \
+        common/submodules/common_cells/src/stream_mux.sv                             \
+        common/submodules/common_cells/src/stream_demux.sv                           \
+        common/submodules/common_cells/src/exp_backoff.sv                            \
+        common/local/util/axi_master_connect.sv                                      \
+        common/local/util/axi_slave_connect.sv                                       \
+        common/local/util/axi_master_connect_rev.sv                                  \
+        common/local/util/axi_slave_connect_rev.sv                                   \
+        corev_apu/axi/src/axi_cut.sv                                                 \
+        corev_apu/axi/src/axi_join.sv                                                \
+        corev_apu/axi/src/axi_delayer.sv                                             \
+        corev_apu/axi/src/axi_to_axi_lite.sv                                         \
+        corev_apu/fpga-support/rtl/SyncSpRamBeNx64.sv                                \
+        common/submodules/common_cells/src/unread.sv                                 \
+        common/submodules/common_cells/src/sync.sv                                   \
+        common/submodules/common_cells/src/cdc_2phase.sv                             \
+        common/submodules/common_cells/src/spill_register.sv                         \
+        common/submodules/common_cells/src/sync_wedge.sv                             \
+        common/submodules/common_cells/src/edge_detect.sv                            \
+        common/submodules/common_cells/src/stream_arbiter.sv                         \
+        common/submodules/common_cells/src/stream_arbiter_flushable.sv               \
+        common/submodules/common_cells/src/deprecated/fifo_v1.sv                     \
+        common/submodules/common_cells/src/deprecated/fifo_v2.sv                     \
+        common/submodules/common_cells/src/fifo_v3.sv                                \
+        common/submodules/common_cells/src/lzc.sv                                    \
+        common/submodules/common_cells/src/popcount.sv                               \
+        common/submodules/common_cells/src/rr_arb_tree.sv                            \
+        common/submodules/common_cells/src/deprecated/rrarbiter.sv                   \
+        common/submodules/common_cells/src/stream_delay.sv                           \
+        common/submodules/common_cells/src/lfsr_8bit.sv                              \
+        common/submodules/common_cells/src/lfsr_16bit.sv                             \
+        common/submodules/common_cells/src/delta_counter.sv                          \
+        common/submodules/common_cells/src/counter.sv                                \
+        common/submodules/common_cells/src/shift_reg.sv                              \
+        corev_apu/src/tech_cells_generic/src/pulp_clock_gating.sv                    \
+        corev_apu/src/tech_cells_generic/src/cluster_clock_inverter.sv               \
+        corev_apu/src/tech_cells_generic/src/pulp_clock_mux2.sv                      \
+        corev_apu/tb/ariane_testharness.sv                                           \
+        corev_apu/tb/ariane_peripherals.sv                                           \
+        corev_apu/tb/common/uart.sv                                                  \
+        corev_apu/tb/common/SimDTM.sv                                                \
+        corev_apu/tb/common/SimJTAG.sv
 
 src := $(addprefix $(root-dir), $(src))
 
@@ -247,7 +263,8 @@ riscv-fp-tests            := $(shell xargs printf '\n%s' < $(riscv-fp-tests-list
 riscv-benchmarks          := $(shell xargs printf '\n%s' < $(riscv-benchmarks-list) | cut -b 1-)
 
 # Search here for include files (e.g.: non-standalone components)
-incdir := src/common_cells/include/
+incdir := common/submodules/common_cells/include/
+
 # Compile and sim flags
 compile_flag     += +cover=bcfst+/dut -incr -64 -nologo -quiet -suppress 13262 -permissive +define+$(defines)
 uvm-flags        += +UVM_NO_RELNOTES +UVM_VERBOSITY=LOW
@@ -539,11 +556,11 @@ xrun-ci: xrun-asm-tests xrun-amo-tests xrun-mul-tests xrun-fp-tests xrun-benchma
 # verilator-specific
 verilate_command := $(verilator)                                                                                 \
                     $(filter-out %.vhd, $(ariane_pkg))                                                           \
-                    $(filter-out src/fpu_wrap.sv, $(filter-out %.vhd, $(src)))                                   \
+                    $(filter-out core/fpu_wrap.sv, $(filter-out %.vhd, $(src)))                                  \
                     +define+$(defines)                                                                           \
-                    src/util/sram.sv                                                                             \
-                    tb/common/mock_uart.sv                                                                       \
-                    +incdir+src/axi_node                                                                         \
+                    common/local/util/sram.sv                                                                    \
+                    corev_apu/tb/common/mock_uart.sv                                                             \
+                    +incdir+corev_apu/axi_node                                                                   \
                     $(if $(verilator_threads), --threads $(verilator_threads))                                   \
                     --unroll-count 256                                                                           \
                     -Werror-PINMISSING                                                                           \
@@ -559,13 +576,13 @@ verilate_command := $(verilator)                                                
                     $(if $(DROMAJO), -DDROMAJO=1,)                                                               \
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
                     $(if $(DEBUG),--trace --trace-structs,)                                                      \
-                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../tb/dromajo/src -ldromajo_cosim,) -lpthread" \
+                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../corev_apu/tb/dromajo/src -ldromajo_cosim,) -lpthread" \
                     -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -DDROMAJO=1,) -DVL_DEBUG"       \
                     -Wall --cc  --vpi                                                                            \
                     $(list_incdir) --top-module ariane_testharness                                               \
                     --Mdir $(ver-library) -O3                                                                    \
-                    --exe tb/ariane_tb.cpp tb/dpi/SimDTM.cc tb/dpi/SimJTAG.cc                                    \
-					tb/dpi/remote_bitbang.cc tb/dpi/msim_helper.cc $(if $(DROMAJO), tb/dpi/dromajo_cosim_dpi.cc,)
+                    --exe corev_apu/tb/ariane_tb.cpp corev_apu/tb/dpi/SimDTM.cc corev_apu/tb/dpi/SimJTAG.cc      \
+                    corev_apu/tb/dpi/remote_bitbang.cc corev_apu/tb/dpi/msim_helper.cc $(if $(DROMAJO), corev_apu/tb/dpi/dromajo_cosim_dpi.cc,)
 
 dromajo:
 	cd ./tb/dromajo/src && make

--- a/README.md
+++ b/README.md
@@ -4,16 +4,22 @@
 
 # EXPERIMENTAL EXPERIMENTAL EXPERIMENTAL
 
-This is an experimental fork/branch of the CVA6 repo used to prototype a new directory/file structurei for this repository.
+This is an experimental fork/branch of the CVA6 repo used to prototype a new directory/file structure for this repository.
 Use at your own risk.
 
-### New Directory Structure:
+## New Directory Structure:
+This branch features a new directory structure that cleanly separates the CVA6 RISC-V CPU core from its [FPGA Emulation](#fpga-emulation) platform known as COREV-APU.
+Files, directories and submodules under `cva6` are for the core _only_ and should not have any dependencies on the APU.
+Files, directories and submodules under `corev_apu` are for the FPGA Emulation platform.
+The CVA6 core can be compiled stand-alone, but obviously the APU is dependent on the core.
+
 #### ci
 Scriptware for CI.
 Unchanged.
 
 #### common
 Source code used by both the CVA6 Core and the COREV APU.
+Subdirectories from here are `local` for common files that are hosted in this repo and `submodules` that are hosted in other repos.
 
 #### core
 Source code for the CVA6 Core only.
@@ -31,19 +37,6 @@ Unchanged.
 #### scripts
 General scriptware.
 Unchanged.
-
-### To try the new structure
-Checkout the repository and initialize all submodules:
-```
-$ git clone -b reorg3_proto https://github.com/MikeOpenHWGroup/cva6.git reorg3_proto
-$ cd reorg3_proto
-$ git submodule update --init --recursive
-$ cd core/example_tb
-$ make
-```
-To run the example_tb you will need Verilator (known to work with V4.108).
-Support for Cadence Xcelium (xrun) and Metrics DSIM is there also.
-
 
 # CVA6 RISC-V CPU
 
@@ -104,15 +97,17 @@ Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 
 ## Getting Started
 
-Go and get the [RISC-V tools](https://github.com/riscv/riscv-tools). Make sure that your `RISCV` environment variable points to your RISC-V installation (see the RISC-V tools and related projects for further information).
-
-Checkout the repository and initialize all submodules
+Go and get the [RISC-V tools](https://github.com/riscv/riscv-tools).
+Make sure that your `RISCV` environment variable points to your RISC-V installation (see the RISC-V tools and related projects for further information).
+<br><br>
+Checkout the repository and initialize all submodules:
 ```
-$ git clone https://github.com/openhwgroup/cva6.git
+$ git clone -b cva6_reorg https://github.com/MikeOpenHWGroup/cva6.git cva6_reorg
+$ cd cva6_reorg
 $ git submodule update --init --recursive
 ```
 
-Build the Verilator model of CVA6 by using the Makefile:
+Build the Verilator model of the COREV-APU by using the Makefile:
 ```
 $ make verilate
 ```
@@ -122,19 +117,32 @@ To build the verilator model with support for vcd files run
 $ make verilate DEBUG=1
 ```
 
-This will create a C++ model of the core including a SystemVerilog wrapper and link it against a C++ testbench (in the `tb` subfolder). The binary can be found in the `work-ver` and accepts a RISC-V ELF binary as an argument, e.g.:
+This will create a C++ model of the core including a SystemVerilog wrapper and link it against a C++ testbench (in the `tb` subfolder).
+The binary can be found in the `work-ver` and accepts a RISC-V ELF binary as an argument, e.g.:
 
 ```
 $ work-ver/Variane_testharness rv64um-v-divuw
 ```
 
-The Verilator testbench makes use of the `riscv-fesvr`. This means that you can use the `riscv-tests` repository as well as `riscv-pk` out-of-the-box. As a general rule of thumb the Verilator model will behave like Spike (exception for being orders of magnitudes slower).
+The Verilator testbench makes use of the `riscv-fesvr`.
+This means that you can use the `riscv-tests` repository as well as `riscv-pk` out-of-the-box.
+As a general rule of thumb the Verilator model will behave like Spike (exception for being orders of magnitudes slower).
 
-Both, the Verilator model as well as the Questa simulation will produce trace logs. The Verilator trace is more basic but you can feed the log to `spike-dasm` to resolve instructions to mnemonics. Unfortunately value inspection is currently not possible for the Verilator trace file.
+Both the Verilator model as well as the Questa simulation will produce trace logs.
+The Verilator trace is more basic but you can feed the log to `spike-dasm` to resolve instructions to mnemonics.
+Unfortunately value inspection is currently not possible for the Verilator trace file.
 
 ```
 $ spike-dasm < trace_hart_00.dasm > logfile.txt
 ```
+
+To build, compile and run the CVA6 core-only in its example testbench using Verilator (known to work with V4.108):
+```
+$ cd core/example_tb
+$ make veri-run
+```
+`make help` will print all supported targets.
+
 
 ### Running User-Space Applications
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is an experimental fork/branch of the CVA6 repo used to prototype a new dir
 Use at your own risk.
 
 ## New Directory Structure:
-This branch features a new directory structure that cleanly separates the CVA6 RISC-V CPU core from its [FPGA Emulation](#fpga-emulation) platform known as COREV-APU.
+This branch features a new directory structure that cleanly separates the [CVA6 RISC-V CPU](#cva6-risc-v-cpu) core from its [FPGA Emulation](#fpga-emulation) platform known as COREV-APU.
 Files, directories and submodules under `cva6` are for the core _only_ and should not have any dependencies on the APU.
 Files, directories and submodules under `corev_apu` are for the FPGA Emulation platform.
 The CVA6 core can be compiled stand-alone, but obviously the APU is dependent on the core.
@@ -27,7 +27,6 @@ There should be no sources in this directory used to build anything other than t
 
 #### corev_apu
 Source code for the CVA6 APU, exclusive of the CVA6 core.
-An illustration of the COREV APU is below (see FPGA Emulation, below).
 There should be no sources in this directory used to build the CVA6 core.
 
 #### docs
@@ -139,7 +138,7 @@ $ spike-dasm < trace_hart_00.dasm > logfile.txt
 To build, compile and run the CVA6 core-only in its example testbench using Verilator (known to work with V4.108):
 ```
 $ cd core/example_tb
-$ make veri-run
+$ make veri_run
 ```
 `make help` will print all supported targets.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is an experimental fork/branch of the CVA6 repo used to prototype a new dir
 Use at your own risk.
 
 ## New Directory Structure:
-This branch features a new directory structure that cleanly separates the [CVA6 RISC-V CPU](#cva6-risc-v-cpu) core from its [FPGA Emulation](#fpga-emulation) platform known as COREV-APU.
+This branch features a new directory structure that cleanly separates the [CVA6 RISC-V CPU](#cva6-risc-v-cpu) core from its [FPGA Emulation](#corev-apu-fpga-emulation) platform known as COREV-APU.
 Files, directories and submodules under `cva6` are for the core _only_ and should not have any dependencies on the APU.
 Files, directories and submodules under `corev_apu` are for the FPGA Emulation platform.
 The CVA6 core can be compiled stand-alone, but obviously the APU is dependent on the core.
@@ -101,7 +101,7 @@ Make sure that your `RISCV` environment variable points to your RISC-V installat
 <br><br>
 Checkout the repository and initialize all submodules:
 ```
-$ git clone -b cva6_reorg https://github.com/MikeOpenHWGroup/cva6.git cva6_reorg
+$ git clone -b cva6_reorg https://github.com/openhwgroup/cva6.git cva6_reorg
 $ cd cva6_reorg
 $ git submodule update --init --recursive
 ```
@@ -180,11 +180,11 @@ $ make sim elf-bin=$RISCV/riscv64-unknown-elf/bin/pk target-options=hello.elf  b
 
 > Be patient! RTL simulation is way slower than Spike. If you think that you ran into problems you can inspect the trace files.
 
-## FPGA Emulation
+## COREV-APU FPGA Emulation
 
 We currently only provide support for the [Genesys 2 board](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual). We provide pre-build bitstream and memory configuration files for the Genesys 2 [here](https://github.com/openhwgroup/cva6/releases).
 
-Tested on Vivado 2018.2. The FPGA SoC currently contains the following peripherals:
+Tested on Vivado 2018.2. The FPGA currently contains the following peripherals:
 
 - DDR3 memory controller
 - SPI controller to conncet to an SDCard


### PR DESCRIPTION
This PR updates the Makefile so that the `make verilate` target compiles the apu and the core.