### PR TITLE
Mask non-enabled interrupts in WFI control

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -966,9 +966,9 @@ module csr_regfile import ariane_pkg::*; #(
     always_comb begin : wfi_ctrl
         // wait for interrupt register
         wfi_d = wfi_q;
-        // if there is any interrupt pending un-stall the core
+        // if there is any (enabled) interrupt pending un-stall the core
         // also un-stall if we want to enter debug mode
-        if (|mip_q || debug_req_i || irq_i[1]) begin
+        if (|(mip_q & mie_q) || debug_req_i || irq_i[1]) begin
             wfi_d = 1'b0;
         // or alternatively if there is no exception pending and we are not in debug mode wait here
         // for the interrupt


### PR DESCRIPTION
This PR addresses issue #321.

The current revision of the RISC-V Priviliged ISA specification states:
> The operation of WFI must be unaffected by the global interrupt bits in mstatus (MIE and SIE) [...], but should honor the individual interrupt enables (e.g, MTIE) (i.e., implementations should avoid resuming the hart if the interrupt is pending but
not individually enabled).

This behaviour is not mandatory but it is suggested (could we say also intuitive?).
Furthermore it would have positive implications on power.

Suppose the core is stalled on a WFI. Suppose timer interrupts are disabled, as we are expecting a SW interrupt to resume the hart. By specification, a timer interrupt will eventually become pending, and if this condition occurs before the SW interrupt arrives, the hart will resume from the WFI and start looping until the SW interrupt pending bit is set or the timer interrupt bit is cleared. In both cases this results in the core doing more work than with the implementation suggested by the spec.