### PR TITLE
Fixed updates of the bht on correct not_taken prediction

### DIFF
--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -68,7 +68,7 @@ module branch_unit (
             if ( ariane_pkg::op_is_branch(fu_data_i.operator) ) begin
                // Set the `cf_type` of the output as `branch`, this will update the BHT.
                resolved_branch_o.cf_type = ariane_pkg::Branch;
-               //If the alu comparison does not agree with BHT prediction set the resolution as mispredicted.
+               // If the ALU comparison does not agree with the BHT prediction set the resolution as mispredicted.
                resolved_branch_o.is_mispredict  = branch_comp_res_i != (branch_predict_i.cf == ariane_pkg::Branch);
             end
             if (fu_data_i.operator == ariane_pkg::JALR


### PR DESCRIPTION
This fix sets the `cf_type` of `resolved_branch_o` as `Branch` when a branch not taken is predicted correctly.
On the current master of CVA6 the following scenario works as following:
* In the frontend when a branch is predicted as not taken sets `cf_type` to `NoCF`;
* When the branch is arrives into the `branch_unit` if the prediction was correct the `cf_type` of `resolved_branch_o` is left as `NoCF`;
* The branch resolution is sent back to the `frontend` and given that `cf_type` is not `Branch` the `valid` of `bht_update` is left to 0 (line 260).

This means that in case of a correct branch prediction where the branch is not taken the entry that refers to that branch will have the saturation counter updated.
This does not seem like an update policy of the predictor (e.g. we only update the predictor on misprediction) because on the scenario where a branch is taken and predicted in a correct way the `cf_type` of `resolved_branch_o` will be set as `Branch` (in the branch unit) which then is forwarded to the frontend where this time the `valid` of `bht_update` is set to 1. This means a correctly predicted branch taken updates the BHT while a correctly predicted branch not taken does not.

The fix consists into setting the value of `cf_type` of `resolved_branch_o` in the `branch_unit` to `Branch` whenever a valid branch arrives. For the signal `is_mispredicted` we have the comparison of the ALU with the prediction from the frontend.

Signed-off-by: Gianmarco Ottavi <gianmarco@openhwgroup.org>