### PR TITLE
Flist.cv64a6_imafdc_sv39_gate, update LIB_VERILOG path

### DIFF
--- a/core/Flist.cv64a6_imafdc_sv39_gate
+++ b/core/Flist.cv64a6_imafdc_sv39_gate
@@ -22,6 +22,6 @@ ${CVA6_REPO_DIR}/core/include/std_cache_pkg.sv
 ${CVA6_REPO_DIR}/core/include/axi_intf.sv
 ${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
 
-${CVA6_REPO_DIR}/${LIB_VERILOG}
+${LIB_VERILOG}
 ${CVA6_REPO_DIR}/pd/synth/ariane_synth_modified.v
 ${CVA6_REPO_DIR}/pd/synth/SyncSpRamBeNx64_1.sv


### PR DESCRIPTION
Modification on the flist gate "Flist.cv64a6_imafdc_sv39_gate" to clean post synthesis simulation jobs.
Most of the time the tech files are in a fixed path on the server and not relative to the project. With the current prefix this forced us to do a workaround.

Already validated in test branch "feature/gitlab-ci" see : #798 