### PR TITLE
Makefile: Fix Verilator random bugs by setting verilator thread to one thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ root-dir := $(dir $(mkfile_path))
 
 support_verilator_4 := $(shell ($(verilator) --version | grep '4\.') > /dev/null 2>&1 ; echo $$?)
 ifeq ($(support_verilator_4), 0)
-	verilator_threads := 2
+	verilator_threads := 1
 endif
 
 ifndef RISCV


### PR DESCRIPTION
Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>