### PR TITLE
Explicit void type should be used for read_section function.

### DIFF
--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -23,7 +23,7 @@ import uvm_pkg::*;
 
 import "DPI-C" function read_elf(input string filename);
 import "DPI-C" function byte get_section(output longint address, output longint len);
-import "DPI-C" context function read_section(input longint address, inout byte buffer[]);
+import "DPI-C" context function void read_section(input longint address, inout byte buffer[]);
 
 module ariane_tb;
 


### PR DESCRIPTION
It is related to #767 pullreq. The prototype of 'read_section' function should return explicitly void in SV side.
What is more issue #514 should be closed.