### PR TITLE
wb_dcache: Forward "atomic transactions" to AXI

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -19,7 +19,6 @@ sources:
     - core/include/riscv_pkg.sv
     - corev_apu/riscv-dbg/src/dm_pkg.sv
     - core/include/ariane_pkg.sv
-    - core/include/std_cache_pkg.sv
     - core/include/wt_cache_pkg.sv
     - corev_apu/axi/src/axi_pkg.sv
     - corev_apu/register_interface/src/reg_intf.sv
@@ -28,6 +27,7 @@ sources:
     - corev_apu/tb/ariane_soc_pkg.sv
     - corev_apu/tb/ariane_axi_soc_pkg.sv
     - core/include/ariane_axi_pkg.sv
+    - core/include/std_cache_pkg.sv
     - core/fpu/src/fpnew_pkg.sv
     - core/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
     # Stand-alone source files

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ ariane_pkg += core/include/riscv_pkg.sv                              \
               corev_apu/riscv-dbg/src/dm_pkg.sv                      \
               core/include/ariane_pkg.sv                             \
               core/include/ariane_rvfi_pkg.sv                        \
-              core/include/std_cache_pkg.sv                          \
               core/include/wt_cache_pkg.sv                           \
               core/include/cvxif_pkg.sv                              \
               corev_apu/axi/src/axi_pkg.sv                           \
@@ -100,6 +99,7 @@ ariane_pkg += core/include/riscv_pkg.sv                              \
               corev_apu/tb/ariane_soc_pkg.sv                         \
               corev_apu/tb/ariane_axi_soc_pkg.sv                     \
               core/include/ariane_axi_pkg.sv                         \
+              core/include/std_cache_pkg.sv                          \
               core/fpu/src/fpnew_pkg.sv                              \
               common/submodules/common_cells/src/cf_math_pkg.sv      \
               core/cvxif_example/include/cvxif_instr_pkg.sv          \

--- a/core/axi_adapter.sv
+++ b/core/axi_adapter.sv
@@ -27,6 +27,7 @@ module axi_adapter #(
 
   input  logic                             req_i,
   input  ariane_axi::ad_req_t              type_i,
+  input  ariane_pkg::amo_t                 amo_i,
   output logic                             gnt_o,
   output logic [AXI_ID_WIDTH-1:0]          gnt_id_o,
   input  logic [riscv::XLEN-1:0]           addr_i,
@@ -51,7 +52,7 @@ module axi_adapter #(
 
   enum logic [3:0] {
     IDLE, WAIT_B_VALID, WAIT_AW_READY, WAIT_LAST_W_READY, WAIT_LAST_W_READY_AW_READY, WAIT_AW_READY_BURST,
-    WAIT_R_VALID, WAIT_R_VALID_MULTIPLE, COMPLETE_READ
+    WAIT_R_VALID, WAIT_R_VALID_MULTIPLE, COMPLETE_READ, WAIT_AMO_R_VALID
   } state_q, state_d;
 
   // counter for AXI transfers
@@ -61,6 +62,8 @@ module axi_adapter #(
   logic [(DATA_WIDTH/riscv::XLEN)-1:0] addr_offset_d, addr_offset_q;
   logic [AXI_ID_WIDTH-1:0]    id_d, id_q;
   logic [ADDR_INDEX-1:0]      index;
+  // "load" atomics response received flag
+  logic amo_resp_d, amo_resp_q;
 
   always_comb begin : axi_fsm
     // Default assignments
@@ -75,7 +78,7 @@ module axi_adapter #(
     axi_req_o.aw.cache  = 4'b0;
     axi_req_o.aw.qos    = 4'b0;
     axi_req_o.aw.id     = id_i;
-    axi_req_o.aw.atop   = '0; // currently not used
+    axi_req_o.aw.atop   = atop_from_amo(amo_i);
     axi_req_o.aw.user   = '0;
 
     axi_req_o.ar_valid  = 1'b0;
@@ -116,6 +119,7 @@ module axi_adapter #(
     cache_line_d  = cache_line_q;
     addr_offset_d = addr_offset_q;
     id_d          = id_q;
+    amo_resp_d    = amo_resp_q;
     index         = '0;
 
     case (state_q)
@@ -145,6 +149,10 @@ module axi_adapter #(
 
             // its a request for the whole cache line
             end else begin
+              // TODO colluca: bursts of AMOs unsupported
+              assert (amo_i == ariane_pkg::AMO_NONE) 
+                else $fatal("Bursts of atomic operations are not supported");
+
               axi_req_o.aw.len = BURST_SIZE; // number of bursts to do
               axi_req_o.w.data = wdata_i[0];
               axi_req_o.w.strb = be_i[0];
