### PR TITLE
decoder: add missing default case for BITMANIP

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -660,6 +660,7 @@ module decoder import ariane_pkg::*; (
                                 else
                                     illegal_instr_bm = 1'b1;
                             end
+                            default: illegal_instr_bm = 1'b1;
                         endcase
                     end
                     illegal_instr = (ariane_pkg::BITMANIP) ? (illegal_instr_non_bm & illegal_instr_bm) : illegal_instr_non_bm;


### PR DESCRIPTION
Default case is missing for unique-case when BITMANIP is enable.