### PR TITLE
PMP improvement

### DIFF
--- a/src/csr_regfile.sv
+++ b/src/csr_regfile.sv
@@ -1154,7 +1154,7 @@ module csr_regfile import ariane_pkg::*; #(
             for(int i = 0; i < 16; i++) begin
                 if(i < NrPMPEntries) begin
                     // We only support >=8-byte granularity, NA4 is disabled
-                    if(pmpcfg_q[i].addr_mode != riscv::NA4) 
+                    if(pmpcfg_d[i].addr_mode != riscv::NA4) 
                         pmpcfg_q[i] <= pmpcfg_d[i];
                     else
                         pmpcfg_q[i] <= pmpcfg_q[i];


### PR DESCRIPTION
- PMPCFG.A=NA4 not allowed
- access allowed in S/U mode when no PMP is configured (from the specs: if no PMP entry matches an S-mode or U-mode access, but at least one PMP entry is implemented, the access fails)

Note: the new signal between the commit_stage and the csr_registers is necessary to remove the combinatorial loop
update_access_exception → csr_regfile_i/csr_exception_o → csr_exception_csr_commit → commit_stage_i/csr_exception_i → commit_stage_i/exception_o → commit_stage_i/csr_wdata_o[4] → csr_wdata_commit_csr[4] → csr_regfile_i/csr_wdata_i[4] → update_access_exception

