### PR TITLE
rvfi_tracer.sv: Use correct width for 'tohost' address.

### DIFF
--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -18,7 +18,7 @@ module rvfi_tracer #(
   input rvfi_pkg::rvfi_instr_t[NR_COMMIT_PORTS-1:0]           rvfi_i
 );
 
-  logic[riscv::XLEN-1:0] TOHOST_ADDR;
+  logic[riscv::PLEN-1:0] TOHOST_ADDR;
   int f;
   int unsigned SIM_FINISH;
   initial begin


### PR DESCRIPTION
Fix the width of `tohost` address representation in `rvfi_tracer.sv` to match the width of the RVFI `mem_paddr` field:
* in 64b mode physical addresses are 56 bits wide (PLEN == 56);
* in 32b mode physical addresses are 34 bits wide (PLEN == 34), meaning that they are wider than XLEN.

This modification is intended to resolve the failures in gate simulations seen with the original test termination PR (#1075) in both 32 and 64 bit configurations.

To keep the code clean, this PR makes `TOHOST_ADDRESS` always `PLEN` bits wide, forcing the correct bit width in the conversion of the corresponding *plusarg*.