### PR TITLE
[tracing] Uniformize VCS and Verilator support of waveform dumps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,7 +586,7 @@ verilate_command := $(verilator)                                                
                     $(filter-out %.vhd, $(ariane_pkg))                                                           \
                     $(filter-out core/fpu_wrap.sv, $(filter-out %.vhd, $(src)))                                  \
                     $(copro_src)                                                                                 \
-                    +define+$(defines)                                                                           \
+                    +define+$(defines)$(if $(TRACE_FAST),+VM_TRACE)$(if $(TRACE_COMPACT),+VM_TRACE+VM_TRACE_FST) \
                     common/local/util/sram.sv                                                                    \
                     corev_apu/tb/common/mock_uart.sv                                                             \
                     +incdir+corev_apu/axi_node                                                                   \
@@ -605,8 +605,10 @@ verilate_command := $(verilator)                                                
                     $(if ($(PRELOAD)!=""), -DPRELOAD=1,)                                                         \
                     $(if $(DROMAJO), -DDROMAJO=1,)                                                               \
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
-                    $(if $(DEBUG),--trace --trace-structs,)                                                      \
-                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../corev_apu/tb/dromajo/src -ldromajo_cosim,) -lpthread" \
+                    $(if $(DEBUG), --trace-structs,)                                                             \
+                    $(if $(TRACE_COMPACT), --trace-fst $(VERILATOR_ROOT)/include/verilated_fst_c.cpp)            \
+                    $(if $(TRACE_FAST), --trace $(VERILATOR_ROOT)/include/verilated_vcd_c.cpp,)                  \
+                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -L../corev_apu/tb/dromajo/src -ldromajo_cosim,) -lpthread $(if $(TRACE_COMPACT), -lz,)" \
                     -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) $(if $(DROMAJO), -DDROMAJO=1,) -DVL_DEBUG"       \
                     -Wall --cc  --vpi                                                                            \
                     $(list_incdir) --top-module ariane_testharness                                               \


### PR DESCRIPTION
This PR supports `core-v-verif` PR https://github.com/openhwgroup/core-v-verif/pull/1424 which unifies the control of waveform generation between VCS and Verilator simulation targets.  It supersedes PR #954 to make the commit history somewhat clearer.

## Outline

### VCS

For VCS configurations, the control of trace generation is handled entirely at the level of VCS and `vsim` invocations in `core-v-verif/cva6/sim/Makefile` (see PR https://github.com/openhwgroup/core-v-verif/pull/1424).

### Verilator

For Verilator, the control of trace generation is partially implemented in the C++ simulation wrapper (cf. file `corev_apu/tb/ariane_tb.cpp`) according to the settings of two C++ macros: `VM_TRACE` and `VM_TRACE_FST`.  Due to current limitations of Veriltaor, the VCD and FST waveform formats cannot be supported by a single simulator build; in other words, a simulator built for a specific trace format  needs to be rebuilt in order to produce traces in the other format.

Usage of the macros:
* If defined, `VM_TRACE` enables tracing.  If macro `VM_TRACE_FST` is not defined (the default), waveform generation will use VCD format.  If the command-line option `-v FILE` or `--vcd=FILE` is given to the compiled simulator, the VCD output will be written to file named `FILE` in the current working dir of the verilated simulator.  If no `-v`/`--vcd=` option is given on cmdline, or an FST-specific trace option is used, the simulator will generate a VCD trace according to the settings in the RTL code.
* if `VM_TRACE_FST` is defined as well, then FST format is used instead of VCD.  If the command line option `-f FILE` or `--fst=FILE` is given to the simulator, the trace will be stored in file `FILE` in the current working dir of the verilated simulator.  If no `-f`/`--fst=` option is given, or a VCD-specific trace option is used, the simulator will generate an FST trace according to the settings in the RTL code.

## Files changed

* Makefile (verilate_command): Set defines according to requested trace mode (fast/compact).  Request inclusion of appropriate support files (source code, compression libraries) into the Verilator-generated Makefile.
* corev_apu/tb/ariane_tb.cpp (toplevel): Include appropriate trace header according to tracing mode (FST or VCD).
  (usage): Add description of flag and sample command line for FST tracing.
  (main): Add long and short FST format option. Add FST format handling.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>