### PR TITLE
Update bender.yml to match new project structure

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -63,7 +63,7 @@ sources:
     - core/mmu_sv39/mmu.sv
     - core/mmu_sv39/ptw.sv
     # - core/mmu_sv39/mult.sv deleted?
-    - core/mult.sv # above replaced with this?
+    - core/mult.sv # above & cva6_mult_sv32.sv replaced with this?
     - core/mmu_sv32/cva6_mmu_sv32.sv
     - core/mmu_sv32/cva6_ptw_sv32.sv
     # - core/mmu_sv32/cva6_mult_sv32.sv deleted?
@@ -184,6 +184,7 @@ sources:
     - corev_apu/axi/src/axi_delayer.sv
     - corev_apu/axi/src/axi_to_axi_lite.sv
     - corev_apu/fpga-support/rtl/SyncSpRamBeNx64.sv
+    - common/submodules/common_cells/src/sync.sv # missing?
     - common/submodules/common_cells/src/popcount.sv
     - common/submodules/common_cells/src/unread.sv
     - common/submodules/common_cells/src/cdc_2phase.sv


### PR DESCRIPTION
In order to simply the synthesis process, I updated the `Bender.yml` configuration to match the new structure. 

TODO:
 - [x] there are still a few sources with a `?`, which either do not exist anymore or have to be double-checked if they are converted correctly
   1. Is there a better option to switch between the 32bit and 64bit version / `XLEN` in `cva6_config_pkg` i.e. `cv32a6_imac_sv0_config_pkg.sv` vs `cv64a6_imacfd_sv39_config_pkg.sv`? Right now, the 32bit version is simply commented out.
   2. Did you combine `core/mmu_sv39/mult.sv` and `core/mmu_sv32/cva6_mult_sv32.sv` in `core/mult.sv`?
   3. `src/synopsys_sram.sv` does not seem to exist anymore, but at least the synthesis workswithout it
   4.   `common/local/util/instruction_tracer_defines.svh`  does not seem to exist anymore, but at least the synthesis workswithout it
   5. `common/submodules/common_cells/src/sync.sv` is required, but not in the list so far. I added this

 - [x] The Synopsis flow does not run through for me yet. I will keep it `WIP` until this works -> has been fixed with the additional commits: The `tcl` script generated with `bender script synopsys` works for me

@niwis You might want to have a look at the `?`
@micprog Should we change the include files to path/git bender dependencies
