### PR TITLE
tb: Fix port width mismatch and compile order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,11 +300,11 @@ build: $(library) $(library)/.build-srcs $(library)/.build-tb $(dpi-library)/ari
 
 # src files
 $(library)/.build-srcs: $(library)
+	$(VLOG) $(compile_flag) -timescale "1ns / 1ns" -work $(library) -pedanticerrors -f core/Flist.cva6 $(list_incdir) -suppress 2583
 	$(VLOG) $(compile_flag) -work $(library) $(filter %.sv,$(ariane_pkg)) $(list_incdir) -suppress 2583
 	# Suppress message that always_latch may not be checked thoroughly by QuestaSim.
 	$(VCOM) $(compile_flag_vhd) -work $(library) -pedanticerrors $(filter %.vhd,$(uart_src))
 	$(VLOG) $(compile_flag) -timescale "1ns / 1ns" -work $(library) -pedanticerrors $(filter %.sv,$(src)) $(list_incdir) -suppress 2583
-	$(VLOG) $(compile_flag) -timescale "1ns / 1ns" -work $(library) -pedanticerrors -f ../core/Flist.cva6 $(list_incdir) -suppress 2583
 	touch $(library)/.build-srcs
 
 # build TBs

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -567,6 +567,7 @@ module ariane_testharness #(
     .AxiAddrWidth ( AXI_ADDRESS_WIDTH        ),
     .AxiDataWidth ( AXI_DATA_WIDTH           ),
     .AxiIdWidth   ( ariane_soc::IdWidthSlave ),
+    .AxiUserWidth ( AXI_USER_WIDTH           ),
 `ifndef VERILATOR
   // disable UART when using Spike, as we need to rely on the mockuart
   `ifdef SPIKE_TANDEM


### PR DESCRIPTION
This PR contains the following two fixes from #988:
1. Fix width mismatch in `ariane_testharness` by propagating the `AXI_USER_WIDTH` from `ariane_testharness` to `ariane_peripherals`
2. Fix the compilation order for Questasim (#1008).