### PR TITLE
Fixed performance bug on Calls via BTB.

### DIFF
--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -151,7 +151,7 @@ module frontend import ariane_pkg::*; #(
       // unconditional jumps with known target -> immediately resolved
       assign is_jump[i] = instruction_valid[i] & (rvi_jump[i] | rvc_jump[i]);
       // unconditional jumps with unknown target -> BTB
-      assign is_jalr[i] = instruction_valid[i] & ~is_return[i] & ~is_call[i] & (rvi_jalr[i] | rvc_jalr[i] | rvc_jr[i]);
+      assign is_jalr[i] = instruction_valid[i] & ~is_return[i] & (rvi_jalr[i] | rvc_jalr[i] | rvc_jr[i]);
     end
 
     // taken/not taken


### PR DESCRIPTION
Calls can be either `jal` or `jalr`. In the case of a function call with a `jalr` the signal `is_jalr` would not be set due to being a call as well (line 154 in `frontend.sv`) which impedes the use of the BTB for predicting the address. This causes a misprediction on each function call via `jalr`.

Signed-off-by: Gianmarco Ottavi <gianmarco@openhwgroup.org>