### PR TITLE
fix dret decoder

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -132,7 +132,7 @@ module decoder import ariane_pkg::*; (
                                 12'b111_1011_0010: begin
                                     instruction_o.op = ariane_pkg::DRET;
                                     // check that we are in debug mode when executing this instruction
-                                    illegal_instr = (!debug_mode_i) ? 1'b1 : 1'b0;
+                                    illegal_instr = (!debug_mode_i) ? 1'b1 : illegal_instr;
                                 end
                                 // WFI
                                 12'b1_0000_0101: begin


### PR DESCRIPTION
from https://github.com/openhwgroup/cva6/issues/899, this patch passed the testcase in the report.
debug mode check reset the illegal_instr signal, use its previous value instead of 0.