@@ -260,17 +268,63 @@ module axi_adapter #(
         end else if (axi_resp_i.w_ready) begin
           cnt_d = cnt_q - 1;
         end
+
+        // TODO colluca: check amo_i can be considered stable or
+        //               has to be registered
+        // some atomics must wait for read data
+        if (amo_returns_data(amo_i)) begin
+          // no data was received yet
+          if (amo_resp_q == 1'b0) begin
+            // mark data received if r_valid
+            if (axi_resp_i.r_valid) begin
+              axi_req_o.r_ready = 1'b1;
+              amo_resp_d = 1'b1;
+            end
+          end
+        end
       end
 
       // ~> finish write transaction
       WAIT_B_VALID: begin
-        axi_req_o.b_ready = 1'b1;
         id_o = axi_resp_i.b.id;
+
+        // TODO colluca: check amo_i can be considered stable or
+        //               has to be registered
+        // some atomics must wait for read data
+        if (amo_returns_data(amo_i)) begin
+          // no data was received yet
+          if (amo_resp_q == 1'b0) begin
+            // mark data received if r_valid
+            if (axi_resp_i.r_valid) begin
+              axi_req_o.r_ready = 1'b1;
+              amo_resp_d = 1'b1;
+            end
+          end
+        end
 
         // Write is valid
         if (axi_resp_i.b_valid) begin
-          state_d = IDLE;
           valid_o = 1'b1;
+          axi_req_o.b_ready = 1'b1;
+
+          // TODO colluca: check amo_i can be considered stable or
+          //               has to be registered
+          // some atomics must wait for read data
+          if (amo_returns_data(amo_i) && !amo_resp_q && !axi_resp_i.r_valid) begin
+            state_d = WAIT_AMO_R_VALID;
+          end else begin
+            state_d = IDLE;
+            amo_resp_d = 1'b0;
+          end
+        end
+      end
+
+      // ~> some atomics wait for read data
+      WAIT_AMO_R_VALID: begin
+        // acknowledge data and terminate atomic
+        if (axi_resp_i.r_valid) begin
+          axi_req_o.r_ready = 1'b1;
+          state_d = IDLE;
         end
       end
 
@@ -336,13 +390,47 @@ module axi_adapter #(
       cache_line_q  <= '0;
       addr_offset_q <= '0;
       id_q          <= '0;
+      amo_resp_q    <= '0;
     end else begin
       state_q       <= state_d;
       cnt_q         <= cnt_d;
       cache_line_q  <= cache_line_d;
       addr_offset_q <= addr_offset_d;
       id_q          <= id_d;
+      amo_resp_q    <= amo_resp_d;
     end
   end
+
+  function automatic axi_pkg::atop_t atop_from_amo(ariane_pkg::amo_t amo);
+    axi_pkg::atop_t result = 6'b000000;
+
+    // TODO colluca: use macros in axi_pkg
+    unique case(amo)
+      ariane_pkg::AMO_NONE: result = 6'b000000;
+      ariane_pkg::AMO_LR  : result = 6'b000000; // TODO colluca: implement
+      ariane_pkg::AMO_SC  : result = 6'b000000; // TODO colluca: implement
+      ariane_pkg::AMO_SWAP: result = 6'b110000;
+      ariane_pkg::AMO_ADD : result = 6'b010000;
+      ariane_pkg::AMO_AND : result = 6'b010001;
+      ariane_pkg::AMO_OR  : result = 6'b010011;
+      ariane_pkg::AMO_XOR : result = 6'b010010;
+      ariane_pkg::AMO_MAX : result = 6'b010100;
+      ariane_pkg::AMO_MAXU: result = 6'b010110;
+      ariane_pkg::AMO_MIN : result = 6'b010101;
+      ariane_pkg::AMO_MINU: result = 6'b010111;
+      ariane_pkg::AMO_CAS1: result = 6'b000000; // Unsupported
+      ariane_pkg::AMO_CAS2: result = 6'b000000; // Unsupported
+      default: result = 6'b000000;
+    endcase
+
+    return result;
+  endfunction
+
+  function automatic logic amo_returns_data(ariane_pkg::amo_t amo);
+    axi_pkg::atop_t atop           = atop_from_amo(amo);
+    logic           is_load        = atop[5:4] == axi_pkg::ATOP_ATOMICLOAD;
+    logic           is_swap_or_cmp = atop[5:4] == axi_pkg::ATOP_ATOMICSWAP[5:4];
+    return is_load || is_swap_or_cmp;
+  endfunction
 
 endmodule

--- a/core/axi_adapter.sv
+++ b/core/axi_adapter.sv
@@ -409,14 +409,14 @@ module axi_adapter #(
     unique case(amo)
       ariane_pkg::AMO_NONE: result = 6'b000000;
       ariane_pkg::AMO_SWAP: result = 6'b110000;
-      ariane_pkg::AMO_ADD : result = 6'b010000;
-      ariane_pkg::AMO_AND : result = 6'b010001;
-      ariane_pkg::AMO_OR  : result = 6'b010011;
-      ariane_pkg::AMO_XOR : result = 6'b010010;
-      ariane_pkg::AMO_MAX : result = 6'b010100;
-      ariane_pkg::AMO_MAXU: result = 6'b010110;
-      ariane_pkg::AMO_MIN : result = 6'b010101;
-      ariane_pkg::AMO_MINU: result = 6'b010111;
+      ariane_pkg::AMO_ADD : result = 6'b100000;
+      ariane_pkg::AMO_AND : result = 6'b100001;
+      ariane_pkg::AMO_OR  : result = 6'b100011;
+      ariane_pkg::AMO_XOR : result = 6'b100010;
+      ariane_pkg::AMO_MAX : result = 6'b100100;
+      ariane_pkg::AMO_MAXU: result = 6'b100110;
+      ariane_pkg::AMO_MIN : result = 6'b100101;
+      ariane_pkg::AMO_MINU: result = 6'b100111;
       ariane_pkg::AMO_CAS1: result = 6'b000000; // Unsupported
       ariane_pkg::AMO_CAS2: result = 6'b000000; // Unsupported
       default: result = 6'b000000;

--- a/core/axi_adapter.sv
+++ b/core/axi_adapter.sv
@@ -29,7 +29,6 @@ module axi_adapter #(
   input  ariane_axi::ad_req_t              type_i,
   input  ariane_pkg::amo_t                 amo_i,
   output logic                             gnt_o,
-  output logic [AXI_ID_WIDTH-1:0]          gnt_id_o,
   input  logic [riscv::XLEN-1:0]           addr_i,
   input  logic                             we_i,
   input  logic [(DATA_WIDTH/riscv::XLEN)-1:0][riscv::XLEN-1:0] wdata_i,
@@ -108,7 +107,6 @@ module axi_adapter #(
     axi_req_o.r_ready   = 1'b0;
 
     gnt_o    = 1'b0;
-    gnt_id_o = id_i;
     valid_o  = 1'b0;
     id_o     = axi_resp_i.r.id;
 

--- a/core/axi_adapter.sv
+++ b/core/axi_adapter.sv
@@ -63,8 +63,6 @@ module axi_adapter #(
   logic [ADDR_INDEX-1:0]      index;
   // save the atomic operation
   ariane_pkg::amo_t amo_d, amo_q;
-  // "load" atomics response received flag
-  logic amo_rvalid_d, amo_rvalid_q;
 
   always_comb begin : axi_fsm
     // Default assignments
@@ -120,7 +118,6 @@ module axi_adapter #(
     addr_offset_d = addr_offset_q;
     id_d          = id_q;
     amo_d         = amo_q;
-    amo_rvalid_d  = amo_rvalid_q;
     index         = '0;
 
     case (state_q)
@@ -280,59 +277,44 @@ module axi_adapter #(
         end else if (axi_resp_i.w_ready) begin
           cnt_d = cnt_q - 1;
         end
-
-        // some atomics must wait for read data
-        if (amo_returns_data(amo_q)) begin
-          // no data was received yet
-          if (amo_rvalid_q == 1'b0) begin
-            // mark data received if r_valid
-            if (axi_resp_i.r_valid) begin
-              axi_req_o.r_ready = 1'b1;
-              amo_rvalid_d = 1'b1;
-            end
-          end
-        end
       end
 
       // ~> finish write transaction
       WAIT_B_VALID: begin
         id_o = axi_resp_i.b.id;
 
-        // some atomics must wait for read data
-        if (amo_returns_data(amo_q)) begin
-          // no data was received yet
-          if (amo_rvalid_q == 1'b0) begin
-            // mark data received if r_valid
-            if (axi_resp_i.r_valid) begin
-              axi_req_o.r_ready = 1'b1;
-              amo_rvalid_d = 1'b1;
-            end
-          end
-        end
-
         // Write is valid
         if (axi_resp_i.b_valid) begin
-          valid_o = 1'b1;
           axi_req_o.b_ready = 1'b1;
 
-          // store-conditional response
-          if (amo_q == ariane_pkg::AMO_SC) begin
-            if (axi_resp_i.b.resp == axi_pkg::RESP_EXOKAY) begin
-              // success -> return 0
-              rdata_o  = 1'b0;
-            // TODO colluca: replace with else if (... == RESP_OKAY)?
-            end else begin
-              // failure -> return 1
-              rdata_o  = 1'b1;
-            end
-          end
-
           // some atomics must wait for read data
-          if (amo_returns_data(amo_q) && !amo_rvalid_q && !axi_resp_i.r_valid) begin
-            state_d = WAIT_AMO_R_VALID;
+          // we only accept it after accepting bvalid
+          if (amo_returns_data(amo_q)) begin
+            if (axi_resp_i.r_valid) begin
+              // return read data if valid
+              valid_o           = 1'b1;
+              axi_req_o.r_ready = 1'b1;
+              state_d           = IDLE;
+              rdata_o           = axi_resp_i.r.data;
+            end else begin
+              // wait otherwise
+              state_d = WAIT_AMO_R_VALID;
+            end
           end else begin
+            valid_o = 1'b1;
             state_d = IDLE;
-            amo_rvalid_d = 1'b0;
+
+            // store-conditional response
+            if (amo_q == ariane_pkg::AMO_SC) begin
+              if (axi_resp_i.b.resp == axi_pkg::RESP_EXOKAY) begin
+                // success -> return 0
+                rdata_o = 1'b0;
+              // TODO colluca: replace with else if (... == RESP_OKAY)?
+              end else begin
+                // failure -> return 1
+                rdata_o = 1'b1;
+              end
+            end
           end
         end
       end
@@ -342,7 +324,9 @@ module axi_adapter #(
         // acknowledge data and terminate atomic
         if (axi_resp_i.r_valid) begin
           axi_req_o.r_ready = 1'b1;
-          state_d = IDLE;
+          state_d           = IDLE;
+          valid_o           = 1'b1;
+          rdata_o           = axi_resp_i.r.data;
         end
       end
 
@@ -409,7 +393,6 @@ module axi_adapter #(
       addr_offset_q <= '0;
       id_q          <= '0;
       amo_q         <= ariane_pkg::AMO_NONE;
-      amo_rvalid_q  <= '0;
     end else begin
       state_q       <= state_d;
       cnt_q         <= cnt_d;
@@ -417,7 +400,6 @@ module axi_adapter #(
       addr_offset_q <= addr_offset_d;
       id_q          <= id_d;
       amo_q         <= amo_d;
-      amo_rvalid_q  <= amo_rvalid_d;
     end
   end
 

--- a/core/axi_adapter.sv
+++ b/core/axi_adapter.sv
@@ -407,18 +407,18 @@ module axi_adapter #(
     axi_pkg::atop_t result = 6'b000000;
 
     unique case(amo)
-      ariane_pkg::AMO_NONE: result = 6'b000000;
-      ariane_pkg::AMO_SWAP: result = 6'b110000;
-      ariane_pkg::AMO_ADD : result = 6'b100000;
-      ariane_pkg::AMO_AND : result = 6'b100001;
-      ariane_pkg::AMO_OR  : result = 6'b100011;
-      ariane_pkg::AMO_XOR : result = 6'b100010;
-      ariane_pkg::AMO_MAX : result = 6'b100100;
-      ariane_pkg::AMO_MAXU: result = 6'b100110;
-      ariane_pkg::AMO_MIN : result = 6'b100101;
-      ariane_pkg::AMO_MINU: result = 6'b100111;
-      ariane_pkg::AMO_CAS1: result = 6'b000000; // Unsupported
-      ariane_pkg::AMO_CAS2: result = 6'b000000; // Unsupported
+      ariane_pkg::AMO_NONE: result = {axi_pkg::ATOP_NONE, 4'b0000};
+      ariane_pkg::AMO_SWAP: result = {axi_pkg::ATOP_ATOMICSWAP};
+      ariane_pkg::AMO_ADD : result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_ADD};
+      ariane_pkg::AMO_AND : result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_CLR};
+      ariane_pkg::AMO_OR  : result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_SET};
+      ariane_pkg::AMO_XOR : result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_EOR};
+      ariane_pkg::AMO_MAX : result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_SMAX};
+      ariane_pkg::AMO_MAXU: result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_UMAX};
+      ariane_pkg::AMO_MIN : result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_SMIN};
+      ariane_pkg::AMO_MINU: result = {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END, axi_pkg::ATOP_UMIN};
+      ariane_pkg::AMO_CAS1: result = {axi_pkg::ATOP_NONE, 4'b0000}; // Unsupported
+      ariane_pkg::AMO_CAS2: result = {axi_pkg::ATOP_NONE, 4'b0000}; // Unsupported
       default: result = 6'b000000;
     endcase
 

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -172,7 +172,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         amo_bypass_req.wdata   = '0;
         amo_bypass_req.be      = '0;
         amo_bypass_req.size    = 2'b11;
-        amo_bypass_req.id      = 4'b1100;
+        amo_bypass_req.id      = 4'b1011;
         // core
         flush_ack_o         = 1'b0;
         miss_o              = 1'b0; // to performance counter

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -59,7 +59,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
     input  cache_line_t [DCACHE_SET_ASSOC-1:0]          data_i,
     output logic                                        we_o
 );
-  
+
     // Three MSHR ports + AMO port
     parameter NR_BYPASS_PORTS = NR_PORTS + 1;
 

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -403,7 +403,9 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
                 req_amo_bypass_amo   = amo_req_i.amo_op;
                 // address is in operand a
                 req_amo_bypass_addr  = amo_req_i.operand_a;
-                req_amo_bypass_we    = 1'b1;
+                if (amo_req_i.amo_op != AMO_LR) begin
+                    req_amo_bypass_we = 1'b1;
+                end
                 req_amo_bypass_size  = amo_req_i.size;
                 req_amo_bypass_id    = 4'b1100;
                 // AXI implements CLR op instead of AND, negate operand

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -172,7 +172,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         amo_bypass_req.wdata   = '0;
         amo_bypass_req.be      = '0;
         amo_bypass_req.size    = 2'b11;
-        amo_bypass_req.id      = 4'b1011;
+        amo_bypass_req.id      = 4'b1100;
         // core
         flush_ack_o         = 1'b0;
         miss_o              = 1'b0; // to performance counter

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -172,7 +172,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         amo_bypass_req.wdata   = '0;
         amo_bypass_req.be      = '0;
         amo_bypass_req.size    = 2'b11;
-        amo_bypass_req.id      = 4'b1100;
+        amo_bypass_req.id      = 4'b1011;
         // core
         flush_ack_o         = 1'b0;
         miss_o              = 1'b0; // to performance counter
@@ -428,7 +428,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
 
                 // when request is accepted, wait for response
                 if (amo_bypass_rsp.gnt) begin
-                    if (amo_bypass_rsp.rvalid) begin
+                    if (amo_bypass_rsp.valid) begin
                         state_d = IDLE;
                         amo_resp_o.ack = 1'b1;
                         amo_resp_o.result = amo_bypass_rsp.rdata;
@@ -438,7 +438,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
                 end
             end
             AMO_WAIT_RESP: begin
-                if (amo_bypass_rsp.rvalid) begin
+                if (amo_bypass_rsp.valid) begin
                     state_d = IDLE;
                     amo_resp_o.ack = 1'b1;
                     amo_resp_o.result = amo_bypass_rsp.rdata;
@@ -513,7 +513,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
             bypass_ports_req[id].size    = miss_req_size[id];
 
             bypass_gnt_o[id]   = bypass_ports_rsp[id].gnt;
-            bypass_valid_o[id] = bypass_ports_rsp[id].rvalid;
+            bypass_valid_o[id] = bypass_ports_rsp[id].valid;
             bypass_data_o[id]  = bypass_ports_rsp[id].rdata;
         end
 
@@ -560,7 +560,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         .be_i                 (bypass_adapter_req.be),
         .size_i               (bypass_adapter_req.size),
         .gnt_o                (bypass_adapter_rsp.gnt),
-        .valid_o              (bypass_adapter_rsp.rvalid),
+        .valid_o              (bypass_adapter_rsp.valid),
         .rdata_o              (bypass_adapter_rsp.rdata),
         .id_o                 (), // not used, single outstanding request in arbiter
         .critical_word_o      (), // not used for single requests
@@ -683,8 +683,8 @@ module axi_adapter_arbiter #(
             end
 
             SERVING: begin
-                if (rsp_i.rvalid) begin
-                    rsp_o[sel_q].rvalid = 1'b1;
+                if (rsp_i.valid) begin
+                    rsp_o[sel_q].valid = 1'b1;
                     state_d = IDLE;
                 end
             end
@@ -711,7 +711,7 @@ module axi_adapter_arbiter #(
     //pragma translate_off
     `ifndef VERILATOR
     // make sure that we eventually get an rvalid after we received a grant
-    assert property (@(posedge clk_i) rsp_i.gnt |-> ##[1:$] rsp_i.rvalid )
+    assert property (@(posedge clk_i) rsp_i.gnt |-> ##[1:$] rsp_i.valid )
         else begin $error("There was a grant without a rvalid"); $stop(); end
     // assert that there is no grant without a request
     assert property (@(negedge clk_i) rsp_i.gnt |-> req_o.req)

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -514,10 +514,10 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
     // Pack bypass ports
     // ----------------------
     always_comb begin
-        logic[$clog2(NR_BYPASS_PORTS)-1:0] id;
+        logic [$clog2(NR_BYPASS_PORTS)-1:0] id;
 
         // Pack MHSR ports first
-        for (id=0; id<NR_PORTS; id++) begin
+        for (id = 0; id < NR_PORTS; id++) begin
             bypass_ports_req[id].req     = miss_req_valid[id] & miss_req_bypass[id];
             bypass_ports_req[id].reqtype = ariane_axi::SINGLE_REQ;
             bypass_ports_req[id].amo     = AMO_NONE;

--- a/core/include/std_cache_pkg.sv
+++ b/core/include/std_cache_pkg.sv
@@ -43,6 +43,24 @@ package std_cache_pkg;
     } miss_req_t;
 
     typedef struct packed {
+        logic                req;
+        ariane_axi::ad_req_t reqtype;
+        ariane_pkg::amo_t    amo;
+        logic [3:0]          id;
+        logic [63:0]         addr;
+        logic [63:0]         wdata;
+        logic                we;
+        logic [7:0]          be;
+        logic [1:0]          size;
+    } bypass_req_t;
+
+    typedef struct packed {
+        logic        gnt;
+        logic        rvalid;
+        logic [63:0] rdata;
+    } bypass_rsp_t;
+
+    typedef struct packed {
         logic [ariane_pkg::DCACHE_TAG_WIDTH-1:0]  tag;    // tag array
         logic [ariane_pkg::DCACHE_LINE_WIDTH-1:0] data;   // data array
         logic                                     valid;  // state array

--- a/core/include/std_cache_pkg.sv
+++ b/core/include/std_cache_pkg.sv
@@ -56,7 +56,7 @@ package std_cache_pkg;
 
     typedef struct packed {
         logic        gnt;
-        logic        rvalid;
+        logic        valid;
         logic [63:0] rdata;
     } bypass_rsp_t;
 

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -567,7 +567,6 @@ axi_adapter #(
     .type_i                ( ariane_axi::SINGLE_REQ    ),
     .amo_i                 ( ariane_pkg::AMO_NONE      ),
     .gnt_o                 ( dm_master_gnt             ),
-    .gnt_id_o              (                           ),
     .addr_i                ( dm_master_add             ),
     .we_i                  ( dm_master_we              ),
     .wdata_i               ( dm_master_wdata           ),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -565,6 +565,7 @@ axi_adapter #(
     .rst_ni                ( rst_n                     ),
     .req_i                 ( dm_master_req             ),
     .type_i                ( ariane_axi::SINGLE_REQ    ),
+    .amo_i                 ( ariane_pkg::AMO_NONE      ),
     .gnt_o                 ( dm_master_gnt             ),
     .gnt_id_o              (                           ),
     .addr_i                ( dm_master_add             ),

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -289,7 +289,6 @@ module ariane_testharness #(
     .type_i                ( ariane_axi::SINGLE_REQ    ),
     .amo_i                 ( ariane_pkg::AMO_NONE      ),
     .gnt_o                 ( dm_master_gnt             ),
-    .gnt_id_o              (                           ),
     .addr_i                ( dm_master_add             ),
     .we_i                  ( dm_master_we              ),
     .wdata_i               ( dm_master_wdata           ),

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -287,6 +287,7 @@ module ariane_testharness #(
     .rst_ni                ( rst_ni                    ),
     .req_i                 ( dm_master_req             ),
     .type_i                ( ariane_axi::SINGLE_REQ    ),
+    .amo_i                 ( ariane_pkg::AMO_NONE      ),
     .gnt_o                 ( dm_master_gnt             ),
     .gnt_id_o              (                           ),
     .addr_i                ( dm_master_add             ),

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
@@ -186,6 +186,32 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
   tb_mem_port_t data_mem_port;
   tb_mem_port_t bypass_mem_port;
 
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidthFull       ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidthFull       ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthFull + 32'd1 ),
+    .AXI_USER_WIDTH ( TbAxiUserWidthFull       )
+  ) axi_bypass ();
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidthFull       ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidthFull       ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthFull + 32'd1 ),
+    .AXI_USER_WIDTH ( TbAxiUserWidthFull       )
+  ) axi_bypass_amo_adapter ();
+
+  AXI_BUS_DV #(
+    .AXI_ADDR_WIDTH ( TbAxiAddrWidthFull       ),
+    .AXI_DATA_WIDTH ( TbAxiDataWidthFull       ),
+    .AXI_ID_WIDTH   ( TbAxiIdWidthFull + 32'd1 ),
+    .AXI_USER_WIDTH ( TbAxiUserWidthFull       )
+  ) axi_bypass_amo_adapter_dv (
+    .clk_i ( clk_i )
+  );
+
+  `AXI_ASSIGN(axi_bypass, axi_bypass_dv)
+  `AXI_ASSIGN(axi_bypass_amo_adapter_dv, axi_bypass_amo_adapter)
+
 ///////////////////////////////////////////////////////////////////////////////
 // Helper tasks
 ///////////////////////////////////////////////////////////////////////////////
@@ -361,8 +387,8 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
   // Instantiate memory and AXI ports
   initial begin : p_sim_mem
     // Create AXI ports
-    data_mem_port   = new(axi_data_dv  , CACHED);
-    bypass_mem_port = new(axi_bypass_dv, BYPASS);
+    data_mem_port   = new(axi_data_dv              , CACHED);
+    bypass_mem_port = new(axi_bypass_amo_adapter_dv, BYPASS);
 
     // Initialize AXI ports and memory
     data_mem_port.reset();
@@ -400,6 +426,24 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
     .axi_bypass_o    ( axi_bypass_o    ),
     .axi_bypass_i    ( axi_bypass_i    )
   );
+
+///////////////////////////////////////////////////////////////////////////////
+// AXI Atomics Adapter
+///////////////////////////////////////////////////////////////////////////////
+
+axi_riscv_atomics_wrap #(
+    .AXI_ADDR_WIDTH     ( TbAxiAddrWidthFull       ),
+    .AXI_DATA_WIDTH     ( TbAxiDataWidthFull       ),
+    .AXI_ID_WIDTH       ( TbAxiIdWidthFull + 32'd1 ),
+    .AXI_USER_WIDTH     ( TbAxiUserWidthFull       ),
+    .AXI_MAX_WRITE_TXNS ( 1                        ),
+    .RISCV_WORD_WIDTH   ( 64                       )
+) i_amo_adapter (
+    .clk_i  ( clk_i                         ),
+    .rst_ni ( rst_ni                        ),
+    .mst    ( axi_bypass_amo_adapter.Master ),
+    .slv    ( axi_bypass.Slave )
+);
 
 ///////////////////////////////////////////////////////////////////////////////
 // port emulation programs
@@ -924,8 +968,8 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
     req_rate     = '{50,0,2};
 
     // AMOs should use cache port
-    bypass_mem_port.set_region(0, 0);
-    data_mem_port.set_region(0, MemBytes-1);
+    bypass_mem_port.set_region(0, MemBytes-1);
+    data_mem_port.set_region(0, 0);
 
     runAMOs(nAMOs,1); // Last sequence flag, terminates agents
     flushCache();

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
@@ -284,8 +284,8 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
     `APPL_WAIT_CYC(clk_i, 1)
 
     forever begin
-      amo_exp_result = 'x;
       `ACQ_WAIT_CYC(clk_i, 1)
+      amo_exp_result = 'x;
 
       // Regular stores. These are directly written to shadow memory.
       if(write_en) begin
@@ -311,7 +311,8 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
 
           // The result that is expected to be returned by AMO and evantually to be stored in rd.
           // For most AMOs, this is the previous memory content.
-          amo_exp_result[31:0] = amo_shadow[31:0];
+          // RISC-V spec requires: "For RV64, 32-bit AMOs always sign-extend the value placed in rd."
+          amo_exp_result = amo_op_a;
 
         // 64-bit AMO
         end else begin

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb_amoport.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb_amoport.sv
@@ -80,7 +80,8 @@ program tb_amoport import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg:
       `APPL_WAIT_CYC(clk_i, delay)
 
       // Apply random stimuli, choose random AMO operand
-      void'(randomize(amo_op) with {!(amo_op inside {AMO_NONE, AMO_CAS1, AMO_CAS2});});
+      // TODO colluca: remove AMO_LR and AMO_SC
+      void'(randomize(amo_op) with {!(amo_op inside {AMO_NONE, AMO_CAS1, AMO_CAS2, AMO_LR, AMO_SC});});
       void'(randomize(data));
       void'(randomize(size) with {size >= 2; size <= 3;});
 

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb_amoport.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb_amoport.sv
@@ -183,6 +183,8 @@ program tb_amoport import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg:
       for (int k=0;k<seq_num_amo_i;k++) begin
         `ACQ_WAIT_SIG(clk_i, dut_amo_resp_port_i.ack)
 
+        // Assert expected data is not 'x, protects against ineffective ==? comparisons
+        assert(exp_result_i !== 'x) else $error("Expected result is unknown");
         // note: wildcard as defined in right operand!
         ok=(dut_amo_resp_port_i.result ==? exp_result_i) && (act_mem_i == exp_mem_i);
 

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb_amoport.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb_amoport.sv
@@ -80,17 +80,18 @@ program tb_amoport import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg:
       `APPL_WAIT_CYC(clk_i, delay)
 
       // Apply random stimuli, choose random AMO operand
-      // TODO colluca: remove AMO_LR and AMO_SC
-      void'(randomize(amo_op) with {!(amo_op inside {AMO_NONE, AMO_CAS1, AMO_CAS2, AMO_LR, AMO_SC});});
+      void'(randomize(amo_op) with {!(amo_op inside {AMO_NONE, AMO_CAS1, AMO_CAS2});});
       void'(randomize(data));
       void'(randomize(size) with {size >= 2; size <= 3;});
 
       // For LRs/SCs, choose from only 4 adresses,
-      // so that valid LR/SC combinations become more likely
+      // so that valid LR/SC combinations become more likely.
+      // Note: AMOs to address 0 are not supported in axi_riscv_atomics module
+      //       so we start at 8 (for alignment purposes)
       if (amo_op inside {AMO_LR, AMO_SC})
-        void'(randomize(paddr) with {paddr >= 0; paddr < 4;});
+        void'(randomize(paddr) with {paddr >= 8; paddr < 12;});
       else
-        void'(randomize(paddr) with {paddr >= 0; paddr < (MemWords<<3);});
+        void'(randomize(paddr) with {paddr >= 8; paddr < (MemWords<<3);});
 
       // Align adress
       if (size == 2)

--- a/corev_apu/tb/tb_wb_dcache/tb.list
+++ b/corev_apu/tb/tb_wb_dcache/tb.list
@@ -35,6 +35,12 @@
 ../../../common/submodules/common_cells/src/stream_demux.sv
 ../../../core/axi_adapter.sv
 ../../../common/local/util/sram.sv
+../../src/axi_riscv_atomics/src/axi_res_tbl.sv
+../../src/axi_riscv_atomics/src/axi_riscv_amos.sv
+../../src/axi_riscv_atomics/src/axi_riscv_amos_alu.sv
+../../src/axi_riscv_atomics/src/axi_riscv_lrsc.sv
+../../src/axi_riscv_atomics/src/axi_riscv_atomics.sv
+../../src/axi_riscv_atomics/src/axi_riscv_atomics_wrap.sv
 
 ../common/tb_dcache_pkg.sv
 ../common/tb_readport.sv


### PR DESCRIPTION
### Description

This PR removes handling of atomic operations inside the WB cache. It forwards them instead on the AXI bypass interface, to be handled closer to memory. 

_Swap_, _fetch-and-op_ and _op_ type atomics are presented on the interface as AXI5 "Atomic Transactions".
_Load-reserved_ and _store-conditional_ are presented on the interface as AXI4 "Exclusive accesses".
This is aligned to how atomics are expected in the [_riscv_axi_atomics_](https://github.com/pulp-platform/axi_riscv_atomics) module.

### Status

- [x] **Forward _swap_, _fetch-and-op_ and _op_ type atomics to AXI interface**
Miss-hander FSM updated. AXI adapter extended to present AXI5 "Atomic transactions" requests and handle respective responses. 
- [x]  **Adapt testbench**
A _riscv_axi_atomics_ module is instantiated and connected between the DUT and the TB memory to handle atomics. The ensemble of the two modules should equal the previous DUT in terms of functionality, hence the rest of the TB can remain unaltered.


- [x] **Pass tests with _swap_, _fetch-and-op_ and _op_ type atomics**

- [x] **Forward _load-reserved_ and _store-conditional_ to AXI interface**
Extend AXI adapter to present AXI4 "Exclusive access" requests and handle respective responses. 

- [x] **Pass tests with _load-reserved_ and _store-conditional_ atomics**