### PR TITLE
Flist.cv64a6_imafdc_sv39_gate: Flist dedicated to gate simulation

### DIFF
--- a/core/Flist.cv64a6_imafdc_sv39_gate
+++ b/core/Flist.cv64a6_imafdc_sv39_gate
@@ -1,0 +1,26 @@
+# Copyright 2021 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Jean-Roch COULON (jean-roch.coulon@thalesgroup.com)
+#
+
+${CVA6_REPO_DIR}/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+${CVA6_REPO_DIR}/core/include/riscv_pkg.sv
+${CVA6_REPO_DIR}/corev_apu/riscv-dbg/src/dm_pkg.sv
+${CVA6_REPO_DIR}/core/include/ariane_pkg.sv
+${CVA6_REPO_DIR}/corev_apu/axi/src/axi_pkg.sv
+${CVA6_REPO_DIR}/core/include/ariane_rvfi_pkg.sv
+
+${CVA6_REPO_DIR}/core/include/ariane_axi_pkg.sv
+${CVA6_REPO_DIR}/core/include/wt_cache_pkg.sv
+${CVA6_REPO_DIR}/core/include/std_cache_pkg.sv
+${CVA6_REPO_DIR}/core/include/axi_intf.sv
+${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
+
+${CVA6_REPO_DIR}/${LIB_VERILOG}
+${CVA6_REPO_DIR}/pd/synth/ariane_synth_modified.v
+${CVA6_REPO_DIR}/pd/synth/SyncSpRamBeNx64_1.sv


### PR DESCRIPTION
Move Flist dedicated to the gate simulation from core-v-verif to cva6 repository.
LIB_VERILOG need to point to the verilog foundry library