### PR TITLE
Add fpga cleanup to make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -779,6 +779,7 @@ clean:
 	rm -rf $(riscv-torture-dir)/output/test*
 	rm -rf $(library)/ $(dpi-library)/ $(ver-library)/ $(vcs-library)/
 	rm -f tmp/*.ucdb tmp/*.log *.wlf *vstf wlft* *.ucdb
+	cd corev_apu/fpga && make clean && cd ../..
 
 .PHONY:
 	build sim sim-verilate clean                                              \


### PR DESCRIPTION
The `make clean` target of the root `Makefile` does not always properly clean the `make fpga` target (i.e. to rebuild the fpga image, `make clean && make fpga` sometimes (depending on the files existing from the previous build) does not rebuild the image.

This PR calls the `make clean` of the `corev_apu/fpga/Makefile` to ensure proper cleanup.

Log
```
andreas@dev-pc:~/cva6$ make clean                                                                                                                                                                                                                                                                                                    │·······························
Makefile:153: XCELIUM_HOME not set which is necessary for compiling DPIs when using XCELIUM                                                                                                                                                                                                                                                  │·······························
rm -rf tmp/riscv-torture/output/test*                                                                                                                                                                                                                                                                                                        │·······························
rm -rf work/ work-dpi/ work-ver/ work-vcs/                                                                                                                                                                                                                                                                                                   │·······························
rm -f tmp/*.ucdb tmp/*.log *.wlf *vstf wlft* *.ucdb                                                                                                                                                                                                                                                                                          │·······························
```

```
andreas@dev-pc:~/cva6$ make fpga                                                                                                                                                                                                                                                                                                     │·······························
Makefile:153: XCELIUM_HOME not set which is necessary for compiling DPIs when using XCELIUM                                                                                                                                                                                                                                                  │·······························
[FPGA] Generate sources                                                                                                                                                                                                                                                                                                                      │·······························
[FPGA] Generate Bitstream                                                                                                                                                                                                                                                                                                                    │·······························
cd corev_apu/fpga && make BOARD=genesys2 XILINX_PART=xc7k325tffg900-2 XILINX_BOARD=digilentinc.com:genesys2:part0:1.1 CLK_PERIOD_NS=20                                                                                                                                                                                                       │·······························
make[1]: Entering directory '/home/andreas/cva6/corev_apu/fpga'                                                                                                                                                                                                                                                                      │·······························
make[1]: Nothing to be done for 'all'.                                                                                                                                                                                                                                                                                                       │·······························
make[1]: Leaving directory '/home/andreas/cva6/corev_apu/fpga' 
```