### PR TITLE
FIX : LOG2_INSTR_PER_FETCH when RVC is disable

### DIFF
--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -299,7 +299,7 @@ package ariane_pkg;
     localparam int unsigned FETCH_WIDTH       = 32;
     // maximum instructions we can fetch on one request (we support compressed instructions)
     localparam int unsigned INSTR_PER_FETCH = RVC == 1'b1 ? (FETCH_WIDTH / 16) : 1;
-    localparam int unsigned LOG2_INSTR_PER_FETCH = RVC == 1'b1 ? 1 : $clog2(ariane_pkg::INSTR_PER_FETCH);
+    localparam int unsigned LOG2_INSTR_PER_FETCH = RVC == 1'b1 ? $clog2(ariane_pkg::INSTR_PER_FETCH) : 1;
 
     // Only use struct when signals have same direction
     // exception


### PR DESCRIPTION
Hello,

A simple fix for `ariane_pkg::LOG2_INSTR_PER_FETCH`. It should equal 1 not 0 when RVC is disable.
@JeanRochCoulon  can you review that ?

Guillaume