### PR TITLE
Add script to generate custom configuration

### DIFF
--- a/config_pkg_generator.py
+++ b/config_pkg_generator.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Guillaume Chauvon (guillaume.chauvon@thalesgroup.com)
+
+import sys
+import os
+import argparse
+import re
+
+def setup_parser_config_generator():
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument("--default_config", type=str, default="cv64a6_imafdc_sv39", required=True,
+                      choices=["cv32a6_imac_sv0","cv32a6_imac_sv32","cv32a6_imafc_sv32","cv64a6_imafdc_sv39"],
+                      help="Default configuration is one of the 4 preexisting configuration: \
+                            cv32a6_imac_sv0, cv32a6_imac_sv32, cv32a6_imafc_sv32, cv64a6_imafdc_sv39")
+  parser.add_argument("--isa", type=str, default=None, required=True,
+                      help="RISC-V ISA subset")
+  parser.add_argument("--fpu", type=int, default=None, choices=[0,1],
+                      help="FPU enable ? 1 : enable, 0 : disable")
+  parser.add_argument("--cvxif", type=int, default=None, choices=[0,1],
+                      help="CoreV-X-Interface enable ? 1 : enable, 0 : disable")
+  parser.add_argument("--c_ext", type=int, default=None, choices=[0,1],
+                      help="C extension enable ? 1 : enable, 0 : disable")
+  return parser
+
+ISA = ""
+MABI = ""
+Config = dict()
+
+MapArgsToParameter={
+  "xlen" : "CVA6ConfigXlen",
+  "fpu" : "CVA6ConfigFpuEn",
+  "cvxif" : "CVA6ConfigCvxifEn",
+  "c_ext" : "CVA6ConfigCExtEn"
+}
+MapParametersToArgs = {i:k for k, i in MapArgsToParameter.items()} #reverse map
+
+def generate_config(argv):
+  parser = setup_parser_config_generator()
+  args = parser.parse_args(argv)
+  Args = vars(args) # give a dictionary of args
+  print("\n[Generating configuration ... ]")
+  print("Default configuration is "+Args['default_config'])
+  print("Make sure to compile your code with this ISA :", Args["isa"], "!")
+  ISA = Args["isa"]
+  if "cv32" in Args['default_config']:
+    gen = "gen32"
+    Args['xlen'] = 32
+    MABI = "ilp32"
+  else:
+    gen = "gen64"
+    Args['xlen'] = 64
+    MABI = "lp64"
+  os.system("cp core/Flist."+Args['default_config']+" core/Flist."+gen) #copy Flist
+  os.system("cp core/include/"+Args['default_config']+"_config_pkg.sv core/include/"+gen+"_config_pkg.sv") # copy package
+  Flistfile = open("core/Flist."+gen, "r")
+  Flistlines = []
+  for line in Flistfile :
+    line = re.sub(r"(\${CVA6_REPO_DIR}/core/include/)"+Args['default_config']+"(_config_pkg.sv)", r"\g<1>"+gen+"\g<2>", line) # change package name in Flist to the one generated
+    Flistlines.append(line)
+  Flistfile = open("core/Flist."+gen, "w")
+  Flistfile.writelines(Flistlines)
+  Flistfile.close
+  for i in Args:
+    configfile = open("core/include/"+gen+"_config_pkg.sv", "r")
+    if i not in ['default_config', 'isa', 'xlen']:
+      if Args[i] != None:
+        print("setting", i, "to", Args[i])
+        alllines = []
+        for line in configfile :
+          line = re.sub(r"(    localparam "+MapArgsToParameter[i]+" = )(.*)(;)", r"\g<1>"+str(Args[i])+"\g<3>", line) # change parameter if required by Args
+          alllines.append(line)
+          linematch = re.match(r"(    localparam (CVA6Config)(?P<param>.*) = )(?P<value>.*)(;)", line) # and read the modified line to know which configuration we are creating
+          if linematch:
+            Param = MapParametersToArgs['CVA6Config'+linematch.group('param')]
+            Config[Param] = linematch.group('value')
+            for k in Config.keys():
+              Config[k] = int(Config[k]) # Convert value from str to int
+        configfile = open("core/include/"+gen+"_config_pkg.sv", "w")
+        configfile.writelines(alllines)
+  configfile.close
+  print("[Generating configuration Done]")
+  return [ISA, MABI, gen, Config] # return ISA, MABI, gen (for testharness), Config for cva6.py in core-v-verif
+
+
+if __name__ == "__main__":
+  generate_config(sys.argv[1:])


### PR DESCRIPTION
Hello,

I have written a python script to generate custom configuration from one of the existing four ( cv32_...._config_pkg, etc...).

This script allows us at Thales to run regression on specific configuration to make sure new commits do not break features which are not in our four configuration. 
Examples: Check that we can still disable X-interface or FPU in 64 bits, activate user bits etc... 

Each parameter can be modified ( in the limit of possible values ) except for the `xlen` parameter.
A mandatory `--isa` parameter is required to make sure code is compiled with the right ISA. If FPU is disable, the CVA6 should not run a code with F or D extension. 
**Note**: --isa is not used to create new configuration but is returned by the script to be used to compile code. It is necessary to compile any test from core-v-verif repositories.

Example of command to disable FPU, X-interface and C extension from the 64 bits configuration: 

`python3 config_pkg_generator.py --default_config=cv64a6_imafdc_sv39 --isa=rv64ima --fpu=0 --cvxif=0 --c_ext=0`

It will generate `core/include/gen64_config_pkg.sv` and `core/Flist.gen64` ( gen32... if default configuration is 32 bits ). Change the `target` parameter in the [Makefile](https://github.com/openhwgroup/cva6/blob/34f63b44873148d371133bfa8642d2b7d388f39b/Makefile) to gen32 or gen64 to build the CVA6 with the generated configuration.

Guillaume