### PR TITLE
[tracing] Uniformize VCS and Verilator support of waveform dumps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,7 +586,7 @@ verilate_command := $(verilator)                                                
                     $(filter-out %.vhd, $(ariane_pkg))                                                           \
                     $(filter-out core/fpu_wrap.sv, $(filter-out %.vhd, $(src)))                                  \
                     $(copro_src)                                                                                 \
-                    +define+$(defines)                                                                           \
+                    +define+$(defines)$(if $(TRACE_FAST),+VM_TRACE)$(if $(TRACE_COMPACT),+VM_TRACE+VM_TRACE_FST) \
                     common/local/util/sram.sv                                                                    \
                     corev_apu/tb/common/mock_uart.sv                                                             \
                     +incdir+corev_apu/axi_node                                                                   \
@@ -605,8 +605,10 @@ verilate_command := $(verilator)                                                
                     $(if ($(PRELOAD)!=""), -DPRELOAD=1,)                                                         \
                     $(if $(DROMAJO), -DDROMAJO=1,)                                                               \
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
-                    $(if $(DEBUG),--trace --trace-structs,)                                                      \
-                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../corev_apu/tb/dromajo/src -ldromajo_cosim,) -lpthread" \
+                    $(if $(DEBUG), --trace-structs,)                                                             \
+                    $(if $(TRACE_COMPACT), --trace-fst $(VERILATOR_ROOT)/include/verilated_fst_c.cpp)            \
+                    $(if $(TRACE_FAST), --trace $(VERILATOR_ROOT)/include/verilated_vcd_c.cpp,)                  \
+                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../corev_apu/tb/dromajo/src -ldromajo_cosim,) -lpthread $(if $(TRACE_COMPACT), -lz,)" \
                     -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -DDROMAJO=1,) -DVL_DEBUG"       \
                     -Wall --cc  --vpi                                                                            \
                     $(list_incdir) --top-module ariane_testharness                                               \

--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -18,7 +18,11 @@
 #include "Variane_testharness.h"
 #include "verilator.h"
 #include "verilated.h"
+#if VM_TRACE_FST
+#include "verilated_fst_c.h"
+#else
 #include "verilated_vcd_c.h"
+#endif
 #include "Variane_testharness__Dpi.h"
 
 #include <stdio.h>
@@ -82,6 +86,7 @@ EMULATOR DEBUG OPTIONS (only supported in debug build -- try `make debug`)\n",
 #endif
   fputs("\
   -v, --vcd=FILE,          Write vcd trace to FILE (or '-' for stdout)\n\
+  -f, --fst-trace=FILE,    Write fst trace to FILE\n\
   -p,                      Print performance statistic at end of test\n\
 ", stdout);
   // fputs("\n" PLUSARG_USAGE_OPTIONS, stdout);
@@ -95,12 +100,14 @@ EMULATOR DEBUG OPTIONS (only supported in debug build -- try `make debug`)\n",
 #if VM_TRACE
 "  - run a bare metal test to generate a VCD waveform:\n"
 "    %s -v rv64ui-p-add.vcd $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add\n"
+"  - run a bare metal test to generate an FST waveform:\n"
+"    %s -f rv64ui-p-add.fst $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add\n"
 #endif
 "  - run an ELF (you wrote, called 'hello') using the proxy kernel:\n"
 "    %s pk hello\n",
          program_name, program_name, program_name
 #if VM_TRACE
-         , program_name
+         , program_name, program_name
 #endif
          );
 }
@@ -131,6 +138,7 @@ int main(int argc, char **argv) {
   uint16_t rbb_port = 0;
 #if VM_TRACE
   FILE * vcdfile = NULL;
+  char * fst_fname = NULL;
   uint64_t start = 0;
 #endif
   char ** htif_argv = NULL;
@@ -147,12 +155,13 @@ int main(int argc, char **argv) {
 #if VM_TRACE
       {"vcd",         required_argument, 0, 'v' },
       {"dump-start",  required_argument, 0, 'x' },
+      {"fst-trace",   required_argument, 0, 'f' },
 #endif
       HTIF_LONG_OPTIONS
     };
     int option_index = 0;
 #if VM_TRACE
-    int c = getopt_long(argc, argv, "-chpm:s:r:v:Vx:", long_options, &option_index);
+    int c = getopt_long(argc, argv, "-chpm:s:r:vf:Vx:", long_options, &option_index);
 #else
     int c = getopt_long(argc, argv, "-chpm:s:r:V", long_options, &option_index);
 #endif
@@ -178,6 +187,11 @@ int main(int argc, char **argv) {
           std::cerr << "Unable to open " << optarg << " for VCD write\n";
           return 1;
         }
+        break;
+      }
+      case 'f': {
+        fst_fname = optarg;
+        std::cerr << "### Request for FST waveform trace into file '" << fst_fname << "'\n";
         break;
       }
       case 'x': start = atoll(optarg);      break;
@@ -293,12 +307,22 @@ done_processing:
 
 #if VM_TRACE
   Verilated::traceEverOn(true); // Verilator must compute traced signals
+#if VM_TRACE_FST
+  std::unique_ptr<VerilatedFstC> tfp(new VerilatedFstC());
+  if (fst_fname) {
+    std::cerr << "### Starting FST waveform dump into file '" << fst_fname << "'...\n";
+    top->trace(tfp.get(), 99);  // Trace 99 levels of hierarchy
+    tfp->open(fst_fname);
+  }
+#else
   std::unique_ptr<VerilatedVcdFILE> vcdfd(new VerilatedVcdFILE(vcdfile));
   std::unique_ptr<VerilatedVcdC> tfp(new VerilatedVcdC(vcdfd.get()));
   if (vcdfile) {
+    std::cerr << "### Starting VCD waveform dump ...\n";
     top->trace(tfp.get(), 99);  // Trace 99 levels of hierarchy
     tfp->open("");
   }
+#endif
 #endif
 
   for (int i = 0; i < 10; i++) {

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -76,6 +76,21 @@ module ariane_testharness #(
   dm::dmi_req_t  debug_req;
   dm::dmi_resp_t debug_resp;
 
+`ifdef VERILATOR
+`ifdef VM_TRACE
+// VL-specific dump control (until fixed on C++ side)
+  initial begin
+    $display("Setting up waveform dump");
+`ifdef VM_TRACE_FST
+    $dumpfile("verilator.fst");
+`else
+    $dumpfile("verilator.vcd");
+`endif
+    $dumpvars(3, dut);
+  end
+`endif
+`endif
+
   assign test_en = 1'b0;
 
   AXI_BUS #(
@@ -731,3 +746,10 @@ module ariane_testharness #(
   );
 `endif
 endmodule
+
+`ifdef VERILATOR
+`ifdef VM_TRACE
+`verilator_config
+tracing_on
+`endif
+`endif


### PR DESCRIPTION
This PR adds the CVA6-side support for VCD and FST dump generation using Verilator.  It has a companion PR on `core-v-verif` (branch `cva6/dev`) that provides the unified trace control for VCS and Verilator in the verification flow.

* Makefile (verilate_command): Set defines according to requested trace mode (fast/compact).  Request inclusion of appropriate support files (source code, compression libraries) into Verilator Makefile.
* corev_apu/tb/ariane_tb.cpp (toplevel): Include appropriate trace header according to tracing mode (FST or VCD). (usage): Add description of flag and sample command line for FST tracing. (main): Add long and short FST format option. Add FST format handling.
* corev_apu/tb/ariane_testharness.sv: Add explicit request for named trace file according to selected tracing mode.  Enable full trace in Verilator in-RTL config.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>