### PR TITLE
fix sfence.vma decoder

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -154,7 +154,7 @@ module decoder import ariane_pkg::*; (
                                     if (instr.instr[31:25] == 7'b1001) begin
                                         // check privilege level, SFENCE.VMA can only be executed in M/S mode
                                         // otherwise decode an illegal instruction
-                                        illegal_instr    = (priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) ? 1'b0 : 1'b1;
+                                        illegal_instr    = (priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) ? illegal_instr : 1'b1;
                                         instruction_o.op = ariane_pkg::SFENCE_VMA;
                                         // check TVM flag and intercept SFENCE.VMA call if necessary
                                         if (priv_lvl_i == riscv::PRIV_LVL_S && tvm_i)


### PR DESCRIPTION
from https://github.com/openhwgroup/cva6/issues/876, this patch passed the testcase in the report.
The original design reset the illegal_instr during privilege check, use the previous value instead 0.