### PR TITLE
compressed_decoder.sv: Fix FP word L/S decompression as per ISA spec v2.2.

### DIFF
--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -60,9 +60,17 @@ module compressed_decoder
                     end
 
                     riscv::OpcodeC0Ld: begin
-                        // c.ld -> ld rd', imm(rs1')
-                        // CLD: | funct3 | imm[5:3] | rs1' | imm[7:6] | rd' | C0 |
-                        instr_o = {4'b0, instr_i[6:5], instr_i[12:10], 3'b000, 2'b01, instr_i[9:7], 3'b011, 2'b01, instr_i[4:2], riscv::OpcodeLoad};
+                        // RV64
+                        //   c.ld -> ld rd', imm(rs1')
+                        // RV32
+                        //   c.flw -> flw fprd', imm(rs1')
+                        if (riscv::XLEN == 64) begin
+                            // CLD: | funct3 | imm[5:3] | rs1' | imm[7:6] | rd' | C0 |
+                            instr_o = {4'b0, instr_i[6:5], instr_i[12:10], 3'b000, 2'b01, instr_i[9:7], 3'b011, 2'b01, instr_i[4:2], riscv::OpcodeLoad};
+                        end else begin
+                            // CFLW: | funct3 (change to LW) | imm[5:3] | rs1' | imm[2|6] | rd' | C0 |
+                            instr_o = {5'b0, instr_i[5], instr_i[12:10], instr[6], 2'b00, 2'b01, instr_i[9:7], 3'b010, 2'b01, instr_i[4:2], riscv::OpcodeLoadFp};
+                        end
                     end
 
                     riscv::OpcodeC0Fsd: begin
@@ -76,8 +84,15 @@ module compressed_decoder
                     end
 
                     riscv::OpcodeC0Sd: begin
-                        // c.sd -> sd rs2', imm(rs1')
-                        instr_o = {4'b0, instr_i[6:5], instr_i[12], 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b011, instr_i[11:10], 3'b000, riscv::OpcodeStore};
+                        // RV64
+                        //   c.sd -> sd rs2', imm(rs1')
+                        // RV32
+                        //   c.fsw -> fsw fprs2', imm(rs1')
+                        if (riscv::XLEN == 64) begin
+                            instr_o = {4'b0, instr_i[6:5], instr_i[12], 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b011, instr_i[11:10], 3'b000, riscv::OpcodeStore};
+                        end else begin
+                            instr_o = {5'b0, instr_i[5], instr_i[12], 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b010, instr_i[11:10], instr_i[6], 2'b00, riscv::OpcodeStoreFp};
+                        end
                     end
 
                     default: begin
@@ -220,9 +235,16 @@ module compressed_decoder
                     end
 
                     riscv::OpcodeC2Ldsp: begin
-                        // c.ldsp -> ld rd, imm(x2)
-                        instr_o = {3'b0, instr_i[4:2], instr_i[12], instr_i[6:5], 3'b000, 5'h02, 3'b011, instr_i[11:7], riscv::OpcodeLoad};
-                        if (instr_i[11:7] == 5'b0)  illegal_instr_o = 1'b1;
+                        // RV64
+                        //   c.ldsp -> ld rd, imm(x2)
+                        // RV32
+                        //   c.flwsp -> flw fprd, imm(x2)
+                        if (riscv::XLEN == 64) begin
+                            instr_o = {3'b0, instr_i[4:2], instr_i[12], instr_i[6:5], 3'b000, 5'h02, 3'b011, instr_i[11:7], riscv::OpcodeLoad};
+                            if (instr_i[11:7] == 5'b0)  illegal_instr_o = 1'b1;
+                        end else begin
+                            instr_o = {4'b0, instr_i[3:2], instr_i[12], instr_i[6:4], 2'b00, 5'h02, 3'b010, instr_i[11:7], riscv::OpcodeLoadFp};
+                        end
                     end
 
                     riscv::OpcodeC2JalrMvAdd: begin
@@ -261,8 +283,15 @@ module compressed_decoder
                     end
 
                     riscv::OpcodeC2Sdsp: begin
-                        // c.sdsp -> sd rs2, imm(x2)
-                        instr_o = {3'b0, instr_i[9:7], instr_i[12], instr_i[6:2], 5'h02, 3'b011, instr_i[11:10], 3'b000, riscv::OpcodeStore};
+                        // RV64
+                        //   c.sdsp -> sd rs2, imm(x2)
+                        // RV32
+                        //   c.fswsp -> fsw fprs2, imm(x2)
+                        if (riscv::XLEN == 64) begin
+                            instr_o = {3'b0, instr_i[9:7], instr_i[12], instr_i[6:2], 5'h02, 3'b011, instr_i[11:10], 3'b000, riscv::OpcodeStore};
+                        end else begin
+                            instr_o = {4'b0, instr_i[8:7], instr_i[12], instr_i[6:2], 5'h02, 3'b010, instr_i[11:9], 2'b00, riscv::OpcodeStoreFp};
+                        end
                     end
 
                     default: begin

--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -69,7 +69,7 @@ module compressed_decoder
                             instr_o = {4'b0, instr_i[6:5], instr_i[12:10], 3'b000, 2'b01, instr_i[9:7], 3'b011, 2'b01, instr_i[4:2], riscv::OpcodeLoad};
                         end else begin
                             // CFLW: | funct3 (change to LW) | imm[5:3] | rs1' | imm[2|6] | rd' | C0 |
-                            instr_o = {5'b0, instr_i[5], instr_i[12:10], instr[6], 2'b00, 2'b01, instr_i[9:7], 3'b010, 2'b01, instr_i[4:2], riscv::OpcodeLoadFp};
+                            instr_o = {5'b0, instr_i[5], instr_i[12:10], instr_i[6], 2'b00, 2'b01, instr_i[9:7], 3'b010, 2'b01, instr_i[4:2], riscv::OpcodeLoadFp};
                         end
                     end
 

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -241,11 +241,13 @@ package riscv;
     localparam OpcodeC0Addi4spn     = 3'b000;
     localparam OpcodeC0Fld          = 3'b001;
     localparam OpcodeC0Lw           = 3'b010;
-    localparam OpcodeC0Ld           = 3'b011;
+    localparam OpcodeC0Ld           = 3'b011; // for RV64 only
+    localparam OpcodeC0Flw          = 3'b011; // for RV32 only
     localparam OpcodeC0Rsrvd        = 3'b100;
     localparam OpcodeC0Fsd          = 3'b101;
     localparam OpcodeC0Sw           = 3'b110;
-    localparam OpcodeC0Sd           = 3'b111;
+    localparam OpcodeC0Sd           = 3'b111; // for RV64 only
+    localparam OpcodeC0Fsw          = 3'b111; // for RV32 only
     // Quadrant 1
     localparam OpcodeC1             = 2'b01;
     localparam OpcodeC1Addi         = 3'b000;
@@ -262,11 +264,13 @@ package riscv;
     localparam OpcodeC2Slli         = 3'b000;
     localparam OpcodeC2Fldsp        = 3'b001;
     localparam OpcodeC2Lwsp         = 3'b010;
-    localparam OpcodeC2Ldsp         = 3'b011;
+    localparam OpcodeC2Ldsp         = 3'b011; // for RV64 only
+    localparam OpcodeC2Flwsp        = 3'b011; // for RV32(F) only
     localparam OpcodeC2JalrMvAdd    = 3'b100;
     localparam OpcodeC2Fsdsp        = 3'b101;
     localparam OpcodeC2Swsp         = 3'b110;
-    localparam OpcodeC2Sdsp         = 3'b111;
+    localparam OpcodeC2Sdsp         = 3'b111; // for RV64 only
+    localparam OpcodeC2Fswsp        = 3'b111; // for RV32(F) only
 
     // ----------------------
     // Virtual Memory

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -241,13 +241,11 @@ package riscv;
     localparam OpcodeC0Addi4spn     = 3'b000;
     localparam OpcodeC0Fld          = 3'b001;
     localparam OpcodeC0Lw           = 3'b010;
-    localparam OpcodeC0Ld           = 3'b011; // for RV64 only
-    localparam OpcodeC0Flw          = 3'b011; // for RV32 only
+    localparam OpcodeC0Ld           = 3'b011;
     localparam OpcodeC0Rsrvd        = 3'b100;
     localparam OpcodeC0Fsd          = 3'b101;
     localparam OpcodeC0Sw           = 3'b110;
-    localparam OpcodeC0Sd           = 3'b111; // for RV64 only
-    localparam OpcodeC0Fsw          = 3'b111; // for RV32 only
+    localparam OpcodeC0Sd           = 3'b111;
     // Quadrant 1
     localparam OpcodeC1             = 2'b01;
     localparam OpcodeC1Addi         = 3'b000;
@@ -264,13 +262,11 @@ package riscv;
     localparam OpcodeC2Slli         = 3'b000;
     localparam OpcodeC2Fldsp        = 3'b001;
     localparam OpcodeC2Lwsp         = 3'b010;
-    localparam OpcodeC2Ldsp         = 3'b011; // for RV64 only
-    localparam OpcodeC2Flwsp        = 3'b011; // for RV32(F) only
+    localparam OpcodeC2Ldsp         = 3'b011;
     localparam OpcodeC2JalrMvAdd    = 3'b100;
     localparam OpcodeC2Fsdsp        = 3'b101;
     localparam OpcodeC2Swsp         = 3'b110;
-    localparam OpcodeC2Sdsp         = 3'b111; // for RV64 only
-    localparam OpcodeC2Fswsp        = 3'b111; // for RV32(F) only
+    localparam OpcodeC2Sdsp         = 3'b111;
 
     // ----------------------
     // Virtual Memory


### PR DESCRIPTION
This PR provides a proposed fix to issue #956.  It adds RV32-specific decompression of compressed L/S instructions that have different meaning on RV32C and RV64C.

Files changed:
* core/compressed_decoder.sv: Use word L/S patterns in FLW/FSW/FLWSP/FSWSP expansions on RV32C.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>