### PR TITLE
frontend: Clear 'speculative' flag on replay

### DIFF
--- a/src/frontend/frontend.sv
+++ b/src/frontend/frontend.sv
@@ -253,8 +253,8 @@ module frontend import ariane_pkg::*; #(
     btb_update_t btb_update;
 
     // assert on branch, deassert when resolved
-    logic speculative_q,speculative_d;
-    assign speculative_d = (speculative_q && !resolved_branch_i.valid || |is_branch || |is_return || |is_jalr) && !flush_i;
+    logic speculative_q, speculative_d;
+    assign speculative_d = ((speculative_q && !resolved_branch_i.valid) || |is_branch || |is_return || |is_jalr) && !flush_i && !replay;
     assign icache_dreq_o.spec = speculative_d;
 
     assign bht_update.valid = resolved_branch_i.valid


### PR DESCRIPTION
Prevent deadlock when replaying speculative instruction from nonidempotent memory region.

Consider the following scenario while executing from nonidempotent memory:
1. A branch instruction is fetched => `speculative_d = 1'b1`
2. The instruction queue is full, `replay` is asserted
3. Once the instruction queue is `ready` again, the frontend sends a request to the icache to refetch the branch instruction
4. The icache blocks as `dreq.spec == 1'b1` (and we do not fetch speculatively from nonidempotent memory)
5. Deadlock

Hence, the `speculative` register needs to be rolled back if the corresponding speculative instruction is not accepted by the instruction queue. Since the speculative instruction should always be the most recently fetched instruction (the icache stalls until the speculative instruction is resolved), clearing `speculative` on a `replay` _should_ be accurate.

(Alternatively we could set `speculative` only if the instruction queue is ready, but I think this might be less accurate as the underlying assumption "`!instr_queue_ready` => `instr` will not enter the instruction queue" might not hold.)