### PR TITLE
Flist: Split Flists for SV32 and SV39 to prevent Questasim elaboration errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,11 +198,12 @@ src :=  core/include/$(target)_config_pkg.sv                                    
         corev_apu/tb/common/SimDTM.sv                                                \
         corev_apu/tb/common/SimJTAG.sv
 
+flists := ${CVA6_REPO_DIR}/core/Flist.cva6
 # SV32 MMU for CV32, SV39 MMU for CV64
 ifeq ($(findstring 32, $(target)),32)
-    src += $(wildcard core/mmu_sv32/*.sv)
+    flists += ${CVA6_REPO_DIR}/core/Flist.mmu-sv32
 else
-    src += $(wildcard core/mmu_sv39/*.sv)
+    flists += ${CVA6_REPO_DIR}/core/Flist.mmu-sv39
 endif
 
 src := $(addprefix $(root-dir), $(src))
@@ -283,7 +284,7 @@ endif
 vcs_build: $(dpi-library)/ariane_dpi.so
 	mkdir -p $(vcs-library)
 	cd $(vcs-library) &&\
-	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog +define+$(defines) -assert svaext -f ../core/Flist.cva6 &&\
+	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog +define+$(defines) -assert svaext $(addprefix -f , ${flists}) &&\
 	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog +define+$(defines) $(filter %.sv,$(ariane_pkg)) +incdir+core/include/+$(VCS_HOME)/etc/uvm-1.2/dpi &&\
 	vhdlan $(if $(VERDI), -kdb,) -full64 -nc $(filter %.vhd,$(uart_src)) &&\
 	vlogan $(if $(VERDI), -kdb,) -full64 -nc -sverilog -assert svaext +define+$(defines) $(filter %.sv,$(src)) +incdir+../vendor/pulp-platform/common_cells/include/+../vendor/pulp-platform/axi/include/+../corev_apu/register_interface/include/ &&\
@@ -301,7 +302,7 @@ build: $(library) $(library)/.build-srcs $(library)/.build-tb $(dpi-library)/ari
 
 # src files
 $(library)/.build-srcs: $(library)
-	$(VLOG) $(compile_flag) -timescale "1ns / 1ns" -work $(library) -pedanticerrors -f core/Flist.cva6 $(list_incdir) -suppress 2583
+	$(VLOG) $(compile_flag) -timescale "1ns / 1ns" -work $(library) -pedanticerrors $(addprefix -f , ${flists}) $(list_incdir) -suppress 2583
 	$(VLOG) $(compile_flag) -work $(library) $(filter %.sv,$(ariane_pkg)) $(list_incdir) -suppress 2583
 	# Suppress message that always_latch may not be checked thoroughly by QuestaSim.
 	$(VCOM) $(compile_flag_vhd) -work $(library) -pedanticerrors $(filter %.vhd,$(uart_src))
@@ -436,7 +437,7 @@ XRUN_COMP = $(XRUN_COMP_FLAGS)		\
 	$(filter %.sv, $(ariane_pkg)) 	\
 	$(filter %.vhd, $(uart_src))  	\
 	$(filter %.sv, $(src))	      	\
-	-f ../core/Flist.cva6    	    \
+	$(addprefix -f , ${flists})                 \
 	$(filter %.sv, $(XRUN_TB))	\
 
 XRUN_RUN = $(XRUN_RUN_FLAGS) 		\
@@ -540,7 +541,7 @@ xrun-ci: xrun-asm-tests xrun-amo-tests xrun-mul-tests xrun-fp-tests xrun-benchma
 
 # verilator-specific
 verilate_command := $(verilator)                                                                                 \
-                    -f core/Flist.cva6                                                                           \
+                    $(addprefix -f , ${flists})                                                                                  \
                     $(filter-out %.vhd, $(ariane_pkg))                                                           \
                     $(filter-out core/fpu_wrap.sv, $(filter-out %.vhd, $(src)))                                  \
                     +define+$(defines)$(if $(TRACE_FAST),+VM_TRACE)$(if $(TRACE_COMPACT),+VM_TRACE+VM_TRACE_FST) \
@@ -719,7 +720,7 @@ check-torture:
 	grep 'All signatures match for $(test-location)' $(riscv-torture-dir)/$(test-location).log
 	diff -s $(riscv-torture-dir)/$(test-location).spike.sig $(riscv-torture-dir)/$(test-location).rtlsim.sig
 
-src_flist := $(addprefix $(root-dir), $(shell cat core/Flist.cva6|grep "$\{CVA6_REPO_DIR.\+sv"|sed "s/.*CVA6_REPO_DIR..//"|sed "s/..TARGET_CFG./$(target)/"))
+src_flist := $(addprefix $(root-dir), $(foreach flist, ${flists}, $(shell cat ${flist} | grep "$\{CVA6_REPO_DIR.\+sv" | sed "s/.*CVA6_REPO_DIR..//" | sed "s/..TARGET_CFG./$(target)/")))
 fpga_filter := $(addprefix $(root-dir), corev_apu/bootrom/bootrom.sv)
 fpga_filter += $(addprefix $(root-dir), core/include/instr_tracer_pkg.sv)
 fpga_filter += $(addprefix $(root-dir), src/util/ex_trace_item.sv)

--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -168,15 +168,4 @@ ${CVA6_REPO_DIR}/common/local/util/tc_sram_wrapper.sv
 ${CVA6_REPO_DIR}/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
 ${CVA6_REPO_DIR}/common/local/util/sram.sv
 
-// MMU Sv39
-${CVA6_REPO_DIR}/core/mmu_sv39/mmu.sv
-${CVA6_REPO_DIR}/core/mmu_sv39/ptw.sv
-${CVA6_REPO_DIR}/core/mmu_sv39/tlb.sv
-
-// MMU Sv32
-${CVA6_REPO_DIR}/core/mmu_sv32/cva6_mmu_sv32.sv
-${CVA6_REPO_DIR}/core/mmu_sv32/cva6_ptw_sv32.sv
-${CVA6_REPO_DIR}/core/mmu_sv32/cva6_tlb_sv32.sv
-${CVA6_REPO_DIR}/core/mmu_sv32/cva6_shared_tlb_sv32.sv
-
 // end of manifest

--- a/core/Flist.mmu-sv32
+++ b/core/Flist.mmu-sv32
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+//
+// Manifest for the CVA6 MMU RTL model.
+//   - This is a MMU-ONLY manifest.
+//   - Relevent synthesis and simulation scripts/Makefiles must set the shell
+//     ENV variable CVA6_REPO_DIR.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+// MMU Sv32
+${CVA6_REPO_DIR}/core/mmu_sv32/cva6_mmu_sv32.sv
+${CVA6_REPO_DIR}/core/mmu_sv32/cva6_ptw_sv32.sv
+${CVA6_REPO_DIR}/core/mmu_sv32/cva6_tlb_sv32.sv
+${CVA6_REPO_DIR}/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+
+// end of manifest

--- a/core/Flist.mmu-sv39
+++ b/core/Flist.mmu-sv39
@@ -1,0 +1,33 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+//
+// Manifest for the CVA6 MMU RTL model.
+//   - This is a MMU-ONLY manifest.
+//   - Relevent synthesis and simulation scripts/Makefiles must set the shell
+//     ENV variable CVA6_REPO_DIR.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+// MMU Sv39
+${CVA6_REPO_DIR}/core/mmu_sv39/mmu.sv
+${CVA6_REPO_DIR}/core/mmu_sv39/ptw.sv
+${CVA6_REPO_DIR}/core/mmu_sv39/tlb.sv
+
+// end of manifest


### PR DESCRIPTION
Fixes the questasim simulation flow. In particular:
~~1. Port width mismatch in `ariane_testharness`. Therefore, propagate the `AXI_USER_WIDTH` from `ariane_testharness` to `ariane_peripherals`~~ :arrow_right: #1043 
~~2. `riscv-tests` do not signal success or failure after execution in questasim. This is due to the `rvfi_tracer` intercepting `ecall`s and terminating the simulation prematurely (they are needed by the proxy kernel for communication). Therefore, disable `RVFI_TRACE` for regular simulations per default.~~ :arrow_right: #1141 
~~3. Some benchmarks time out in Questasim simulation. For instance, `rsort` requires over 4M cycles on the WB cache, which is well above the current default timeout of 2M cycles (not sure if this is due to a performance regression). Therefore, set the default timeout to 6M cycles which is a safe value for all riscv tests and benchmarks.~~ :wastebasket:
~~4. Fix the compilation order for Questasim (#1008).~~ :arrow_right: #1043 
~~5. Increase the testbench's memory size (#1014).~~ :wastebasket:
6. Questasim will error when elaborating the SV32 MMU for 64-bit CVA6. We had this issue a while again and filtered out the incompatible MMU version depending on the target. This was broken again with the change to file lists. Hence, split the MMU out of the common file list into a separate one that can be chosen from the Makefile. I believe using bender would be a more elegant and maintainable solution at this point. Furthermore, why the file name inversion (`Flist.<target>`)?