### PR TITLE
tb/cache: Fix regressions

### DIFF
--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -96,7 +96,7 @@ package ariane_pkg;
 
     function automatic logic range_check(logic[63:0] base, logic[63:0] len, logic[63:0] address);
       // if len is a power of two, and base is properly aligned, this check could be simplified
-      return (address >= base) && (address < (base+len));
+      return (address >= base) && (address < (65'(base)+len));
     endfunction : range_check
 
     function automatic logic is_inside_nonidempotent_regions (ariane_cfg_t Cfg, logic[63:0] address);

--- a/corev_apu/tb/tb_cva6_icache/tb.list
+++ b/corev_apu/tb/tb_cva6_icache/tb.list
@@ -3,6 +3,7 @@
 ../../riscv-dbg/src/dm_pkg.sv
 ../../../core/include/ariane_pkg.sv
 ../../../core/include/wt_cache_pkg.sv
+../../../common/submodules/common_cells/src/cf_math_pkg.sv
 ../../fpga-support/rtl/SyncSpRamBeNx64.sv
 ../../../core/cache_subsystem/cva6_icache.sv
 ../../../common/submodules/common_cells/src/lfsr.sv

--- a/corev_apu/tb/tb_wb_dcache/Makefile
+++ b/corev_apu/tb/tb_wb_dcache/Makefile
@@ -20,7 +20,7 @@ src          := $(shell xargs printf '\n%s' < $(src-list)  | cut -b 1-)
 compile_flag += +cover+i_dut -incr -64 -nologo -svinputport=compat -override_timescale 1ns/1ps -suppress 2583 -suppress 13262 +cover
 sim_opts     += -64 -coverage -classdebug -voptargs="+acc"
 questa_version ?= ${QUESTASIM_VERSION}
-incdir       += ../common/
+incdir       += ../common/ ../../axi/include/
 
 # Iterate over all include directories and write them with +incdir+ prefixed
 # +incdir+ works for Verilator and QuestaSim

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
@@ -30,6 +30,30 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
   parameter logic [63:0] CachedAddrBeg = MemBytes>>3;//1/8th of the memory is NC
   parameter logic [63:0] CachedAddrEnd = 64'hFFFF_FFFF_FFFF_FFFF;
 
+  localparam ariane_cfg_t ArianeDefaultConfig = '{
+    RASDepth: 2,
+    BTBEntries: 32,
+    BHTEntries: 128,
+    // idempotent region
+    NrNonIdempotentRules:  0,
+    NonIdempotentAddrBase: {64'b0},
+    NonIdempotentLength:   {64'b0},
+    // executable region
+    NrExecuteRegionRules:  0,
+    ExecuteRegionAddrBase: {64'h0},
+    ExecuteRegionLength:   {64'h0},
+    // cached region
+    NrCachedRegionRules:   1,
+    CachedRegionAddrBase:  {CachedAddrBeg},//1/8th of the memory is NC
+    CachedRegionLength:    {CachedAddrEnd-CachedAddrBeg+64'b1},
+    // cache config
+    Axi64BitCompliant:     1'b1,
+    SwapEndianess:         1'b0,
+    // debug
+    DmBaseAddress:         64'h0,
+    NrPMPEntries:          0
+  };
+
   // contention and invalidation rates (in %)
   parameter MemRandHitRate   = 75;
   parameter MemRandInvRate   = 10;
@@ -359,7 +383,7 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
 ///////////////////////////////////////////////////////////////////////////////
 
   std_nbdcache  #(
-    .CACHE_START_ADDR ( CachedAddrBeg )
+    .ArianeCfg ( ArianeDefaultConfig )
   ) i_dut (
     .clk_i           ( clk_i           ),
     .rst_ni          ( rst_ni          ),

--- a/corev_apu/tb/tb_wt_dcache/Makefile
+++ b/corev_apu/tb/tb_wt_dcache/Makefile
@@ -20,11 +20,15 @@ src          := $(shell xargs printf '\n%s' < $(src-list)  | cut -b 1-)
 compile_flag += +cover+i_dut -incr -64 -nologo -svinputport=compat -override_timescale 1ns/1ps -suppress 2583 -suppress 13262 +cover
 sim_opts     += -64 -coverage -classdebug -voptargs="+acc"
 questa_version ?= ${QUESTASIM_VERSION}
-incdir       += ../common/
+incdir       += ../common/ ../../axi/include/
+
+# Iterate over all include directories and write them with +incdir+ prefixed
+# +incdir+ works for Verilator and QuestaSim
+list_incdir := $(foreach dir, ${incdir}, +incdir+$(dir))
 
 build: clean
 	vlib${questa_version} $(library)
-	vlog${questa_version} -work $(library) -pedanticerrors $(src) $(compile_flag) +incdir+$(incdir)
+	vlog${questa_version} -work $(library) -pedanticerrors $(src) $(compile_flag) $(list_incdir)
 	touch $(library)/.build
 
 # this starts modelsim with gui


### PR DESCRIPTION
Due to recent changes, the modular cache test benches are unable to run. Fix them by
- updating the parameter interface of `std_nbdcache`,
- updating the dependencies and include directories,
- preventing an overflow during `range_check`.