### PR TITLE
cvxif_fu.sv: add register to hold illegal instruction information

### DIFF
--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -29,6 +29,10 @@ module cvxif_fu import ariane_pkg::*; (
     input  cvxif_pkg::cvxif_resp_t            cvxif_resp_i
 );
 
+    logic illegal_n, illegal_q;
+    logic [TRANS_ID_BITS-1:0] illegal_id_n, illegal_id_q;
+    logic [31:0] illegal_instr_n, illegal_instr_q;
+
     always_comb begin
       cvxif_req_o = '0;
       cvxif_req_o.x_result_ready = 1'b1;
@@ -50,22 +54,44 @@ module cvxif_fu import ariane_pkg::*; (
     end
 
     always_comb begin
-      if (~cvxif_resp_i.x_issue_resp.accept && cvxif_req_o.x_issue_valid && cvxif_resp_i.x_issue_ready) begin
-          x_trans_id_o          = cvxif_req_o.x_issue_req.id;
-          x_result_o            = 0;
-          x_valid_o             = 1;
+      illegal_n       = illegal_q;
+      illegal_id_n    = illegal_id_q;
+      illegal_instr_n = illegal_instr_q;
+      if (~cvxif_resp_i.x_issue_resp.accept && cvxif_req_o.x_issue_valid && cvxif_resp_i.x_issue_ready && ~illegal_n) begin
+          illegal_n       = 1'b1;
+          illegal_id_n    = cvxif_req_o.x_issue_req.id;
+          illegal_instr_n = cvxif_req_o.x_issue_req.instr;
+      end
+      x_valid_o             = cvxif_resp_i.x_result_valid; //Read result only when CVXIF is enabled
+      x_trans_id_o          = x_valid_o ? cvxif_resp_i.x_result.id : '0;
+      x_result_o            = x_valid_o ? cvxif_resp_i.x_result.data : '0;
+      x_exception_o.cause   = x_valid_o ? cvxif_resp_i.x_result.exccode : '0;
+      x_exception_o.valid   = x_valid_o ? cvxif_resp_i.x_result.exc : '0;
+      x_exception_o.tval    = '0;
+      x_we_o                = x_valid_o ? cvxif_resp_i.x_result.we : '0;
+      if (illegal_n) begin
+        if (~x_valid_o) begin
+          x_trans_id_o          = illegal_id_n;
+          x_result_o            = '0;
+          x_valid_o             = 1'b1;
           x_exception_o.cause   = riscv::ILLEGAL_INSTR;
-          x_exception_o.valid   = 1;
-          x_exception_o.tval    = cvxif_req_o.x_issue_req.instr;
+          x_exception_o.valid   = 1'b1;
+          x_exception_o.tval    = illegal_instr_n;
           x_we_o                = '0;
+          illegal_n             = '0; // Reset flag for illegal instr. illegal_id and illegal instr values are a don't care, no need to reset it.
+        end
+      end
+    end
+
+    always_ff @(posedge clk_i, negedge rst_ni) begin
+      if (~rst_ni) begin
+        illegal_q       <= 1'b0;
+        illegal_id_q    <= '0;
+        illegal_instr_q <= '0;
       end else begin
-          x_valid_o             = cvxif_resp_i.x_result_valid; //Read result only when CVXIF is enabled
-          x_trans_id_o          = x_valid_o ? cvxif_resp_i.x_result.id : '0;
-          x_result_o            = x_valid_o ? cvxif_resp_i.x_result.data : '0;
-          x_exception_o.cause   = x_valid_o ? cvxif_resp_i.x_result.exccode : '0;
-          x_exception_o.valid   = x_valid_o ? cvxif_resp_i.x_result.exc : '0;
-          x_exception_o.tval    = '0;
-          x_we_o                = x_valid_o ? cvxif_resp_i.x_result.we : '0;
+        illegal_q       <= illegal_n;
+        illegal_id_q    <= illegal_id_n;
+        illegal_instr_q <= illegal_instr_n;
       end
     end
 


### PR DESCRIPTION
Hello,

We encountered an issue when illegal instruction were offloaded to CVXIF the same cycle CVXIF sent back result from a previous custom instruction. Illegal instruction was prioritized over the result instruction. The CVA6 would then stall infinitely waiting for this custom instruction result which would never come.

The solution I propose add a register to hold illegal instruction information so we raise the illegal instruction once the CVXIF's result interface is not valid anymore.

Guillaume. 