### PR TITLE
elfloader.cc: change read_section prototype

### DIFF
--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -23,7 +23,7 @@ import uvm_pkg::*;
 
 import "DPI-C" function read_elf(input string filename);
 import "DPI-C" function byte get_section(output longint address, output longint len);
-import "DPI-C" context function byte read_section(input longint address, inout byte buffer[]);
+import "DPI-C" context function read_section(input longint address, inout byte buffer[]);
 
 module ariane_tb;
 

--- a/corev_apu/tb/dpi/elfloader.cc
+++ b/corev_apu/tb/dpi/elfloader.cc
@@ -49,7 +49,7 @@ extern "C" char get_section (long long* address, long long* len) {
     } else return 0;
 }
 
-extern "C" char read_section (long long address, const svOpenArrayHandle buffer) {
+extern "C" void read_section (long long address, const svOpenArrayHandle buffer) {
     // get actual poitner
     void* buf = svGetArrayPtr(buffer);
     // check that the address points to a section


### PR DESCRIPTION
As read_section does not return any value, return type is void.

VCS generates segmentation fault when preloading elf without this fix. Related to issue #514.