### PR TITLE
ariane_xilinx: Fix xbar clock

### DIFF
--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -289,7 +289,7 @@ axi_xbar_intf #(
   .Cfg            ( AXI_XBAR_CFG            ),
   .rule_t         ( axi_pkg::xbar_rule_64_t )
 ) i_axi_xbar (
-  .clk_i                 ( clk_i      ),
+  .clk_i                 ( clk        ),
   .rst_ni                ( ndmreset_n ),
   .test_i                ( test_en    ),
   .slv_ports             ( slave      ),


### PR DESCRIPTION
**Issue**
On FPGA, Ariane deadlocks immediately after loading the bitstream while attempting to fetch from bootrom.

**Methodology**
Hundreds of ILA probes in and around the crossbar.

**Solution**
Fix the name of the clock net provided to the crossbar.
