### PR TITLE
FPGA: Add scripts to check linux boot linux on fpga

### DIFF
--- a/corev_apu/fpga/Makefile
+++ b/corev_apu/fpga/Makefile
@@ -40,7 +40,7 @@ program:
 	$(VIVADO) $(VIVADOFLAGS) -source scripts/program.tcl
 
 clean:
-	rm -rf *.log *.jou *.str *.mif *.xpr $(work-dir) ariane.cache ariane.hw ariane.ip_user_files
+	rm -rf *.log *.jou *.str *.mif *.xpr $(work-dir) ariane.cache ariane.hw ariane.ip_user_files scripts/vivado*
 
 .PHONY:
 	clean

--- a/corev_apu/fpga/scripts/check_fpga_boot.sh
+++ b/corev_apu/fpga/scripts/check_fpga_boot.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2022 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Guillaume CHAUVON (guillaume.chauvon@thalesgroup.com)
+
+
+BITSTREAM=../work-fpga/ariane_xilinx.bit
+
+if ! [ -n "$VIVADO_CMD" ]; then
+  echo "Error: VIVADO_CMD variable undefined.
+It most likely should be VIVADO_CMD=vivado_lab if you installed 2022's version of vivado."
+  return
+fi
+
+if [ -f "$BITSTREAM" ]; then
+    $VIVADO_CMD -mode batch -source program_genesys2.tcl &&\
+    python3 linux_boot.py
+fi

--- a/corev_apu/fpga/scripts/linux_boot.py
+++ b/corev_apu/fpga/scripts/linux_boot.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Guillaume CHAUVON (guillaume.chauvon@thalesgroup.com)
+
+# Check that linux boots by reading FPGA's UART.
+# If linux does not boot, this script will loop infinitely so it is recommended to kill it.
+# In Thales-CI it is killed from the timeout of the job triggering it.
+
+import sys
+import serial
+import os
+
+
+ser = serial.Serial(os.getenv("UART_SERIAL"), 115200, timeout=60)
+ser.baudrate = 115200
+
+with open("fpga_boot.rpt", "w") as f:
+    while True:
+        firstChar = ser.read().decode("utf-8")
+        line = ser.readline().decode("utf-8")
+        print(firstChar + line, end="")
+        f.write(firstChar + line)
+        # Check for command prompt
+        if firstChar == "#" and line == " ":
+            ser.write(b"uname -a\n")
+        elif firstChar == "" and line == "":
+            sys.exit(1)
+            break
+        if ("Linux buildroot" in firstChar + line) and (
+            "riscv" in firstChar + line
+        ):
+            break
+
+print("Successful Linux boot !")
+ser.close()
+sys.exit(0)

--- a/corev_apu/fpga/scripts/program_genesys2.tcl
+++ b/corev_apu/fpga/scripts/program_genesys2.tcl
@@ -1,0 +1,20 @@
+# Copyright 2022 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Guillaume CHAUVON (guillaume.chauvon@thalesgroup.com)
+
+# Program Genesys2 FPGA board connected to $HW_SERVER_URL with bitstream ../work-fpga/ariane_xilinx.bit
+
+open_hw_manager
+# Connect to an HW_SERVER connected to the FPGA.
+# It is recommended to launch the hw_server before using this script to specify its URL.
+connect_hw_server -url $env(HW_SERVER_URL)
+open_hw_target
+current_hw_device [get_hw_devices xc7k325t_0]
+set_property PROGRAM.FILE {../work-fpga/ariane_xilinx.bit} [get_hw_device xc7k325t_0]
+program_hw_devices [get_hw_devices xc7k325t_0]
+refresh_hw_device [lindex [get_hw_devices xc7k325t_0] 0]


### PR DESCRIPTION
Add 3 scripts to check linux boot on FPGA using Vivado. 

- `check_fpga_boot.sh`: Top script, check that `VIVADO_CMD` is set and `BITSTREAM `exist before programming and checking linux boot.
- `program_genesys2.tcl`: Vivado tcl script to program fpga connected to an `HW_SERVER`
- `linux_boot.py`: python script that reads `UART_SERIAL` and check that linux boot successfully.

All those scripts are used by an incoming PR in core-v-verif that creates a job in Thales-CI and is integrated to Thales Dashboard

@JeanRochCoulon @yanicasa Can you look at this ?