### PR TITLE
Add PMP section and fix addressing CV64A6

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -615,12 +615,16 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_PMPCFG1: begin
                     if (riscv::XLEN == 32) begin
                         for (int i = 0; i < 4; i++) if (!pmpcfg_q[i+4].locked) pmpcfg_d[i+4]  = csr_wdata[i*8+:8];
+                    end else begin
+                      update_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_PMPCFG2:    for (int i = 0; i < (riscv::XLEN/8); i++) if (!pmpcfg_q[i+8].locked) pmpcfg_d[i+8]  = csr_wdata[i*8+:8];
                 riscv::CSR_PMPCFG3: begin
                     if (riscv::XLEN == 32) begin
                         for (int i = 0; i < 4; i++) if (!pmpcfg_q[i+12].locked) pmpcfg_d[i+12]  = csr_wdata[i*8+:8];
+                    end else begin
+                      update_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_PMPADDR0,

--- a/docs/01_cva6_user/PMP.rst
+++ b/docs/01_cva6_user/PMP.rst
@@ -36,6 +36,7 @@ The PMP grain is ``2**G+2``. Only a PMP granularity of 8 bytes (``G=1``) is
 supported in CVA6. PMP address length is equal to the processors physical
 address length. Since ``G=1`` the ``NA4`` modes is not selectable.
 
-Writes to ``pmpaddr`` are WARL and depend on the address mode. For ``NAPOT`` it is
-set to ``1``, for ``TOR`` / ``OFF`` it is set to ``0``.
+Writes to ``pmpaddr`` are WARL and depend on the address mode. For naturally
+aligned power-of 2 addressing mode (``NAPOT``) it is set to ``1``, for top
+boundary of an arbitrary range (``TOR``) or ``OFF`` it is set to ``0``.
 

--- a/docs/01_cva6_user/PMP.rst
+++ b/docs/01_cva6_user/PMP.rst
@@ -20,6 +20,22 @@
 
 PMP
 ===
-Gap for step1 verification. Reuse DVplan from CV32E40S? Mike will reach out to some people who could help.
-Refer to RISC-V specs and focus on the parameters (regions, granularity)
+The CVA6 includes a Physical Memory Protection (PMP) unit. The PMP is both
+statically and dynamically configurable. The static configuration is performed
+through the top level parameters ``ArianeCfg.NrPMPEntries``. The dynamic
+configuration is performed through the CSRs described in Control and Status
+Registers. A maximum of 16 PMP entries are supported.
+
+All PMP CSRs are always implemented, but CSRs (or bitfields of CSRs) related to
+PMP entries with number ``ArianeCfg.NrPMPEntries`` and above are hardwired to
+zero. All PMPs reset to zero.
+
+When the ``L`` (Lock) bit is set, PMPs are also enforced in M-mode.
+
+The PMP grain is ``2**G+2``. Only a PMP granularity of 8 bytes (``G=1``) is
+supported in CVA6. PMP address length is equal to the processors physical
+address length. Since ``G=1`` the ``NA4`` modes is not selectable.
+
+Writes to ``pmpaddr`` are WARL and depend on the address mode. For ``NAPOT`` it is
+set to ``1``, for ``TOR`` / ``OFF`` it is set to ``0``.
 


### PR DESCRIPTION
As requested here is the PMP section for the user guide, plus a fix for the CSRs for CV64A6 which should trap on PMP access `CSR_PMPCFG1` and `CSR_PMPCFG3`. 

Fixes #1095 