### PR TITLE
Add support for "high" counter CSRs in 32-bit mode

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -136,8 +136,8 @@ module csr_regfile import ariane_pkg::*; #(
 
     logic        wfi_d,       wfi_q;
 
-    riscv::xlen_t cycle_q,     cycle_d;
-    riscv::xlen_t instret_q,   instret_d;
+    logic [63:0] cycle_q,     cycle_d;
+    logic [63:0] instret_q,   instret_d;
 
     riscv::pmpcfg_t [15:0]    pmpcfg_q,  pmpcfg_d;
     logic [15:0][riscv::PLEN-3:0]        pmpaddr_q,  pmpaddr_d;
@@ -242,11 +242,15 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MARCHID:            csr_rdata = ARIANE_MARCHID;
                 riscv::CSR_MIMPID:             csr_rdata = '0; // not implemented
                 riscv::CSR_MHARTID:            csr_rdata = hart_id_i;
-                riscv::CSR_MCYCLE:             csr_rdata = cycle_q;
-                riscv::CSR_MINSTRET:           csr_rdata = instret_q;
                 // Counters and Timers
-                riscv::CSR_CYCLE:              csr_rdata = cycle_q;
-                riscv::CSR_INSTRET:            csr_rdata = instret_q;
+                riscv::CSR_MCYCLE:             csr_rdata = cycle_q[riscv::XLEN-1:0];
+                riscv::CSR_MCYCLEH:            if (riscv::XLEN == 32) csr_rdata = cycle_q[63:32]; else read_access_exception = 1'b1;
+                riscv::CSR_MINSTRET:           csr_rdata = instret_q[riscv::XLEN-1:0];
+                riscv::CSR_MINSTRETH:          if (riscv::XLEN == 32) csr_rdata = instret_q[63:32]; else read_access_exception = 1'b1;
+                riscv::CSR_CYCLE:              csr_rdata = cycle_q[riscv::XLEN-1:0];
+                riscv::CSR_CYCLEH:             if (riscv::XLEN == 32) csr_rdata = cycle_q[63:32]; else read_access_exception = 1'b1;
+                riscv::CSR_INSTRET:            csr_rdata = instret_q[riscv::XLEN-1:0];
+                riscv::CSR_INSTRETH:           if (riscv::XLEN == 32) csr_rdata = instret_q[63:32]; else read_access_exception = 1'b1;
                 riscv::CSR_ML1_ICACHE_MISS,
                 riscv::CSR_ML1_DCACHE_MISS,
                 riscv::CSR_MITLB_MISS,

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -397,7 +397,9 @@ package riscv;
         CSR_MIMPID         = 12'hF13,
         CSR_MHARTID        = 12'hF14,
         CSR_MCYCLE         = 12'hB00,
+        CSR_MCYCLEH        = 12'hB80,
         CSR_MINSTRET       = 12'hB02,
+        CSR_MINSTRETH      = 12'hB82,
         // Performance counters (Machine Mode)
         CSR_ML1_ICACHE_MISS = 12'hB03,  // L1 Instr Cache Miss
         CSR_ML1_DCACHE_MISS = 12'hB04,  // L1 Data Cache Miss
@@ -444,8 +446,11 @@ package riscv;
         CSR_DSCRATCH1      = 12'h7b3, // optional
         // Counters and Timers (User Mode - R/O Shadows)
         CSR_CYCLE          = 12'hC00,
+        CSR_CYCLEH         = 12'hC80,
         CSR_TIME           = 12'hC01,
+        CSR_TIMEH          = 12'hC81,
         CSR_INSTRET        = 12'hC02,
+        CSR_INSTRETH       = 12'hC82,
         // Performance counters (User Mode - R/O Shadows)
         CSR_L1_ICACHE_MISS = 12'hC03,  // L1 Instr Cache Miss
         CSR_L1_DCACHE_MISS = 12'hC04,  // L1 Data Cache Miss


### PR DESCRIPTION
In 32bit mode HMCYCLEH, MINSTRETH, CYCLEH, TIMEH and INSTRETH are
used to return the most significant 32-bit value of the counters
which are now always 64-bit wide.

Signed-off-by: Steffen Persvold <spersvold@gmail.com>