### PR TITLE
Make the cache size and assoc configurable

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -186,6 +186,7 @@ sources:
     - src/common_cells/src/rr_arb_tree.sv
     - src/common_cells/src/deprecated/rrarbiter.sv
     - src/common_cells/src/stream_delay.sv
+    - src/common_cells/src/lfsr.sv
     - src/common_cells/src/lfsr_8bit.sv
     - src/common_cells/src/lfsr_16bit.sv
     - src/common_cells/src/counter.sv

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
         src/common_cells/src/rr_arb_tree.sv                                    \
         src/common_cells/src/deprecated/rrarbiter.sv                           \
         src/common_cells/src/stream_delay.sv                                   \
+        src/common_cells/src/lfsr.sv                                           \
         src/common_cells/src/lfsr_8bit.sv                                      \
         src/common_cells/src/lfsr_16bit.sv                                     \
         src/common_cells/src/delta_counter.sv                                  \

--- a/include/ariane_pkg.sv
+++ b/include/ariane_pkg.sv
@@ -419,13 +419,13 @@ package ariane_pkg;
 `else
     // I$
 		localparam int unsigned CONFIG_L1I_SIZE    = 16*1024;
-    localparam int unsigned ICACHE_SET_ASSOC   = 4;
+    localparam int unsigned ICACHE_SET_ASSOC   = 4; // Must be between 4 to 64
     localparam int unsigned ICACHE_INDEX_WIDTH = $clog2(CONFIG_L1I_SIZE / ICACHE_SET_ASSOC);  // in bit, contains also offset width
     localparam int unsigned ICACHE_TAG_WIDTH   = riscv::PLEN-ICACHE_INDEX_WIDTH;  // in bit
     localparam int unsigned ICACHE_LINE_WIDTH  = 128; // in bit
     // D$
 		localparam int unsigned CONFIG_L1D_SIZE    = 32*1024;
-	  localparam int unsigned DCACHE_SET_ASSOC   = 8;
+	  localparam int unsigned DCACHE_SET_ASSOC   = 8; // Must be between 4 to 64
     localparam int unsigned DCACHE_INDEX_WIDTH = $clog2(CONFIG_L1D_SIZE / DCACHE_SET_ASSOC);  // in bit, contains also offset width
     localparam int unsigned DCACHE_TAG_WIDTH   = riscv::PLEN-DCACHE_INDEX_WIDTH;  // in bit
     localparam int unsigned DCACHE_LINE_WIDTH  = 128; // in bit

--- a/include/wt_cache_pkg.sv
+++ b/include/wt_cache_pkg.sv
@@ -114,14 +114,14 @@ package wt_cache_pkg;
     ICACHE_IFILL_ACK
   } icache_in_t;
 
+  // icache interface
   typedef struct packed {
     logic                                            vld;         // invalidate only affected way
     logic                                            all;         // invalidate all ways
     logic [ariane_pkg::ICACHE_INDEX_WIDTH-1:0]       idx;         // physical address to invalidate
     logic [L15_WAY_WIDTH-1:0]                        way;         // way to invalidate
-  } cache_inval_t;
+  } icache_inval_t;
 
-  // icache interface
   typedef struct packed {
     logic [$clog2(ariane_pkg::ICACHE_SET_ASSOC)-1:0] way;         // way to replace
     logic [riscv::PLEN-1:0]                          paddr;       // physical address
@@ -132,11 +132,18 @@ package wt_cache_pkg;
   typedef struct packed {
     icache_in_t                                      rtype;       // see definitions above
     logic [ariane_pkg::ICACHE_LINE_WIDTH-1:0]        data;        // full cache line width
-    cache_inval_t                                    inv;         // invalidation vector
+    icache_inval_t                                   inv;         // invalidation vector
     logic [CACHE_ID_WIDTH-1:0]                       tid;         // threadi id (used as transaction id in Ariane)
   } icache_rtrn_t;
 
   // dcache interface
+  typedef struct packed {
+    logic                                            vld;         // invalidate only affected way
+    logic                                            all;         // invalidate all ways
+    logic [ariane_pkg::DCACHE_INDEX_WIDTH-1:0]       idx;         // physical address to invalidate
+    logic [L15_WAY_WIDTH-1:0]                        way;         // way to invalidate
+  } dcache_inval_t;
+
   typedef struct packed {
     dcache_out_t                                     rtype;       // see definitions above
     logic [2:0]                                      size;        // transaction size: 000=Byte 001=2Byte; 010=4Byte; 011=8Byte; 111=Cache line (16/32Byte)
@@ -151,7 +158,7 @@ package wt_cache_pkg;
   typedef struct packed {
     dcache_in_t                                      rtype;       // see definitions above
     logic [ariane_pkg::DCACHE_LINE_WIDTH-1:0]        data;        // full cache line width
-    cache_inval_t                                    inv;         // invalidation vector
+    dcache_inval_t                                   inv;         // invalidation vector
     logic [CACHE_ID_WIDTH-1:0]                       tid;         // threadi id (used as transaction id in Ariane)
   } dcache_rtrn_t;
 

--- a/src/cache_subsystem/cva6_icache.sv
+++ b/src/cache_subsystem/cva6_icache.sv
@@ -369,14 +369,14 @@ end else begin : gen_piton_offset
   );
 
   // generate random cacheline index
-  lfsr_8bit #(
-    .WIDTH (ICACHE_SET_ASSOC)
+  lfsr #(
+    .LfsrWidth  ( ariane_pkg::ICACHE_SET_ASSOC        ),
+    .OutWidth   ( $clog2(ariane_pkg::ICACHE_SET_ASSOC))
   ) i_lfsr (
     .clk_i          ( clk_i       ),
     .rst_ni         ( rst_ni      ),
     .en_i           ( update_lfsr ),
-    .refill_way_oh  (             ),
-    .refill_way_bin ( rnd_way     )
+    .out_o          ( rnd_way     )
   );
 
 

--- a/src/cache_subsystem/wt_axi_adapter.sv
+++ b/src/cache_subsystem/wt_axi_adapter.sv
@@ -356,7 +356,7 @@ module wt_axi_adapter import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic [ICACHE_LINE_WIDTH/64-1:0][63:0] icache_rd_shift_d, icache_rd_shift_q;
   logic [DCACHE_LINE_WIDTH/64-1:0][63:0] dcache_rd_shift_d, dcache_rd_shift_q;
   wt_cache_pkg::dcache_in_t dcache_rtrn_type_d, dcache_rtrn_type_q;
-  wt_cache_pkg::cache_inval_t dcache_rtrn_inv_d, dcache_rtrn_inv_q;
+  wt_cache_pkg::dcache_inval_t dcache_rtrn_inv_d, dcache_rtrn_inv_q;
   logic dcache_sc_rtrn, axi_rd_last;
 
   always_comb begin : p_axi_rtrn_shift

--- a/src/cache_subsystem/wt_dcache_missunit.sv
+++ b/src/cache_subsystem/wt_dcache_missunit.sv
@@ -150,14 +150,14 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   );
 
   // generate random cacheline index
-  lfsr_8bit #(
-    .WIDTH ( ariane_pkg::DCACHE_SET_ASSOC )
+  lfsr #(
+    .LfsrWidth  ( ariane_pkg::DCACHE_SET_ASSOC        ),
+    .OutWidth   ( $clog2(ariane_pkg::DCACHE_SET_ASSOC))
   ) i_lfsr_inv (
     .clk_i          ( clk_i       ),
     .rst_ni         ( rst_ni      ),
     .en_i           ( update_lfsr ),
-    .refill_way_oh  (             ),
-    .refill_way_bin ( rnd_way     )
+    .out_o          ( rnd_way     )
   );
 
   assign repl_way               = (all_ways_valid) ? rnd_way : inv_way;


### PR DESCRIPTION
The current replacement policy prevented to have a configurable cache size and associativity. Instead, I replaced it with the Galois LFSR present in common_cells.