### PR TITLE
Add Verdi option and memory preloading for VCS simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,16 +303,18 @@ else
 endif
 
 vcs_build: $(dpi-library)/ariane_dpi.so
-	vlogan -full64 -nc -sverilog -ntb_opts uvm-1.2
-	vlogan -full64 -nc -sverilog -ntb_opts uvm-1.2 +define+WT_CACHE +define+RVFI_TRACE $(filter %.sv,$(ariane_pkg)) +incdir+core/include/+$(VCS_HOME)/etc/uvm-1.2/dpi
-	vlogan -full64 -nc -sverilog -ntb_opts uvm-1.2 +define+WT_CACHE +define+RVFI_TRACE $(filter %.sv,$(util)) +incdir+common/local/util+core/include/+src/util/+$(VCS_HOME)/etc/uvm-1.2/dpi
-	vhdlan -full64 $(filter %.vhd,$(uart_src))
-	vlogan -full64 -nc -sverilog -ntb_opts uvm-1.2 -assert svaext +define+WT_CACHE +define+RVFI_TRACE $(filter %.sv,$(src)) +incdir+core/include/+common/submodules/common_cells/include/+common/local/util/+$(VCS_HOME)/etc/uvm-1.2/dpi
-	vlogan -full64 -nc -sverilog -ntb_opts uvm-1.2 $(tbs) +define+RVFI_TRACE
-	vcs -full64 -timescale=1ns/1ns -ntb_opts uvm-1.2 work.ariane_tb
+	mkdir -p vcs_result
+	cd vcs_result &&\
+	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog -ntb_opts uvm-1.2
+	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog -ntb_opts uvm-1.2 +define+WT_CACHE +define+RVFI_TRACE $(filter %.sv,$(ariane_pkg)) +incdir+core/include/+$(VCS_HOME)/etc/uvm-1.2/dpi
+	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog -ntb_opts uvm-1.2 +define+WT_CACHE +define+RVFI_TRACE $(filter %.sv,$(util)) +incdir+common/local/util+core/include/+src/util/+$(VCS_HOME)/etc/uvm-1.2/dpi
+	vhdlan $(if $(VERDI), -kdb,) -full64 $(filter %.vhd,$(uart_src))
+	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog -ntb_opts uvm-1.2 -assert svaext +define+WT_CACHE +define+RVFI_TRACE $(filter %.sv,$(src)) +incdir+core/include/+common/submodules/common_cells/include/+common/local/util/+$(VCS_HOME)/etc/uvm-1.2/dpi
+	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog -ntb_opts uvm-1.2 $(tbs) +define+RVFI_TRACE
+	vcs $(if $(VERDI), -kdb -debug_access+all -lca,) -full64 -timescale=1ns/1ns -ntb_opts uvm-1.2 work.ariane_tb
 
 vcs: vcs_build
-	./simv +permissive -sv_lib work-dpi/ariane_dpi +permissive-off ++$(elf-bin) | tee vcs.log
+	cd vcs_result && ./simv  $(if $(VERDI), -verdi,) +permissive -sv_lib ../work-dpi/ariane_dpi +permissive-off ++$(elf-bin) | tee vcs.log
 
 # Build the TB and module using QuestaSim
 build: $(library) $(library)/.build-srcs $(library)/.build-tb $(dpi-library)/ariane_dpi.so

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -610,8 +610,8 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         .valid_o             ( valid_miss_fsm     ),
         .rdata_o             ( data_miss_fsm      ),
         .id_o                (                    ),
-        .critical_word_o,
-        .critical_word_valid_o,
+        .critical_word_o     ( critical_word_o    ),
+        .critical_word_valid_o (critical_word_valid_o),
         .axi_req_o           ( axi_data_o         ),
         .axi_resp_i          ( axi_data_i         )
     );


### PR DESCRIPTION
Hello,

I added some support for vcs :
- moved vcs work files to a work directory.
- added debug options to vcs compilation to use VERDI.
- enable preloading for vcs and disable debug because it was reloading memory.
- made explicit the connection for critical_word in miss_handler, it was raising an error for vcs when using 32bit configuration.

Memory preloading makes simulation faster.