### PR TITLE
Flist.cv32a60x: add example coprocessor to Flist

### DIFF
--- a/core/Flist.cv32a60x
+++ b/core/Flist.cv32a60x
@@ -52,7 +52,10 @@ ${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
 
 //CVXIF
 ${CVA6_REPO_DIR}/core/include/cvxif_pkg.sv
+${CVA6_REPO_DIR}/core/cvxif_example/include/cvxif_instr_pkg.sv
 ${CVA6_REPO_DIR}/core/cvxif_fu.sv
+${CVA6_REPO_DIR}/core/cvxif_example/cvxif_example_coprocessor.sv
+${CVA6_REPO_DIR}/core/cvxif_example/instr_decoder.sv
 
 // Common Cells
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/cf_math_pkg.sv
@@ -64,6 +67,10 @@ ${CVA6_REPO_DIR}/common/submodules/common_cells/src/shift_reg.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/unread.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/popcount.sv
 ${CVA6_REPO_DIR}/common/submodules/common_cells/src/exp_backoff.sv
+
+// Common Cells for example coprocessor
+${CVA6_REPO_DIR}/common/submodules/common_cells/src/counter.sv
+${CVA6_REPO_DIR}/common/submodules/common_cells/src/delta_counter.sv
 
 // Floating point unit
 ${CVA6_REPO_DIR}/core/fpu/src/fpnew_pkg.sv


### PR DESCRIPTION
Needed by core-v-verif  uvm  testbenchdue to ariane.sv depedencies