### PR TITLE
Adding Access Region exception feature

### DIFF
--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -53,6 +53,7 @@ package ariane_pkg;
       //
       logic [63:0]                      DmBaseAddress;         // offset of the debug module
       int unsigned                      NrPMPEntries;          // Number of PMP entries
+      logic [63:0]                      AccessRegionLength;
     } ariane_cfg_t;
 
     localparam ariane_cfg_t ArianeDefaultConfig = '{
@@ -76,7 +77,9 @@ package ariane_pkg;
       SwapEndianess:          1'b0,
       // debug
       DmBaseAddress:          64'h0,
-      NrPMPEntries:           8
+      NrPMPEntries:           8,
+      //Access Region
+      AccessRegionLength:     64'hC000_0000
     };
 
     // Function being called to check parameters
@@ -126,6 +129,13 @@ package ariane_pkg;
       end
       return |pass;
     endfunction : is_inside_cacheable_regions
+
+    function automatic logic is_inside_access_regions (ariane_cfg_t Cfg, logic[63:0] address);
+      automatic logic pass;
+      pass = '0;
+      pass = range_check(Cfg.DmBaseAddress, Cfg.AccessRegionLength, address);
+      return |pass;
+    endfunction : is_inside_access_regions
 
     // TODO: Slowly move those parameters to the new system.
     localparam NR_SB_ENTRIES = 8; // number of scoreboard entries

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -196,6 +196,7 @@ module mmu import ariane_pkg::*; #(
     //-----------------------
     logic match_any_execute_region;
     logic pmp_instr_allow;
+    logic is_fetch_access_ex;
 
     // The instruction interface is a simple request response interface
     always_comb begin : instr_interface
@@ -259,15 +260,17 @@ module mmu import ariane_pkg::*; #(
                 else icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, ptw_bad_paddr}, 1'b1};
             end
         end
-        // if it didn't match any execute region throw an `Instruction Access Fault`
+        // if it didn't match any execute region or access region throw an `Instruction Access Fault`
         // or: if we are not translating, check PMPs immediately on the paddr
         if ((!match_any_execute_region && !ptw_error) || (!enable_translation_i && !pmp_instr_allow)) begin
