### PR TITLE
Enable CVXIF for target cv32a60X and add renaming for cvxif when using 3 operands

### DIFF
--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -18,7 +18,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigF8En = 0;
     localparam CVA6ConfigFVecEn = 0;
 
-    localparam CVA6ConfigCvxifEn = 0;
+    localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
 

--- a/core/re_name.sv
+++ b/core/re_name.sv
@@ -69,7 +69,7 @@ module re_name import ariane_pkg::*; (
         issue_instr_o.rs2 = { ENABLE_RENAME & name_bit_rs2, issue_instr_i.rs2[4:0] };
 
         // re-name the third operand in imm if it's actually an operand
-        if (is_imm_fpr(issue_instr_i.op)) begin
+        if (is_imm_fpr(issue_instr_i.op) || (issue_instr_i.op == OFFLOAD && ariane_pkg::NR_RGPR_PORTS == 3)) begin
             issue_instr_o.result = { ENABLE_RENAME & name_bit_rs3, issue_instr_i.result[4:0]};
         end
         // re-name the destination register


### PR DESCRIPTION
Enable X-interface in cv32a60x package
Enable renaming for cvxif when using 3 operands

@JeanRochCoulon can you look at this ? 