### PR TITLE
ariane_testharness: Fix ariane port list

### DIFF
--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -692,7 +692,9 @@ module ariane_testharness #(
     .irq_i                ( irqs                ),
     .ipi_i                ( ipi                 ),
     .time_irq_i           ( timer_irq           ),
+`ifdef RVFI_TRACE
     .rvfi_o               ( rvfi                ),
+`endif
 // Disable Debug when simulating with Spike
 `ifdef SPIKE_TANDEM
     .debug_req_i          ( 1'b0                ),


### PR DESCRIPTION
Update the port list of ariane's instantiation according to its definition:
https://github.com/openhwgroup/cva6/blob/3ddf797e95923fd11113c8e443046105dfbf8843/core/ariane.sv#L45-L49