### PR TITLE
Fixed issue counter in order to leverage the full scoreboad length.

### DIFF
--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -74,14 +74,14 @@ module scoreboard #(
   sb_mem_t [NR_ENTRIES-1:0] mem_q, mem_n;
 
   logic                    issue_full, issue_en;
-  logic [BITS_ENTRIES-1:0] issue_cnt_n,      issue_cnt_q;
+  logic [BITS_ENTRIES:0]   issue_cnt_n,      issue_cnt_q;
   logic [BITS_ENTRIES-1:0] issue_pointer_n,  issue_pointer_q;
   logic [NR_COMMIT_PORTS-1:0][BITS_ENTRIES-1:0] commit_pointer_n, commit_pointer_q;
   logic [$clog2(NR_COMMIT_PORTS):0] num_commit;
 
   // the issue queue is full don't issue any new instructions
   // works since aligned to power of 2
-  assign issue_full = &issue_cnt_q;
+  assign issue_full = (issue_cnt_q[BITS_ENTRIES] == 1'b1);
 
   assign sb_full_o = issue_full;
 


### PR DESCRIPTION
The scoreboard issue counter `issue_cnt_q` and `issue_cnt_n` have length equal to `log2(NUM_ENTRIES) - 1` where `NUM_ENTRIES` is the number of scoreboard entries. In the standard case where `NUM_ENTRIES = 8` the counters are 3 bits long meaning that they can count from 0 to 7 making it impossible to use the full scoreboard (always leaving one spot free).