### PR TITLE
Add detailed simulation flow installation info & helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Table of Contents
 
    * [CVA6 RISC-V CPU](#cva6-risc-v-cpu)
    * [Table of Contents](#table-of-contents)
+      * [Installation](#installation) 
+         * [Verilator Simulation Flow](#verilator-simulation-flow) 
       * [Getting Started](#getting-started)
          * [Running User-Space Applications](#running-user-space-applications)
       * [FPGA Emulation](#fpga-emulation)
@@ -77,12 +79,17 @@ Table of Contents
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 
-## Tool Requirements
+## Installation 
 
-* `verilator >= 4.002`
+### Verilator Simulation Flow
 
-> There is currently a known issue with version 4.106 and 4.108. 4.106 does not
-> compile and 4.108 hangs after a couple of cycles simulation time.
+1. Setup install directory `RISCV` environment variable i.e. `export RISCV=/YOUR/INSTALLATION/DIRECTORY`
+2. Run `./ci/setup.sh` to install all required tools (i.e. verilator, device-tree-compiler, riscv64-unknown-elf-*, ..)
+3. Build the Verilator model `make verilate` and run simulations e.g. `work-ver/Variane_testharness rv64um-v-divuw`. More information can be found in [Getting Started](#getting-started)
+
+You can install verilator from source using `./ci/install_verilator.sh` or by manually installing `verilator >= 4.002`
+Note: There is currently a known issue with version 4.106 and 4.108. 4.106 does not compile and 4.108 hangs after a couple of cycles simulation time.)
+
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ Table of Contents
 
    * [CVA6 RISC-V CPU](#cva6-risc-v-cpu)
    * [Table of Contents](#table-of-contents)
-      * [Installation](#installation) 
-         * [Verilator Simulation Flow](#verilator-simulation-flow) 
       * [Getting Started](#getting-started)
-         * [Running User-Space Applications](#running-user-space-applications)
+        * [Checkout Repo](#checkout-repo)
+        * [Install Verilator Simulation Flow](#install-verilator-simulation-flow)
+        * [Build Model and Run Simulations](#build-model-and-run-simulations)
+        * [Running User-Space Applications](#running-user-space-applications)
       * [FPGA Emulation](#fpga-emulation)
          * [Programming the Memory Configuration File](#programming-the-memory-configuration-file)
          * [Preparing the SD Card](#preparing-the-sd-card)
@@ -93,17 +94,27 @@ Note: There is currently a known issue with version 4.106 and 4.108. 4.106 does 
 
 ## Getting Started
 
-Go and get the [RISC-V tools](https://github.com/riscv/riscv-tools).
-Make sure that your `RISCV` environment variable points to your RISC-V installation (see the RISC-V tools and related projects for further information).
-<br><br>
-Checkout the repository and initialize all submodules:
+### Checkout Repo
+
+Checkout the repository and initialize all submodules
 ```
-$ git clone -b cva6_reorg https://github.com/openhwgroup/cva6.git cva6_reorg
-$ cd cva6_reorg
+$ git clone https://github.com/openhwgroup/cva6.git
 $ git submodule update --init --recursive
 ```
 
-Build the Verilator model of the COREV-APU by using the Makefile:
+### Install Verilator Simulation Flow
+
+1. Setup install directory `RISCV` environment variable i.e. `export RISCV=/YOUR/TOOLCHAIN/INSTALLATION/DIRECTORY`
+2. Run `./ci/setup.sh` to install all required tools (i.e. verilator, device-tree-compiler, riscv64-unknown-elf-*, ..)
+
+You can install verilator from source using `./ci/install_verilator.sh` or by manually installing `verilator >= 4.002`
+Note: There is currently a known issue with version 4.106 and 4.108. 4.106 does not compile and 4.108 hangs after a 
+couple of cycles simulation time.)
+
+
+### Build Model and Run Simulations
+
+Build the Verilator model of COREV-APU by using the Makefile:
 ```
 $ make verilate
 ```

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Note: There is currently a known issue with version 4.106 and 4.108. 4.106 does 
 
 Checkout the repository and initialize all submodules
 ```
-$ git clone https://github.com/openhwgroup/cva6.git
-$ git submodule update --init --recursive
+git clone https://github.com/openhwgroup/cva6.git
+git submodule update --init --recursive
 ```
 
 ### Install Verilator Simulation Flow
@@ -116,19 +116,19 @@ couple of cycles simulation time.)
 
 Build the Verilator model of COREV-APU by using the Makefile:
 ```
-$ make verilate
+make verilate
 ```
 
 To build the verilator model with support for vcd files run
 ```
-$ make verilate DEBUG=1
+make verilate DEBUG=1
 ```
 
 This will create a C++ model of the core including a SystemVerilog wrapper and link it against a C++ testbench (in the `tb` subfolder).
 The binary can be found in the `work-ver` and accepts a RISC-V ELF binary as an argument, e.g.:
 
 ```
-$ work-ver/Variane_testharness rv64um-v-divuw
+work-ver/Variane_testharness rv64um-v-divuw
 ```
 
 The Verilator testbench makes use of the `riscv-fesvr`.
@@ -140,7 +140,7 @@ The Verilator trace is more basic but you can feed the log to `spike-dasm` to re
 Unfortunately value inspection is currently not possible for the Verilator trace file.
 
 ```
-$ spike-dasm < trace_hart_00.dasm > logfile.txt
+spike-dasm < trace_hart_00.dasm > logfile.txt
 ```
 
 To build, compile and run the CVA6 core-only in its example testbench using Verilator (known to work with V4.108):
@@ -156,34 +156,34 @@ $ make veri_run
 It is possible to run user-space binaries on CVA6 with `riscv-pk` ([link](https://github.com/riscv/riscv-pk)).
 
 ```
-$ mkdir build
-$ cd build
-$ ../configure --prefix=$RISCV --host=riscv64-unknown-elf
-$ make
-$ make install
+mkdir build
+cd build
+../configure --prefix=$RISCV --host=riscv64-unknown-elf
+make
+make install
 ```
 
 Then to run a RISC-V ELF using the Verilator model do:
 
 ```
-$ echo '
+echo '
 #include <stdio.h>
 
 int main(int argc, char const *argv[]) {
     printf("Hello CVA6!\\n");
     return 0;
 }' > hello.c
-$ riscv64-unknown-elf-gcc hello.c -o hello.elf
+riscv64-unknown-elf-gcc hello.c -o hello.elf
 ```
 
 ```
-$ make verilate
-$ work-ver/Variane_testharness $RISCV/riscv64-unknown-elf/bin/pk hello.elf
+make verilate
+work-ver/Variane_testharness $RISCV/riscv64-unknown-elf/bin/pk hello.elf
 ```
 
 If you want to use QuestaSim to run it you can use the following command:
 ```
-$ make sim elf-bin=$RISCV/riscv64-unknown-elf/bin/pk target-options=hello.elf  batch-mode=1
+make sim elf-bin=$RISCV/riscv64-unknown-elf/bin/pk target-options=hello.elf  batch-mode=1
 ```
 
 > Be patient! RTL simulation is way slower than Spike. If you think that you ran into problems you can inspect the trace files.
@@ -220,7 +220,7 @@ The first stage bootloader will boot from SD Card by default. Get yourself a sui
 
 Connect a terminal to the USB serial device opened by the FTDI chip e.g.:
 ```
-$ screen /dev/ttyUSB0 115200
+screen /dev/ttyUSB0 115200
 ```
 
 Default baudrate set by the bootlaoder and Linux is `115200`.
@@ -232,7 +232,7 @@ After you've inserted the SD Card and programmed the FPGA you can connect to the
 To generate the FPGA bitstream (and memory configuration) yourself for the Genesys II board run:
 
 ```
-$ make fpga
+make fpga
 ```
 
 This will produce a bitstream file and memory configuration file (in `fpga/work-fpga`) which you can permanently flash by running the above commands.
@@ -257,7 +257,8 @@ Bus 005 Device 019: ID 0403:6010 Future Technology Devices International, Ltd FT
 If this is the case, you can go on and start openocd with the `fpga/ariane.cfg` configuration file:
 
 ```
-$ openocd -f fpga/ariane.cfg
+openocd -f fpga/ariane.cfg
+
 Open On-Chip Debugger 0.10.0+dev-00195-g933cb87 (2018-09-14-19:32)
 Licensed under GNU GPL v2
 For bug reports, read
@@ -279,7 +280,8 @@ Info : accepting 'gdb' connection on tcp/3333
 Then you will be able to either connect through `telnet` or with `gdb`:
 
 ```
-$ riscv64-unknown-elf-gdb /path/to/elf
+riscv64-unknown-elf-gdb /path/to/elf
+
 (gdb) target remote localhost:3333
 (gdb) load
 Loading section .text, size 0x6508 lma 0x80000000
@@ -324,7 +326,7 @@ The core has been developed with a full licensed version of QuestaSim. If you ha
 
 To specify the test to run use (e.g.: you want to run `rv64ui-p-sraw` inside the `tmp/risc-tests/build/isa` folder:
 ```
-$ make sim elf-bin=path/to/rv64ui-p-sraw
+make sim elf-bin=path/to/rv64ui-p-sraw
 ```
 
 If you call `sim` with `batch-mode=1` it will run without the GUI. QuestaSim uses `riscv-fesvr` for communication as well.
@@ -338,17 +340,17 @@ If you would like to run the CI test suites locally on your machine, follow any 
 Once everything is set up and installed, you can run the tests suites as follows (using Verilator):
 
 ```
-$ make verilate
-$ make run-asm-tests-verilator
-$ make run-benchmarks-verilator
+make verilate
+make run-asm-tests-verilator
+make run-benchmarks-verilator
 ```
 
 In order to run randomized Torture tests, you first have to generate the randomized program prior to running the simulation:
 
 ```
-$ ./ci/get-torture.sh
-$ make torture-gen
-$ make torture-rtest-verilator
+./ci/get-torture.sh
+make torture-gen
+make torture-rtest-verilator
 ```
 This runs the randomized program on Spike and on the RTL target, and checks whether the two signatures match. The random instruction mix can be configured in the `./tmp/riscv-torture/config/default.config` file.
 
@@ -363,12 +365,12 @@ This will dump a file called `trace_hart_*_*_commit.log`.
 This can be helpful for debugging long traces (e.g.: torture traces). To compile Spike with the commit log feature do:
 
 ```
-$ apt-get install device-tree-compiler
-$ mkdir build
-$ cd build
-$ ../configure --prefix=$RISCV --with-fesvr=$RISCV --enable-commitlog
-$ make
-$ [sudo] make install
+apt-get install device-tree-compiler
+mkdir build
+cd build
+../configure --prefix=$RISCV --with-fesvr=$RISCV --enable-commitlog
+make
+make install
 ```
 
 ### Memory Preloading
@@ -380,7 +382,7 @@ to a binary which will be preloaded.
 > You will loose all `riscv-fesvr` communcation like sytemcalls and eoc capabilities.
 
 ```
-$ make sim preload=elf
+make sim preload=elf
 ```
 
 <!-- ### Tandem Verification with Spike

--- a/README.md
+++ b/README.md
@@ -8,6 +8,33 @@ It has configurable size, separate TLBs, a hardware PTW and branch-prediction (b
 
 ![](docs/_static/ariane_overview.png)
 
+## New Directory Structure:
+The directory structure has been changed to cleanly separate the [CVA6 RISC-V CPU](#cva6-risc-v-cpu) core from the COREV-APU [FPGA Emulation](#corev-apu-fpga-emulation).
+Files, directories and submodules under `cva6` are for the core _only_ and should not have any dependencies on the APU.
+Files, directories and submodules under `corev_apu` are for the FPGA Emulation platform.
+The CVA6 core can be compiled stand-alone, and obviously the APU is dependent on the core.
+
+#### ci
+Scriptware for CI (unchanged).
+
+#### common
+Source code used by both the CVA6 Core and the COREV APU.
+Subdirectories from here are `local` for common files that are hosted in this repo and `submodules` that are hosted in other repos.
+
+#### core
+Source code for the CVA6 Core only.
+There should be no sources in this directory used to build anything other than the CVA6 core.
+
+#### corev_apu
+Source code for the CVA6 APU, exclusive of the CVA6 core.
+There should be no sources in this directory used to build the CVA6 core.
+
+#### docs
+Documentation (unchanged).
+
+#### scripts
+General scriptware (unchanged).
+
 ## Publication
 
 If you use CVA6 in your academic work you can cite us:
@@ -99,6 +126,14 @@ Both, the Verilator model as well as the Questa simulation will produce trace lo
 spike-dasm < trace_hart_00.dasm > logfile.txt
 ```
 
+To build, compile and run the CVA6 core-only in its example testbench using Verilator (known to work with V4.108):
+```
+$ cd core/example_tb
+$ make veri_run
+```
+`make help` will print all supported targets.
+
+
 ### Running User-Space Applications
 
 It is possible to run user-space binaries on CVA6 with ([RISC-V Proxy Kernel and Boot Loader](https://github.com/riscv/riscv-pk)). 
@@ -137,11 +172,11 @@ make sim elf-bin=$RISCV/riscv64-unknown-elf/bin/pk target-options=hello.elf  bat
 
 > Be patient! RTL simulation is way slower than Spike. If you think that you ran into problems you can inspect the trace files.
 
-## FPGA Emulation
+## COREV-APU FPGA Emulation
 
 We currently only provide support for the [Genesys 2 board](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual). We provide pre-build bitstream and memory configuration files for the Genesys 2 [here](https://github.com/openhwgroup/cva6/releases).
 
-Tested on Vivado 2018.2. The FPGA SoC currently contains the following peripherals:
+Tested on Vivado 2018.2. The FPGA currently contains the following peripherals:
 
 - DDR3 memory controller
 - SPI controller to conncet to an SDCard

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ git submodule update --init --recursive
 1. Setup install directory `RISCV` environment variable i.e. `export RISCV=/YOUR/TOOLCHAIN/INSTALLATION/DIRECTORY`
 2. Run `./ci/setup.sh` to install all required tools (i.e. verilator, device-tree-compiler, riscv64-unknown-elf-*, ..)
 
-You can install verilator from source using `./ci/install_verilator.sh` or by manually installing `verilator >= 4.002`
+You can install verilator from source using `./ci/install-verilator.sh` or by manually installing `verilator >= 4.002`
 Note: There is currently a known issue with version 4.106 and 4.108. 4.106 does not compile and 4.108 hangs after a 
 couple of cycles simulation time.)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ spike-dasm < trace_hart_00.dasm > logfile.txt
 
 ### Running User-Space Applications
 
-It is possible to run user-space binaries on CVA6 with `riscv-pk` ([link](https://github.com/riscv/riscv-pk)).
+It is possible to run user-space binaries on CVA6 with ([RISC-V Proxy Kernel and Boot Loader](https://github.com/riscv/riscv-pk)). 
+RISC-V PK can be installed by running: `./ci/install-riscvpk.sh`
 
 ```
 mkdir build

--- a/ci/install-riscvpk.sh
+++ b/ci/install-riscvpk.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PATH=$RISCV/bin:/bin:$PATH
+
+cd $ROOT/tmp
+
+echo "Installing RISC-V Proxy Kernel and Boot Loader"
+git clone https://github.com/riscv-software-src/riscv-pk.git
+cd riscv-pk
+mkdir -p build
+cd build
+../configure --prefix=$RISCV --host=riscv64-unknown-elf
+make
+make install

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -15,7 +15,10 @@ sudo apt install verilator-4.100 device-tree-compiler
 
 ci/make-tmp.sh
 sudo mkdir -p $RISCV && sudo chmod 777 $RISCV
-wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14.tar.gz
-tar -x -f riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14.tar.gz --strip-components=1 -C $RISCV
+RISCV64_UNKNOWN_ELF_GCC=riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14.tar.gz
+if [ ! -f "$RISCV64_UNKNOWN_ELF_GCC" ]; then
+  wget https://static.dev.sifive.com/dev-tools/$RISCV64_UNKNOWN_ELF_GCC
+fi
+tar -x -f $RISCV64_UNKNOWN_ELF_GCC --strip-components=1 -C $RISCV
 ci/install-fesvr.sh
 ci/build-riscv-tests.sh


### PR DESCRIPTION
This PR aims to simplify the installation process by extending the documentation and by adding additional installation scripts (as discussed with @niwis, @bluewww, @micprog):
- add tutorial on how to use the already existing ci scripts to install the required tools for verilator software simulation
- add RISC-V proxy kernel and bootloader installation script
- removal of $ signs in commands: allows to copy and paste commands from the `README.md` file to the command line