### PR TITLE
icache: Reset FSM to FLUSH

### DIFF
--- a/src/cache_subsystem/cva6_icache.sv
+++ b/src/cache_subsystem/cva6_icache.sv
@@ -457,7 +457,7 @@ end else begin : gen_piton_offset
       cmp_en_q      <= '0;
       cache_en_q    <= '0;
       flush_q       <= '0;
-      state_q       <= IDLE;
+      state_q       <= FLUSH;
       cl_offset_q   <= '0;
       repl_way_oh_q <= '0;
       inv_q         <= '0;


### PR DESCRIPTION
@suehtamacv encountered this unexpected behavior. The current implementation resets the icache FSM to `IDLE`, where the icache checks if it was just enabled (rising edge of `en_i`), and flushes (initialises) itself if so. This assumes that `en_i` is deasserted during reset, which is not necessarily the case (e.g. hardwired `en_i`), possibly leaving the cache uninitialised. Hence, reset to `FLUSH` directly.