### PR TITLE
Makefile: use init_testharness.do when VCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ vcs_build: $(dpi-library)/ariane_dpi.so
 	vcs $(if $(VERDI), -kdb -debug_access+all -lca,) -full64 -timescale=1ns/1ns -ntb_opts uvm-1.2 work.ariane_tb
 
 vcs: vcs_build
-	cd $(vcs-library) && ./simv  $(if $(VERDI), -verdi,) +permissive -sv_lib ../work-dpi/ariane_dpi +PRELOAD=$(elf-bin) +permissive-off ++$(elf-bin)| tee vcs.log
+	cd $(vcs-library) && ./simv  $(if $(VERDI), -verdi -do $(root-dir)/init_testharness.do,) +permissive -sv_lib ../work-dpi/ariane_dpi +PRELOAD=$(elf-bin) +permissive-off ++$(elf-bin)| tee vcs.log
 
 # Build the TB and module using QuestaSim
 build: $(library) $(library)/.build-srcs $(library)/.build-tb $(dpi-library)/ariane_dpi.so

--- a/init_testharness.do
+++ b/init_testharness.do
@@ -1,0 +1,1 @@
+fsdbDumpvars 0 "ariane_tb"  +all +trace_process


### PR DESCRIPTION
The init.do is executed at simulaiton start in Verdi to dump all testbench signals. Very useful when debuging RTL !

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>