### PR TITLE
Bump Verilator to v4.224

### DIFF
--- a/ci/install-verilator.sh
+++ b/ci/install-verilator.sh
@@ -7,13 +7,14 @@ if [ -z ${NUM_JOBS} ]; then
     NUM_JOBS=1
 fi
 
+VERSION="4.224"
+
 if [ ! -e "$VERILATOR_ROOT/bin/verilator" ]; then
     echo "Installing Verilator"
-    rm -f verilator*.tgz
-    wget https://www.veripool.org/ftp/verilator-4.014.tgz
-    tar xzf verilator*.tgz
-    rm -f verilator*.tgz
-    cd verilator-4.014
+    wget https://github.com/verilator/verilator/archive/refs/tags/v${VERSION}.tar.gz
+    tar xzf v${VERSION}.tar.gz
+    rm -f v${VERSION}.tar.gz
+    cd verilator-${VERSION}
     mkdir -p $VERILATOR_ROOT
     # copy scripts
     autoconf && ./configure --prefix="$VERILATOR_ROOT" && make -j${NUM_JOBS}

--- a/ci/path-setup.sh
+++ b/ci/path-setup.sh
@@ -10,7 +10,7 @@ export CXX=g++-7 CC=gcc-7
 
 # where to install the tools
 export RISCV=$TOP/riscv_install
-export VERILATOR_ROOT=$TOP/verilator-4.014/
+export VERILATOR_ROOT=$TOP/verilator-4.224/
 
 export PATH=$RISCV/bin:$VERILATOR_ROOT/bin:$PATH
 export LIBRARY_PATH=$RISCV/lib

--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -20,6 +20,7 @@
 #include "verilated.h"
 #include "verilated_vcd_c.h"
 #include "Variane_testharness__Dpi.h"
+#include "Variane_testharness___024root.h"
 
 #include <stdio.h>
 #include <iostream>
@@ -320,7 +321,7 @@ done_processing:
 
   // Preload memory.
   size_t mem_size = 0xFFFFFF;
-  memif.read(0x80000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram);
+  memif.read(0x80000000, mem_size, (void *)top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram.m_storage);
   // memif.read(0x84000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__gen_mem_user__DOT__i_tc_sram_wrapper_user__DOT__i_tc_sram__DOT__sram);
 
 #ifndef DROMAJO


### PR DESCRIPTION
We're working on bumping Verilator to a modern release in Chipyard (https://github.com/ucb-bar/chipyard/pull/1205) and as part of that process we ran into a segfault when trying to simulate a Chipyard SoC with an Ariane core (which might be a Verilator bug). 

To isolate the issue, I bumped Verilator in cva6 and verified that the simulation using your infrastructure works fine. This PR contains the minor changes required ([see](https://verilator.org/guide/latest/connecting.html#model-interface-changes-in-version-4-210)) if you all are interested. Feel free to close this otherwise. 

Seemingly resolves (https://github.com/openhwgroup/cva6/issues/931) (vcd dumping works with the latest Verilator) and (https://github.com/openhwgroup/cva6/issues/934)