### PR TITLE
Update to synthesis and simulation gate flow

### DIFF
--- a/core/Flist.cv32a60x_gate
+++ b/core/Flist.cv32a60x_gate
@@ -8,7 +8,7 @@
 # Original Author: Jean-Roch COULON (jean-roch.coulon@thalesgroup.com)
 #
 
-${CVA6_REPO_DIR}/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+${CVA6_REPO_DIR}/core/include/cv32a60x_config_pkg.sv
 ${CVA6_REPO_DIR}/core/include/riscv_pkg.sv
 ${CVA6_REPO_DIR}/corev_apu/riscv-dbg/src/dm_pkg.sv
 ${CVA6_REPO_DIR}/core/include/ariane_pkg.sv
@@ -22,8 +22,9 @@ ${CVA6_REPO_DIR}/core/include/std_cache_pkg.sv
 ${CVA6_REPO_DIR}/core/include/axi_intf.sv
 ${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
 
+# NETLIST
 ${LIB_VERILOG}
-${CVA6_REPO_DIR}/pd/synth/cva6_cv64a6_imafdc_sv39_synth_modified.v
+${CVA6_REPO_DIR}/pd/synth/cva6_cv32a60x_synth_modified.v
 
 ${CVA6_REPO_DIR}/pd/synth/tc_sram_wrapper_256_64_00000008_00000001_00000001_none_0.sv
 ${CVA6_REPO_DIR}/common/local/util/tc_sram_wrapper.sv

--- a/pd/synth/Makefile
+++ b/pd/synth/Makefile
@@ -8,7 +8,7 @@
 # Original Author: Jean-Roch COULON (jean-roch.coulon@thalesgroup.com)
 #
 
-DESIGN_NAME           = ariane
+DESIGN_NAME           = cva6
 PERIOD               ?= 17
 FOUNDRY_PATH         ?=
 TECH_NAME            ?=
@@ -19,7 +19,7 @@ DC_SHELL_PATH        ?= /opt/synopsys/syn/Q-2019.12/bin/
 NAND2_AREA           ?= 1120
 TARGET               ?= cv64a6_imafdc_sv39
 
-EXPORT_LIST=SNPSLMD_QUEUE=TRUE TECH_NAME=$(TECH_NAME) DESIGN_NAME=$(DESIGN_NAME) TERM=vt100 PERIOD=$(PERIOD) FOUNDRY_PATH=$(FOUNDRY_PATH) TARGET_LIBRARY_FILES=$(TARGET_LIBRARY_FILES) INPUT_DELAY=$(INPUT_DELAY) OUTPUT_DELAY=$(OUTPUT_DELAY)
+EXPORT_LIST=SNPSLMD_QUEUE=TRUE TECH_NAME=$(TECH_NAME) DESIGN_NAME=$(DESIGN_NAME) TARGET=$(TARGET) TERM=vt100 PERIOD=$(PERIOD) FOUNDRY_PATH=$(FOUNDRY_PATH) TARGET_LIBRARY_FILES=$(TARGET_LIBRARY_FILES) INPUT_DELAY=$(INPUT_DELAY) OUTPUT_DELAY=$(OUTPUT_DELAY)
 
 ifndef FOUNDRY_PATH
   $(error "Please provide FOUNDRY techno")
@@ -35,11 +35,14 @@ pre_cva6_synth:
 cva6_synth: pre_cva6_synth
 	@echo $(PERIOD)
 	@export $(EXPORT_LIST); $(DC_SHELL_PATH)/dc_shell -f ./cva6_synth.tcl -output synthesis_batch.log
-	python scripts/gate_analysis.py '$(DESIGN_NAME)/reports/$(PERIOD)/$(DESIGN_NAME)_$(TECH_NAME)_synth_area.rpt' $(NAND2_AREA)
-	sed 's/tc_sram_wrapper_256_64_00000008_00000001_00000001_none_0 gen/tc_sram_wrapper gen/' ariane_synth.v > ariane_synth_modified.v
+	python scripts/gate_analysis.py '$(DESIGN_NAME)_$(TARGET)/reports/$(PERIOD)/$(DESIGN_NAME)_$(TECH_NAME)_synth_area.rpt' $(NAND2_AREA)
+	mv $(DESIGN_NAME)_synth.v $(DESIGN_NAME)_$(TARGET)_synth.v
+	mv $(DESIGN_NAME)_synth.v.sdf $(DESIGN_NAME)_$(TARGET)_synth.v.sdf
+	sed -n -e '/module tc_sram_wrapper_256_64_00000008_00000001_00000001_none_0/,/endmodule/!p' $(DESIGN_NAME)_$(TARGET)_synth.v > $(DESIGN_NAME)_$(TARGET)_synth_modified.v
+	sed -i 's/cva6_ /cva6 /g' $(DESIGN_NAME)_$(TARGET)_synth_modified.v
 
 cva6_read:
 	@export $(EXPORT_LIST); $(DC_SHELL_PATH)/dc_shell -f cva6_read.tcl -gui
 
 clean:
-	@rm -rf work alib* *_LIB *log *svf netlist reports ${DESIGN_NAME}
+	@rm -rf work alib* *_LIB *log *svf netlist reports ${DESIGN_NAME}_${TARGET}

--- a/pd/synth/cva6_synth.tcl
+++ b/pd/synth/cva6_synth.tcl
@@ -34,10 +34,10 @@ link
 create_clock [get_ports $clk_port] -name $clk_name -period $clk_period
 
 #set_dont_touch to keep sram as black boxes
-set_dont_touch i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams[*].i_tag_sram
-set_dont_touch i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks[*].i_data_sram
-set_dont_touch i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram[*].data_sram
-set_dont_touch i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram[*].tag_sram
+set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams[*].i_tag_sram
+set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks[*].i_data_sram
+set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].data_sram
+set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].tag_sram
 
 write -hierarchy -format ddc -output ${DCRM_ELABORATED_DESIGN_DDC_OUTPUT_FILE}
 
