### PR TITLE
[RVFI] Many files: Add support for tracing addr/mask/data of memory ops.

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -71,6 +71,13 @@ module cva6 import ariane_pkg::*; #(
   logic                       eret;
   logic [NR_COMMIT_PORTS-1:0] commit_ack;
 
+  // RVFI
+  logic [riscv::XLEN-1:0]                               rvfi_mem_addr_o;
+  logic [(riscv::XLEN/8)-1:0]                           rvfi_mem_rmask_o;
+  logic [(riscv::XLEN/8)-1:0]                           rvfi_mem_rdata_o;
+  logic [(riscv::XLEN/8)-1:0]                           rvfi_mem_wmask_o;
+  logic [riscv::XLEN-1:0]                               rvfi_mem_wdata_o;
+
   // --------------
   // PCGEN <-> CSR
   // --------------
@@ -470,6 +477,11 @@ module cva6 import ariane_pkg::*; #(
     .dcache_req_ports_o     ( dcache_req_ports_ex_cache   ),
     .dcache_wbuffer_empty_i ( dcache_commit_wbuffer_empty ),
     .dcache_wbuffer_not_ni_i ( dcache_commit_wbuffer_not_ni ),
+    .rvfi_mem_addr_o        ( rvfi_mem_addr_o             ),
+    .rvfi_mem_rmask_o       ( rvfi_mem_rmask_o            ),
+    .rvfi_mem_rdata_o       ( rvfi_mem_rdata_o            ),
+    .rvfi_mem_wmask_o       ( rvfi_mem_wmask_o            ),
+    .rvfi_mem_wdata_o       ( rvfi_mem_wdata_o            ),
     // PMP
     .pmpcfg_i               ( pmpcfg                      ),
     .pmpaddr_i              ( pmpaddr                     )
@@ -957,6 +969,14 @@ module cva6 import ariane_pkg::*; #(
       rvfi_o[i].rd_addr  = commit_instr_id_commit[i].rd;
       rvfi_o[i].rd_wdata = ariane_pkg::is_rd_fpr(commit_instr_id_commit[i].op) == 0 ? wdata_commit_id[i] : commit_instr_id_commit[i].result;
       rvfi_o[i].pc_rdata = commit_instr_id_commit[i].pc;