+        if ((!match_any_execute_region && !ptw_error) || (!enable_translation_i && !pmp_instr_allow) || !is_fetch_access_ex) begin
           icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr}, 1'b1};
         end
     end
 
     // check for execute flag on memory
     assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(ArianeCfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
+    assign is_fetch_access_ex = ariane_pkg::is_inside_access_regions(ArianeCfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
 
     // Instruction fetch
     pmp #(
@@ -291,6 +294,7 @@ module mmu import ariane_pkg::*; #(
     logic [riscv::VLEN-1:0] lsu_vaddr_n,     lsu_vaddr_q;
     riscv::pte_t dtlb_pte_n,      dtlb_pte_q;
     exception_t  misaligned_ex_n, misaligned_ex_q;
+    logic        is_data_access_ex;
     logic        lsu_req_n,       lsu_req_q;
     logic        lsu_is_store_n,  lsu_is_store_q;
     logic        dtlb_hit_n,      dtlb_hit_q;
@@ -299,6 +303,7 @@ module mmu import ariane_pkg::*; #(
 
     // check if we need to do translation or if we are always ready (e.g.: we are not translating anything)
     assign lsu_dtlb_hit_o = (en_ld_st_translation_i) ? dtlb_lu_hit :  1'b1;
+    assign is_data_access_ex = ariane_pkg::is_inside_access_regions(ArianeCfg, {{64-riscv::PLEN{1'b0}}, lsu_paddr_o});
 
     // Wires to PMP checks
     riscv::pmp_access_t pmp_access_type;
@@ -361,8 +366,8 @@ module mmu import ariane_pkg::*; #(
                     // also check if the dirty flag is set
                     if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
                         lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1};
-                    // Check if any PMPs are violated
-                    end else if (!pmp_data_allow) begin
+                    // Check if any PMPs are violated or data is not in access range
+                    end else if (!pmp_data_allow ||!is_data_access_ex) begin
                         lsu_exception_o = {riscv::ST_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1};
                     end
 
@@ -371,8 +376,8 @@ module mmu import ariane_pkg::*; #(
                     // check for sufficient access privileges - throw a page fault if necessary
                     if (daccess_err) begin
                         lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1};
-                    // Check if any PMPs are violated
-                    end else if (!pmp_data_allow) begin
+                    // Check if any PMPs are violated or data is not in access range
+                    end else if (!pmp_data_allow || !is_data_access_ex) begin
                         lsu_exception_o = {riscv::LD_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1};
                     end
                 end
@@ -407,8 +412,8 @@ module mmu import ariane_pkg::*; #(
                 end
             end
         end
-        // If translation is not enabled, check the paddr immediately against PMPs
-        else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow) begin
+        // If translation is not enabled, check the paddr immediately against PMPs and check that data is in access range
+        else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow || (lsu_req_q && !is_data_access_ex)) begin
             if (lsu_is_store_q) begin
                 lsu_exception_o = {riscv::ST_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1};
             end else begin

--- a/corev_apu/openpiton/ariane_verilog_wrap.sv
+++ b/corev_apu/openpiton/ariane_verilog_wrap.sv
@@ -37,7 +37,8 @@ module ariane_verilog_wrap
   parameter logic [NrMaxRules*64-1:0]  CachedRegionAddrBase  = '0,
   parameter logic [NrMaxRules*64-1:0]  CachedRegionLength    = '0,
   // PMP
-  parameter int unsigned               NrPMPEntries          =  8
+  parameter int unsigned               NrPMPEntries          =  8,
+  parameter logic [63:0]               AccessRegionLength    =  64'h0
 ) (
   input                       clk_i,
   input                       reset_l,      // this is an openpiton-specific name, do not change (hier. paths in TB use this)
@@ -190,7 +191,9 @@ module ariane_verilog_wrap
     SwapEndianess:         SwapEndianess,
     // debug
     DmBaseAddress:         DmBaseAddress,
-    NrPMPEntries:          NrPMPEntries
+    NrPMPEntries:          NrPMPEntries,
+    //Access Region
+    AccessRegionLength:    AccessRegionLength
   };
 
   ariane #(

--- a/corev_apu/tb/ariane_soc_pkg.sv
+++ b/corev_apu/tb/ariane_soc_pkg.sv
@@ -89,7 +89,8 @@ package ariane_soc;
     SwapEndianess:          1'b0,
     // debug
     DmBaseAddress:          DebugBase,
-    NrPMPEntries:           8
+    NrPMPEntries:           8,
+    AccessRegionLength:     64'hC000_0000
   };
 
 endpackage

--- a/corev_apu/tb/tb_cva6_icache/hdl/tb.sv
+++ b/corev_apu/tb/tb_cva6_icache/hdl/tb.sv
@@ -58,7 +58,8 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
     SwapEndianess:         1'b0,
     // debug
     DmBaseAddress:         64'h0,
-    NrPMPEntries:          0
+    NrPMPEntries:          0,
+    AccessRegionLength:    64'hC000_0000
   };
 
   // rates are in percent

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
@@ -51,7 +51,8 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
     SwapEndianess:         1'b0,
     // debug
     DmBaseAddress:         64'h0,
-    NrPMPEntries:          0
+    NrPMPEntries:          0,
+    AccessRegionLength:    64'hC000_0000
   };
 
   // contention and invalidation rates (in %)

--- a/corev_apu/tb/tb_wt_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wt_dcache/hdl/tb.sv
@@ -59,7 +59,8 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
     SwapEndianess:         1'b0,
     // debug
     DmBaseAddress:         64'h0,
-    NrPMPEntries:          0
+    NrPMPEntries:          0,
+    AccessRegionLength:    64'hC000_0000
   };
 
   // contention and invalidation rates (in %)


### PR DESCRIPTION
This PR closes #879. 

It adds the unsupported feature of access exception i.e when if an instruction attempts to access memory at an inaccessible address, an exception is raised for the instruction. Vacant locations in the address space are never accessible.

A function is_inside_access_region has been added in ariane_pkg.sv, which checks the address is in access range or not. The function is called in mmu unit, where physical address is passed to function and then raise exception if function check fails. 

The changes can be verified by the [access test](https://github.com/riscv-software-src/riscv-tests/blob/master/isa/rv64mi/access.S) which changes the last bit of the address to 1, making it outside the access region, and try to jump at that address. If the feature is enabled, accessing that address should raise instruction access fault. 
