### PR TITLE
Flist.*: use lfsr.sv instead of lfsr_8bit.sv

### DIFF
--- a/core/Flist.cv32a6_imac_sv0
+++ b/core/Flist.cv32a6_imac_sv0
@@ -53,7 +53,7 @@ ${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
 
 // Common Cells
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/fifo_v3.sv
-${CVA6_REPO_DIR}/common/submodules/common_cells/src/lfsr_8bit.sv
+${CVA6_REPO_DIR}/common/submodules/common_cells/src/lfsr.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/lzc.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/rr_arb_tree.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/shift_reg.sv

--- a/core/Flist.cv64a6_imafdc_sv39
+++ b/core/Flist.cv64a6_imafdc_sv39
@@ -53,7 +53,7 @@ ${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
 
 // Common Cells
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/fifo_v3.sv
-${CVA6_REPO_DIR}/common/submodules/common_cells/src/lfsr_8bit.sv
+${CVA6_REPO_DIR}/common/submodules/common_cells/src/lfsr.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/lzc.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/rr_arb_tree.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/shift_reg.sv


### PR DESCRIPTION
as such replacement was done in cache subsystem
with PR #690 (caf18728375538fe7cf65d8146f5abd5a9c293a9)

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>