### PR TITLE
update make fpga variant=32 to support linux 32b

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 # Sources
 # Package files -> compile first
 ifeq ($(findstring 32, $(variant)),32)
-    ariane_pkg := core/include/cv32a6_imac_sv0_config_pkg.sv
+    ariane_pkg := core/include/cv32a6_imac_sv32_config_pkg.sv
 else
     ariane_pkg := core/include/cv64a6_imacfd_sv39_config_pkg.sv
 endif

--- a/README.md
+++ b/README.md
@@ -140,13 +140,24 @@ make sim elf-bin=$RISCV/riscv64-unknown-elf/bin/pk target-options=hello.elf  bat
 
 We currently only provide support for the [Genesys 2 board](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual). We provide pre-build bitstream and memory configuration files for the Genesys 2 [here](https://github.com/openhwgroup/cva6/releases).
 
-Tested on Vivado 2018.2. The FPGA currently contains the following peripherals:
+
+Tested on Vivado 2020.1. The FPGA currently contains the following peripherals:
 
 - DDR3 memory controller
 - SPI controller to conncet to an SDCard
 - Ethernet controller
 - JTAG port (see debugging section below)
 - Bootrom containing zero stage bootloader and device tree.
+
+If you want to generate bitstream for the 64 bits variant of CVA6  --> `CV64A6`, you can run the following command:
+```
+make fpga
+```
+Ortherwise, if you want to generate bitstream for the 32 bits variant of CVA6  -->  `CV32A6`, you can run the following command:
+```
+make fpga variant=32
+```
+
 
 ![](docs/_static/fpga_bd.png)
 
@@ -164,7 +175,7 @@ Tested on Vivado 2018.2. The FPGA currently contains the following peripherals:
 
 ## Preparing the SD Card
 
-The first stage bootloader will boot from SD Card by default. Get yourself a suitable SD Card (we use [this](https://www.amazon.com/Kingston-Digital-Mobility-MBLY10G2-32GB/dp/B00519BEQO) one). Either grab a pre-built Linux image from [here](https://github.com/openhwgroup/cva6-sdk/releases) or generate the Linux image yourself following the README in the [ariane-sdk repository](https://github.com/pulp-platform/ariane-sdk). Prepare the SD Card by following the "Booting from SD card" section in the ariane-sdk repository.
+The first stage bootloader will boot from SD Card by default. Get yourself a suitable SD Card (we use [this](https://www.amazon.com/Kingston-Digital-Mobility-MBLY10G2-32GB/dp/B00519BEQO) one). Either grab a pre-built Linux image from [here](https://github.com/openhwgroup/cva6-sdk/releases) or generate the Linux image yourself following the README in the [cva6-sdk repository](https://github.com/openhwgroup/cva6-sdk). Prepare the SD Card by following the "Booting from SD card" section in the ariane-sdk repository.
 
 Connect a terminal to the USB serial device opened by the FTDI chip e.g.:
 ```

--- a/core/Flist.cv32a6_imac_sv32
+++ b/core/Flist.cv32a6_imac_sv32
@@ -31,7 +31,7 @@
 +incdir+${CVA6_REPO_DIR}/common/submodules/common_cells/src/
 +incdir+${CVA6_REPO_DIR}/common/local/util/
 
-${CVA6_REPO_DIR}/core/include/cv32a6_imac_sv0_config_pkg.sv
+${CVA6_REPO_DIR}/core/include/cv32a6_imac_sv32_config_pkg.sv
 // Broken (?) dependencies in packages:
 //    - include/ariane_pkg.sv is dependent on src/riscv-dbg/src/dm_pkg.sv
 //      (ariane should not depend on debug-module)

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -11,5 +11,6 @@
 package cva6_config_pkg;
 
     localparam CVA6ConfigXlen = 32;
+    localparam CVA6ConfigFPU = 1'b0;
 
 endpackage

--- a/core/include/cv64a6_imacfd_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imacfd_sv39_config_pkg.sv
@@ -11,5 +11,6 @@
 package cva6_config_pkg;
 
     localparam CVA6ConfigXlen = 64;
+    localparam CVA6ConfigFPU = 1'b1;
 
 endpackage

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -48,7 +48,7 @@ package riscv;
     localparam SV         = (MODE_SV == ModeSv32) ? 32 : 39;
     localparam VPN2       = (VLEN-31 < 8) ? VLEN-31 : 8;
 
-    localparam  FPU_EN     = 1'b1; // This bit is to select FPU in the design, FPU_EN = 1'b0 disables FPU in the design
+    localparam  FPU_EN     = cva6_config_pkg::CVA6ConfigFPU; // This bit is to select FPU in the design, FPU_EN = 1'b0 disables FPU in the design
 
     typedef logic [XLEN-1:0] xlen_t;
 


### PR DESCRIPTION
Following @nathpranay issue, I updated release 4.3 to ease cv32a6 release.