### PR TITLE
Bootrom.sv : upgraded to python 3

### DIFF
--- a/corev_apu/bootrom/gen_rom.py
+++ b/corev_apu/bootrom/gen_rom.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" Convert binary output of objcopy -O binary into a system verilog module and
+""" Convert binary output of 'objcopy -O binary elfFile' into a system verilog module and
 a header file for simulation
 """
 
@@ -9,7 +9,7 @@ import os.path
 import sys
 
 
-def parse() :
+def parse():
     parser = argparse.ArgumentParser(description='Convert binary file to verilog rom')
     parser.add_argument('filename', metavar='filename', nargs=1,
             help='filename of input binary')

--- a/corev_apu/bootrom/gen_rom.py
+++ b/corev_apu/bootrom/gen_rom.py
@@ -125,8 +125,11 @@ def generate_sv(filename, rom):
         s = Template(MODULE_TEMPLATE)
         f.write(s.substitute(filename=filename, size=int(len(rom)/8), content=rom_str))
 
-if __name__ == "__main__":
+def main():
     filename = parse()
     rom = read_bin(filename)
     generate_sv(filename, rom)
     generate_h(filename, rom)
+
+if __name__ == "__main__":
+    main()

--- a/corev_apu/bootrom/gen_rom.py
+++ b/corev_apu/bootrom/gen_rom.py
@@ -80,15 +80,13 @@ $content
 def read_bin():
 
     with open(filename + ".img", 'rb') as f:
-        rom = binascii.hexlify(f.read())
-        rom = map(''.join, zip(rom[::2], rom[1::2]))
-
+        rom = f.read()
 
     # align to 64 bit
     align = (int((len(rom) + 7) / 8 )) * 8;
 
     for i in range(len(rom), align):
-        rom.append("00")
+        rom += b"\x00"
 
     return rom
 
@@ -100,7 +98,7 @@ with open(filename + ".h", "w") as f:
     rom_str = ""
     # process in junks of 32 bit (4 byte)
     for i in range(0, int(len(rom)/4)):
-        rom_str += "    0x" + "".join(rom[i*4:i*4+4][::-1]) + ",\n"
+        rom_str += "    0x" + bytes(reversed(rom[i*4:i*4+4])).hex() + ",\n"
 
     # remove the trailing comma
     rom_str = rom_str[:-2]
@@ -114,9 +112,10 @@ with open(filename + ".h", "w") as f:
 """
 with open(filename + ".sv", "w") as f:
     rom_str = ""
+    rom = bytes(reversed(rom))
     # process in junks of 64 bit (8 byte)
-    for i in reversed(range(int(len(rom)/8))):
-        rom_str += "        64'h" + "".join(rom[i*8+4:i*8+8][::-1]) + "_" + "".join(rom[i*8:i*8+4][::-1]) + ",\n"
+    for i in range(int(len(rom)/8)):
+        rom_str += "        64'h" + rom[i*8:i*8+4].hex() + "_" + rom[i*8+4:i*8+8].hex() + ",\n"
 
     # remove the trailing comma
     rom_str = rom_str[:-2]

--- a/corev_apu/fpga/src/bootrom/Makefile
+++ b/corev_apu/fpga/src/bootrom/Makefile
@@ -1,7 +1,7 @@
 XLEN ?= 64
 CROSSCOMPILE ?= riscv64-unknown-elf-
 CC = ${CROSSCOMPILE}gcc
-PYTHON=python
+PYTHON=python2
 
 ifeq ($(XLEN), 64)
 CFLAGS = -Os -ggdb -march=rv64imac -mabi=lp64 -Wall -mcmodel=medany -mexplicit-relocs

--- a/corev_apu/fpga/src/bootrom/Makefile
+++ b/corev_apu/fpga/src/bootrom/Makefile
@@ -1,7 +1,6 @@
 XLEN ?= 64
 CROSSCOMPILE ?= riscv64-unknown-elf-
 CC = ${CROSSCOMPILE}gcc
-PYTHON=python2
 
 ifeq ($(XLEN), 64)
 CFLAGS = -Os -ggdb -march=rv64imac -mabi=lp64 -Wall -mcmodel=medany -mexplicit-relocs
@@ -50,7 +49,7 @@ $(MAIN): $(DTB) $(OBJS_C) $(OBJS_S) linker.lds
 	dtc -I dts $< -O dtb -o $@
 
 %.sv: %.img
-	$(PYTHON) ./gen_rom.py $<
+	./gen_rom.py $<
 	@echo "PYTHON >= $(MAIN_SV)"
 
 clean:


### PR DESCRIPTION
The makefile target to generate the bootrom system verilog assumes a python2 binary behind the python environment call. Python2 is not the default anymore on many systems.
This solves issue #1086.