### PR TITLE
decoder.sv: fix sfence.vma when rs1 != 0

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -158,7 +158,7 @@ module decoder import ariane_pkg::*; (
                                     if (instr.instr[31:25] == 7'b1001) begin
                                         // check privilege level, SFENCE.VMA can only be executed in M/S mode
                                         // otherwise decode an illegal instruction
-                                        illegal_instr    = (priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) ? illegal_instr : 1'b1;
+                                        illegal_instr    = ((priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) && instr.itype.rd == '0) ? 1'b0 : 1'b1;
                                         instruction_o.op = ariane_pkg::SFENCE_VMA;
                                         // check TVM flag and intercept SFENCE.VMA call if necessary
                                         if (priv_lvl_i == riscv::PRIV_LVL_S && tvm_i)


### PR DESCRIPTION
Hello,

Related to  PR #921 and issue #876. @Phantom1003 you might want to check this. 


Unlike other instructions with minor opcode == PRIV (000), SFENCE.VMA do not check for rs1 != 0.
Illegal instruction happens if  : 
- rd !=0
-  privilege mode not in S or M.

The solution I propose check for rd != 0 which should solved the issue raised in #876. 
It also reset the illegal instruction flag to 0 in case it has been raised in the if case below :

https://github.com/openhwgroup/cva6/blob/56ccf8089e80e5c7950038cad5796e50c64aa0c2/core/decoder.sv#L99-L103

