### PR TITLE
ariane_pkg: Parametrise cache layout

### DIFF
--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -453,19 +453,19 @@ package ariane_pkg;
     localparam int unsigned DCACHE_USER_WIDTH  = DATA_USER_WIDTH;
 `else
     // I$
-    localparam int unsigned CONFIG_L1I_SIZE    = cva6_config_pkg::CVA6ConfigIcacheSetAssoc * 4096; // one icache way is 4 KBytes
+    localparam int unsigned CONFIG_L1I_SIZE    = cva6_config_pkg::CVA6ConfigIcacheSetAssoc * cva6_config_pkg::CVA6ConfigIcacheLines;
     localparam int unsigned ICACHE_SET_ASSOC   = cva6_config_pkg::CVA6ConfigIcacheSetAssoc; // number of ways
     localparam int unsigned ICACHE_INDEX_WIDTH = $clog2(CONFIG_L1I_SIZE / ICACHE_SET_ASSOC);  // in bit, contains also offset width
     localparam int unsigned ICACHE_TAG_WIDTH   = riscv::PLEN-ICACHE_INDEX_WIDTH;  // in bit
-    localparam int unsigned ICACHE_LINE_WIDTH  = 128; // in bit
-    localparam int unsigned ICACHE_USER_LINE_WIDTH  = (AXI_USER_WIDTH == 1) ? 4 : 128; // in bit
+    localparam int unsigned ICACHE_LINE_WIDTH  = cva6_config_pkg::CVA6ConfigIcacheLineWidth; // in bit
+    localparam int unsigned ICACHE_USER_LINE_WIDTH  = (AXI_USER_WIDTH == 1) ? 4 : cva6_config_pkg::CVA6ConfigIcacheLineWidth; // in bit
     // D$
-    localparam int unsigned CONFIG_L1D_SIZE    = cva6_config_pkg::CVA6ConfigDcacheSetAssoc * 4096; // one icache way is 4 KBytes
+    localparam int unsigned CONFIG_L1D_SIZE    = cva6_config_pkg::CVA6ConfigDcacheSetAssoc * cva6_config_pkg::CVA6ConfigDcacheLines;
     localparam int unsigned DCACHE_SET_ASSOC   = cva6_config_pkg::CVA6ConfigDcacheSetAssoc; // number of ways
     localparam int unsigned DCACHE_INDEX_WIDTH = $clog2(CONFIG_L1D_SIZE / DCACHE_SET_ASSOC);  // in bit, contains also offset width
     localparam int unsigned DCACHE_TAG_WIDTH   = riscv::PLEN-DCACHE_INDEX_WIDTH;  // in bit
-    localparam int unsigned DCACHE_LINE_WIDTH  = 128; // in bit
-    localparam int unsigned DCACHE_USER_LINE_WIDTH  = (AXI_USER_WIDTH == 1) ? 4 : 128; // in bit
+    localparam int unsigned DCACHE_LINE_WIDTH  = cva6_config_pkg::CVA6ConfigDcacheLineWidth; // in bit
+    localparam int unsigned DCACHE_USER_LINE_WIDTH  = (AXI_USER_WIDTH == 1) ? 4 : cva6_config_pkg::CVA6ConfigDcacheLineWidth; // in bit
     localparam int unsigned DCACHE_USER_WIDTH  = DATA_USER_WIDTH;
 `endif
 

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -30,7 +30,11 @@ package cva6_config_pkg;
     localparam CVA6ConfigRenameEn = 0;
 
     localparam CVA6ConfigIcacheSetAssoc = 4;
+    localparam CVA6ConfigIcacheLines = 4096;
+    localparam CVA6ConfigIcacheLineWidth = 128;
     localparam CVA6ConfigDcacheSetAssoc = 8;
+    localparam CVA6ConfigDcacheLines = 4096;
+    localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigNrCommitPorts = 1;
     localparam CVA6ConfigNrScoreboardEntries = 4;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -30,7 +30,11 @@ package cva6_config_pkg;
     localparam CVA6ConfigRenameEn = 0;
 
     localparam CVA6ConfigIcacheSetAssoc = 2;
+    localparam CVA6ConfigIcacheLines = 4096;
+    localparam CVA6ConfigIcacheLineWidth = 128;
     localparam CVA6ConfigDcacheSetAssoc = 2;
+    localparam CVA6ConfigDcacheLines = 4096;
+    localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigNrCommitPorts = 1;
     localparam CVA6ConfigNrScoreboardEntries = 4;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -30,7 +30,11 @@ package cva6_config_pkg;
     localparam CVA6ConfigRenameEn = 0;
 
     localparam CVA6ConfigIcacheSetAssoc = 4;
+    localparam CVA6ConfigIcacheLines = 4096;
+    localparam CVA6ConfigIcacheLineWidth = 128;
     localparam CVA6ConfigDcacheSetAssoc = 8;
+    localparam CVA6ConfigDcacheLines = 4096;
+    localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigNrCommitPorts = 2;
     localparam CVA6ConfigNrScoreboardEntries = 8;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -30,7 +30,11 @@ package cva6_config_pkg;
     localparam CVA6ConfigRenameEn = 0;
 
     localparam CVA6ConfigIcacheSetAssoc = 4;
+    localparam CVA6ConfigIcacheLines = 4096;
+    localparam CVA6ConfigIcacheLineWidth = 128;
     localparam CVA6ConfigDcacheSetAssoc = 8;
+    localparam CVA6ConfigDcacheLines = 4096;
+    localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigNrCommitPorts = 2;
     localparam CVA6ConfigNrScoreboardEntries = 8;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -30,7 +30,11 @@ package cva6_config_pkg;
     localparam CVA6ConfigRenameEn = 0;
 
     localparam CVA6ConfigIcacheSetAssoc = 4;
+    localparam CVA6ConfigIcacheLines = 4096;
+    localparam CVA6ConfigIcacheLineWidth = 128;
     localparam CVA6ConfigDcacheSetAssoc = 8;
+    localparam CVA6ConfigDcacheLines = 4096;
+    localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigNrCommitPorts = 2;
     localparam CVA6ConfigNrScoreboardEntries = 8;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -30,7 +30,11 @@ package cva6_config_pkg;
     localparam CVA6ConfigRenameEn = 0;
 
     localparam CVA6ConfigIcacheSetAssoc = 4;
+    localparam CVA6ConfigIcacheLines = 4096;
+    localparam CVA6ConfigIcacheLineWidth = 128;
     localparam CVA6ConfigDcacheSetAssoc = 8;
+    localparam CVA6ConfigDcacheLines = 4096;
+    localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigNrCommitPorts = 2;
     localparam CVA6ConfigNrScoreboardEntries = 8;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -30,7 +30,11 @@ package cva6_config_pkg;
     localparam CVA6ConfigRenameEn = 0;
 
     localparam CVA6ConfigIcacheSetAssoc = 4;
+    localparam CVA6ConfigIcacheLines = 4096;
+    localparam CVA6ConfigIcacheLineWidth = 128;
     localparam CVA6ConfigDcacheSetAssoc = 8;
+    localparam CVA6ConfigDcacheLines = 4096;
+    localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigNrCommitPorts = 2;
     localparam CVA6ConfigNrScoreboardEntries = 8;


### PR DESCRIPTION
Required by #1024.

With this change, different CVA6 configurations can define different cache layouts in their respective `cva6_config_pkg`.