### PR TITLE
Makefile, ariane_testharness.sv, rvfi_tracer.sv: configure SIM_FINISH, InclSimDTM

### DIFF
--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -45,7 +45,7 @@
 // allow modulus.  You can also use a double, if you wish.
 static vluint64_t main_time = 0;
 
-static const char *verilog_plusargs[] = {"jtag_rbb_enable"};
+static const char *verilog_plusargs[] = {"jtag_rbb_enable", "time_out", "debug_disable"};
 
 #ifndef DROMAJO
 extern dtm_t* dtm;

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -102,8 +102,10 @@ module ariane_testharness #(
   // ---------------
   assign init_done = rst_ni;
 
+  logic debug_enable;
   initial begin
     if (!$value$plusargs("jtag_rbb_enable=%b", jtag_enable)) jtag_enable = 'h0;
+    if ($test$plusargs("debug_disable")) debug_enable = 'h0; else debug_enable = 'h1;
     if (riscv::XLEN != 32 & riscv::XLEN != 64) $error("XLEN different from 32 and 64");
   end
 
@@ -187,7 +189,8 @@ module ariane_testharness #(
   int dmi_del_cnt_d, dmi_del_cnt_q;
 
   assign dmi_del_cnt_d  = (dmi_del_cnt_q) ? dmi_del_cnt_q - 1 : 0;
-  assign debug_req_core = (dmi_del_cnt_q) ? 1'b0 : debug_req_core_ungtd;
+  assign debug_req_core = (dmi_del_cnt_q) ? 1'b0 :
+                          (!debug_enable) ? 1'b0 : debug_req_core_ungtd;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_dmi_del_cnt
     if(!rst_ni) begin
@@ -729,7 +732,6 @@ module ariane_testharness #(
   end
 
   rvfi_tracer  #(
-    .SIM_FINISH(2000000),
     .HART_ID(hart_id),
     .DEBUG_START(0),
     .DEBUG_STOP(0)

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -8,7 +8,6 @@
 // Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
 
 module rvfi_tracer #(
-  parameter int unsigned SIM_FINISH  = 1000000,
   parameter logic [7:0] HART_ID      = '0,
   parameter int unsigned DEBUG_START = 0,
   parameter int unsigned NR_COMMIT_PORTS = 2,
@@ -20,7 +19,12 @@ module rvfi_tracer #(
 );
 
   int f;
-  initial f = $fopen($sformatf("trace_rvfi_hart_%h.dasm", HART_ID), "w");
+  int unsigned SIM_FINISH;
+  initial begin
+    f = $fopen($sformatf("trace_rvfi_hart_%h.dasm", HART_ID), "w");
+    if (!$value$plusargs("time_out=%d", SIM_FINISH)) SIM_FINISH = 2000000;
+  end
+
   final $fclose(f);
 
   logic [31:0] cycles;


### PR DESCRIPTION
For instance, thanks to DTM disable, possible to run longer simulations