### PR TITLE
Fixes some width in wt_dcache.

### DIFF
--- a/core/cache_subsystem/wt_dcache_ctrl.sv
+++ b/core/cache_subsystem/wt_dcache_ctrl.sv
@@ -82,7 +82,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign miss_size_o           = (miss_nc_o) ? data_size_q : 3'b111;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign miss_nc_o = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{{64-DCACHE_TAG_WIDTH}{1'b0}}, address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
+  assign miss_nc_o = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH}{1'b0}}, address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
 
 
   assign miss_we_o    = '0;

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -91,7 +91,7 @@ module wt_dcache_mem import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic [DCACHE_WBUF_DEPTH-1:0]                                 wbuffer_hit_oh;
   logic [7:0]                                                   wbuffer_be;
   logic [63:0]                                                  wbuffer_rdata, rdata;
-  logic [63:0]                                                  wbuffer_cmp_addr;
+  logic [riscv::PLEN-1:0]                                       wbuffer_cmp_addr;
 
   logic                                                         cmp_en_d, cmp_en_q;
   logic                                                         rd_acked;

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -137,10 +137,10 @@ module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic is_nc_miss;
   logic is_ni;
   assign miss_tag = miss_paddr_o[ariane_pkg::DCACHE_INDEX_WIDTH+:ariane_pkg::DCACHE_TAG_WIDTH];
-  assign is_nc_miss = !ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{64-DCACHE_TAG_WIDTH{1'b0}}, miss_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
+  assign is_nc_miss = !ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, miss_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
   assign miss_nc_o = !cache_en_i || is_nc_miss; 
   // Non-idempotent if request goes to NI region
-  assign is_ni = ariane_pkg::is_inside_nonidempotent_regions(ArianeCfg, {{64-DCACHE_TAG_WIDTH{1'b0}}, req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
+  assign is_ni = ariane_pkg::is_inside_nonidempotent_regions(ArianeCfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
 
   assign miss_we_o       = 1'b1;
   assign miss_vld_bits_o = '0;

--- a/core/include/wt_cache_pkg.sv
+++ b/core/include/wt_cache_pkg.sv
@@ -75,7 +75,7 @@ package wt_cache_pkg;
 
 
   typedef struct packed {
-    logic [ariane_pkg::DCACHE_INDEX_WIDTH+ariane_pkg::DCACHE_TAG_WIDTH-1:0] wtag;
+    logic [ariane_pkg::DCACHE_TAG_WIDTH+(ariane_pkg::DCACHE_INDEX_WIDTH-3)-1:0] wtag;
     logic [63:0]                                                            data;
     logic [7:0]                                                             dirty;   // byte is dirty
     logic [7:0]                                                             valid;   // byte is valid


### PR DESCRIPTION
width of wtag in wbuffer_t should be PLEN-3, or DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-3.

width of wbuffer_cmp_addr should be PLEN.

width of the second param of is_inside_*_regions should be 64bits.

'cause of the reorgnizaiton of cva6, I can't fix conflicts of last pr #728, so I open a new pr.