### PR TITLE
mmu: Prevent elaboration of incompatible MMU version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,6 @@ src :=  $(filter-out core/ariane_regfile.sv, $(wildcard core/*.sv))             
         $(filter-out core/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv,         \
         $(wildcard core/fpu/src/fpu_div_sqrt_mvp/hdl/*.sv))                          \
         $(wildcard core/frontend/*.sv)                                               \
-        $(wildcard core/mmu_sv32/*.sv)                                               \
-        $(wildcard core/mmu_sv39/*.sv)                                               \
         $(filter-out core/cache_subsystem/std_no_dcache.sv,                          \
         $(wildcard core/cache_subsystem/*.sv))                                       \
         $(wildcard corev_apu/bootrom/*.sv)                                           \
@@ -227,6 +225,13 @@ src :=  $(filter-out core/ariane_regfile.sv, $(wildcard core/*.sv))             
         corev_apu/tb/common/uart.sv                                                  \
         corev_apu/tb/common/SimDTM.sv                                                \
         corev_apu/tb/common/SimJTAG.sv
+
+# SV32 MMU for CV32, SV39 MMU for CV64
+ifeq ($(findstring 32, $(variant)),32)
+    src += $(wildcard core/mmu_sv32/*.sv)
+else
+    src += $(wildcard core/mmu_sv39/*.sv)
+endif
 
 src := $(addprefix $(root-dir), $(src))
 

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -49,7 +49,7 @@ package riscv;
     localparam VPN2       = (VLEN-31 < 8) ? VLEN-31 : 8;
 
     localparam  FPU_EN     = 1'b1; // This bit is to select FPU in the design, FPU_EN = 1'b0 disables FPU in the design
-  
+
     typedef logic [XLEN-1:0] xlen_t;
 
     // --------------------


### PR DESCRIPTION
Fix the VCS flow for 64-bit CVA6 by guarding incompatible MMU implementations. For instance, `mmu_sv32` assumes `PLEN` > `VLEN`, which is not the case for RV64.

Example:
https://github.com/openhwgroup/cva6/blob/720b59e2ca6e002b9b3a2c47ed4ad85b847978a3/src/mmu_sv32/cva6_mmu_sv32.sv#L212
causes for 64-bit CVA6:
```
(vlog-8607) Negative replication multiplier (-8)
```