@@ -47,15 +47,15 @@ change_name -rule verilog -hier
 set_fix_multiple_port_nets -all -buffer_constants
 
 #constraint the timing to and from the sram black boxes
-set_input_delay -clock main_clk -max $input_delay i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
-set_input_delay -clock main_clk -max $input_delay i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
-set_input_delay -clock main_clk -max $input_delay i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
-set_input_delay -clock main_clk -max $input_delay i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
 
-set_output_delay $output_delay -max -clock main_clk i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
-set_output_delay $output_delay -max -clock main_clk i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
-set_output_delay $output_delay -max -clock main_clk i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
-set_output_delay $output_delay -max -clock main_clk i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
 
 # Check the current design for consistency
 check_design -summary > ${DCRM_CHECK_DESIGN_REPORT}
@@ -69,17 +69,18 @@ write -format verilog -hierarchy -output ${DESIGN_NAME}_synth.v
 write -format ddc     -hierarchy -output ${DCRM_FINAL_DDC_OUTPUT_FILE}
 
 report_timing -nworst 10  >  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
-report_timing -through i_cva6/i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_ram/rdata_o[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
+report_timing -through i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/addr_i[*] >>  ${DCRM_FINAL_TIMING_REPORT}
 
 report_area -hier -nosplit > ${DCRM_FINAL_AREA_REPORT}
 write_parasitics -output ${DCRM_FINAL_SPEF_OUTPUT_FILE}
 write_sdc ${DCRM_FINAL_SDC_OUTPUT_FILE}
+write_sdf ${DESIGN_NAME}_synth.v.sdf
 
 exit

--- a/pd/synth/scripts/dc_setup.tcl
+++ b/pd/synth/scripts/dc_setup.tcl
@@ -11,6 +11,7 @@
 # Variables common to all reference methodology scripts
 set PERIOD                        [getenv PERIOD];
 set DESIGN_NAME                   [getenv DESIGN_NAME]  ;#  The name of the top-level design
+set TARGET                        [getenv TARGET];
 set TECH                          [getenv TECH_NAME];
 set techno                        [getenv TECH_NAME];
 set FOUNDRY_PATH                  [getenv FOUNDRY_PATH];

--- a/pd/synth/scripts/dc_setup_filenames.tcl
+++ b/pd/synth/scripts/dc_setup_filenames.tcl
@@ -17,9 +17,9 @@ puts "RM-Info: Running script [info script]\n"
 # Copyright (C) 2010-2015 Synopsys, Inc. All rights reserved.
 #################################################################################
 
-set INPUTS_DIR ${DESIGN_NAME}/inputs/
-set REPORTS_DIR ${DESIGN_NAME}/reports/${PERIOD}/
-set OUTPUTS_DIR ${DESIGN_NAME}/outputs/${PERIOD}/
+set INPUTS_DIR ${DESIGN_NAME}_${TARGET}/inputs/
+set REPORTS_DIR ${DESIGN_NAME}_${TARGET}/reports/${PERIOD}/
+set OUTPUTS_DIR ${DESIGN_NAME}_${TARGET}/outputs/${PERIOD}/
 file mkdir ${INPUTS_DIR}
 file mkdir ${REPORTS_DIR}
 file mkdir ${OUTPUTS_DIR}

--- a/pd/synth/tc_sram_wrapper_256_64_00000008_00000001_00000001_none_0.sv
+++ b/pd/synth/tc_sram_wrapper_256_64_00000008_00000001_00000001_none_0.sv
@@ -1,0 +1,60 @@
+// Copyright 2022 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON (jean-roch.coulon@thalesgroup.com)
+
+module tc_sram_wrapper_256_64_00000008_00000001_00000001_none_0 #(
+  parameter int unsigned NumWords     = 32'd256, // Number of Words in data array
+  parameter int unsigned DataWidth    = 32'd64,  // Data signal width
+  parameter int unsigned ByteWidth    = 32'd8,    // Width of a data byte
+  parameter int unsigned NumPorts     = 32'd1,    // Number of read and write ports
+  parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
+  parameter              SimInit      = "none",   // Simulation initialization
+  parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
+  parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
+  parameter type         addr_t    = logic [AddrWidth-1:0],
+  parameter type         data_t    = logic [DataWidth-1:0],
+  parameter type         be_t      = logic [BeWidth-1:0]
+) (
+  input  logic                 clk_i,      // Clock
+  input  logic                 rst_ni,     // Asynchronous reset active low
+  // input ports
+  input  logic  [NumPorts-1:0] req_i,      // request
+  input  logic  [NumPorts-1:0] we_i,       // write enable
+  input  addr_t [NumPorts-1:0] addr_i,     // request address
+  input  data_t [NumPorts-1:0] wdata_i,    // write data
+  input  be_t   [NumPorts-1:0] be_i,       // write byte enable
+  // output ports
+  output data_t [NumPorts-1:0] rdata_o     // read data
+);
+
+// synthesis translate_off
+
+  tc_sram #(
+    .NumWords(NumWords),
+    .DataWidth(DataWidth),
+    .ByteWidth(ByteWidth),
+    .NumPorts(NumPorts),
+    .Latency(Latency),
+    .SimInit(SimInit),
+    .PrintSimCfg(PrintSimCfg)
+  ) i_tc_sram (
+      .clk_i    ( clk_i   ),
+      .rst_ni   ( rst_ni  ),
+      .req_i    ( req_i   ),
+      .we_i     ( we_i    ),
+      .be_i     ( be_i    ),
+      .wdata_i  ( wdata_i ),
+      .addr_i   ( addr_i  ),
+      .rdata_o  ( rdata_o )
+    );
+
+// synthesis translate_on
+
+endmodule


### PR DESCRIPTION
core/Flist.cv32a60x: [NEW] Add Flist for gate simulation with cv32a60x configuration
core/Flist.cv64a6_imafdc_sv39: Update to support uvm testbench
                               match $DESIGN_NAME variable in Makefile
pd/synth/Makefile: Add $TARGET variable to chose which config to synthetise
                   Change DESIGN_NAME to cva6 module so it is the top module
pd/synth/cva6_synth.tcl: Update to match new topmodule
pd/synth/dc_setup.tcl;dc_setup_filenames.tcl: Uptade to match new path with $TARGET
pd/synth/tc_sram_wrapper_...sv: Add a copy of tc_sram with specific parameters to replace tc_sram in netlist

@JeanRochCoulon @yanicasa can you look at that ?

