### PR TITLE
Remove redundant RTL from multiplier file

### DIFF
--- a/core/multiplier.sv
+++ b/core/multiplier.sv
@@ -78,10 +78,6 @@ module multiplier import ariane_pkg::*; (
 
     assign mult_valid      = mult_valid_i && (operator_i inside {MUL, MULH, MULHU, MULHSU, MULW, CLMUL, CLMULH, CLMULR});
 
-    // datapath
-    logic [riscv::XLEN*2-1:0] mult_result;
-    assign mult_result   = $signed({operand_a_i[riscv::XLEN-1] & sign_a, operand_a_i}) * $signed({operand_b_i[riscv::XLEN-1] & sign_b, operand_b_i});
-
     // Sign Select MUX
     always_comb begin
         sign_a = 1'b0;


### PR DESCRIPTION
Hey @zarubaf, @JeanRochCoulon 

As mentioned in [issue#863](https://github.com/openhwgroup/cva6/issues/863), the following two lines are not being used in the entire module, so they seem to be redundant:

```
logic [riscv::XLEN*2-1:0] mult_result;
assign mult_result   = $signed({operand_a_i[riscv::XLEN-1] & sign_a, operand_a_i}) * 
                                     $signed({operand_b_i[riscv::XLEN-1] & sign_b, operand_b_i});
```

Moreover, the RTL of the line [number#49](https://github.com/openhwgroup/cva6/blob/2c3d0f741d5d7ce55b06181a417280bfae499583/core/multiplier.sv#L49) is similar to the one in line [number#72](https://github.com/openhwgroup/cva6/blob/2c3d0f741d5d7ce55b06181a417280bfae499583/core/multiplier.sv#L72), as shown below:

```
assign mult_result_d   = $signed({operand_a_i[riscv::XLEN-1] & sign_a, operand_a_i}) *
                                        $signed({operand_b_i[riscv::XLEN-1] & sign_b, operand_b_i});
```
                                        
 I have removed these lines form `multiplier.sv` file.
 
 Thanks!