+      rvfi_o[i].mem_addr  = rvfi_mem_addr_o;
+
+      rvfi_o[i].mem_wmask = rvfi_mem_wmask_o;
+      rvfi_o[i].mem_wdata = rvfi_mem_wdata_o;
+
+      rvfi_o[i].mem_rmask = rvfi_mem_rmask_o;
+      rvfi_o[i].mem_rdata = rvfi_mem_rdata_o;
+
     end
   end
 `endif

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -114,6 +114,12 @@ module ex_stage import ariane_pkg::*; #(
     // Performance counters
     output logic                                   itlb_miss_o,
     output logic                                   dtlb_miss_o,
+    // RVFI
+    output logic [riscv::XLEN-1:0]                 rvfi_mem_addr_o,
+    output logic [(riscv::XLEN/8)-1:0]             rvfi_mem_rmask_o,
+    output logic [riscv::XLEN-1:0]                 rvfi_mem_rdata_o,
+    output logic [(riscv::XLEN/8)-1:0]             rvfi_mem_wmask_o,
+    output logic [riscv::XLEN-1:0]                 rvfi_mem_wdata_o,
     // PMPs
     input  riscv::pmpcfg_t [15:0]                  pmpcfg_i,
     input  logic[15:0][riscv::PLEN-3:0]            pmpaddr_i
@@ -326,6 +332,11 @@ module ex_stage import ariane_pkg::*; #(
         .amo_valid_commit_i,
         .amo_req_o,
         .amo_resp_i,
+        .rvfi_mem_addr_o,
+        .rvfi_mem_rmask_o,
+        .rvfi_mem_rdata_o,
+        .rvfi_mem_wmask_o,
+        .rvfi_mem_wdata_o,
         .pmpcfg_i,
         .pmpaddr_i
     );

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -69,6 +69,12 @@ module load_store_unit import ariane_pkg::*; #(
     // AMO interface
     output amo_req_t                 amo_req_o,
     input  amo_resp_t                amo_resp_i,
+    // RVFI
+    output logic [riscv::XLEN-1:0]   rvfi_mem_addr_o,
+    output logic [(riscv::XLEN/8)-1:0] rvfi_mem_rmask_o,
+    output logic [riscv::XLEN-1:0]     rvfi_mem_rdata_o,
+    output logic [(riscv::XLEN/8)-1:0] rvfi_mem_wmask_o,
+    output logic [riscv::XLEN-1:0]     rvfi_mem_wdata_o,
     // PMP
     input  riscv::pmpcfg_t [15:0]    pmpcfg_i,
     input  logic [15:0][riscv::PLEN-3:0] pmpaddr_i
@@ -126,6 +132,9 @@ module load_store_unit import ariane_pkg::*; #(
     exception_t               misaligned_exception;
     exception_t               ld_ex;
     exception_t               st_ex;
+
+    // RVFI
+    assign rvfi_mem_addr_o = {'0, mmu_paddr};
 
     // -------------------
     // MMU e.g.: TLBs/PTW
@@ -256,6 +265,9 @@ module load_store_unit import ariane_pkg::*; #(
         // AMOs
         .amo_req_o,
         .amo_resp_i,
+        // RFVI
+        .rvfi_mem_wmask_o,
+        .rvfi_mem_wdata_o,
         // to memory arbiter
         .req_port_i             ( dcache_req_ports_i [2] ),
         .req_port_o             ( dcache_req_ports_o [2] )

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -43,6 +43,9 @@ module load_unit import ariane_pkg::*; #(
     // D$ interface
     input dcache_req_o_t             req_port_i,
     output dcache_req_i_t            req_port_o,
+    // RVFI
+    output logic [(riscv::XLEN/8)-1:0] rvfi_mem_rmask_o,
+    output logic [riscv::XLEN-1:0]   rvfi_mem_rdata_o,
     input  logic                     dcache_wbuffer_not_ni_i
 );
     enum logic [3:0] { IDLE, WAIT_GNT, SEND_TAG, WAIT_PAGE_OFFSET,
@@ -57,6 +60,8 @@ module load_unit import ariane_pkg::*; #(
         fu_op                             operator;
     } load_data_d, load_data_q, in_data;
 
+    // RVFI
+    assign rvfi_mem_rmask_o = state_q == 4'b10 ? 1'b1 : 1'b0;
     // page offset is defined as the lower 12 bits, feed through for address checker
     assign page_offset_o = lsu_ctrl_i.vaddr[11:0];
     // feed-through the virtual address for VA translation
@@ -365,6 +370,8 @@ module load_unit import ariane_pkg::*; #(
             default:    result_o = shifted_data[riscv::XLEN-1:0];
         endcase
     end
+
+    assign rvfi_mem_rdata_o = result_o;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
         if (~rst_ni) begin

--- a/core/store_unit.sv
+++ b/core/store_unit.sv
@@ -43,6 +43,9 @@ module store_unit import ariane_pkg::*; (
     // D$ interface
     output amo_req_t                 amo_req_o,
     input  amo_resp_t                amo_resp_i,
+    // RVFI
+    output logic [(riscv::XLEN/8)-1:0] rvfi_mem_wmask_o,
+    output logic [riscv::XLEN-1:0]     rvfi_mem_wdata_o,
     input  dcache_req_o_t            req_port_i,
     output dcache_req_i_t            req_port_o
 );
@@ -202,6 +205,9 @@ module store_unit import ariane_pkg::*; (
 
     logic store_buffer_valid, amo_buffer_valid;
     logic store_buffer_ready, amo_buffer_ready;
+
+    assign rvfi_mem_wmask_o = store_buffer_valid;
+    assign rvfi_mem_wdata_o = st_data_q;
 
     // multiplex between store unit and amo buffer
     assign store_buffer_valid = st_valid & (amo_op_q == AMO_NONE);


### PR DESCRIPTION
This PR adds the upward propagation of address, mask and data of memory operations from the LOAD/STORE unit level to the RVFI tracer.  The address and data information is required for orderly termination of tests (detection of write at specified address, including the value written) and will also help improving RTL coverage.

### Files changed

* core/cva6.sv (rvfi_mem_addr_o): New global signal from ex_stage.
  (rvfi_mem_rmask_o): Ditto.
  (rvfi_mem_rdata_o): Ditto.
  (rvfi_mem_wmask_o): Ditto.
  (rvfi_mem_wdata_o): Ditto.
  (rvfi_o): Set memory-related fields of current commit port.
* core/ex_stage.sv (rvfi_mem_addr_o): New output, pass-thru from LSU.
  (rvfi_mem_rmask_o): Ditto.
  (rvfi_mem_rdata_o): Ditto.
  (rvfi_mem_wmask_o): Ditto.
  (rvfi_mem_wdata_o): Ditto.
* core/load_store_unit.sv (rvfi_mem_addr_o): New output, uses physical addr
  with zero extension.
  (rvfi_mem_rmask_o): New output, pass-through from load unit.
  (rvfi_mem_rdata_o): Ditto.
  (rvfi_mem_wmask_o): New output, pass-through from store unit.
  (rvfi_mem_wdata_o): Ditto.
* core/load_unit.sv (rvfi_mem_rmask_o): New output.  Set according to state
  of the unit.
  (rvfi_mem_rdata_o): New output, equal to load result.
* core/store_unit.sv (rvfi_mem_wmask_o): New output.
  (rvfi_mem_wdata): Ditto.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>