### PR TITLE
rvfi: fix mem_wdata

### DIFF
--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -162,7 +162,7 @@ module scoreboard #(
     end else if (lsu_wmask_i != 0) begin
       mem_n[lsu_addr_trans_id_i].sbe.lsu_addr = lsu_addr_i;
       mem_n[lsu_addr_trans_id_i].sbe.lsu_wmask = lsu_wmask_i;
-      mem_n[lsu_addr_trans_id_i].sbe.lsu_wdata = wbdata_i[2];
+      mem_n[lsu_addr_trans_id_i].sbe.lsu_wdata = wbdata_i[1];
     end
 `endif
 


### PR DESCRIPTION
Was looking at the wrong WB port, `load_result` instead of `store_result`.
Broken from 4c01614f83cd9dd91d115aa190bd4fc6a284b59e