### PR TITLE
fix fence(.i) decoder

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -234,9 +234,6 @@ module decoder import ariane_pkg::*; (
 
                         default: illegal_instr = 1'b1;
                     endcase
-
-                    if (instr.stype.rs1 != '0 || instr.stype.imm0 != '0 || instr.instr[31:28] != '0)
-                        illegal_instr = 1'b1;
                 end
 
                 // --------------------------


### PR DESCRIPTION
from https://github.com/openhwgroup/cva6/issues/900, this patch passed the testcase in the report.
As specification suggests: `For forward compatibility, base implementations shall ignore these fields, and standard software shall zero these fields`, remove the check on related fields.

