### PR TITLE
Add hypervisor extension support

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -31,6 +31,9 @@ sources:
           - core/mmu_sv39/tlb.sv
           - core/mmu_sv39/mmu.sv
           - core/mmu_sv39/ptw.sv
+          - core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+          - core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+          - core/mmu_sv39x4/cva6_ptw_sv39x4.sv
 
       - target: cv32a6_imac_sv0
         files:

--- a/Flist.ariane
+++ b/Flist.ariane
@@ -81,11 +81,13 @@ core/load_unit.sv
 core/load_store_unit.sv
 core/lsu_bypass.sv
 core/mmu_sv39/mmu.sv
+core/mmu_sv39x4/cva6_mmu_sv39x4.sv
 core/mult.sv
 core/multiplier.sv
 core/serdiv.sv
 core/perf_counters.sv
 core/mmu_sv39/ptw.sv
+core/mmu_sv39x4/ptw_sv39x4.sv
 core/ariane_regfile_ff.sv
 core/re_name.sv
 core/scoreboard.sv
@@ -93,6 +95,7 @@ core/store_buffer.sv
 core/amo_buffer.sv
 core/store_unit.sv
 core/mmu_sv39/tlb.sv
+core/mmu_sv39x4/tlb_sv39x4.sv
 core/commit_stage.sv
 core/cache_subsystem/wt_dcache_ctrl.sv
 core/cache_subsystem/wt_dcache_mem.sv

--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -173,6 +173,11 @@ ${CVA6_REPO_DIR}/core/mmu_sv39/mmu.sv
 ${CVA6_REPO_DIR}/core/mmu_sv39/ptw.sv
 ${CVA6_REPO_DIR}/core/mmu_sv39/tlb.sv
 
+// MMU Sv39x4
+${CVA6_REPO_DIR}/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+${CVA6_REPO_DIR}/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+${CVA6_REPO_DIR}/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+
 // MMU Sv32
 ${CVA6_REPO_DIR}/core/mmu_sv32/cva6_mmu_sv32.sv
 ${CVA6_REPO_DIR}/core/mmu_sv32/cva6_ptw_sv32.sv

--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -88,6 +88,7 @@ module branch_unit (
         branch_exception_o.cause = riscv::INSTR_ADDR_MISALIGNED;
         branch_exception_o.valid = 1'b0;
         branch_exception_o.tval  = {{riscv::XLEN-riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
+        branch_exception_o.tinst  = {riscv::XLEN{1'b0}};
         // only throw exception if this is indeed a branch
         if (branch_valid_i && target_address[0] != 1'b0) branch_exception_o.valid = 1'b1;
     end

--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -89,7 +89,7 @@ module branch_unit (
         branch_exception_o.cause = riscv::INSTR_ADDR_MISALIGNED;
         branch_exception_o.valid = 1'b0;
         branch_exception_o.tval  = {{riscv::XLEN-riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
-        branch_exception_o.tval2 = {riscv::XLEN{1'b0}};
+        branch_exception_o.tval2 = {riscv::GPLEN{1'b0}};
         branch_exception_o.tinst = {riscv::XLEN{1'b0}};
         branch_exception_o.gva   = ariane_pkg::RVH ? v_i : 1'b0;
         // only throw exception if this is indeed a branch

--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -15,6 +15,7 @@
 module branch_unit (
     input  logic                      clk_i,
     input  logic                      rst_ni,
+    input  logic                      v_i,
     input  logic                      debug_mode_i,
     input  ariane_pkg::fu_data_t      fu_data_i,
     input  logic [riscv::VLEN-1:0]    pc_i,                   // PC of instruction
@@ -88,7 +89,9 @@ module branch_unit (
         branch_exception_o.cause = riscv::INSTR_ADDR_MISALIGNED;
         branch_exception_o.valid = 1'b0;
         branch_exception_o.tval  = {{riscv::XLEN-riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
-        branch_exception_o.tinst  = {riscv::XLEN{1'b0}};
+        branch_exception_o.tval2 = {riscv::XLEN{1'b0}};
+        branch_exception_o.tinst = {riscv::XLEN{1'b0}};
+        branch_exception_o.gva   = v_i;
         // only throw exception if this is indeed a branch
         if (branch_valid_i && target_address[0] != 1'b0) branch_exception_o.valid = 1'b1;
     end

--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -91,7 +91,7 @@ module branch_unit (
         branch_exception_o.tval  = {{riscv::XLEN-riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
         branch_exception_o.tval2 = {riscv::XLEN{1'b0}};
         branch_exception_o.tinst = {riscv::XLEN{1'b0}};
-        branch_exception_o.gva   = v_i;
+        branch_exception_o.gva   = ariane_pkg::RVH ? v_i : 1'b0;
         // only throw exception if this is indeed a branch
         if (branch_valid_i && target_address[0] != 1'b0) branch_exception_o.valid = 1'b1;
     end

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -260,6 +260,7 @@ module commit_stage import ariane_pkg::*; #(
         exception_o.valid = 1'b0;
         exception_o.cause = '0;
         exception_o.tval  = '0;
+        exception_o.tinst = '0;
         // we need a valid instruction in the commit stage
         if (commit_instr_i[0].valid) begin
             // ------------------------

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -302,7 +302,7 @@ module commit_stage import ariane_pkg::*; #(
                 // if no earlier exception happened the commit instruction will still contain
                 // the instruction bits from the ID stage. If a earlier exception happened we don't care
                 // as we will overwrite it anyway in the next IF bl
-                exception_o.tval  = commit_instr_i[0].ex.tval;
+                exception_o.tval = commit_instr_i[0].ex.tval;
                 if(ariane_pkg::RVH) begin 
                     exception_o.tinst = commit_instr_i[0].ex.tinst;
                     exception_o.tval2 = commit_instr_i[0].ex.tval2;

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -303,7 +303,7 @@ module commit_stage import ariane_pkg::*; #(
                 // the instruction bits from the ID stage. If a earlier exception happened we don't care
                 // as we will overwrite it anyway in the next IF bl
                 exception_o.tval = commit_instr_i[0].ex.tval;
-                if(ariane_pkg::RVH) begin 
+                if (ariane_pkg::RVH) begin 
                     exception_o.tinst = commit_instr_i[0].ex.tinst;
                     exception_o.tval2 = commit_instr_i[0].ex.tval2;
                     exception_o.gva   = commit_instr_i[0].ex.gva;

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -180,7 +180,7 @@ module commit_stage import ariane_pkg::*; #(
             // hfence.vvma is idempotent so we can safely re-execute it after returning
             // from interrupt service routine
             // check if this instruction was a HFENCE_VVMA
-            if (commit_instr_i[0].op == HFENCE_VVMA) begin
+            if (ariane_pkg::RVH && commit_instr_i[0].op == HFENCE_VVMA) begin
                 // no store pending so we can flush the TLBs and pipeline
                 hfence_vvma_o = no_st_pending_i;
                 // wait for the store buffer to drain until flushing the pipeline
@@ -192,7 +192,7 @@ module commit_stage import ariane_pkg::*; #(
             // hfence.gvma is idempotent so we can safely re-execute it after returning
             // from interrupt service routine
             // check if this instruction was a HFENCE_GVMA
-            if (commit_instr_i[0].op == HFENCE_GVMA) begin
+            if (ariane_pkg::RVH && commit_instr_i[0].op == HFENCE_GVMA) begin
                 // no store pending so we can flush the TLBs and pipeline
                 hfence_gvma_o = no_st_pending_i;
                 // wait for the store buffer to drain until flushing the pipeline
@@ -303,9 +303,11 @@ module commit_stage import ariane_pkg::*; #(
                 // the instruction bits from the ID stage. If a earlier exception happened we don't care
                 // as we will overwrite it anyway in the next IF bl
                 exception_o.tval  = commit_instr_i[0].ex.tval;
-                exception_o.tinst = commit_instr_i[0].ex.tinst;
-                exception_o.tval2 = commit_instr_i[0].ex.tval2;
-                exception_o.gva   = commit_instr_i[0].ex.gva;
+                if(ariane_pkg::RVH) begin 
+                    exception_o.tinst = commit_instr_i[0].ex.tinst;
+                    exception_o.tval2 = commit_instr_i[0].ex.tval2;
+                    exception_o.gva   = commit_instr_i[0].ex.gva;
+                end
             end
             // ------------------------
             // Earlier Exceptions

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -132,7 +132,7 @@ module controller import ariane_pkg::*; (
             flush_unissued_instr_o = 1'b1;
             flush_id_o             = 1'b1;
             flush_ex_o             = 1'b1;
-            if(v_i)
+            if(ariane_pkg::RVH && v_i)
                 flush_tlb_vvma_o       = 1'b1;
             else
                 flush_tlb_o            = 1'b1;
@@ -141,7 +141,7 @@ module controller import ariane_pkg::*; (
         // ---------------------------------
         // HFENCE.VVMA
         // ---------------------------------
-        if (hfence_vvma_i) begin
+        if (ariane_pkg::RVH && hfence_vvma_i) begin
             set_pc_commit_o        = 1'b1;
             flush_if_o             = 1'b1;
             flush_unissued_instr_o = 1'b1;
@@ -154,7 +154,7 @@ module controller import ariane_pkg::*; (
         // ---------------------------------
         // HFENCE.GVMA
         // ---------------------------------
-        if (hfence_gvma_i) begin
+        if (ariane_pkg::RVH && hfence_gvma_i) begin
             set_pc_commit_o        = 1'b1;
             flush_if_o             = 1'b1;
             flush_unissued_instr_o = 1'b1;

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -132,36 +132,39 @@ module controller import ariane_pkg::*; (
             flush_unissued_instr_o = 1'b1;
             flush_id_o             = 1'b1;
             flush_ex_o             = 1'b1;
-            if(ariane_pkg::RVH && v_i)
+            if(ariane_pkg::RVH && v_i) begin
                 flush_tlb_vvma_o       = 1'b1;
-            else
+            end else begin
                 flush_tlb_o            = 1'b1;
+            end
         end
 
-        // ---------------------------------
-        // HFENCE.VVMA
-        // ---------------------------------
-        if (ariane_pkg::RVH && hfence_vvma_i) begin
-            set_pc_commit_o        = 1'b1;
-            flush_if_o             = 1'b1;
-            flush_unissued_instr_o = 1'b1;
-            flush_id_o             = 1'b1;
-            flush_ex_o             = 1'b1;
+        if (ariane_pkg::RVH) begin
+            // ---------------------------------
+            // HFENCE.VVMA
+            // ---------------------------------
+            if (hfence_vvma_i) begin
+                set_pc_commit_o        = 1'b1;
+                flush_if_o             = 1'b1;
+                flush_unissued_instr_o = 1'b1;
+                flush_id_o             = 1'b1;
+                flush_ex_o             = 1'b1;
 
-            flush_tlb_vvma_o       = 1'b1;
-        end
+                flush_tlb_vvma_o       = 1'b1;
+            end
 
-        // ---------------------------------
-        // HFENCE.GVMA
-        // ---------------------------------
-        if (ariane_pkg::RVH && hfence_gvma_i) begin
-            set_pc_commit_o        = 1'b1;
-            flush_if_o             = 1'b1;
-            flush_unissued_instr_o = 1'b1;
-            flush_id_o             = 1'b1;
-            flush_ex_o             = 1'b1;
+            // ---------------------------------
+            // HFENCE.GVMA
+            // ---------------------------------
+            if (hfence_gvma_i) begin
+                set_pc_commit_o        = 1'b1;
+                flush_if_o             = 1'b1;
+                flush_unissued_instr_o = 1'b1;
+                flush_id_o             = 1'b1;
+                flush_ex_o             = 1'b1;
 
-            flush_tlb_gvma_o       = 1'b1;
+                flush_tlb_gvma_o       = 1'b1;
+            end
         end
 
         // Set PC to commit stage and flush pipleine

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1411,14 +1411,14 @@ module csr_regfile import ariane_pkg::*; #(
         if (!debug_mode_q) begin
             dcsr_d.prv = priv_lvl_o;
             // save virtualization mode bit
-            dcsr_d.v   = (ariane_pkg::RVH) ? 1'b0 : v_q;
+            dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
             // trigger module fired
 
             // caused by a breakpoint
             if (ex_i.valid && ex_i.cause == riscv::BREAKPOINT) begin
                 dcsr_d.prv = priv_lvl_o;
                 // save virtualization mode bit
-                dcsr_d.v   = ariane_pkg::RVH ? 1'b0 : v_q;
+                dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
                 // check that we actually want to enter debug depending on the privilege level we are currently in
                 unique case (priv_lvl_o)
                     riscv::PRIV_LVL_M: begin
@@ -1444,7 +1444,7 @@ module csr_regfile import ariane_pkg::*; #(
             if (ex_i.valid && ex_i.cause == riscv::DEBUG_REQUEST) begin
                 dcsr_d.prv = priv_lvl_o;
                 // save virtualization mode bit
-                dcsr_d.v   = (ariane_pkg::RVH) ? 1'b0 : v_q;
+                dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
                 // save the PC
                 dpc_d = {{riscv::XLEN-riscv::VLEN{pc_i[riscv::VLEN-1]}},pc_i};
                 // enter debug mode
@@ -1459,7 +1459,7 @@ module csr_regfile import ariane_pkg::*; #(
             if (dcsr_q.step && commit_ack_i[0]) begin
                 dcsr_d.prv = priv_lvl_o;
                 // save virtualization mode bit
-                dcsr_d.v   = (ariane_pkg::RVH) ? 1'b0 : v_q;
+                dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
                 // valid CTRL flow change
                 if (commit_instr_i[0].fu == CTRL_FLOW) begin
                     // we saved the correct target address during execute

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1959,6 +1959,7 @@ module csr_regfile import ariane_pkg::*; #(
     assign vmid_o           = ariane_pkg::RVH ? hgatp_q.vmid[VmidWidth-1:0] : '0;
     assign sum_o            = mstatus_q.sum;
     assign vs_sum_o         = ariane_pkg::RVH ? vsstatus_q.sum : '0;
+    assign hu_o             = ariane_pkg::RVH ? hstatus_q.hu : '0;
     // we support bare memory addressing and SV39
     if(ariane_pkg::RVH) begin
         assign en_translation_o = ((((riscv::vm_mode_t'(satp_q.mode) == riscv::MODE_SV && !v_q) || (riscv::vm_mode_t'(vsatp_q.mode) == riscv::MODE_SV && v_q)) &&

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -171,6 +171,11 @@ module csr_regfile import ariane_pkg::*; #(
     riscv::xlen_t vscause_q,   vscause_d;
     riscv::xlen_t vstval_q,    vstval_d;
 
+    // Environment Configuration Registers
+    riscv::envcfg_rv_t menvcfg_q, menvcfg_d;
+    riscv::envcfg_rv_t senvcfg_q, senvcfg_d;
+    riscv::envcfg_rv_t henvcfg_q, henvcfg_d;
+
     riscv::xlen_t dcache_q,    dcache_d;
     riscv::xlen_t icache_q,    icache_d;
 
@@ -324,6 +329,7 @@ module csr_regfile import ariane_pkg::*; #(
                         csr_rdata = v_q ? vsatp_q : satp_q;
                     end
                 end
+                riscv::CSR_SENVCFG:            csr_rdata = senvcfg_q;
                 // hypervisor mode registers
                 riscv::CSR_HSTATUS:            csr_rdata = hstatus_extended;
                 riscv::CSR_HEDELEG:            csr_rdata = hedeleg_q;
@@ -344,6 +350,7 @@ module csr_regfile import ariane_pkg::*; #(
                         csr_rdata = hgatp_q;
                     end
                 end
+                riscv::CSR_HENVCFG:            csr_rdata = henvcfg_q;
 
                 // machine mode registers
                 riscv::CSR_MSTATUS:            csr_rdata = mstatus_extended;
@@ -362,8 +369,10 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MARCHID:            csr_rdata = ARIANE_MARCHID;
                 riscv::CSR_MIMPID:             csr_rdata = '0; // not implemented
                 riscv::CSR_MHARTID:            csr_rdata = hart_id_i;
+                riscv::CSR_MCONFIGPTR:         csr_rdata = '0; // no configuration data structure
                 riscv::CSR_MTINST:             csr_rdata = mtinst_q;
                 riscv::CSR_MTVAL2:             csr_rdata = mtval2_q;
+                riscv::CSR_MENVCFG:            csr_rdata = menvcfg_q;
                 // Counters and Timers
                 riscv::CSR_MCYCLE:             csr_rdata = cycle_q[riscv::XLEN-1:0];
                 riscv::CSR_MCYCLEH:            if (riscv::XLEN == 32) csr_rdata = cycle_q[63:32]; else read_access_exception = 1'b1;
@@ -584,6 +593,10 @@ module csr_regfile import ariane_pkg::*; #(
         htval_d                 = htval_q;
         htinst_d                = htinst_q;
 
+        menvcfg_d               = menvcfg_q;
+        senvcfg_d               = senvcfg_q;
+        henvcfg_d               = henvcfg_q;
+
         en_ld_st_translation_d  = en_ld_st_translation_q;
         en_ld_st_g_translation_d = en_ld_st_g_translation_q;
         dirty_fp_state_csr      = 1'b0;
@@ -790,6 +803,12 @@ module csr_regfile import ariane_pkg::*; #(
                     // the next instruction by executing a flush
                     flush_o = 1'b1;
                 end
+                riscv::CSR_SENVCFG: begin
+                    mask = ariane_pkg::ENVCFG_WRITE_MASK[riscv::XLEN-1:0];
+                    senvcfg_d = (senvcfg_q & ~mask) | (csr_wdata & mask);
+                    // this instruction has side-effects
+                    flush_o = 1'b1;
+                end
                 //hypervisor mode registers
                 riscv::CSR_HSTATUS: begin
                     mask = ariane_pkg::HSTATUS_WRITE_MASK[riscv::XLEN-1:0];
@@ -848,6 +867,13 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                     // changing the mode can have side-effects on address translation (e.g.: other instructions), re-fetch
                     // the next instruction by executing a flush
+                    flush_o = 1'b1;
+                end
+                riscv::CSR_HENVCFG: begin
+                    mask = ariane_pkg::ENVCFG_WRITE_MASK[riscv::XLEN-1:0];
+                    henvcfg_d = (henvcfg_q & ~mask) | (csr_wdata & mask);
+                    henvcfg_d.pbmte = menvcfg_q.pbmte ? henvcfg_d.pbmte : 1'b0;
+                    // this instruction has side-effects
                     flush_o = 1'b1;
                 end
 
@@ -912,6 +938,12 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MTVAL:              mtval_d     = csr_wdata;
                 riscv::CSR_MTINST:             mtinst_d    = {{riscv::XLEN-32{1'b0}}, csr_wdata[31:0]};
                 riscv::CSR_MTVAL2:             mtval2_d    = csr_wdata;
+                riscv::CSR_MENVCFG: begin
+                    mask = ariane_pkg::ENVCFG_WRITE_MASK[riscv::XLEN-1:0];
+                    menvcfg_d = (menvcfg_q & ~mask) | (csr_wdata & mask);
+                    // this instruction has side-effects
+                    flush_o = 1'b1;
+                end
                 riscv::CSR_MIP: begin
                     mask = riscv::MIP_SSIP | riscv::MIP_STIP | riscv::MIP_SEIP | riscv::MIP_VSSIP;
                     mip_d = (mip_q & ~mask) | (csr_wdata & mask);
@@ -1670,6 +1702,9 @@ module csr_regfile import ariane_pkg::*; #(
             mtval_q                <= {riscv::XLEN{1'b0}};
             mtval2_q               <= {riscv::XLEN{1'b0}};
             mtinst_q               <= {riscv::XLEN{1'b0}};
+            menvcfg_q              <= {riscv::XLEN{1'b0}};
+            senvcfg_q              <= {riscv::XLEN{1'b0}};
+            henvcfg_q              <= {riscv::XLEN{1'b0}};
             dcache_q               <= {{riscv::XLEN-1{1'b0}}, 1'b1};
             icache_q               <= {{riscv::XLEN-1{1'b0}}, 1'b1};
             // supervisor mode registers
@@ -1733,6 +1768,9 @@ module csr_regfile import ariane_pkg::*; #(
             mtval_q                <= mtval_d;
             mtval2_q               <= mtval2_d;
             mtinst_q               <= mtinst_d;
+            menvcfg_q              <= menvcfg_d;
+            senvcfg_q              <= senvcfg_d;
+            henvcfg_q              <= henvcfg_d;
             dcache_q               <= dcache_d;
             icache_q               <= icache_d;
             // supervisor mode registers

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -124,7 +124,6 @@ module csr_regfile import ariane_pkg::*; #(
     riscv::status_rv_t    vsstatus_q,  vsstatus_d;
 
     riscv::xlen_t         mstatus_extended;
-    riscv::xlen_t         hstatus_extended;
     riscv::xlen_t         vsstatus_extended;
     riscv::satp_t         vsatp_q, vsatp_d;
     riscv::hgatp_t        hgatp_q, hgatp_d;
@@ -208,11 +207,9 @@ module csr_regfile import ariane_pkg::*; #(
     assign mstatus_extended  = riscv::IS_XLEN64 ? mstatus_q[riscv::XLEN-1:0] :
                               {mstatus_q.sd, mstatus_q.wpri3[7:0], mstatus_q[22:0]};
     if(ariane_pkg::RVH) begin
-        assign hstatus_extended  = hstatus_q[riscv::XLEN-1:0];
         assign vsstatus_extended = riscv::IS_XLEN64 ? vsstatus_q[riscv::XLEN-1:0] :
                                 {vsstatus_q.sd, vsstatus_q.wpri3[7:0], vsstatus_q[22:0]};
-    end else begin 
-        assign hstatus_extended  = '0;
+    end else begin
         assign vsstatus_extended = '0;
     end
 
@@ -334,7 +331,7 @@ module csr_regfile import ariane_pkg::*; #(
                 // hypervisor mode registers
                 riscv::CSR_HSTATUS: begin
                     if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
-                    else csr_rdata = hstatus_extended;
+                    else csr_rdata = hstatus_q[riscv::XLEN-1:0];
                 end
                 riscv::CSR_HEDELEG: begin
                     if(~ariane_pkg::RVH) read_access_exception = 1'b1;           

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -204,7 +204,7 @@ module csr_regfile import ariane_pkg::*; #(
     // ----------------
     // CSR Read logic
     // ----------------
-    assign mstatus_extended  = riscv::IS_XLEN64 ? mstatus_q[riscv::XLEN-1:0] :
+    assign mstatus_extended = riscv::IS_XLEN64 ? mstatus_q[riscv::XLEN-1:0] :
                               {mstatus_q.sd, mstatus_q.wpri3[7:0], mstatus_q[22:0]};
     if(ariane_pkg::RVH) begin
         assign vsstatus_extended = riscv::IS_XLEN64 ? vsstatus_q[riscv::XLEN-1:0] :
@@ -594,8 +594,8 @@ module csr_regfile import ariane_pkg::*; #(
         dscratch1_d             = dscratch1_q;
         mstatus_d               = mstatus_q;
         if(ariane_pkg::RVH) begin
-            hstatus_d               = hstatus_q;
-            vsstatus_d              = vsstatus_q;
+            hstatus_d           = hstatus_q;
+            vsstatus_d          = vsstatus_q;
         end
 
         // check whether we come out of reset
@@ -620,20 +620,19 @@ module csr_regfile import ariane_pkg::*; #(
         mscratch_d              = mscratch_q;
         mtval_d                 = mtval_q;
         if(ariane_pkg::RVH) begin
-            mtinst_d                = mtinst_q;
-            mtval2_d                = mtval2_q;
+            mtinst_d            = mtinst_q;
+            mtval2_d            = mtval2_q;
         end
         dcache_d                = dcache_q;
         icache_d                = icache_q;
 
         if(ariane_pkg::RVH) begin
-            vsstatus_d              = vsstatus_q;
-            vstvec_d                = vstvec_q;
-            vsscratch_d             = vsscratch_q;
-            vsepc_d                 = vsepc_q;
-            vscause_d               = vscause_q;
-            vstval_d                = vstval_q;
-            vsatp_d                 = vsatp_q;
+            vstvec_d            = vstvec_q;
+            vsscratch_d         = vsscratch_q;
+            vsepc_d             = vsepc_q;
+            vscause_d           = vscause_q;
+            vstval_d            = vstval_q;
+            vsatp_d             = vsatp_q;
         end
 
         sepc_d                  = sepc_q;
@@ -645,14 +644,14 @@ module csr_regfile import ariane_pkg::*; #(
         satp_d                  = satp_q;
 
         if(ariane_pkg::RVH) begin
-            hedeleg_d               = hedeleg_q;
-            hideleg_d               = hideleg_q;
-            hgeie_d                 = hgeie_q;
-            hgatp_d                 = hgatp_q;
-            hcounteren_d            = hcounteren_q;
-            htval_d                 = htval_q;
-            htinst_d                = htinst_q;
-            henvcfg_d               = henvcfg_q;
+            hedeleg_d           = hedeleg_q;
+            hideleg_d           = hideleg_q;
+            hgeie_d             = hgeie_q;
+            hgatp_d             = hgatp_q;
+            hcounteren_d        = hcounteren_q;
+            htval_d             = htval_q;
+            htinst_d            = htinst_q;
+            henvcfg_d           = henvcfg_q;
         end
 
         menvcfg_d               = menvcfg_q;
@@ -1274,7 +1273,7 @@ module csr_regfile import ariane_pkg::*; #(
                     // so if we are already in M mode, stay there
                     trap_to_priv_lvl = (priv_lvl_o == riscv::PRIV_LVL_M) ? riscv::PRIV_LVL_M : riscv::PRIV_LVL_S;
                 end else if ((ex_i.cause[riscv::XLEN-1] && hideleg_q[ex_i.cause[$clog2(riscv::XLEN)-1:0]]) ||
-                        (~ex_i.cause[riscv::XLEN-1] && hedeleg_q[ex_i.cause[$clog2(riscv::XLEN)-1:0]])) begin
+                             (~ex_i.cause[riscv::XLEN-1] && hedeleg_q[ex_i.cause[$clog2(riscv::XLEN)-1:0]])) begin
                     trap_to_priv_lvl = (priv_lvl_o == riscv::PRIV_LVL_M) ? riscv::PRIV_LVL_M : riscv::PRIV_LVL_S;
                     // trap to VS only if it is  the currently active mode
                     trap_to_v   = v_q;
@@ -1285,7 +1284,7 @@ module csr_regfile import ariane_pkg::*; #(
                     // traps never transition from a more-privileged mode to a less privileged mode
                     // so if we are already in M mode, stay there
                     trap_to_priv_lvl = (priv_lvl_o == riscv::PRIV_LVL_M) ? riscv::PRIV_LVL_M : riscv::PRIV_LVL_S;
-            end
+                end
             end
 
             // trap to supervisor mode
@@ -1939,13 +1938,13 @@ module csr_regfile import ariane_pkg::*; #(
             htinst_q               <= {riscv::XLEN{1'b0}};
             henvcfg_q              <= '0;
             // virtual supervisor mode registers
-            vsstatus_q              <= 64'b0;
-            vsepc_q                 <= {riscv::XLEN{1'b0}};
-            vscause_q               <= {riscv::XLEN{1'b0}};
-            vstvec_q                <= {riscv::XLEN{1'b0}};
-            vsscratch_q             <= {riscv::XLEN{1'b0}};
-            vstval_q                <= {riscv::XLEN{1'b0}};
-            vsatp_q                 <= {riscv::XLEN{1'b0}};
+            vsstatus_q             <= 64'b0;
+            vsepc_q                <= {riscv::XLEN{1'b0}};
+            vscause_q              <= {riscv::XLEN{1'b0}};
+            vstvec_q               <= {riscv::XLEN{1'b0}};
+            vsscratch_q            <= {riscv::XLEN{1'b0}};
+            vstval_q               <= {riscv::XLEN{1'b0}};
+            vsatp_q                <= {riscv::XLEN{1'b0}};
             // timer and counters
             cycle_q                <= {riscv::XLEN{1'b0}};
             instret_q              <= {riscv::XLEN{1'b0}};
@@ -2006,13 +2005,13 @@ module csr_regfile import ariane_pkg::*; #(
             htinst_q               <= htinst_d;
             henvcfg_q              <= henvcfg_d;
             // virtual supervisor mode registers
-            vsstatus_q              <= vsstatus_d;
-            vsepc_q                 <= vsepc_d;
-            vscause_q               <= vscause_d;
-            vstvec_q                <= vstvec_d;
-            vsscratch_q             <= vsscratch_d;
-            vstval_q                <= vstval_d;
-            vsatp_q                 <= vsatp_d;
+            vsstatus_q             <= vsstatus_d;
+            vsepc_q                <= vsepc_d;
+            vscause_q              <= vscause_d;
+            vstvec_q               <= vstvec_d;
+            vsscratch_q            <= vsscratch_d;
+            vstval_q               <= vstval_d;
+            vsatp_q                <= vsatp_d;
             // timer and counters
             cycle_q                <= cycle_d;
             instret_q              <= instret_d;

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -769,7 +769,6 @@ module csr_regfile import ariane_pkg::*; #(
                         update_access_exception = 1'b1;
                     end else begin
                         vstvec_d    = {csr_wdata[riscv::XLEN-1:2], 1'b0, csr_wdata[0]};
-                        if (csr_wdata[0]) vstvec_d = {csr_wdata[riscv::XLEN-1:8], 7'b0, csr_wdata[0]};
                     end
                 end
                 riscv::CSR_VSSCRATCH: begin
@@ -845,10 +844,7 @@ module csr_regfile import ariane_pkg::*; #(
                     mip_d = (mip_q & ~mask) | (csr_wdata & mask);
                 end
 
-                riscv::CSR_STVEC: begin
-                    stvec_d = {csr_wdata[riscv::XLEN-1:2], 1'b0, csr_wdata[0]};
-                    if (csr_wdata[0]) stvec_d = {csr_wdata[riscv::XLEN-1:8], 7'b0, csr_wdata[0]};
-                end
+                riscv::CSR_STVEC:              stvec_d = {csr_wdata[riscv::XLEN-1:2], 1'b0, csr_wdata[0]};
                 riscv::CSR_SCOUNTEREN:         scounteren_d = {{riscv::XLEN-32{1'b0}}, csr_wdata[31:0]};
                 riscv::CSR_SSCRATCH:           sscratch_d   = csr_wdata;
                 riscv::CSR_SEPC:               sepc_d       = {csr_wdata[riscv::XLEN-1:1], 1'b0};

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -206,12 +206,8 @@ module csr_regfile import ariane_pkg::*; #(
     // ----------------
     assign mstatus_extended = riscv::IS_XLEN64 ? mstatus_q[riscv::XLEN-1:0] :
                               {mstatus_q.sd, mstatus_q.wpri3[7:0], mstatus_q[22:0]};
-    if(ariane_pkg::RVH) begin
-        assign vsstatus_extended = riscv::IS_XLEN64 ? vsstatus_q[riscv::XLEN-1:0] :
-                                {vsstatus_q.sd, vsstatus_q.wpri3[7:0], vsstatus_q[22:0]};
-    end else begin
-        assign vsstatus_extended = '0;
-    end
+    assign vsstatus_extended = (ariane_pkg::RVH) ? (riscv::IS_XLEN64 ? vsstatus_q[riscv::XLEN-1:0] :
+                                {vsstatus_q.sd, vsstatus_q.wpri3[7:0], vsstatus_q[22:0]}) : '0;
 
     always_comb begin : csr_read_process
         // a read access exception can only occur if we attempt to read a CSR which does not exist
@@ -262,40 +258,40 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_TDATA2:;  // not implemented
                 riscv::CSR_TDATA3:;  // not implemented
                 riscv::CSR_VSSTATUS: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = vsstatus_extended;
                 end
                 riscv::CSR_VSIE: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = (mie_q & VS_DELEG_INTERRUPTS & hideleg_q) >> 1;
                 end
                 riscv::CSR_VSIP: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = (mip_q & VS_DELEG_INTERRUPTS & hideleg_q) >> 1;
                 end
                 riscv::CSR_VSTVEC: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = vstvec_q;
                 end
                 riscv::CSR_VSSCRATCH: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = vsscratch_q;
                 end
                 riscv::CSR_VSEPC: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = vsepc_q;
                 end
                 riscv::CSR_VSCAUSE: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = vscause_q;
                 end
                 riscv::CSR_VSTVAL: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = vstval_q;
                 end
                 riscv::CSR_VSATP: begin
                     // intercept reads to VSATP if in VS-Mode and VTVM is enabled
-                    if(~ariane_pkg::RVH) begin
+                    if (!ariane_pkg::RVH) begin
                         read_access_exception = 1'b1;
                     end else if (priv_lvl_o == riscv::PRIV_LVL_S && hstatus_q.vtvm && v_q) begin
                         virtual_read_access_exception = 1'b1;
@@ -330,51 +326,51 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_SENVCFG: csr_rdata = senvcfg_q[riscv::XLEN-1:0];
                 // hypervisor mode registers
                 riscv::CSR_HSTATUS: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = hstatus_q[riscv::XLEN-1:0];
                 end
                 riscv::CSR_HEDELEG: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = hedeleg_q;
                 end
                 riscv::CSR_HIDELEG: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = hideleg_q;
                 end
                 riscv::CSR_HIE: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = mie_q & HS_DELEG_INTERRUPTS;
                 end
                 riscv::CSR_HIP: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = mip_q & HS_DELEG_INTERRUPTS;
                 end
                 riscv::CSR_HVIP: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = mip_q & VS_DELEG_INTERRUPTS;
                 end
                 riscv::CSR_HCOUNTEREN: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = hcounteren_q;
                 end
                 riscv::CSR_HTVAL: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = htval_q;
                 end
                 riscv::CSR_HTINST: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = htinst_q;
                 end
                 riscv::CSR_HGEIE: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = '0;
                 end
                 riscv::CSR_HGEIP: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;           
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = '0;
                 end
                 riscv::CSR_HGATP: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         read_access_exception = 1'b1;
                     // intercept reads to HGATP if in HS-Mode and TVM is enabled
                     end else if (priv_lvl_o == riscv::PRIV_LVL_S && !v_q && mstatus_q.tvm) begin
@@ -384,7 +380,7 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_HENVCFG: begin
-                    if(~ariane_pkg::RVH) read_access_exception = 1'b1;
+                    if (!ariane_pkg::RVH) read_access_exception = 1'b1;
                     else csr_rdata = henvcfg_q[riscv::XLEN-1:0];
                 end
                 // machine mode registers
@@ -406,16 +402,16 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MHARTID:            csr_rdata = hart_id_i;
                 riscv::CSR_MCONFIGPTR:         csr_rdata = '0; // no configuration data structure
                 riscv::CSR_MTINST: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         read_access_exception = 1'b1;
-                    end else begin 
+                    end else begin
                         csr_rdata = mtinst_q;
                     end
                 end
                 riscv::CSR_MTVAL2: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         read_access_exception = 1'b1;
-                    end else begin 
+                    end else begin
                         csr_rdata = mtval2_q;
                     end
                 end
@@ -548,13 +544,6 @@ module csr_regfile import ariane_pkg::*; #(
         automatic logic [63:0] instret;
 
         satp = satp_q;
-        if(ariane_pkg::RVH) begin
-            vsatp = vsatp_q;
-            hgatp = hgatp_q;
-        end else begin
-            vsatp = '0;
-            hgatp = '0;
-        end
         instret = instret_q;
 
         // --------------------
@@ -593,9 +582,36 @@ module csr_regfile import ariane_pkg::*; #(
         dscratch0_d             = dscratch0_q;
         dscratch1_d             = dscratch1_q;
         mstatus_d               = mstatus_q;
-        if(ariane_pkg::RVH) begin
-            hstatus_d           = hstatus_q;
+
+        if (ariane_pkg::RVH) begin
+            vsatp = vsatp_q;
+            hgatp = hgatp_q;
+
+            en_ld_st_g_translation_d = en_ld_st_g_translation_q;
+
             vsstatus_d          = vsstatus_q;
+            vstvec_d            = vstvec_q;
+            vsscratch_d         = vsscratch_q;
+            vsepc_d             = vsepc_q;
+            vscause_d           = vscause_q;
+            vstval_d            = vstval_q;
+            vsatp_d             = vsatp_q;
+
+            hstatus_d           = hstatus_q;
+            hedeleg_d           = hedeleg_q;
+            hideleg_d           = hideleg_q;
+            hgeie_d             = hgeie_q;
+            hgatp_d             = hgatp_q;
+            hcounteren_d        = hcounteren_q;
+            htval_d             = htval_q;
+            htinst_d            = htinst_q;
+            henvcfg_d           = henvcfg_q;
+
+            mtinst_d            = mtinst_q;
+            mtval2_d            = mtval2_q;
+        end else begin
+            vsatp = '0;
+            hgatp = '0;
         end
 
         // check whether we come out of reset
@@ -619,21 +635,10 @@ module csr_regfile import ariane_pkg::*; #(
         mcounteren_d            = mcounteren_q;
         mscratch_d              = mscratch_q;
         mtval_d                 = mtval_q;
-        if(ariane_pkg::RVH) begin
-            mtinst_d            = mtinst_q;
-            mtval2_d            = mtval2_q;
-        end
+        menvcfg_d               = menvcfg_q;
+
         dcache_d                = dcache_q;
         icache_d                = icache_q;
-
-        if(ariane_pkg::RVH) begin
-            vstvec_d            = vstvec_q;
-            vsscratch_d         = vsscratch_q;
-            vsepc_d             = vsepc_q;
-            vscause_d           = vscause_q;
-            vstval_d            = vstval_q;
-            vsatp_d             = vsatp_q;
-        end
 
         sepc_d                  = sepc_q;
         scause_d                = scause_q;
@@ -642,25 +647,9 @@ module csr_regfile import ariane_pkg::*; #(
         sscratch_d              = sscratch_q;
         stval_d                 = stval_q;
         satp_d                  = satp_q;
-
-        if(ariane_pkg::RVH) begin
-            hedeleg_d           = hedeleg_q;
-            hideleg_d           = hideleg_q;
-            hgeie_d             = hgeie_q;
-            hgatp_d             = hgatp_q;
-            hcounteren_d        = hcounteren_q;
-            htval_d             = htval_q;
-            htinst_d            = htinst_q;
-            henvcfg_d           = henvcfg_q;
-        end
-
-        menvcfg_d               = menvcfg_q;
         senvcfg_d               = senvcfg_q;
 
         en_ld_st_translation_d  = en_ld_st_translation_q;
-        if(ariane_pkg::RVH) begin
-            en_ld_st_g_translation_d = en_ld_st_g_translation_q;
-        end
         dirty_fp_state_csr      = 1'b0;
 
         pmpcfg_d                = pmpcfg_q;
@@ -730,7 +719,7 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_TDATA3:;  // not implemented
                 // virtual supervisor registers
                 riscv::CSR_VSSTATUS: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         mask = ariane_pkg::SMODE_STATUS_WRITE_MASK[riscv::XLEN-1:0];
@@ -745,14 +734,14 @@ module csr_regfile import ariane_pkg::*; #(
                     flush_o = 1'b1;
                 end
                 riscv::CSR_VSIE: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mie_d = (mie_q & ~hideleg_q) | ((csr_wdata << 1) & hideleg_q);
                     end
                 end
                 riscv::CSR_VSIP: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         // only the virtual supervisor software interrupt is write-able, iff delegated
@@ -761,35 +750,35 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_VSTVEC: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         vstvec_d    = {csr_wdata[riscv::XLEN-1:2], 1'b0, csr_wdata[0]};
                     end
                 end
                 riscv::CSR_VSSCRATCH: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         vsscratch_d = csr_wdata;
                     end
                 end
                 riscv::CSR_VSEPC: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         vsepc_d = {csr_wdata[riscv::XLEN-1:1], 1'b0};
                     end
                 end
                 riscv::CSR_VSCAUSE: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         vscause_d = csr_wdata;
                     end
                 end
                 riscv::CSR_VSTVAL: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         vstval_d = csr_wdata;
@@ -797,7 +786,7 @@ module csr_regfile import ariane_pkg::*; #(
                 end
                 // virtual supervisor address translation and protection
                 riscv::CSR_VSATP: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end if (priv_lvl_o == riscv::PRIV_LVL_S && v_q && hstatus_q.vtvm)
                             virtual_update_access_exception = 1'b1;
@@ -815,11 +804,11 @@ module csr_regfile import ariane_pkg::*; #(
                 // sstatus is a subset of mstatus - mask it accordingly
                 riscv::CSR_SSTATUS: begin
                     mask = ariane_pkg::SMODE_STATUS_WRITE_MASK[riscv::XLEN-1:0];
-                    mstatus_d  = (mstatus_q & ~{{64-riscv::XLEN{1'b0}}, mask}) | {{64-riscv::XLEN{1'b0}}, (csr_wdata & mask)};
+                    mstatus_d = (mstatus_q & ~{{64-riscv::XLEN{1'b0}}, mask}) | {{64-riscv::XLEN{1'b0}}, (csr_wdata & mask)};
                     // hardwire to zero if floating point extension is not present
                     if (!FP_PRESENT) begin
                         mstatus_d.fs  = riscv::Off;
-                        if(ariane_pkg::RVH) begin
+                        if (ariane_pkg::RVH) begin
                             vsstatus_d.fs = riscv::Off;
                         end
                     end
@@ -871,7 +860,7 @@ module csr_regfile import ariane_pkg::*; #(
                 end
                 //hypervisor mode registers
                 riscv::CSR_HSTATUS: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mask = ariane_pkg::HSTATUS_WRITE_MASK[riscv::XLEN-1:0];
@@ -881,7 +870,7 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_HEDELEG: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mask = (1 << riscv::INSTR_ADDR_MISALIGNED) |
@@ -900,14 +889,14 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_HIDELEG: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         hideleg_d = (hideleg_q & ~VS_DELEG_INTERRUPTS) | (csr_wdata & VS_DELEG_INTERRUPTS);
                     end
                 end
                 riscv::CSR_HIE: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mask = HS_DELEG_INTERRUPTS;
@@ -915,7 +904,7 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_HIP: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mask = riscv::MIP_VSSIP;
@@ -923,7 +912,7 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_HVIP: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mask = VS_DELEG_INTERRUPTS;
@@ -931,21 +920,21 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_HCOUNTEREN: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         hcounteren_d = {{riscv::XLEN-32{1'b0}}, csr_wdata[31:0]};
                     end
                 end
                 riscv::CSR_HTVAL: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         htval_d = csr_wdata;
                     end
                 end
                 riscv::CSR_HTINST: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         htinst_d = {{riscv::XLEN-32{1'b0}}, csr_wdata[31:0]};
@@ -953,12 +942,12 @@ module csr_regfile import ariane_pkg::*; #(
                 end
                 //TODO Hyp: implement hgeie write
                 riscv::CSR_HGEIE: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_HGATP: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         // intercept HGATP writes if in HS-Mode and TVM is enabled
@@ -980,7 +969,7 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_HENVCFG: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin
                         mask = ariane_pkg::ENVCFG_WRITE_MASK[riscv::XLEN-1:0];
@@ -1029,7 +1018,7 @@ module csr_regfile import ariane_pkg::*; #(
                 // we do not support user interrupt delegation
                 riscv::CSR_MIDELEG: begin
                     mask = riscv::MIP_SSIP | riscv::MIP_STIP | riscv::MIP_SEIP;
-                    if(~ariane_pkg::RVH) begin
+                    if (!ariane_pkg::RVH) begin
                         mideleg_d = (mideleg_q & ~mask) | (csr_wdata & mask);
                     end else begin
                         mideleg_d = (mideleg_q & ~mask) | (csr_wdata & mask) | HS_DELEG_INTERRUPTS;
@@ -1037,7 +1026,7 @@ module csr_regfile import ariane_pkg::*; #(
                 end
                 // mask the register so that unsupported interrupts can never be set
                 riscv::CSR_MIE: begin
-                    if(~ariane_pkg::RVH) begin
+                    if (!ariane_pkg::RVH) begin
                          mask = riscv::MIP_SSIP | riscv::MIP_STIP | riscv::MIP_SEIP | riscv::MIP_MSIP | riscv::MIP_MTIP | riscv::MIP_MEIP;
                     end else begin
                         mask = HS_DELEG_INTERRUPTS | riscv::MIP_SSIP | riscv::MIP_STIP | riscv::MIP_SEIP | riscv::MIP_MSIP | riscv::MIP_MTIP | riscv::MIP_MEIP;
@@ -1058,14 +1047,14 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MCAUSE:             mcause_d    = csr_wdata;
                 riscv::CSR_MTVAL:              mtval_d     = csr_wdata;
                 riscv::CSR_MTINST: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mtinst_d    = {{riscv::XLEN-32{1'b0}}, csr_wdata[31:0]};
                     end
                 end
                 riscv::CSR_MTVAL2: begin
-                    if(~ariane_pkg::RVH) begin 
+                    if (!ariane_pkg::RVH) begin
                         update_access_exception = 1'b1;
                     end else begin 
                         mtval2_d    = csr_wdata;
@@ -1088,7 +1077,7 @@ module csr_regfile import ariane_pkg::*; #(
                     end
                 end
                 riscv::CSR_MIP: begin
-                    if (~ariane_pkg::RVH) begin
+                    if (!ariane_pkg::RVH) begin
                         mask = riscv::MIP_SSIP | riscv::MIP_STIP | riscv::MIP_SEIP;
                     end else begin
                         mask = riscv::MIP_SSIP | riscv::MIP_STIP | riscv::MIP_SEIP | riscv::MIP_VSSIP;
@@ -1403,14 +1392,14 @@ module csr_regfile import ariane_pkg::*; #(
         if (!debug_mode_q) begin
             dcsr_d.prv = priv_lvl_o;
             // save virtualization mode bit
-            dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
+            dcsr_d.v = (!ariane_pkg::RVH) ? 1'b0 : v_q;
             // trigger module fired
 
             // caused by a breakpoint
             if (ex_i.valid && ex_i.cause == riscv::BREAKPOINT) begin
                 dcsr_d.prv = priv_lvl_o;
                 // save virtualization mode bit
-                dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
+                dcsr_d.v = (!ariane_pkg::RVH) ? 1'b0 : v_q;
                 // check that we actually want to enter debug depending on the privilege level we are currently in
                 unique case (priv_lvl_o)
                     riscv::PRIV_LVL_M: begin
@@ -1436,7 +1425,7 @@ module csr_regfile import ariane_pkg::*; #(
             if (ex_i.valid && ex_i.cause == riscv::DEBUG_REQUEST) begin
                 dcsr_d.prv = priv_lvl_o;
                 // save virtualization mode bit
-                dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
+                dcsr_d.v = (!ariane_pkg::RVH) ? 1'b0 : v_q;
                 // save the PC
                 dpc_d = {{riscv::XLEN-riscv::VLEN{pc_i[riscv::VLEN-1]}},pc_i};
                 // enter debug mode
@@ -1451,7 +1440,7 @@ module csr_regfile import ariane_pkg::*; #(
             if (dcsr_q.step && commit_ack_i[0]) begin
                 dcsr_d.prv = priv_lvl_o;
                 // save virtualization mode bit
-                dcsr_d.v   = (~ariane_pkg::RVH) ? 1'b0 : v_q;
+                dcsr_d.v = (!ariane_pkg::RVH) ? 1'b0 : v_q;
                 // valid CTRL flow change
                 if (commit_instr_i[0].fu == CTRL_FLOW) begin
                     // we saved the correct target address during execute
@@ -1494,8 +1483,8 @@ module csr_regfile import ariane_pkg::*; #(
                 en_ld_st_translation_d = en_translation_o;
             end
 
-            if(mprv && (mstatus_q.mpv == 1'b1)) begin
-                if(riscv::vm_mode_t'(hgatp_q.mode) == riscv::MODE_SV) begin
+            if (mprv && (mstatus_q.mpv == 1'b1)) begin
+                if (riscv::vm_mode_t'(hgatp_q.mode) == riscv::MODE_SV) begin
                     en_ld_st_g_translation_d = 1'b1;
                 end else begin
                     en_ld_st_g_translation_d = 1'b0;
@@ -1504,7 +1493,7 @@ module csr_regfile import ariane_pkg::*; #(
                 en_ld_st_g_translation_d = en_g_translation_o;
             end
 
-            if(csr_hs_ld_st_inst_i)
+            if (csr_hs_ld_st_inst_i)
                 ld_st_priv_lvl_o = riscv::priv_lvl_t'(hstatus_q.spvp);
             else
                 ld_st_priv_lvl_o = (mprv) ? mstatus_q.mpp : priv_lvl_o;
@@ -1563,7 +1552,7 @@ module csr_regfile import ariane_pkg::*; #(
             mstatus_d.spp  = 1'b0;
             // set spie to 1
             mstatus_d.spie = 1'b1;
-            if(ariane_pkg::RVH) begin
+            if (ariane_pkg::RVH) begin
                 // set virtualization mode
                 v_d            = hstatus_q.spv;
                 //set hstatus spv to false
@@ -1591,7 +1580,7 @@ module csr_regfile import ariane_pkg::*; #(
             eret_o = 1'b1;
             // restore the previous privilege level
             priv_lvl_d     = riscv::priv_lvl_t'(dcsr_q.prv);
-            if(ariane_pkg::RVH) begin
+            if (ariane_pkg::RVH) begin
             // restore the previous virtualization mode
                 v_d            = dcsr_q.v;
             end
@@ -1656,9 +1645,8 @@ module csr_regfile import ariane_pkg::*; #(
                                     & (~dcsr_q.step | dcsr_q.stepie)
                                     & ((mstatus_q.mie & (priv_lvl_o == riscv::PRIV_LVL_M))
                                     | (priv_lvl_o != riscv::PRIV_LVL_M));
-
-    always_comb begin : privilege_check
-        if(ariane_pkg::RVH) begin
+    if (ariane_pkg::RVH) begin : gen_hprivilege_check
+        always_comb begin
             automatic riscv::priv_lvl_t access_priv;
             automatic riscv::priv_lvl_t curr_priv;
             // transforms S mode accesses into HS mode
@@ -1702,7 +1690,9 @@ module csr_regfile import ariane_pkg::*; #(
                     endcase
                 end
             end
-        end else begin
+        end
+    end else begin : gen_privilege_check
+        always_comb begin
             // -----------------
             // Privilege Check
             // -----------------
@@ -1727,7 +1717,7 @@ module csr_regfile import ariane_pkg::*; #(
                     endcase
                 end
             end
-        end    
+        end
     end
     // ----------------------
     // CSR Exception Control
@@ -1850,7 +1840,7 @@ module csr_regfile import ariane_pkg::*; #(
     assign vs_sum_o         = ariane_pkg::RVH ? vsstatus_q.sum : '0;
     assign hu_o             = ariane_pkg::RVH ? hstatus_q.hu : '0;
     // we support bare memory addressing and SV39
-    if(ariane_pkg::RVH) begin
+    if (ariane_pkg::RVH) begin
         assign en_translation_o = ((((riscv::vm_mode_t'(satp_q.mode) == riscv::MODE_SV && !v_q) || (riscv::vm_mode_t'(vsatp_q.mode) == riscv::MODE_SV && v_q)) &&
                                    priv_lvl_o != riscv::PRIV_LVL_M)
                                   ? 1'b1

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -54,6 +54,7 @@ module cva6 import ariane_pkg::*; #(
   // Signals connecting more than one module
   // ------------------------------------------
   riscv::priv_lvl_t           priv_lvl;
+  logic                       v;
   exception_t                 ex_commit; // exception from commit stage
   bp_resolve_t                resolved_branch;
   logic [riscv::VLEN-1:0]     pc_commit;
@@ -168,6 +169,7 @@ module cva6 import ariane_pkg::*; #(
   // --------------
   logic [4:0]               fflags_csr_commit;
   riscv::xs_t               fs;
+  riscv::xs_t               vfs;
   logic [2:0]               frm_csr_id_issue_ex;
   logic [6:0]               fprec_csr_ex;
   logic                     enable_translation_csr_ex;
@@ -184,7 +186,9 @@ module cva6 import ariane_pkg::*; #(
   exception_t               csr_exception_csr_commit;
   logic                     tvm_csr_id;
   logic                     tw_csr_id;
+  logic                     vtw_csr_id;
   logic                     tsr_csr_id;
+  logic                     hu;
   irq_ctrl_t                irq_ctrl_csr_id;
   logic                     dcache_en_csr_nbdcache;
   logic                     csr_write_fflags_commit_cs;
@@ -296,14 +300,18 @@ module cva6 import ariane_pkg::*; #(
     .issue_instr_ack_i          ( issue_instr_issue_id       ),
 
     .priv_lvl_i                 ( priv_lvl                   ),
+    .v_i                        ( v                          ),
     .fs_i                       ( fs                         ),
+    .vfs_i                      ( vfs                        ),
     .frm_i                      ( frm_csr_id_issue_ex        ),
     .irq_i                      ( irq_i                      ),
     .irq_ctrl_i                 ( irq_ctrl_csr_id            ),
     .debug_mode_i               ( debug_mode                 ),
     .tvm_i                      ( tvm_csr_id                 ),
     .tw_i                       ( tw_csr_id                  ),
-    .tsr_i                      ( tsr_csr_id                 )
+    .vtw_i                      ( vtw_csr_id                 ),
+    .tsr_i                      ( tsr_csr_id                 ),
+    .hu_i                       ( hu                         )
   );
 
   logic [NR_WB_PORTS-1:0][TRANS_ID_BITS-1:0] trans_id_ex_id;
@@ -576,7 +584,9 @@ module cva6 import ariane_pkg::*; #(
     .set_debug_pc_o         ( set_debug_pc                  ),
     .trap_vector_base_o     ( trap_vector_base_commit_pcgen ),
     .priv_lvl_o             ( priv_lvl                      ),
+    .v_o                    ( v                             ),
     .fs_o                   ( fs                            ),
+    .vfs_o                  ( vfs                           ),
     .fflags_o               ( fflags_csr_commit             ),
     .frm_o                  ( frm_csr_id_issue_ex           ),
     .fprec_o                ( fprec_csr_ex                  ),
@@ -590,7 +600,9 @@ module cva6 import ariane_pkg::*; #(
     .asid_o                 ( asid_csr_ex                   ),
     .tvm_o                  ( tvm_csr_id                    ),
     .tw_o                   ( tw_csr_id                     ),
+    .vtw_o                  ( vtw_csr_id                    ),
     .tsr_o                  ( tsr_csr_id                    ),
+    .hu_o                   ( hu                            ),
     .debug_mode_o           ( debug_mode                    ),
     .single_step_o          ( single_step_csr_commit        ),
     .dcache_en_o            ( dcache_en_csr_nbdcache        ),

--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -68,6 +68,9 @@ module cvxif_fu import ariane_pkg::*; (
       x_exception_o.cause   = x_valid_o ? cvxif_resp_i.x_result.exccode : '0;
       x_exception_o.valid   = x_valid_o ? cvxif_resp_i.x_result.exc : '0;
       x_exception_o.tval    = '0;
+      x_exception_o.tinst   = '0;
+      x_exception_o.tval2   = '0;
+      x_exception_o.gva     = '0;
       x_we_o                = x_valid_o ? cvxif_resp_i.x_result.we : '0;
       if (illegal_n) begin
         if (~x_valid_o) begin
@@ -77,6 +80,9 @@ module cvxif_fu import ariane_pkg::*; (
           x_exception_o.cause   = riscv::ILLEGAL_INSTR;
           x_exception_o.valid   = 1'b1;
           x_exception_o.tval    = illegal_instr_n;
+          x_exception_o.tinst   = '0;
+          x_exception_o.tval2   = '0;
+          x_exception_o.gva     = '0;
           x_we_o                = '0;
           illegal_n             = '0; // Reset flag for illegal instr. illegal_id and illegal instr values are a don't care, no need to reset it.
         end

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -32,18 +32,23 @@ module decoder import ariane_pkg::*; (
     input  irq_ctrl_t          irq_ctrl_i,              // interrupt control and status information from CSRs
     // From CSR
     input  riscv::priv_lvl_t   priv_lvl_i,              // current privilege level
+    input  logic               v_i,                     // current virtualization mode
     input  logic               debug_mode_i,            // we are in debug mode
     input  riscv::xs_t         fs_i,                    // floating point extension status
+    input  riscv::xs_t         vfs_i,                   // virtual floating point extension status
     input  logic [2:0]         frm_i,                   // floating-point dynamic rounding mode
     input  logic               tvm_i,                   // trap virtual memory
     input  logic               tw_i,                    // timeout wait
+    input  logic               vtw_i,                   // virtual timeout wait
     input  logic               tsr_i,                   // trap sret
+    input  logic               hu_i,                    // hypervisor user mode
     output scoreboard_entry_t  instruction_o,           // scoreboard entry to scoreboard
     output logic               is_control_flow_instr_o  // this instruction will change the control flow
 );
     logic illegal_instr;
     logic illegal_instr_bm;
     logic illegal_instr_non_bm;
+    logic virtual_illegal_instr;
     // this instruction is an environment call (ecall), it is handled like an exception
     logic ecall;
     // this instruction is a software break-point
@@ -73,6 +78,7 @@ module decoder import ariane_pkg::*; (
         illegal_instr               = 1'b0;
         illegal_instr_non_bm        = 1'b0;
         illegal_instr_bm            = 1'b0;
+        virtual_illegal_instr       = 1'b0;
         instruction_o.pc            = pc_i;
         instruction_o.trans_id      = '0;
         instruction_o.fu            = NONE;
@@ -84,6 +90,7 @@ module decoder import ariane_pkg::*; (
         instruction_o.is_compressed = is_compressed_i;
         instruction_o.use_zimm      = 1'b0;
         instruction_o.bp            = branch_predict_i;
+        instruction_o.ex.tinst      = '0;
         ecall                       = 1'b0;
         ebreak                      = 1'b0;
         check_fprm                  = 1'b0;
@@ -99,8 +106,13 @@ module decoder import ariane_pkg::*; (
                     unique case (instr.itype.funct3)
                         3'b000: begin
                             // check if the RD and and RS1 fields are zero, this may be reset for the SENCE.VMA instruction
-                            if (instr.itype.rs1 != '0 || instr.itype.rd != '0)
-                                illegal_instr = 1'b1;
+                            if (instr.itype.rs1 != '0 || instr.itype.rd != '0) begin
+                                if(v_i) begin
+                                  virtual_illegal_instr = 1'b1;
+                                end else begin
+                                  illegal_instr = 1'b1;
+                                end
+                            end
                             // decode the immiediate field
                             case (instr.itype.imm)
                                 // ECALL -> inject exception
@@ -113,13 +125,21 @@ module decoder import ariane_pkg::*; (
                                     // check privilege level, SRET can only be executed in S and M mode
                                     // we'll just decode an illegal instruction if we are in the wrong privilege level
                                     if (priv_lvl_i == riscv::PRIV_LVL_U) begin
-                                        illegal_instr = 1'b1;
+                                        if(v_i) begin
+                                            virtual_illegal_instr = 1'b1;
+                                        end else begin
+                                            illegal_instr = 1'b1;
+                                        end
                                         //  do not change privilege level if this is an illegal instruction
                                         instruction_o.op = ariane_pkg::ADD;
                                     end
                                     // if we are in S-Mode and Trap SRET (tsr) is set -> trap on illegal instruction
                                     if (priv_lvl_i == riscv::PRIV_LVL_S && tsr_i) begin
-                                        illegal_instr = 1'b1;
+                                        if(v_i) begin
+                                            virtual_illegal_instr = 1'b1;
+                                        end else begin
+                                            illegal_instr = 1'b1;
+                                        end
                                         //  do not change privilege level if this is an illegal instruction
                                         instruction_o.op = ariane_pkg::ADD;
                                     end
@@ -147,9 +167,14 @@ module decoder import ariane_pkg::*; (
                                         illegal_instr = 1'b1;
                                         instruction_o.op = ariane_pkg::ADD;
                                     end
+                                    if(priv_lvl_i == riscv::PRIV_LVL_S && v_i && vtw_i && !tw_i) begin
+                                        virtual_illegal_instr = 1'b1;
+                                        instruction_o.op = ariane_pkg::ADD;
+                                    end
                                     // we don't support U mode interrupts so WFI is illegal in this context
                                     if (priv_lvl_i == riscv::PRIV_LVL_U) begin
-                                        illegal_instr = 1'b1;
+                                        virtual_illegal_instr = v_i;
+                                        illegal_instr = !v_i;
                                         instruction_o.op = ariane_pkg::ADD;
                                     end
                                 end
@@ -158,16 +183,101 @@ module decoder import ariane_pkg::*; (
                                     if (instr.instr[31:25] == 7'b1001) begin
                                         // check privilege level, SFENCE.VMA can only be executed in M/S mode
                                         // otherwise decode an illegal instruction
-                                        illegal_instr    = ((priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) && instr.itype.rd == '0) ? 1'b0 : 1'b1;
+                                        if(v_i) begin
+                                            virtual_illegal_instr = (priv_lvl_i == riscv::PRIV_LVL_S) ? 1'b0 : 1'b1;
+                                        end else begin
+                                            illegal_instr    = ((priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) && instr.itype.rd == '0) ? 1'b0 : 1'b1;
+                                        end
                                         instruction_o.op = ariane_pkg::SFENCE_VMA;
                                         // check TVM flag and intercept SFENCE.VMA call if necessary
-                                        if (priv_lvl_i == riscv::PRIV_LVL_S && tvm_i)
-                                            illegal_instr = 1'b1;
-                                    end else begin
-                                       illegal_instr = 1'b1;
+                                        if (priv_lvl_i == riscv::PRIV_LVL_S && tvm_i) begin
+                                            virtual_illegal_instr = v_i;
+                                            illegal_instr = !v_i;
+                                        end
+                                    end
+                                    if (instr.instr[31:25] == 7'b10001) begin
+                                        // check privilege level, HFENCE.VVMA can only be executed in M/S mode
+                                        // otherwise decode an illegal instruction or virtual illegal instruction
+                                        if(v_i) begin
+                                            virtual_illegal_instr = 1'b1;
+                                        end else begin
+                                            illegal_instr    = (priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) ? 1'b0 : 1'b1;
+                                        end
+                                        instruction_o.op = ariane_pkg::HFENCE_VVMA;
+                                    end
+                                    if (instr.instr[31:25] == 7'b110001) begin
+                                        // check privilege level, HFENCE.GVMA can only be executed in M/S mode
+                                        // otherwise decode an illegal instruction or virtual illegal instruction
+                                        if(v_i) begin
+                                            virtual_illegal_instr = 1'b1;
+                                        end else begin
+                                            illegal_instr    = (priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) ? 1'b0 : 1'b1;
+                                        end
+                                        instruction_o.op = ariane_pkg::HFENCE_GVMA;
+                                        // check TVM flag and intercept HFENCE.GVMA call if necessary
+                                        if (priv_lvl_i == riscv::PRIV_LVL_S && !v_i && tvm_i)
+                                            illegal_instr  = 1'b1;
                                     end
                                 end
                             endcase
+                        end
+                        3'b100: begin
+                            if(instr.instr[25] != 1'b0) begin
+                                instruction_o.fu  = STORE;
+                                imm_select = NOIMM;
+                                instruction_o.rs1[4:0]  = instr.stype.rs1;
+                                instruction_o.rs2[4:0]  = instr.stype.rs2;
+                            end else begin
+                                instruction_o.fu  = LOAD;
+                                imm_select = NOIMM;
+                                instruction_o.rs1[4:0] = instr.itype.rs1;
+                                instruction_o.rd[4:0]  = instr.itype.rd;
+                            end
+                            // Hypervisor load/store instructions when V=1 cause virtual instruction
+                            if (v_i)
+                                virtual_illegal_instr = 1'b1;
+                            // Hypervisor load/store instructions in U-mode when hstatus.HU=0 cause an illegal instruction trap.
+                            else if(!hu_i && priv_lvl_i == riscv::PRIV_LVL_U)
+                                illegal_instr = 1'b1;
+                            unique case (instr.rtype.funct7)
+                            7'b011_0000: begin
+                                if(instr.rtype.rs2 == 5'b0) begin
+                                    instruction_o.op = ariane_pkg::HLV_B;
+                                end
+                                if(instr.rtype.rs2 == 5'b1) begin
+                                    instruction_o.op = ariane_pkg::HLV_BU;
+                                end
+                            end
+                            7'b011_0010: begin
+                                if(instr.rtype.rs2 == 5'b0) begin
+                                    instruction_o.op = ariane_pkg::HLV_H;
+                                end
+                                if(instr.rtype.rs2 == 5'b1) begin
+                                    instruction_o.op = ariane_pkg::HLV_HU;
+                                end
+                                if(instr.rtype.rs2 == 5'b11) begin
+                                    instruction_o.op = ariane_pkg::HLVX_HU;
+                                end
+                            end
+                            7'b011_0100: begin
+                                if(instr.rtype.rs2 == 5'b0) begin
+                                    instruction_o.op = ariane_pkg::HLV_W;
+                                end
+                                if(instr.rtype.rs2 == 5'b1) begin
+                                    instruction_o.op = ariane_pkg::HLV_WU;
+                                end
+                                if(instr.rtype.rs2 == 5'b11) begin
+                                    instruction_o.op = ariane_pkg::HLVX_WU;
+                                end
+                            end
+                            7'b011_0001: instruction_o.op = ariane_pkg::HSV_B;
+                            7'b011_0011: instruction_o.op = ariane_pkg::HSV_H;
+                            7'b011_0101: instruction_o.op = ariane_pkg::HSV_W;
+                            7'b011_0110: instruction_o.op = ariane_pkg::HLV_D;
+                            7'b011_0111: instruction_o.op = ariane_pkg::HSV_D;
+
+                            endcase
+                            instruction_o.ex.tinst = {instr.rtype.funct7,instr.rtype.rs2,5'b0,instr.rtype.funct3,instr.rtype.rd,instr.rtype.opcode};
                         end
                         // atomically swaps values in the CSR and integer register
                         3'b001: begin// CSRRW
@@ -249,7 +359,7 @@ module decoder import ariane_pkg::*; (
                     // --------------------------------------------
                     if (instr.rvftype.funct2 == 2'b10) begin // Prefix 10 for all Xfvec ops
                         // only generate decoder if FP extensions are enabled (static)
-                        if (FP_PRESENT && XFVEC && fs_i != riscv::Off) begin
+                        if (FP_PRESENT && XFVEC && fs_i != riscv::Off && (!v_i || vfs_i != riscv::Off)) begin
                             automatic logic allow_replication; // control honoring of replication flag
 
                             instruction_o.fu       = FPU_VEC; // Same unit, but sets 'vectorial' signal
@@ -729,10 +839,12 @@ module decoder import ariane_pkg::*; (
                         3'b000: instruction_o.op  = ariane_pkg::SB;
                         3'b001: instruction_o.op  = ariane_pkg::SH;
                         3'b010: instruction_o.op  = ariane_pkg::SW;
-                        3'b011: if (riscv::XLEN==64) instruction_o.op  = ariane_pkg::SD; 
+                        3'b011: if (riscv::XLEN==64) instruction_o.op  = ariane_pkg::SD;
                                 else illegal_instr = 1'b1;
                         default: illegal_instr = 1'b1;
                     endcase
+                    instruction_o.ex.tinst = {7'b0,instr.stype.rs2,5'b0,instr.stype.funct3,5'b0,instr.stype.opcode};
+                    instruction_o.ex.tinst[1] = is_compressed_i ? 1'b1 : 'b0;
                 end
 
                 riscv::OpcodeLoad: begin
@@ -748,17 +860,19 @@ module decoder import ariane_pkg::*; (
                         3'b100: instruction_o.op  = ariane_pkg::LBU;
                         3'b101: instruction_o.op  = ariane_pkg::LHU;
                         3'b110: instruction_o.op  = ariane_pkg::LWU;
-                        3'b011: if (riscv::XLEN==64) instruction_o.op  = ariane_pkg::LD; 
+                        3'b011: if (riscv::XLEN==64) instruction_o.op  = ariane_pkg::LD;
                                 else illegal_instr = 1'b1;
                         default: illegal_instr = 1'b1;
                     endcase
+                    instruction_o.ex.tinst = {17'b0,instr.itype.funct3,instr.itype.rd,instr.itype.opcode};
+                    instruction_o.ex.tinst[1] = is_compressed_i ? 1'b1 : 'b0;
                 end
 
                 // --------------------------------
                 // Floating-Point Load/store
                 // --------------------------------
                 riscv::OpcodeStoreFp: begin
-                    if (FP_PRESENT && fs_i != riscv::Off) begin // only generate decoder if FP extensions are enabled (static)
+                    if (FP_PRESENT && fs_i != riscv::Off && (!v_i || vfs_i != riscv::Off)) begin // only generate decoder if FP extensions are enabled (static)
                         instruction_o.fu  = STORE;
                         imm_select = SIMM;
                         instruction_o.rs1        = instr.stype.rs1;
@@ -776,12 +890,14 @@ module decoder import ariane_pkg::*; (
                                     else illegal_instr = 1'b1;
                             default: illegal_instr = 1'b1;
                         endcase
+                        instruction_o.ex.tinst = {7'b0,instr.stype.rs2,5'b0,instr.stype.funct3,5'b0,instr.stype.opcode};
+                        instruction_o.ex.tinst[1] = is_compressed_i ? 1'b1 : 'b0;
                     end else
                         illegal_instr = 1'b1;
                 end
 
                 riscv::OpcodeLoadFp: begin
-                    if (FP_PRESENT && fs_i != riscv::Off) begin // only generate decoder if FP extensions are enabled (static)
+                    if (FP_PRESENT && fs_i != riscv::Off && (!v_i || vfs_i != riscv::Off)) begin // only generate decoder if FP extensions are enabled (static)
                         instruction_o.fu  = LOAD;
                         imm_select = IIMM;
                         instruction_o.rs1       = instr.itype.rs1;
@@ -799,6 +915,8 @@ module decoder import ariane_pkg::*; (
                                     else illegal_instr = 1'b1;
                             default: illegal_instr = 1'b1;
                         endcase
+                        instruction_o.ex.tinst = {17'b0,instr.itype.funct3,instr.itype.rd,instr.itype.opcode};
+                        instruction_o.ex.tinst[1] = is_compressed_i ? 1'b1 : 'b0;
                     end else
                         illegal_instr = 1'b1;
                 end
@@ -810,7 +928,7 @@ module decoder import ariane_pkg::*; (
                 riscv::OpcodeMsub,
                 riscv::OpcodeNmsub,
                 riscv::OpcodeNmadd: begin
-                    if (FP_PRESENT && fs_i != riscv::Off) begin // only generate decoder if FP extensions are enabled (static)
+                    if (FP_PRESENT && fs_i != riscv::Off && (!v_i || vfs_i != riscv::Off)) begin // only generate decoder if FP extensions are enabled (static)
                         instruction_o.fu  = FPU;
                         instruction_o.rs1 = instr.r4type.rs1;
                         instruction_o.rs2 = instr.r4type.rs2;
@@ -863,7 +981,7 @@ module decoder import ariane_pkg::*; (
                 end
 
                 riscv::OpcodeOpFp: begin
-                    if (FP_PRESENT && fs_i != riscv::Off) begin // only generate decoder if FP extensions are enabled (static)
+                    if (FP_PRESENT && fs_i != riscv::Off && (!v_i || vfs_i != riscv::Off)) begin // only generate decoder if FP extensions are enabled (static)
                         instruction_o.fu  = FPU;
                         instruction_o.rs1 = instr.rftype.rs1;
                         instruction_o.rs2 = instr.rftype.rs2;
@@ -1060,6 +1178,8 @@ module decoder import ariane_pkg::*; (
                     end else begin
                         illegal_instr = 1'b1;
                     end
+                    instruction_o.ex.tinst = {instr.instr[31:25],instr.atype.rs2,5'b0,instr.stype.funct3,instr.atype.rd,instr.atype.opcode};
+                    instruction_o.ex.tinst[1] = is_compressed_i ? 1'b1 : 1'b0;
                 end
 
                 // --------------------------------
@@ -1204,6 +1324,10 @@ module decoder import ariane_pkg::*; (
                 if (!CVXIF_PRESENT) instruction_o.ex.valid = 1'b1;
                 // we decoded an illegal exception here
                 instruction_o.ex.cause = riscv::ILLEGAL_INSTR;
+            end else if (virtual_illegal_instr) begin
+                instruction_o.ex.valid = 1'b1;
+                // we decoded an virtual illegal exception here
+                instruction_o.ex.cause = riscv::VIRTUAL_INSTRUCTION;
             // we got an ecall, set the correct cause depending on the current privilege level
             end else if (ecall) begin
                 // this exception is valid
@@ -1211,7 +1335,7 @@ module decoder import ariane_pkg::*; (
                 // depending on the privilege mode, set the appropriate cause
                 case (priv_lvl_i)
                     riscv::PRIV_LVL_M: instruction_o.ex.cause = riscv::ENV_CALL_MMODE;
-                    riscv::PRIV_LVL_S: instruction_o.ex.cause = riscv::ENV_CALL_SMODE;
+                    riscv::PRIV_LVL_S: instruction_o.ex.cause = v_i ? riscv::ENV_CALL_VSMODE : riscv::ENV_CALL_SMODE;
                     riscv::PRIV_LVL_U: instruction_o.ex.cause = riscv::ENV_CALL_UMODE;
                     default:; // this should not happen
                 endcase
@@ -1228,6 +1352,22 @@ module decoder import ariane_pkg::*; (
             // throw any previous exception.
             // we have three interrupt sources: external interrupts, software interrupts, timer interrupts (order of precedence)
             // for two privilege levels: Supervisor and Machine Mode
+            // Virtual Supervisor Interrupt
+            if (irq_ctrl_i.mie[riscv::VS_TIMER_INTERRUPT[$clog2(riscv::XLEN)-1:0]] && irq_ctrl_i.mip[riscv::VS_TIMER_INTERRUPT[$clog2(riscv::XLEN)-1:0]]) begin
+                interrupt_cause = riscv::VS_TIMER_INTERRUPT;
+            end
+            // Virtual Supervisor Software Interrupt
+            if (irq_ctrl_i.mie[riscv::VS_SW_INTERRUPT[$clog2(riscv::XLEN)-1:0]] && irq_ctrl_i.mip[riscv::VS_SW_INTERRUPT[$clog2(riscv::XLEN)-1:0]]) begin
+                interrupt_cause = riscv::VS_SW_INTERRUPT;
+            end
+            // Virtual Supervisor External Interrupt
+            if (irq_ctrl_i.mie[riscv::VS_EXT_INTERRUPT[$clog2(riscv::XLEN)-1:0]] && irq_ctrl_i.mip[riscv::VS_EXT_INTERRUPT[$clog2(riscv::XLEN)-1:0]]) begin
+                interrupt_cause = riscv::VS_EXT_INTERRUPT;
+            end
+            // Hypervisor Guest External Interrupts
+            if (irq_ctrl_i.mie[riscv::HS_EXT_INTERRUPT[$clog2(riscv::XLEN)-1:0]] && irq_ctrl_i.mip[riscv::HS_EXT_INTERRUPT[$clog2(riscv::XLEN)-1:0]]) begin
+                interrupt_cause = riscv::HS_EXT_INTERRUPT;
+            end
             // Supervisor Timer Interrupt
             if (irq_ctrl_i.mie[riscv::S_TIMER_INTERRUPT[$clog2(riscv::XLEN)-1:0]] && irq_ctrl_i.mip[riscv::S_TIMER_INTERRUPT[$clog2(riscv::XLEN)-1:0]]) begin
                 interrupt_cause = riscv::S_TIMER_INTERRUPT;
@@ -1260,7 +1400,15 @@ module decoder import ariane_pkg::*; (
                 // mode equals the delegated privilege mode (S or U) and that mode’s interrupt enable bit
                 // (SIE or UIE in mstatus) is set, or if the current privilege mode is less than the delegated privilege mode.
                 if (irq_ctrl_i.mideleg[interrupt_cause[$clog2(riscv::XLEN)-1:0]]) begin
-                    if ((irq_ctrl_i.sie && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_U) begin
+                    if (v_i &&  irq_ctrl_i.hideleg[interrupt_cause[$clog2(riscv::XLEN)-1:0]]) begin
+                        if ((irq_ctrl_i.sie && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_U) begin
+                            instruction_o.ex.valid = 1'b1;
+                            instruction_o.ex.cause = interrupt_cause;
+                        end
+                    end else if (v_i && ~irq_ctrl_i.hideleg[interrupt_cause[$clog2(riscv::XLEN)-1:0]]) begin
+                            instruction_o.ex.valid = 1'b1;
+                            instruction_o.ex.cause = interrupt_cause;
+                    end else if (!v_i && ((irq_ctrl_i.sie && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_U) && ~irq_ctrl_i.hideleg[interrupt_cause[$clog2(riscv::XLEN)-1:0]]) begin
                         instruction_o.ex.valid = 1'b1;
                         instruction_o.ex.cause = interrupt_cause;
                     end

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -127,7 +127,7 @@ module decoder import ariane_pkg::*; (
                                     // check privilege level, SRET can only be executed in S and M mode
                                     // we'll just decode an illegal instruction if we are in the wrong privilege level
                                     if (priv_lvl_i == riscv::PRIV_LVL_U) begin
-                                        if(ariane_pkg::RVH && v_i) begin
+                                        if (ariane_pkg::RVH && v_i) begin
                                             virtual_illegal_instr = 1'b1;
                                         end else begin
                                             illegal_instr = 1'b1;
@@ -137,7 +137,7 @@ module decoder import ariane_pkg::*; (
                                     end
                                     // if we are in S-Mode and Trap SRET (tsr) is set -> trap on illegal instruction
                                     if (priv_lvl_i == riscv::PRIV_LVL_S && tsr_i) begin
-                                        if(ariane_pkg::RVH && v_i) begin
+                                        if (ariane_pkg::RVH && v_i) begin
                                             virtual_illegal_instr = 1'b1;
                                         end else begin
                                             illegal_instr = 1'b1;
@@ -201,7 +201,7 @@ module decoder import ariane_pkg::*; (
                                               illegal_instr = 1'b1;
                                         end
                                     end
-                                    if(ariane_pkg::RVH) begin
+                                    if (ariane_pkg::RVH) begin
                                         if (instr.instr[31:25] == 7'b10001) begin
                                             // check privilege level, HFENCE.VVMA can only be executed in M/S mode
                                             // otherwise decode an illegal instruction or virtual illegal instruction
@@ -241,13 +241,11 @@ module decoder import ariane_pkg::*; (
                                 instruction_o.rs1[4:0] = instr.itype.rs1;
                                 instruction_o.rd[4:0]  = instr.itype.rd;
                             end
-                            if(ariane_pkg::RVH) begin
+                            if (ariane_pkg::RVH) begin
                                 // Hypervisor load/store instructions when V=1 cause virtual instruction
-                                if (v_i)
-                                    virtual_illegal_instr = 1'b1;
+                                if (v_i) virtual_illegal_instr = 1'b1;
                                 // Hypervisor load/store instructions in U-mode when hstatus.HU=0 cause an illegal instruction trap.
-                                else if(!hu_i && priv_lvl_i == riscv::PRIV_LVL_U)
-                                    illegal_instr = 1'b1;
+                                else if(!hu_i && priv_lvl_i == riscv::PRIV_LVL_U) illegal_instr = 1'b1;
                                 unique case (instr.rtype.funct7)
                                 7'b011_0000: begin
                                     if(instr.rtype.rs2 == 5'b0) begin
@@ -853,7 +851,7 @@ module decoder import ariane_pkg::*; (
                                 else illegal_instr = 1'b1;
                         default: illegal_instr = 1'b1;
                     endcase
-                    if(ariane_pkg::RVH) begin
+                    if (ariane_pkg::RVH) begin
                         tinst = {7'b0, instr.stype.rs2, 5'b0, instr.stype.funct3, 5'b0, instr.stype.opcode};
                         tinst[1] = is_compressed_i ? 1'b0 : 'b1;
                     end
@@ -876,7 +874,7 @@ module decoder import ariane_pkg::*; (
                                 else illegal_instr = 1'b1;
                         default: illegal_instr = 1'b1;
                     endcase
-                    if(ariane_pkg::RVH) begin
+                    if (ariane_pkg::RVH) begin
                         tinst = {17'b0, instr.itype.funct3, instr.itype.rd, instr.itype.opcode};
                         tinst[1] = is_compressed_i ? 1'b0 : 'b1;
                     end
@@ -904,7 +902,7 @@ module decoder import ariane_pkg::*; (
                                     else illegal_instr = 1'b1;
                             default: illegal_instr = 1'b1;
                         endcase
-                        if(ariane_pkg::RVH) begin
+                        if (ariane_pkg::RVH) begin
                             tinst = {7'b0, instr.stype.rs2,5'b0, instr.stype.funct3, 5'b0, instr.stype.opcode};
                             tinst[1] = is_compressed_i ? 1'b0 : 'b1;
                         end
@@ -931,7 +929,7 @@ module decoder import ariane_pkg::*; (
                                     else illegal_instr = 1'b1;
                             default: illegal_instr = 1'b1;
                         endcase
-                        if(ariane_pkg::RVH) begin
+                        if (ariane_pkg::RVH) begin
                             tinst = {17'b0, instr.itype.funct3, instr.itype.rd, instr.itype.opcode};
                             tinst[1] = is_compressed_i ? 1'b0 : 'b1;
                         end
@@ -1196,7 +1194,7 @@ module decoder import ariane_pkg::*; (
                     end else begin
                         illegal_instr = 1'b1;
                     end
-                    if(ariane_pkg::RVH) begin
+                    if (ariane_pkg::RVH) begin
                         tinst = {instr.atype.funct5, instr.atype.aq, instr.atype.rl, instr.atype.rs2, 5'b0, instr.atype.funct3, instr.atype.rd, instr.atype.opcode};
                     end
                 end
@@ -1377,7 +1375,7 @@ module decoder import ariane_pkg::*; (
             // we have three interrupt sources: external interrupts, software interrupts, timer interrupts (order of precedence)
             // for two privilege levels: Supervisor and Machine Mode
             // Virtual Supervisor Interrupt
-            if(ariane_pkg::RVH) begin
+            if (ariane_pkg::RVH) begin
                 if (irq_ctrl_i.mie[riscv::VS_TIMER_INTERRUPT[$clog2(riscv::XLEN)-1:0]] && irq_ctrl_i.mip[riscv::VS_TIMER_INTERRUPT[$clog2(riscv::XLEN)-1:0]]) begin
                     interrupt_cause = riscv::VS_TIMER_INTERRUPT;
                 end
@@ -1426,7 +1424,7 @@ module decoder import ariane_pkg::*; (
                 // mode equals the delegated privilege mode (S or U) and that mode’s interrupt enable bit
                 // (SIE or UIE in mstatus) is set, or if the current privilege mode is less than the delegated privilege mode.
                 if (irq_ctrl_i.mideleg[interrupt_cause[$clog2(riscv::XLEN)-1:0]]) begin
-                    if(ariane_pkg::RVH) begin : hyp_int_gen
+                    if (ariane_pkg::RVH) begin : hyp_int_gen
                         if (v_i &&  irq_ctrl_i.hideleg[interrupt_cause[$clog2(riscv::XLEN)-1:0]]) begin
                             if ((irq_ctrl_i.sie && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_U) begin
                                 instruction_o.ex.valid = 1'b1;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -427,10 +427,12 @@ module ex_stage import ariane_pkg::*; #(
 		if (~rst_ni) begin
             vmid_to_be_flushed      <= '0;
 		    asid_to_be_flushed      <= '0;
-			vaddr_to_be_flushed     <=  '0;
-            gpaddr_to_be_flushed    <=  '0;
+			vaddr_to_be_flushed     <= '0;
+            gpaddr_to_be_flushed    <= '0;
     // If the current instruction in EX_STAGE is a sfence.vma, in the next cycle no writes will happen
-		end else if ((~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA ) && csr_valid_i))) begin
+		end else if ((~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && 
+                     (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA) &&
+                     csr_valid_i))) begin
 			vaddr_to_be_flushed     <= rs1_forwarding_i;
             gpaddr_to_be_flushed    <= ariane_pkg::RVH ? rs1_forwarding_i >> 2 : '0;
 			asid_to_be_flushed      <= rs2_forwarding_i[ASID_WIDTH-1:0];

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -16,6 +16,7 @@
 
 module ex_stage import ariane_pkg::*; #(
     parameter int unsigned ASID_WIDTH = 1,
+    parameter int unsigned VMID_WIDTH = 1,
     parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
 ) (
     input  logic                                   clk_i,    // Clock
@@ -29,6 +30,7 @@ module ex_stage import ariane_pkg::*; #(
     input  logic [riscv::VLEN-1:0]                 pc_i,                  // PC of current instruction
     input  logic                                   is_compressed_instr_i, // we need to know if this was a compressed instruction
                                                                           // in order to calculate the next PC on a mis-predict
+    input  riscv::xlen_t                           tinst_i,
     // Fixed latency unit(s)
     output riscv::xlen_t                           flu_result_o,
     output logic [TRANS_ID_BITS-1:0]               flu_trans_id_o,        // ID of scoreboard entry at which to write back
@@ -91,16 +93,28 @@ module ex_stage import ariane_pkg::*; #(
     input  cvxif_pkg::cvxif_resp_t                 cvxif_resp_i,
     // Memory Management
     input  logic                                   enable_translation_i,
+    input  logic                                   enable_g_translation_i,
     input  logic                                   en_ld_st_translation_i,
+    input  logic                                   en_ld_st_g_translation_i,
     input  logic                                   flush_tlb_i,
+    input  logic                                   flush_tlb_vvma_i,
+    input  logic                                   flush_tlb_gvma_i,
 
     input  riscv::priv_lvl_t                       priv_lvl_i,
+    input logic                                    v_i,
     input  riscv::priv_lvl_t                       ld_st_priv_lvl_i,
+    input  logic                                   ld_st_v_i,
+    output logic                                   csr_hs_ld_st_inst_o,
     input  logic                                   sum_i,
+    input  logic                                   vs_sum_i,
     input  logic                                   mxr_i,
+    input  logic                                   vmxr_i,
     input  logic [riscv::PPNW-1:0]                 satp_ppn_i,
     input  logic [ASID_WIDTH-1:0]                  asid_i,
-    // icache translation requests
+    input  logic [riscv::PPNW-1:0]                 vsatp_ppn_i,
+    input  logic [ASID_WIDTH-1:0]                  vs_asid_i,
+    input  logic [riscv::PPNW-1:0]                 hgatp_ppn_i,
+    input  logic [VMID_WIDTH-1:0]                  vmid_i,
     input  icache_areq_o_t                         icache_areq_i,
     output icache_areq_i_t                         icache_areq_o,
 
@@ -148,11 +162,14 @@ module ex_stage import ariane_pkg::*; #(
 
 
     logic current_instruction_is_sfence_vma;
+    logic current_instruction_is_hfence_vvma;
+    logic current_instruction_is_hfence_gvma;
     // These two register store the rs1 and rs2 parameters in case of `SFENCE_VMA`
     // instruction to be used for TLB flush in the next clock cycle.
+    logic [VMID_WIDTH-1:0] vmid_to_be_flushed;
     logic [ASID_WIDTH-1:0] asid_to_be_flushed;
     logic [riscv::VLEN-1:0] vaddr_to_be_flushed;
-
+    logic [riscv::GPLEN-1:0] gpaddr_to_be_flushed;
     // from ALU to branch unit
     logic alu_branch_res; // branch comparison result
     riscv::xlen_t alu_result, csr_result, mult_result;
@@ -180,6 +197,7 @@ module ex_stage import ariane_pkg::*; #(
     branch_unit branch_unit_i (
         .clk_i,
         .rst_ni,
+        .v_i,
         .debug_mode_i,
         .fu_data_i,
         .pc_i,
@@ -291,6 +309,7 @@ module ex_stage import ariane_pkg::*; #(
 
     load_store_unit #(
         .ASID_WIDTH ( ASID_WIDTH ),
+        .VMID_WIDTH ( VMID_WIDTH ),
         .ArianeCfg ( ArianeCfg )
     ) lsu_i (
         .clk_i,
@@ -312,18 +331,33 @@ module ex_stage import ariane_pkg::*; #(
         .commit_ready_o        ( lsu_commit_ready_o ),
         .commit_tran_id_i,
         .enable_translation_i,
+        .enable_g_translation_i,
         .en_ld_st_translation_i,
+        .en_ld_st_g_translation_i,
         .icache_areq_i,
         .icache_areq_o,
         .priv_lvl_i,
+        .v_i,
         .ld_st_priv_lvl_i,
+        .ld_st_v_i,
+        .csr_hs_ld_st_inst_o,
         .sum_i,
+        .vs_sum_i,
         .mxr_i,
+        .vmxr_i,
         .satp_ppn_i,
+        .vsatp_ppn_i,
+        .hgatp_ppn_i,
         .asid_i,
+        .vs_asid_i,
         .asid_to_be_flushed_i (asid_to_be_flushed),
+        .vmid_i,
+        .vmid_to_be_flushed_i (vmid_to_be_flushed),
         .vaddr_to_be_flushed_i (vaddr_to_be_flushed),
+        .gpaddr_to_be_flushed_i(gpaddr_to_be_flushed),
         .flush_tlb_i,
+        .flush_tlb_vvma_i,
+        .flush_tlb_gvma_i,
         .itlb_miss_o,
         .dtlb_miss_o,
         .dcache_req_ports_i,
@@ -331,6 +365,7 @@ module ex_stage import ariane_pkg::*; #(
         .dcache_wbuffer_empty_i,
         .dcache_wbuffer_not_ni_i,
         .amo_valid_commit_i,
+        .tinst_i,
         .amo_req_o,
         .amo_resp_i,
         .pmpcfg_i,
@@ -371,25 +406,37 @@ module ex_stage import ariane_pkg::*; #(
     always_ff @(posedge clk_i or negedge rst_ni) begin
         if (~rst_ni) begin
           current_instruction_is_sfence_vma <= 1'b0;
-          end else begin
+          current_instruction_is_hfence_vvma <= 1'b0;
+          current_instruction_is_hfence_gvma <= 1'b0;
+		  end else begin
           if (flush_i) begin
               current_instruction_is_sfence_vma <= 1'b0;
-          end else if ((fu_data_i.operation == SFENCE_VMA) && csr_valid_i) begin
+              current_instruction_is_hfence_vvma <= 1'b0;
+              current_instruction_is_hfence_gvma <= 1'b0;
+          end else if ((fu_data_i.operation == SFENCE_VMA && !v_i) && csr_valid_i) begin
               current_instruction_is_sfence_vma <= 1'b1;
+          end else if (((fu_data_i.operation == SFENCE_VMA && v_i) || fu_data_i.operation == HFENCE_VVMA) && csr_valid_i) begin
+              current_instruction_is_hfence_vvma <= 1'b1;
+          end else if ((fu_data_i.operation == HFENCE_GVMA) && csr_valid_i) begin
+              current_instruction_is_hfence_gvma <= 1'b1;
           end
       end
   end
 
   // This process stores the rs1 and rs2 parameters of a SFENCE_VMA instruction.
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-            asid_to_be_flushed  <= '0;
-              vaddr_to_be_flushed <=  '0;
-    // if the current instruction in EX_STAGE is a sfence.vma, in the next cycle no writes will happen
-        end else if ((~current_instruction_is_sfence_vma) && (~((fu_data_i.operation == SFENCE_VMA) && csr_valid_i))) begin
-              vaddr_to_be_flushed <=  rs1_forwarding_i;
-              asid_to_be_flushed  <= rs2_forwarding_i[ASID_WIDTH-1:0];
-        end
-    end
+	always_ff @(posedge clk_i or negedge rst_ni) begin
+		if (~rst_ni) begin
+            vmid_to_be_flushed  <= '0;
+		    asid_to_be_flushed  <= '0;
+			vaddr_to_be_flushed <=  '0;
+            gpaddr_to_be_flushed <=  '0;
+        // If the current instruction in EX_STAGE is a sfence.vma, in the next cycle no writes will happen
+		end else if ((~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA ) && csr_valid_i))) begin
+			vaddr_to_be_flushed <=  rs1_forwarding_i;
+            gpaddr_to_be_flushed <=  rs1_forwarding_i >> 2;
+			asid_to_be_flushed  <= rs2_forwarding_i[ASID_WIDTH-1:0];
+            vmid_to_be_flushed  <= rs2_forwarding_i[VMID_WIDTH-1:0];
+		end
+	end
 
 endmodule

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -431,7 +431,7 @@ module ex_stage import ariane_pkg::*; #(
             gpaddr_to_be_flushed    <= '0;
     // If the current instruction in EX_STAGE is a sfence.vma, in the next cycle no writes will happen
 		end else if ((~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && 
-                     (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA) &&
+                     (!((fu_data_i.operation  inside {SFENCE_VMA, HFENCE_VVMA, HFENCE_GVMA}) &&
                      csr_valid_i))) begin
 			vaddr_to_be_flushed     <= rs1_forwarding_i;
             gpaddr_to_be_flushed    <= ariane_pkg::RVH ? rs1_forwarding_i >> 2 : '0;

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -50,6 +50,9 @@ module frontend import ariane_pkg::*; #(
     logic                   icache_valid_q;
     ariane_pkg::frontend_exception_t icache_ex_valid_q;
     logic [riscv::VLEN-1:0] icache_vaddr_q;
+    logic [riscv::GPLEN-1:0]icache_gpaddr_q;
+    logic [riscv::XLEN-1:0] icache_tinst_q;
+    logic                   icache_gva_q;
     logic                   instr_queue_ready;
     logic [ariane_pkg::INSTR_PER_FETCH-1:0] instr_queue_consumed;
     // upper-most branch-prediction from last cycle
@@ -360,6 +363,9 @@ module frontend import ariane_pkg::*; #(
         icache_data_q     <= '0;
         icache_valid_q    <= 1'b0;
         icache_vaddr_q    <= 'b0;
+        icache_gpaddr_q   <= 'b0;
+        icache_tinst_q    <= 'b0;
+        icache_gva_q      <= 1'b0;
         icache_ex_valid_q <= ariane_pkg::FE_NONE;
         btb_q             <= '0;
         bht_q             <= '0;
@@ -371,8 +377,14 @@ module frontend import ariane_pkg::*; #(
         if (icache_dreq_i.valid) begin
           icache_data_q        <= icache_data;
           icache_vaddr_q       <= icache_dreq_i.vaddr;
+          icache_gpaddr_q      <= icache_dreq_i.ex.tval2[riscv::GPLEN-1:0];
+          icache_tinst_q       <= icache_dreq_i.ex.tinst;
+          icache_gva_q         <= icache_dreq_i.ex.gva;
+
           // Map the only three exceptions which can occur in the frontend to a two bit enum
-          if (icache_dreq_i.ex.cause == riscv::INSTR_PAGE_FAULT) begin
+          if(icache_dreq_i.ex.cause == riscv::INSTR_GUEST_PAGE_FAULT) begin
+            icache_ex_valid_q <= ariane_pkg::FE_INSTR_GUEST_PAGE_FAULT;
+          end else if (icache_dreq_i.ex.cause == riscv::INSTR_PAGE_FAULT) begin
             icache_ex_valid_q <= ariane_pkg::FE_INSTR_PAGE_FAULT;
           end else if (icache_dreq_i.ex.cause == riscv::INSTR_ACCESS_FAULT) begin
             icache_ex_valid_q <= ariane_pkg::FE_INSTR_ACCESS_FAULT;
@@ -468,6 +480,9 @@ module frontend import ariane_pkg::*; #(
       .addr_i              ( addr                 ), // from re-aligner
       .exception_i         ( icache_ex_valid_q    ), // from I$
       .exception_addr_i    ( icache_vaddr_q       ),
+      .exception_gpaddr_i  ( icache_gpaddr_q      ),
+      .exception_tinst_i   ( icache_tinst_q       ),
+      .exception_gva_i     ( icache_gva_q         ),
       .predict_address_i   ( predict_address      ),
       .cf_type_i           ( cf_type              ),
       .valid_i             ( instruction_valid    ), // from re-aligner

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -194,9 +194,9 @@ module instr_queue import ariane_pkg::*; (
       assign instr_data_in[i].cf = cf[i + idx_is_q];
       assign instr_data_in[i].ex = exception_i; // exceptions hold for the whole fetch packet
       assign instr_data_in[i].ex_vaddr = exception_addr_i;
-      assign instr_data_in[i].ex_gpaddr= exception_gpaddr_i;
+      assign instr_data_in[i].ex_gpaddr = exception_gpaddr_i;
       assign instr_data_in[i].ex_tinst = exception_tinst_i;
-      assign instr_data_in[i].ex_gva   = exception_gva_i;
+      assign instr_data_in[i].ex_gva = exception_gva_i;
       /* verilator lint_on WIDTH */
     end
   end else begin : gen_multiple_instr_per_fetch_without_C
@@ -226,9 +226,9 @@ module instr_queue import ariane_pkg::*; (
     assign instr_data_in[0].cf = cf_type_i[0];
     assign instr_data_in[0].ex = exception_i; // exceptions hold for the whole fetch packet
     assign instr_data_in[0].ex_vaddr = exception_addr_i;
-    assign instr_data_in[0].ex_gpaddr= exception_gpaddr_i;
+    assign instr_data_in[0].ex_gpaddr = exception_gpaddr_i;
     assign instr_data_in[0].ex_tinst = exception_tinst_i;
-    assign instr_data_in[0].ex_gva   = exception_gva_i;
+    assign instr_data_in[0].ex_gva = exception_gva_i;
     /* verilator lint_on WIDTH */
   end
 
@@ -277,8 +277,8 @@ module instr_queue import ariane_pkg::*; (
       fetch_entry_o.ex.cause = '0;
 
       fetch_entry_o.ex.tval = '0;
-      fetch_entry_o.ex.tval2= '0;
-      fetch_entry_o.ex.gva  = 1'b0;
+      fetch_entry_o.ex.tval2 = '0;
+      fetch_entry_o.ex.gva = 1'b0;
       // tinst hardwire to 0 for Instruction page fault and access fault exceptions
       fetch_entry_o.ex.tinst = '0;
       fetch_entry_o.branch_predict.predict_address = address_out;

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -30,14 +30,18 @@ module id_stage (
     input  logic                          issue_instr_ack_i,   // issue stage acknowledged sampling of instructions
     // from CSR file
     input  riscv::priv_lvl_t              priv_lvl_i,          // current privilege level
+    input  logic                          v_i,                 // current virtualization mode
     input  riscv::xs_t                    fs_i,                // floating point extension status
+    input  riscv::xs_t                    vfs_i,               // floating point extension virtual status
     input  logic [2:0]                    frm_i,               // floating-point dynamic rounding mode
     input  logic [1:0]                    irq_i,
     input  ariane_pkg::irq_ctrl_t         irq_ctrl_i,
     input  logic                          debug_mode_i,        // we are in debug mode
     input  logic                          tvm_i,
     input  logic                          tw_i,
-    input  logic                          tsr_i
+    input  logic                          vtw_i,
+    input  logic                          tsr_i,
+    input  logic                          hu_i                 // hypervisor user mode
 );
     // ID/ISSUE register stage
     typedef struct packed {
@@ -84,12 +88,16 @@ module id_stage (
         .branch_predict_i        ( fetch_entry_i.branch_predict    ),
         .ex_i                    ( fetch_entry_i.ex                ),
         .priv_lvl_i              ( priv_lvl_i                      ),
+        .v_i                     ( v_i                             ),
         .debug_mode_i            ( debug_mode_i                    ),
         .fs_i,
+        .vfs_i,
         .frm_i,
         .tvm_i,
         .tw_i,
+        .vtw_i,
         .tsr_i,
+        .hu_i,
         .instruction_o           ( decoded_instruction          ),
         .is_control_flow_instr_o ( is_control_flow_instr        )
     );

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -293,6 +293,8 @@ package ariane_pkg;
                                                     | riscv::HSTATUS_VTW
                                                     | riscv::HSTATUS_VTSR;
 
+    localparam logic [63:0] ENVCFG_WRITE_MASK       = riscv::MENVCFG_FIOM;
+
     // hypervisor delegable interrupts
     localparam logic [63:0] HS_DELEG_INTERRUPTS     = riscv::MIP_VSSIP
                                                     | riscv::MIP_VSTIP

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -166,6 +166,7 @@ package ariane_pkg;
     localparam bit RVD = (riscv::IS_XLEN64 ? 1:0) & riscv::FPU_EN;              // Is D extension enabled for only 64 bit CPU
 `endif
     localparam bit RVA = cva6_config_pkg::CVA6ConfigAExtEn; // Is A extension enabled
+    localparam bit RVH = cva6_config_pkg::CVA6ConfigHExtEn; // Is H extension enabled (disabled by default)
 
     // Transprecision floating-point extensions configuration
     localparam bit XF16    = cva6_config_pkg::CVA6ConfigF16En; // Is half-precision float extension (Xf16) enabled
@@ -211,7 +212,7 @@ package ariane_pkg;
                                       | (riscv::XLEN'(RVC) <<  2)                         // C - Compressed extension
                                       | (riscv::XLEN'(RVD) <<  3)                         // D - Double precsision floating-point extension
                                       | (riscv::XLEN'(RVF) <<  5)                         // F - Single precsision floating-point extension
-                                      | (riscv::XLEN'(1  ) <<  7)                         // H - Hypervisor mode implemented
+                                      | (riscv::XLEN'(RVH) <<  7)                         // H - Hypervisor mode implemented
                                       | (riscv::XLEN'(1  ) <<  8)                         // I - RV32I/64I/128I base ISA
                                       | (riscv::XLEN'(1  ) << 12)                         // M - Integer Multiply/Divide extension
                                       | (riscv::XLEN'(0  ) << 13)                         // N - User level interrupts supported

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -1044,11 +1044,9 @@ package ariane_pkg;
         if (s_st_enbl) begin
             gpaddr = {pte.ppn[(riscv::GPPNW-1):0], vaddr[11:0]};
             // Giga page
-            if (is_1G)
-                gpaddr[29:12] = vaddr[29:12];
+            if (is_1G) gpaddr[29:12] = vaddr[29:12];
             // Mega page
-            if (is_2M)
-                gpaddr[20:12] = vaddr[20:12];
+            if (is_2M) gpaddr[20:12] = vaddr[20:12];
         end else begin
             gpaddr = vaddr[(riscv::GPLEN-1):0];
         end

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -1027,19 +1027,19 @@ package ariane_pkg;
     // ----------------------
 
     // checks if final translation page size is 1G when H-extension is enabled
-    function logic is_trans_1G(input logic s_st_enbl, input logic g_st_enbl, input logic is_s_1G, input logic is_g_1G);
+    function automatic logic is_trans_1G(input logic s_st_enbl, input logic g_st_enbl, input logic is_s_1G, input logic is_g_1G);
       return (((is_s_1G && s_st_enbl) || !s_st_enbl) && ((is_g_1G && g_st_enbl) || !g_st_enbl));
     endfunction : is_trans_1G
 
     // checks if final translation page size is 2M when H-extension is enabled
-    function logic is_trans_2M(input logic s_st_enbl, input logic g_st_enbl, input logic is_s_1G, input logic is_s_2M, input logic is_g_1G, input logic is_g_2M);
+    function automatic logic is_trans_2M(input logic s_st_enbl, input logic g_st_enbl, input logic is_s_1G, input logic is_s_2M, input logic is_g_1G, input logic is_g_2M);
       return  (s_st_enbl && g_st_enbl) ? 
                 ((is_s_2M && (is_g_1G || is_g_2M)) || (is_g_2M && (is_s_1G || is_s_2M))) :
                 ((is_s_2M && s_st_enbl) || (is_g_2M && g_st_enbl));
     endfunction : is_trans_2M
 
     // computes the paddr based on the page size, ppn and offset
-    function logic [(riscv::GPLEN-1):0] make_gpaddr(input logic s_st_enbl, input logic is_1G, input logic is_2M, input logic [(riscv::VLEN-1):0] vaddr, input riscv::pte_t pte);
+    function automatic logic [(riscv::GPLEN-1):0] make_gpaddr(input logic s_st_enbl, input logic is_1G, input logic is_2M, input logic [(riscv::VLEN-1):0] vaddr, input riscv::pte_t pte);
         logic [(riscv::GPLEN-1):0] gpaddr;
         if (s_st_enbl) begin
             gpaddr = {pte.ppn[(riscv::GPPNW-1):0], vaddr[11:0]};
@@ -1056,7 +1056,7 @@ package ariane_pkg;
     endfunction : make_gpaddr
 
      // computes the final gppn based on the guest physical address
-    function logic [(riscv::GPPNW-1):0] make_gppn(input logic s_st_enbl, input logic is_2M, input logic is_1G, input logic [28:0] vpn, input riscv::pte_t pte);
+    function automatic logic [(riscv::GPPNW-1):0] make_gppn(input logic s_st_enbl, input logic is_2M, input logic is_1G, input logic [28:0] vpn, input riscv::pte_t pte);
         logic [(riscv::GPPNW-1):0] gppn;
         if (s_st_enbl) begin
             gppn = pte.ppn[(riscv::GPPNW-1):0];

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -341,7 +341,7 @@ package ariane_pkg;
          riscv::xlen_t       cause; // cause of exception
          riscv::xlen_t       tval;  // additional information of causing exception (e.g.: instruction causing it),
                              // address of LD/ST fault
-         riscv::xlen_t       tval2; // additional information when the causing exception in a guest exception
+         logic [riscv::GPLEN-1:0] tval2; // additional information when the causing exception in a guest exception
          riscv::xlen_t       tinst;  // transformed instruction information
          logic        gva;          // signals when a guest virtual address is written to tval
          logic        valid;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -1021,4 +1021,53 @@ package ariane_pkg;
             default:     return 2'b11;
         endcase
     endfunction
+
+    // ----------------------
+    // MMU Functions
+    // ----------------------
+
+    // checks if final translation page size is 1G when H-extension is enabled
+    function logic is_trans_1G(input logic s_st_enbl, input logic g_st_enbl, input logic is_s_1G, input logic is_g_1G);
+      return (((is_s_1G && s_st_enbl) || !s_st_enbl) && ((is_g_1G && g_st_enbl) || !g_st_enbl));
+    endfunction : is_trans_1G
+
+    // checks if final translation page size is 2M when H-extension is enabled
+    function logic is_trans_2M(input logic s_st_enbl, input logic g_st_enbl, input logic is_s_1G, input logic is_s_2M, input logic is_g_1G, input logic is_g_2M);
+      return  (s_st_enbl && g_st_enbl) ? 
+                ((is_s_2M && (is_g_1G || is_g_2M)) || (is_g_2M && (is_s_1G || is_s_2M))) :
+                ((is_s_2M && s_st_enbl) || (is_g_2M && g_st_enbl));
+    endfunction : is_trans_2M
+
+    // computes the paddr based on the page size, ppn and offset
+    function logic [(riscv::GPLEN-1):0] make_gpaddr(input logic s_st_enbl, input logic is_1G, input logic is_2M, input logic [(riscv::VLEN-1):0] vaddr, input riscv::pte_t pte);
+        logic [(riscv::GPLEN-1):0] gpaddr;
+        if (s_st_enbl) begin
+            gpaddr = {pte.ppn[(riscv::GPPNW-1):0], vaddr[11:0]};
+            // Giga page
+            if (is_1G)
+                gpaddr[29:12] = vaddr[29:12];
+            // Mega page
+            if (is_2M)
+                gpaddr[20:12] = vaddr[20:12];
+        end else begin
+            gpaddr = vaddr[(riscv::GPLEN-1):0];
+        end
+        return gpaddr;
+    endfunction : make_gpaddr
+
+     // computes the final gppn based on the guest physical address
+    function logic [(riscv::GPPNW-1):0] make_gppn(input logic s_st_enbl, input logic is_2M, input logic is_1G, input logic [28:0] vpn, input riscv::pte_t pte);
+        logic [(riscv::GPPNW-1):0] gppn;
+        if (s_st_enbl) begin
+            gppn = pte.ppn[(riscv::GPPNW-1):0];
+            if(is_2M)
+                gppn[8:0] = vpn[8:0];
+            if(is_1G)
+                gppn[17:0] = vpn[17:0];
+        end else begin
+            gppn = vpn;
+        end
+        return gppn;
+    endfunction : make_gppn
+
 endpackage

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -297,11 +297,11 @@ package ariane_pkg;
     localparam logic [63:0] ENVCFG_WRITE_MASK       = riscv::MENVCFG_FIOM;
 
     // hypervisor delegable interrupts
-    localparam logic [63:0] HS_DELEG_INTERRUPTS     = riscv::MIP_VSSIP
+    localparam logic [riscv::XLEN-1:0] HS_DELEG_INTERRUPTS = riscv::MIP_VSSIP
                                                     | riscv::MIP_VSTIP
                                                     | riscv::MIP_VSEIP;
     // virtual supervisor delegable interrupts
-    localparam logic [63:0] VS_DELEG_INTERRUPTS     = riscv::MIP_VSSIP
+    localparam logic [riscv::XLEN-1:0] VS_DELEG_INTERRUPTS = riscv::MIP_VSSIP
                                                     | riscv::MIP_VSTIP
                                                     | riscv::MIP_VSEIP;
 

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigHExtEn = 0; // always disabled
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -26,6 +26,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
+    localparam CVA6ConfigHExtEn = 0; // always disabled
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigHExtEn = 0; // always disabled
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigHExtEn = 0; // always disabled
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigHExtEn = 0; // always disabled
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigHExtEn = 0; // always disabled
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigHExtEn = 0; // hypervisor extension disabled by default
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigHExtEn = 0; // hypervisor extension disabled by default
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -841,6 +841,23 @@ package riscv;
         return 32'h00000000;
     endfunction
 
+    // This functions converts S-mode CSR addresses into VS-mode CSR addresses
+    // when V=1 (i.e., running in VS-mode).
+    function automatic csr_t convert_vs_access_csr(csr_t csr_addr, logic v);
+        csr_t ret;
+        ret = csr_addr;
+        unique case (csr_addr.address) inside
+            [CSR_SSTATUS:CSR_STVEC],
+            [CSR_SSCRATCH:CSR_SATP]: begin
+                if(v) begin
+                    ret.csr_decode.priv_lvl = PRIV_LVL_HS;
+                end
+                return ret;
+            end
+            default: return ret;
+        endcase
+    endfunction
+
 
     // trace log compatible to spikes commit log feature
     // pragma translate_off

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -142,6 +142,15 @@ package riscv;
     } envcfg_rv_t;
 
     typedef struct packed {
+        logic [XLEN-1:8]  wpri1;  // writes preserved reads ignored
+        logic             cbze;   // not implemented - requires Zicboz extension
+        logic             cbcfe;  // not implemented - requires Zicbom extension
+        logic [1:0]       cbie;   // not implemented - requires Zicbom extension
+        logic [2:0]       wpri0;  // writes preserved reads ignored
+        logic             fiom;   // fence of I/O implies memory
+    } senvcfg_rv_t;
+
+    typedef struct packed {
         logic [ModeW-1:0] mode;
         logic [ASIDW-1:0] asid;
         logic [PPNW-1:0]  ppn;

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -131,6 +131,17 @@ package riscv;
     } hstatus_rv_t;
 
     typedef struct packed {
+        logic         stce;   // not implemented - requires Sctc extension
+        logic         pbmte;  // not implemented - requires Svpbmt extension
+        logic [61:8]  wpri1;  // writes preserved reads ignored
+        logic         cbze;   // not implemented - requires Zicboz extension
+        logic         cbcfe;  // not implemented - requires Zicbom extension
+        logic [1:0]   cbie;   // not implemented - requires Zicbom extension
+        logic [2:0]   wpri0;  // writes preserved reads ignored
+        logic         fiom;   // fence of I/O implies memory
+    } envcfg_rv_t;
+
+    typedef struct packed {
         logic [ModeW-1:0] mode;
         logic [ASIDW-1:0] asid;
         logic [PPNW-1:0]  ppn;
@@ -424,6 +435,7 @@ package riscv;
         CSR_SIE            = 12'h104,
         CSR_STVEC          = 12'h105,
         CSR_SCOUNTEREN     = 12'h106,
+        CSR_SENVCFG        = 12'h10A,
         CSR_SSCRATCH       = 12'h140,
         CSR_SEPC           = 12'h141,
         CSR_SCAUSE         = 12'h142,
@@ -442,6 +454,8 @@ package riscv;
         CSR_HVIP           = 12'h645,
         CSR_HTINST         = 12'h64A,
         CSR_HGEIP          = 12'hE12,
+        CSR_HENVCFG        = 12'h60A,
+        CSR_HENVCFGH       = 12'h61A,
         CSR_HGATP          = 12'h680,
         CSR_HCONTEXT       = 12'h6A8,
         CSR_HTIMEDELTA     = 12'h605,
@@ -467,6 +481,8 @@ package riscv;
         CSR_MIP            = 12'h344,
         CSR_MTINST         = 12'h34A,
         CSR_MTVAL2         = 12'h34B,
+        CSR_MENVCFG        = 12'h30A,
+        CSR_MENVCFGH       = 12'h31A,
         CSR_PMPCFG0        = 12'h3A0,
         CSR_PMPCFG1        = 12'h3A1,
         CSR_PMPCFG2        = 12'h3A2,
@@ -491,6 +507,7 @@ package riscv;
         CSR_MARCHID        = 12'hF12,
         CSR_MIMPID         = 12'hF13,
         CSR_MHARTID        = 12'hF14,
+        CSR_MCONFIGPTR     = 12'hF15,
         CSR_MCYCLE         = 12'hB00,
         CSR_MCYCLEH        = 12'hB80,
         CSR_MINSTRET       = 12'hB02,
@@ -652,6 +669,15 @@ package riscv;
     localparam logic [63:0] MSTATUS_UXL  = {30'h0000000, IS_XLEN64, IS_XLEN64, 32'h00000000};
     localparam logic [63:0] MSTATUS_SXL  = {28'h0000000, IS_XLEN64, IS_XLEN64, 34'h00000000};
     localparam logic [63:0] MSTATUS_SD   = {IS_XLEN64, 31'h00000000, ~IS_XLEN64, 31'h00000000};
+
+    localparam logic [63:0] MENVCFG_FIOM  = 'h00000001;
+    localparam logic [63:0] MENVCFG_CBIE  = 'h00000030;
+    localparam logic [63:0] MENVCFG_CBFE  = 'h00000040;
+    localparam logic [63:0] MENVCFG_CBZE  = 'h00000080;
+    localparam logic [63:0] MENVCFG_PBMTE = 64'h4000000000000000;
+    localparam logic [63:0] MENVCFG_STCE  = 64'h8000000000000000;
+
+
 
     typedef enum logic [2:0] {
         CSRRW  = 3'h1,

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -39,6 +39,7 @@ package riscv;
     // Warning: VLEN must be superior or equal to PLEN
     localparam VLEN             = (XLEN == 32) ? 32 : 64;    // virtual address length
     localparam PLEN             = (XLEN == 32) ? 34 : 56;    // physical address length
+    localparam GPLEN            = (XLEN == 32) ? 34 : 41;    // guest physical address length
 
     localparam IS_XLEN32        = (XLEN == 32) ? 1'b1 : 1'b0;
     localparam IS_XLEN64        = (XLEN == 32) ? 1'b0 : 1'b1;
@@ -46,9 +47,12 @@ package riscv;
     localparam ASIDW            = (XLEN == 32) ? 9 : 16;
     localparam VMIDW            = (XLEN == 32) ? 7 : 14;
     localparam PPNW             = (XLEN == 32) ? 22 : 44;
+    localparam GPPNW            = (XLEN == 32) ? 22 : 29;
     localparam vm_mode_t        MODE_SV = (XLEN == 32) ? ModeSv32 : ModeSv39;
     localparam SV               = (MODE_SV == ModeSv32) ? 32 : 39;
+    localparam SVX              = (MODE_SV == ModeSv32) ? 34 : 41;
     localparam VPN2             = (VLEN-31 < 8) ? VLEN-31 : 8;
+    localparam GPPN2            = (XLEN == 32) ? riscv::VLEN-33 : 10;
     localparam XLEN_ALIGN_BYTES = $clog2(XLEN/8);
 
     typedef logic [XLEN-1:0] xlen_t;
@@ -388,6 +392,14 @@ package riscv;
     localparam logic [XLEN-1:0] M_EXT_INTERRUPT    = (1 << (XLEN-1)) | XLEN'(IRQ_M_EXT);
     localparam logic [XLEN-1:0] HS_EXT_INTERRUPT   = (1 << (XLEN-1)) | XLEN'(IRQ_HS_EXT);
 
+    // ----------------------
+    // PseudoInstructions Codes
+    // ----------------------
+    localparam logic [XLEN-1:0] READ_32_PSEUDOINSTRUCTION  = 32'h00002000;
+    localparam logic [XLEN-1:0] WRITE_32_PSEUDOINSTRUCTION = 32'h00002020;
+    localparam logic [XLEN-1:0] READ_64_PSEUDOINSTRUCTION  = 64'h00003000;
+    localparam logic [XLEN-1:0] WRITE_64_PSEUDOINSTRUCTION = 64'h00003020;
+
     // -----
     // CSRs
     // -----
@@ -454,6 +466,7 @@ package riscv;
         CSR_MTVAL          = 12'h343,
         CSR_MIP            = 12'h344,
         CSR_MTINST         = 12'h34A,
+        CSR_MTVAL2         = 12'h34B,
         CSR_PMPCFG0        = 12'h3A0,
         CSR_PMPCFG1        = 12'h3A1,
         CSR_PMPCFG2        = 12'h3A2,

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -743,7 +743,9 @@ package riscv;
     // -----
     typedef struct packed {
         logic [31:28]     xdebugver;
-        logic [27:16]     zero2;
+        logic [27:18]     zero2;
+        logic             ebreakvs;
+        logic             ebreakvu;
         logic             ebreakm;
         logic             zero1;
         logic             ebreaks;
@@ -752,7 +754,7 @@ package riscv;
         logic             stopcount;
         logic             stoptime;
         logic [8:6]       cause;
-        logic             zero0;
+        logic             v;
         logic             mprven;
         logic             nmip;
         logic             step;

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -860,7 +860,7 @@ package riscv;
         unique case (csr_addr.address) inside
             [CSR_SSTATUS:CSR_STVEC],
             [CSR_SSCRATCH:CSR_SATP]: begin
-                if(v) begin
+                if (v) begin
                     ret.csr_decode.priv_lvl = PRIV_LVL_HS;
                 end
                 return ret;

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -44,6 +44,7 @@ module issue_read_operands import ariane_pkg::*; #(
     output riscv::xlen_t                           rs2_forwarding_o,  // unregistered version of fu_data_o.operandb
     output logic [riscv::VLEN-1:0]                 pc_o,
     output logic                                   is_compressed_instr_o,
+    output riscv::xlen_t                           tinst_o,          // Transformed instruction
     // ALU 1
     input  logic                                   flu_ready_i,      // Fixed latency unit ready to accept a new request
     output logic                                   alu_valid_o,      // Output is valid
@@ -101,6 +102,7 @@ module issue_read_operands import ariane_pkg::*; #(
     logic [TRANS_ID_BITS-1:0] trans_id_n, trans_id_q;
     fu_op operator_n, operator_q; // operation to perform
     fu_t  fu_n,       fu_q; // functional unit to use
+    riscv::xlen_t tinst_n, tinst_q; // transformed instruction
 
     // forwarding signals
     logic forward_rs1, forward_rs2, forward_rs3;
@@ -131,6 +133,7 @@ module issue_read_operands import ariane_pkg::*; #(
     assign cvxif_valid_o       = CVXIF_PRESENT ? cvxif_valid_q : '0;
     assign cvxif_off_instr_o   = CVXIF_PRESENT ? cvxif_off_instr_q : '0;
     assign stall_issue_o       = stall;
+    assign tinst_o             = tinst_q;
     // ---------------
     // Issue Stage
     // ---------------
@@ -179,7 +182,7 @@ module issue_read_operands import ariane_pkg::*; #(
             // check if the clobbering instruction is not a CSR instruction, CSR instructions can only
             // be fetched through the register file since they can't be forwarded
             // if the operand is available, forward it. CSRs don't write to/from FPR
-            if (rs1_valid_i && (is_rs1_fpr(issue_instr_i.op) ? 1'b1 : ((rd_clobber_gpr_i[issue_instr_i.rs1] != CSR) || (issue_instr_i.op == SFENCE_VMA)))) begin
+            if (rs1_valid_i && (is_rs1_fpr(issue_instr_i.op) ? 1'b1 : ((rd_clobber_gpr_i[issue_instr_i.rs1] != CSR) || (issue_instr_i.op == SFENCE_VMA || issue_instr_i.op == HFENCE_VVMA || issue_instr_i.op == HFENCE_GVMA)))) begin
                 forward_rs1 = 1'b1;
             end else begin // the operand is not available -> stall
                 stall = 1'b1;
@@ -189,7 +192,7 @@ module issue_read_operands import ariane_pkg::*; #(
         if (is_rs2_fpr(issue_instr_i.op) ? rd_clobber_fpr_i[issue_instr_i.rs2] != NONE
                                          : rd_clobber_gpr_i[issue_instr_i.rs2] != NONE) begin
             // if the operand is available, forward it. CSRs don't write to/from FPR
-            if (rs2_valid_i && (is_rs2_fpr(issue_instr_i.op) ? 1'b1 : ( (rd_clobber_gpr_i[issue_instr_i.rs2] != CSR) || (issue_instr_i.op == SFENCE_VMA))))  begin
+            if (rs2_valid_i && (is_rs2_fpr(issue_instr_i.op) ? 1'b1 : ( (rd_clobber_gpr_i[issue_instr_i.rs2] != CSR) || (issue_instr_i.op == SFENCE_VMA || issue_instr_i.op == HFENCE_VVMA || issue_instr_i.op == HFENCE_GVMA))))  begin
                 forward_rs2 = 1'b1;
             end else begin // the operand is not available -> stall
                 stall = 1'b1;
@@ -224,6 +227,7 @@ module issue_read_operands import ariane_pkg::*; #(
         trans_id_n = issue_instr_i.trans_id;
         fu_n       = issue_instr_i.fu;
         operator_n = issue_instr_i.op;
+        tinst_n    = issue_instr_i.ex.tinst;
         // or should we forward
         if (forward_rs1) begin
             operand_a_n  = rs1_i;
@@ -509,6 +513,7 @@ module issue_read_operands import ariane_pkg::*; #(
             fu_q                  <= NONE;
             operator_q            <= ADD;
             trans_id_q            <= '0;
+            tinst_q               <= '0;
             pc_o                  <= '0;
             is_compressed_instr_o <= 1'b0;
             branch_predict_o      <= {cf_t'(0), {riscv::VLEN{1'b0}}};
@@ -519,6 +524,7 @@ module issue_read_operands import ariane_pkg::*; #(
             fu_q                  <= fu_n;
             operator_q            <= operator_n;
             trans_id_q            <= trans_id_n;
+            tinst_q               <= tinst_n;
             pc_o                  <= issue_instr_i.pc;
             is_compressed_instr_o <= issue_instr_i.is_compressed;
             branch_predict_o      <= issue_instr_i.bp;

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -36,6 +36,7 @@ module issue_stage import ariane_pkg::*; #(
     output fu_data_t                                 fu_data_o,
     output logic [riscv::VLEN-1:0]                   pc_o,
     output logic                                     is_compressed_instr_o,
+    output riscv::xlen_t                             tinst_o,
     input  logic                                     flu_ready_i,
     output logic                                     alu_valid_o,
     // ex just resolved our predicted branch, we are ready to accept new requests
@@ -210,6 +211,7 @@ module issue_stage import ariane_pkg::*; #(
         .rs1_forwarding_o    ( rs1_forwarding_xlen             ),
         .rs2_forwarding_o    ( rs2_forwarding_xlen             ),
         .stall_issue_o       ( stall_issue_o                   ),
+        .tinst_o             ( tinst_o                         ),
         .*
     );
 

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -15,6 +15,7 @@
 
 module load_store_unit import ariane_pkg::*; #(
     parameter int unsigned ASID_WIDTH = 1,
+    parameter int unsigned VMID_WIDTH = 1,
     parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
 )(
     input  logic                     clk_i,
@@ -22,6 +23,7 @@ module load_store_unit import ariane_pkg::*; #(
     input  logic                     flush_i,
     output logic                     no_st_pending_o,
     input  logic                     amo_valid_commit_i,
+    input  riscv::xlen_t             tinst_i,
 
     input  fu_data_t                 fu_data_i,
     output logic                     lsu_ready_o,              // FU is ready e.g. not busy
@@ -42,21 +44,36 @@ module load_store_unit import ariane_pkg::*; #(
     input  logic [TRANS_ID_BITS-1:0] commit_tran_id_i,
 
     input  logic                     enable_translation_i,     // enable virtual memory translation
+    input  logic                     enable_g_translation_i,   // enable G-Stage translation
     input  logic                     en_ld_st_translation_i,   // enable virtual memory translation for load/stores
+    input  logic                     en_ld_st_g_translation_i, // enable G-stage translation for load/stores
 
     // icache translation requests
     input  icache_areq_o_t           icache_areq_i,
     output icache_areq_i_t           icache_areq_o,
 
     input  riscv::priv_lvl_t         priv_lvl_i,               // From CSR register file
+    input logic                      v_i,                      // From CSR register file
     input  riscv::priv_lvl_t         ld_st_priv_lvl_i,         // From CSR register file
+    input  logic                     ld_st_v_i,                // From CSR register file
+    output logic                     csr_hs_ld_st_inst_o,
     input  logic                     sum_i,                    // From CSR register file
+    input  logic                     vs_sum_i,                    // From CSR register file
     input  logic                     mxr_i,                    // From CSR register file
+    input  logic                     vmxr_i,                   // From CSR register file
     input  logic [riscv::PPNW-1:0]   satp_ppn_i,               // From CSR register file
     input  logic [ASID_WIDTH-1:0]    asid_i,                   // From CSR register file
+    input  logic [riscv::PPNW-1:0]   vsatp_ppn_i,              // From CSR register file
+    input  logic [ASID_WIDTH-1:0]    vs_asid_i,                // From CSR register file
     input  logic [ASID_WIDTH-1:0]    asid_to_be_flushed_i,
+    input  logic [riscv::PPNW-1:0]   hgatp_ppn_i,              // From CSR register file
+    input  logic [VMID_WIDTH-1:0]    vmid_i,                   // From CSR register file
+    input  logic [VMID_WIDTH-1:0]    vmid_to_be_flushed_i,
     input  logic [riscv::VLEN-1:0]   vaddr_to_be_flushed_i,
+    input  logic [riscv::GPLEN-1:0]  gpaddr_to_be_flushed_i,
     input  logic                     flush_tlb_i,
+    input  logic                     flush_tlb_vvma_i,
+    input  logic                     flush_tlb_gvma_i,
     // Performance counters
     output logic                     itlb_miss_o,
     output logic                     dtlb_miss_o,
@@ -98,24 +115,34 @@ module load_store_unit import ariane_pkg::*; #(
     // virtual address as calculated by the AGU in the first cycle
     logic [riscv::VLEN-1:0]           vaddr_i;
     riscv::xlen_t                     vaddr_xlen;
-    logic                             overflow;
+    logic                             overflow, g_overflow;
     logic [(riscv::XLEN/8)-1:0]       be_i;
 
     assign vaddr_xlen = $unsigned($signed(fu_data_i.imm) + $signed(fu_data_i.operand_a));
     assign vaddr_i = vaddr_xlen[riscv::VLEN-1:0];
     // we work with SV39 or SV32, so if VM is enabled, check that all bits [XLEN-1:38] or [XLEN-1:31] are equal
     assign overflow = !((&vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b1 || (|vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b0);
+    assign g_overflow = !((|vaddr_xlen[riscv::XLEN-1:riscv::SVX]) == 1'b0);
 
     logic                     st_valid_i;
     logic                     ld_valid_i;
     logic                     ld_translation_req;
     logic                     st_translation_req;
     logic [riscv::VLEN-1:0]   ld_vaddr;
+    logic [riscv::XLEN-1:0]   ld_tinst;
+    logic                     ld_hs_ld_st_inst;
+    logic                     ld_hlvx_inst;
     logic [riscv::VLEN-1:0]   st_vaddr;
+    logic [riscv::XLEN-1:0]   st_tinst;
+    logic                     st_hs_ld_st_inst;
+    logic                     st_hlvx_inst;
     logic                     translation_req;
     logic                     translation_valid;
     logic [riscv::VLEN-1:0]   mmu_vaddr;
     logic [riscv::PLEN-1:0]   mmu_paddr, mmu_vaddr_plen, fetch_vaddr_plen;
+    logic [riscv::XLEN-1:0]   mmu_tinst;
+    logic                     mmu_hs_ld_st_inst;
+    logic                     mmu_hlvx_inst;
     exception_t               mmu_exception;
     logic                     dtlb_hit;
     logic [riscv::PPNW-1:0]   dtlb_ppn;
@@ -134,6 +161,8 @@ module load_store_unit import ariane_pkg::*; #(
     exception_t               ld_ex;
     exception_t               st_ex;
 
+    logic                     hs_ld_st_inst;
+    logic                     hlvx_inst;
     // -------------------
     // MMU e.g.: TLBs/PTW
     // -------------------
@@ -142,6 +171,7 @@ module load_store_unit import ariane_pkg::*; #(
             .INSTR_TLB_ENTRIES      ( ariane_pkg::INSTR_TLB_ENTRIES ),
             .DATA_TLB_ENTRIES       ( ariane_pkg::DATA_TLB_ENTRIES ),
             .ASID_WIDTH             ( ASID_WIDTH             ),
+            .VMID_WIDTH             ( VMID_WIDTH             ),
             .ArianeCfg              ( ArianeCfg              )
         ) i_cva6_mmu (
             // misaligned bypass
@@ -149,6 +179,7 @@ module load_store_unit import ariane_pkg::*; #(
             .lsu_is_store_i         ( st_translation_req     ),
             .lsu_req_i              ( translation_req        ),
             .lsu_vaddr_i            ( mmu_vaddr              ),
+            .lsu_tinst_i            ( mmu_tinst              ),
             .lsu_valid_o            ( translation_valid      ),
             .lsu_paddr_o            ( mmu_paddr              ),
             .lsu_exception_o        ( mmu_exception          ),
@@ -160,10 +191,15 @@ module load_store_unit import ariane_pkg::*; #(
             // icache address translation requests
             .icache_areq_i          ( icache_areq_i          ),
             .asid_to_be_flushed_i,
+            .vmid_to_be_flushed_i,
             .vaddr_to_be_flushed_i,
+            .gpaddr_to_be_flushed_i,
             .icache_areq_o          ( icache_areq_o          ),
             .pmpcfg_i,
             .pmpaddr_i,
+            // Hypervisor load/store signals
+            .hlvx_inst_i            ( mmu_hlvx_inst          ),
+            .hs_ld_st_inst_i        ( mmu_hs_ld_st_inst      ),
             .*
         );
     end else if (MMU_PRESENT && (riscv::XLEN == 32)) begin : gen_mmu_sv32
@@ -264,6 +300,9 @@ module load_store_unit import ariane_pkg::*; #(
         .translation_req_o     ( st_translation_req   ),
         .vaddr_o               ( st_vaddr             ),
         .mem_paddr_o           ( mem_paddr_o          ),
+        .tinst_o               ( st_tinst             ),
+        .hs_ld_st_inst_o       ( st_hs_ld_st_inst     ),
+        .hlvx_inst_o           ( st_hlvx_inst         ),
         .paddr_i               ( mmu_paddr            ),
         .ex_i                  ( mmu_exception        ),
         .dtlb_hit_i            ( dtlb_hit             ),
@@ -295,6 +334,9 @@ module load_store_unit import ariane_pkg::*; #(
         // MMU port
         .translation_req_o     ( ld_translation_req   ),
         .vaddr_o               ( ld_vaddr             ),
+        .tinst_o               ( ld_tinst             ),
+        .hs_ld_st_inst_o       ( ld_hs_ld_st_inst     ),
+        .hlvx_inst_o           ( ld_hlvx_inst         ),
         .paddr_i               ( mmu_paddr            ),
         .ex_i                  ( mmu_exception        ),
         .dtlb_hit_i            ( dtlb_hit             ),
@@ -346,6 +388,9 @@ module load_store_unit import ariane_pkg::*; #(
 
         translation_req      = 1'b0;
         mmu_vaddr            = {riscv::VLEN{1'b0}};
+        mmu_tinst            = {riscv::XLEN{1'b0}};
+        mmu_hs_ld_st_inst    = 1'b0;
+        mmu_hlvx_inst        = 1'b0;
 
         // check the operation to activate the right functional unit accordingly
         unique case (lsu_ctrl.fu)
@@ -354,18 +399,46 @@ module load_store_unit import ariane_pkg::*; #(
                 ld_valid_i           = lsu_ctrl.valid;
                 translation_req      = ld_translation_req;
                 mmu_vaddr            = ld_vaddr;
+                mmu_tinst            = ld_tinst;
+                mmu_hs_ld_st_inst    = ld_hs_ld_st_inst;
+                mmu_hlvx_inst        = ld_hlvx_inst;
             end
             // all stores go here
             STORE: begin
                 st_valid_i           = lsu_ctrl.valid;
                 translation_req      = st_translation_req;
                 mmu_vaddr            = st_vaddr;
+                mmu_tinst            = st_tinst;
+                mmu_hs_ld_st_inst    = st_hs_ld_st_inst;
+                mmu_hlvx_inst        = st_hlvx_inst;
             end
             // not relevant for the LSU
             default: ;
         endcase
     end
 
+    // ------------------------
+    // Hypervisor Load/Store
+    // ------------------------
+    // determine whether this is a hypervisor load or store
+    always_comb begin : hyp_ld_st
+        // check the operator to activate the right functional unit accordingly
+        hs_ld_st_inst = 1'b0;
+        hlvx_inst     = 1'b0;
+        case (lsu_ctrl.operator)
+            // all loads go here
+            HLV_B, HLV_BU, HLV_H, HLV_HU,
+            HLV_W, HSV_B, HSV_H, HSV_W,
+            HLV_WU, HLV_D, HSV_D: begin
+                    hs_ld_st_inst = 1'b1;
+            end
+            HLVX_WU, HLVX_HU: begin
+                    hs_ld_st_inst = 1'b1;
+                    hlvx_inst     = 1'b1;
+            end
+            default:;
+        endcase
+    end
 
     // ---------------
     // Byte Enable
@@ -383,13 +456,14 @@ module load_store_unit import ariane_pkg::*; #(
     // the misaligned exception is passed to the functional unit via the MMU, which in case
     // can augment the exception if other memory related exceptions like a page fault or access errors
     always_comb begin : data_misaligned_detection
-
         misaligned_exception = {
             {riscv::XLEN{1'b0}},
             {riscv::XLEN{1'b0}},
+            {riscv::XLEN{1'b0}},
+            {riscv::XLEN{1'b0}},
+            1'b0,
             1'b0
         };
-
         data_misaligned = 1'b0;
 
         if (lsu_ctrl.valid) begin
@@ -399,7 +473,7 @@ module load_store_unit import ariane_pkg::*; #(
                 AMO_LRD, AMO_SCD,
                 AMO_SWAPD, AMO_ADDD, AMO_ANDD, AMO_ORD,
                 AMO_XORD, AMO_MAXD, AMO_MAXDU, AMO_MIND,
-                AMO_MINDU: begin
+                AMO_MINDU, HLV_D, HSV_D: begin
                     if (lsu_ctrl.vaddr[2:0] != 3'b000) begin
                         data_misaligned = 1'b1;
                     end
@@ -409,13 +483,13 @@ module load_store_unit import ariane_pkg::*; #(
                 AMO_LRW, AMO_SCW,
                 AMO_SWAPW, AMO_ADDW, AMO_ANDW, AMO_ORW,
                 AMO_XORW, AMO_MAXW, AMO_MAXWU, AMO_MINW,
-                AMO_MINWU: begin
+                AMO_MINWU, HLV_W, HLV_WU, HLVX_WU, HSV_W: begin
                     if (lsu_ctrl.vaddr[1:0] != 2'b00) begin
                         data_misaligned = 1'b1;
                     end
                 end
                 // half word
-                LH, LHU, SH, FLH, FSH: begin
+                LH, LHU, SH, FLH, FSH, HLV_H, HLV_HU, HLVX_HU, HSV_H: begin
                     if (lsu_ctrl.vaddr[0] != 1'b0) begin
                         data_misaligned = 1'b1;
                     end
@@ -431,6 +505,9 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::LD_ADDR_MISALIGNED,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_ctrl.tinst,
+                    ld_st_v_i,
                     1'b1
                 };
 
@@ -438,6 +515,9 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::ST_ADDR_MISALIGNED,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_ctrl.tinst,
+                    ld_st_v_i,
                     1'b1
                 };
             end
@@ -449,6 +529,9 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::LD_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_ctrl.tinst,
+                    ld_st_v_i,
                     1'b1
                 };
 
@@ -456,6 +539,33 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::ST_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_ctrl.tinst,
+                    ld_st_v_i,
+                    1'b1
+                };
+            end
+        end
+
+        if (en_ld_st_g_translation_i && !en_ld_st_translation_i && lsu_ctrl.g_overflow) begin
+
+            if (lsu_ctrl.fu == LOAD) begin
+                misaligned_exception = {
+                    riscv::LOAD_GUEST_PAGE_FAULT,
+                    {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_ctrl.tinst,
+                    ld_st_v_i,
+                    1'b1
+                };
+
+            end else if (lsu_ctrl.fu == STORE) begin
+                misaligned_exception = {
+                    riscv::STORE_GUEST_PAGE_FAULT,
+                    {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_ctrl.tinst,
+                    ld_st_v_i,
                     1'b1
                 };
             end
@@ -468,7 +578,7 @@ module load_store_unit import ariane_pkg::*; #(
     // new data arrives here
     lsu_ctrl_t lsu_req_i;
 
-    assign lsu_req_i = {lsu_valid_i, vaddr_i, overflow, fu_data_i.operand_b, be_i, fu_data_i.fu, fu_data_i.operation, fu_data_i.trans_id};
+    assign lsu_req_i = {lsu_valid_i, vaddr_i, tinst_i, hs_ld_st_inst, hlvx_inst, overflow, g_overflow, fu_data_i.operand_b, be_i, fu_data_i.fu, fu_data_i.operation, fu_data_i.trans_id};
 
     lsu_bypass lsu_bypass_i (
         .lsu_req_i          ( lsu_req_i   ),
@@ -487,4 +597,3 @@ module load_store_unit import ariane_pkg::*; #(
     assign lsu_addr_trans_id_o = lsu_ctrl.trans_id;
 
 endmodule
-

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -432,7 +432,7 @@ module load_store_unit import ariane_pkg::*; #(
                 ld_valid_i           = lsu_ctrl.valid;
                 translation_req      = ld_translation_req;
                 mmu_vaddr            = ld_vaddr;
-                if(ariane_pkg::RVH) begin
+                if (ariane_pkg::RVH) begin
                     mmu_tinst            = ld_tinst;
                     mmu_hs_ld_st_inst    = ld_hs_ld_st_inst;
                     mmu_hlvx_inst        = ld_hlvx_inst;
@@ -443,7 +443,7 @@ module load_store_unit import ariane_pkg::*; #(
                 st_valid_i           = lsu_ctrl.valid;
                 translation_req      = st_translation_req;
                 mmu_vaddr            = st_vaddr;
-                if(ariane_pkg::RVH) begin
+                if (ariane_pkg::RVH) begin
                     mmu_tinst            = st_tinst;
                     mmu_hs_ld_st_inst    = st_hs_ld_st_inst;
                     mmu_hlvx_inst        = st_hlvx_inst;
@@ -458,7 +458,7 @@ module load_store_unit import ariane_pkg::*; #(
     // Hypervisor Load/Store
     // ------------------------
     // determine whether this is a hypervisor load or store
-    if(ariane_pkg::RVH) begin
+    if (ariane_pkg::RVH) begin
         always_comb begin : hyp_ld_st
             // check the operator to activate the right functional unit accordingly
             hs_ld_st_inst = 1'b0;
@@ -476,7 +476,7 @@ module load_store_unit import ariane_pkg::*; #(
                 end
                 default:;
             endcase
-        end 
+        end
     end else begin
             assign hs_ld_st_inst = 1'b0;
             assign hlvx_inst     = 1'b0;

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -501,7 +501,7 @@ module load_store_unit import ariane_pkg::*; #(
         misaligned_exception = {
             {riscv::XLEN{1'b0}},
             {riscv::XLEN{1'b0}},
-            {riscv::XLEN{1'b0}},
+            {riscv::GPLEN{1'b0}},
             {riscv::XLEN{1'b0}},
             1'b0,
             1'b0
@@ -547,7 +547,7 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::LD_ADDR_MISALIGNED,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_ctrl.tinst,
                     ld_st_v_i,
                     1'b1
@@ -557,7 +557,7 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::ST_ADDR_MISALIGNED,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_ctrl.tinst,
                     ld_st_v_i,
                     1'b1
@@ -571,7 +571,7 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::LD_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_ctrl.tinst,
                     ld_st_v_i,
                     1'b1
@@ -581,7 +581,7 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::ST_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_ctrl.tinst,
                     ld_st_v_i,
                     1'b1
@@ -595,7 +595,7 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::LOAD_GUEST_PAGE_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_ctrl.tinst,
                     ld_st_v_i,
                     1'b1
@@ -605,7 +605,7 @@ module load_store_unit import ariane_pkg::*; #(
                 misaligned_exception = {
                     riscv::STORE_GUEST_PAGE_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}},lsu_ctrl.vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_ctrl.tinst,
                     ld_st_v_i,
                     1'b1

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -463,7 +463,7 @@ module load_store_unit import ariane_pkg::*; #(
             // check the operator to activate the right functional unit accordingly
             hs_ld_st_inst = 1'b0;
             hlvx_inst     = 1'b0;
-            case (lsu_ctrl.operator)
+            case (lsu_ctrl.operation)
                 // all loads go here
                 HLV_B, HLV_BU, HLV_H, HLV_HU,
                 HLV_W, HSV_B, HSV_H, HSV_W,

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -78,6 +78,7 @@ module load_unit import ariane_pkg::*; #(
     // directly forward exception fields (valid bit is set below)
     assign ex_o.cause = ex_i.cause;
     assign ex_o.tval  = ex_i.tval;
+    assign ex_o.tinst = ex_i.tinst;
 
     // Check that NI operations follow the necessary conditions
     logic paddr_ni;

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -288,7 +288,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                 icache_areq_o.fetch_exception = {
                     riscv::INSTR_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     {riscv::XLEN{1'b0}},
                     1'b0,
                     1'b1
@@ -318,7 +318,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                     icache_areq_o.fetch_exception = {
                         riscv::INSTR_PAGE_FAULT,
                         {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         1'b0,
                         1'b1
@@ -328,7 +328,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                     icache_areq_o.fetch_exception = {
                         riscv::INSTR_ACCESS_FAULT,
                         icache_areq_i.fetch_vaddr,
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         1'b0,
                         1'b1
@@ -345,7 +345,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                 if (ptw_error) icache_areq_o.fetch_exception = {
                                     riscv::INSTR_PAGE_FAULT,
                                     {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
-                                    {riscv::XLEN{1'b0}},
+                                    {riscv::GPLEN{1'b0}},
                                     {riscv::XLEN{1'b0}},
                                     1'b0,
                                     1'b1
@@ -355,7 +355,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                 else icache_areq_o.fetch_exception = {
                         riscv::INSTR_ACCESS_FAULT,
                         ptw_bad_paddr[riscv::PLEN-1:2],
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         1'b0,
                         1'b1
@@ -369,7 +369,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
             icache_areq_o.fetch_exception = {
                 riscv::INSTR_ACCESS_FAULT,
                 icache_areq_o.fetch_paddr[riscv::PLEN-1:2],
-                {riscv::XLEN{1'b0}},
+                {riscv::GPLEN{1'b0}},
                 {riscv::XLEN{1'b0}},
                 1'b0,
                 1'b1
@@ -468,7 +468,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::STORE_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -479,7 +479,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::ST_ACCESS_FAULT,
                             lsu_paddr_o[riscv::PLEN-1:2],
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -493,7 +493,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LOAD_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -504,7 +504,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LD_ACCESS_FAULT,
                             lsu_paddr_o[riscv::PLEN-1:2],
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -527,7 +527,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::STORE_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -536,7 +536,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LOAD_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -551,7 +551,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                     lsu_exception_o = {
                         riscv::LD_ACCESS_FAULT,
                         ptw_bad_paddr[riscv::PLEN-1:2],
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         1'b0,
                         1'b1
@@ -565,7 +565,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                 lsu_exception_o = {
                     riscv::ST_ACCESS_FAULT,
                     lsu_paddr_o[riscv::PLEN-1:2],
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     {riscv::XLEN{1'b0}},
                     1'b0,
                     1'b1
@@ -574,7 +574,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
                 lsu_exception_o = {
                     riscv::LD_ACCESS_FAULT,
                     lsu_paddr_o[riscv::PLEN-1:2],
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     {riscv::XLEN{1'b0}},
                     1'b0,
                     1'b1

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -221,7 +221,7 @@ module mmu import ariane_pkg::*; #(
                 icache_areq_o.fetch_exception = {
                     riscv::INSTR_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     {riscv::XLEN{1'b0}},
                     1'b0,
                     1'b1
@@ -253,7 +253,7 @@ module mmu import ariane_pkg::*; #(
                     icache_areq_o.fetch_exception = {
                         riscv::INSTR_PAGE_FAULT,
                         {{riscv::XLEN-riscv::VLEN{1'b0}},icache_areq_i.fetch_vaddr},
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         1'b0,
                         1'b1
@@ -262,7 +262,7 @@ module mmu import ariane_pkg::*; #(
                     icache_areq_o.fetch_exception = {
                         riscv::INSTR_ACCESS_FAULT,
                         {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         1'b0,
                         1'b1
@@ -278,7 +278,7 @@ module mmu import ariane_pkg::*; #(
                 if (ptw_error) icache_areq_o.fetch_exception = {
                                     riscv::INSTR_PAGE_FAULT,
                                     {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
-                                    {riscv::XLEN{1'b0}},
+                                    {riscv::GPLEN{1'b0}},
                                     {riscv::XLEN{1'b0}},
                                     1'b0,
                                     1'b1
@@ -287,7 +287,7 @@ module mmu import ariane_pkg::*; #(
                 else icache_areq_o.fetch_exception = {
                     riscv::INSTR_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::PLEN{1'b0}}, ptw_bad_paddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     {riscv::XLEN{1'b0}},
                     1'b0,
                     1'b1
@@ -300,7 +300,7 @@ module mmu import ariane_pkg::*; #(
           icache_areq_o.fetch_exception = {
                 riscv::INSTR_ACCESS_FAULT,
                 {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr},
-                {riscv::XLEN{1'b0}},
+                {riscv::GPLEN{1'b0}},
                 {riscv::XLEN{1'b0}},
                 1'b0,
                 1'b1
@@ -405,7 +405,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::STORE_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -415,7 +415,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::ST_ACCESS_FAULT,
                             {{riscv::XLEN-riscv::PLEN{1'b0}},lsu_paddr_o},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -429,7 +429,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LOAD_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -439,7 +439,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LD_ACCESS_FAULT,
                             {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -462,7 +462,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::STORE_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -471,7 +471,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LOAD_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -487,7 +487,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::ST_ACCESS_FAULT,
                             {{riscv::XLEN-riscv::VLEN{1'b0}}, lsu_vaddr_n},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -496,7 +496,7 @@ module mmu import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LD_ACCESS_FAULT,
                             {{riscv::XLEN-riscv::VLEN{1'b0}}, lsu_vaddr_n},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             1'b0,
                             1'b1
@@ -511,7 +511,7 @@ module mmu import ariane_pkg::*; #(
                 lsu_exception_o = {
                     riscv::ST_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     {riscv::XLEN{1'b0}},
                     1'b0,
                     1'b1
@@ -520,7 +520,7 @@ module mmu import ariane_pkg::*; #(
                 lsu_exception_o = {
                     riscv::LD_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     {riscv::XLEN{1'b0}},
                     1'b0,
                     1'b1

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -218,7 +218,14 @@ module mmu import ariane_pkg::*; #(
         if (enable_translation_i) begin
             // we work with SV39 or SV32, so if VM is enabled, check that all bits [riscv::VLEN-1:riscv::SV-1] are equal
             if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b1 || (|icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b0)) begin
-                icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr}, 1'b1};
+                icache_areq_o.fetch_exception = {
+                    riscv::INSTR_ACCESS_FAULT,
+                    {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
+                    {riscv::XLEN{1'b0}},
+                    {riscv::XLEN{1'b0}},
+                    1'b0,
+                    1'b1
+                };
             end
 
             icache_areq_o.fetch_valid = 1'b0;
@@ -243,9 +250,23 @@ module mmu import ariane_pkg::*; #(
                 // we got an access error
                 if (iaccess_err) begin
                     // throw a page fault
-                    icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr}, 1'b1};
+                    icache_areq_o.fetch_exception = {
+                        riscv::INSTR_PAGE_FAULT,
+                        {{riscv::XLEN-riscv::VLEN{1'b0}},icache_areq_i.fetch_vaddr},
+                        {riscv::XLEN{1'b0}},
+                        {riscv::XLEN{1'b0}},
+                        1'b0,
+                        1'b1
+                    };
                 end else if (!pmp_instr_allow) begin
-                    icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_i.fetch_vaddr}, 1'b1};
+                    icache_areq_o.fetch_exception = {
+                        riscv::INSTR_ACCESS_FAULT,
+                        {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
+                        {riscv::XLEN{1'b0}},
+                        {riscv::XLEN{1'b0}},
+                        1'b0,
+                        1'b1
+                    };
                 end
             end else
             // ---------
@@ -254,15 +275,36 @@ module mmu import ariane_pkg::*; #(
             // watch out for exceptions happening during walking the page table
             if (ptw_active && walking_instr) begin
                 icache_areq_o.fetch_valid = ptw_error | ptw_access_exception;
-                if (ptw_error) icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr}, 1'b1};
+                if (ptw_error) icache_areq_o.fetch_exception = {
+                                    riscv::INSTR_PAGE_FAULT,
+                                    {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
+                                    {riscv::XLEN{1'b0}},
+                                    {riscv::XLEN{1'b0}},
+                                    1'b0,
+                                    1'b1
+                                };
                 // TODO(moschn,zarubaf): What should the value of tval be in this case?
-                else icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, ptw_bad_paddr}, 1'b1};
+                else icache_areq_o.fetch_exception = {
+                    riscv::INSTR_ACCESS_FAULT,
+                    {{riscv::XLEN-riscv::PLEN{1'b0}}, ptw_bad_paddr},
+                    {riscv::XLEN{1'b0}},
+                    {riscv::XLEN{1'b0}},
+                    1'b0,
+                    1'b1
+                };
             end
         end
         // if it didn't match any execute region throw an `Instruction Access Fault`
         // or: if we are not translating, check PMPs immediately on the paddr
         if ((!match_any_execute_region && !ptw_error) || (!enable_translation_i && !pmp_instr_allow)) begin
-          icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr}, 1'b1};
+          icache_areq_o.fetch_exception = {
+                riscv::INSTR_ACCESS_FAULT,
+                {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr},
+                {riscv::XLEN{1'b0}},
+                {riscv::XLEN{1'b0}},
+                1'b0,
+                1'b1
+            };
         end
     end
 
@@ -360,20 +402,48 @@ module mmu import ariane_pkg::*; #(
                     // check if the page is write-able and we are not violating privileges
                     // also check if the dirty flag is set
                     if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
-                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::STORE_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     // Check if any PMPs are violated
                     end else if (!pmp_data_allow) begin
-                        lsu_exception_o = {riscv::ST_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::ST_ACCESS_FAULT,
+                            {{riscv::XLEN-riscv::PLEN{1'b0}},lsu_paddr_o},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     end
 
                 // this is a load
                 end else begin
                     // check for sufficient access privileges - throw a page fault if necessary
                     if (daccess_err) begin
-                        lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::LOAD_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     // Check if any PMPs are violated
                     end else if (!pmp_data_allow) begin
-                        lsu_exception_o = {riscv::LD_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::LD_ACCESS_FAULT,
+                            {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     end
                 end
             end else
@@ -389,9 +459,23 @@ module mmu import ariane_pkg::*; #(
                     lsu_valid_o = 1'b1;
                     // the page table walker can only throw page faults
                     if (lsu_is_store_q) begin
-                        lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::STORE_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     end else begin
-                        lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::LOAD_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     end
                 end
 
@@ -400,9 +484,23 @@ module mmu import ariane_pkg::*; #(
                     lsu_valid_o = 1'b1;
                     // Any fault of the page table walk should be based of the original access type
                     if (lsu_is_store_q) begin
-                        lsu_exception_o = {riscv::ST_ACCESS_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, lsu_vaddr_n}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::ST_ACCESS_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{1'b0}}, lsu_vaddr_n},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     end else begin
-                        lsu_exception_o = {riscv::LD_ACCESS_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, lsu_vaddr_n}, 1'b1};
+                        lsu_exception_o = {
+                            riscv::LD_ACCESS_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{1'b0}}, lsu_vaddr_n},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            1'b0,
+                            1'b1
+                        };
                     end
                 end
             end
@@ -410,9 +508,23 @@ module mmu import ariane_pkg::*; #(
         // If translation is not enabled, check the paddr immediately against PMPs
         else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow) begin
             if (lsu_is_store_q) begin
-                lsu_exception_o = {riscv::ST_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1};
+                lsu_exception_o = {
+                    riscv::ST_ACCESS_FAULT,
+                    {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o},
+                    {riscv::XLEN{1'b0}},
+                    {riscv::XLEN{1'b0}},
+                    1'b0,
+                    1'b1
+                };
             end else begin
-                lsu_exception_o = {riscv::LD_ACCESS_FAULT, {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1};
+                lsu_exception_o = {
+                    riscv::LD_ACCESS_FAULT,
+                    {{riscv::XLEN-riscv::PLEN{1'b0}}, lsu_paddr_o},
+                    {riscv::XLEN{1'b0}},
+                    {riscv::XLEN{1'b0}},
+                    1'b0,
+                    1'b1
+                };
             end
         end
     end

--- a/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
@@ -10,6 +10,7 @@
 //
 // Author: Bruno Sá
 // Date: 14/08/2022
+// Acknowledges: Technology Innovation Institute (TII)
 //
 // Description: Memory Management Unit for CV32A6, contains TLB and
 //              address translation unit. Sv39x4 as defined in RISC-V

--- a/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
@@ -98,7 +98,6 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
     logic                   ptw_error_at_g_st;    // PTW threw an exception at the G-Stage
     logic                   ptw_err_at_g_int_st;  // PTW threw an exception at the G-Stage during S-Stage translation
     logic                   ptw_access_exception; // PTW threw an access exception (PMPs)
-    logic [riscv::PLEN-1:0] ptw_bad_paddr; // PTW PMP exception bad physical addr
     logic [riscv::GPLEN-1:0] ptw_bad_gpaddr; // PTW guest page fault bad guest physical addr
 
     logic [riscv::VLEN-1:0] update_vaddr;
@@ -232,7 +231,6 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
         .req_port_o             ( req_port_o            ),
         .pmpcfg_i,
         .pmpaddr_i,
-        .bad_paddr_o            ( ptw_bad_paddr         ),
         .bad_gpaddr_o           ( ptw_bad_gpaddr        ),
         .*
     );

--- a/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
@@ -1,0 +1,704 @@
+// Copyright (c) 2022  Bruno Sá and Zero-Day Labs.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Bruno Sá
+// Date: 14/08/2022
+//
+// Description: Memory Management Unit for CV32A6, contains TLB and
+//              address translation unit. Sv39x4 as defined in RISC-V
+//              privilege specification 1.12.
+//              This module is an adaptation of the MMU Sv39x4 developed
+//              by Florian Zaruba to the Sv39x4 standard.
+
+
+module cva6_mmu_sv39x4 import ariane_pkg::*; #(
+    parameter int unsigned INSTR_TLB_ENTRIES     = 4,
+    parameter int unsigned DATA_TLB_ENTRIES      = 4,
+    parameter int unsigned ASID_WIDTH            = 1,
+    parameter int unsigned VMID_WIDTH            = 1,
+    parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+) (
+    input  logic                            clk_i,
+    input  logic                            rst_ni,
+    input  logic                            flush_i,
+    input  logic                            enable_translation_i,
+    input  logic                            enable_g_translation_i,
+    input  logic                            en_ld_st_translation_i,   // enable virtual memory translation for load/stores
+    input  logic                            en_ld_st_g_translation_i, // enable G-Stage translation for load/stores
+    // IF interface
+    input  icache_areq_o_t                  icache_areq_i,
+    output icache_areq_i_t                  icache_areq_o,
+    // LSU interface
+    // this is a more minimalistic interface because the actual addressing logic is handled
+    // in the LSU as we distinguish load and stores, what we do here is simple address translation
+    input  exception_t                      misaligned_ex_i,
+    input  logic                            lsu_req_i,        // request address translation
+    input  logic [riscv::VLEN-1:0]          lsu_vaddr_i,      // virtual address in
+    input  riscv::xlen_t                    lsu_tinst_i,      // transformed instruction in
+    input  logic                            lsu_is_store_i,   // the translation is requested by a store
+    output logic                            csr_hs_ld_st_inst_o, // hyp load store instruction
+    // if we need to walk the page table we can't grant in the same cycle
+    // Cycle 0
+    output logic                            lsu_dtlb_hit_o,   // sent in the same cycle as the request if translation hits in the DTLB
+    output logic [riscv::PPNW-1:0]          lsu_dtlb_ppn_o,   // ppn (send same cycle as hit)
+    // Cycle 1
+    output logic                            lsu_valid_o,      // translation is valid
+    output logic [riscv::PLEN-1:0]          lsu_paddr_o,      // translated address
+    output exception_t                      lsu_exception_o,  // address translation threw an exception
+    // General control signals
+    input riscv::priv_lvl_t                 priv_lvl_i,
+    input logic                             v_i,
+    input riscv::priv_lvl_t                 ld_st_priv_lvl_i,
+    input logic                             ld_st_v_i,
+    input logic                             sum_i,
+    input logic                             vs_sum_i,
+    input logic                             mxr_i,
+    input logic                             vmxr_i,
+    input logic                             hlvx_inst_i,
+    input logic                             hs_ld_st_inst_i,
+    // input logic flag_mprv_i,
+    input logic [riscv::PPNW-1:0]           satp_ppn_i,
+    input logic [riscv::PPNW-1:0]           vsatp_ppn_i,
+    input logic [riscv::PPNW-1:0]           hgatp_ppn_i,
+    input logic [ASID_WIDTH-1:0]            asid_i,
+    input logic [ASID_WIDTH-1:0]            vs_asid_i,
+    input logic [ASID_WIDTH-1:0]            asid_to_be_flushed_i,
+    input logic [VMID_WIDTH-1:0]            vmid_i,
+    input logic [VMID_WIDTH-1:0]            vmid_to_be_flushed_i,
+    input logic [riscv::VLEN-1:0]           vaddr_to_be_flushed_i,
+    input logic [riscv::GPLEN-1:0]          gpaddr_to_be_flushed_i,
+    input logic                             flush_tlb_i,
+    input logic                             flush_tlb_vvma_i,
+    input logic                             flush_tlb_gvma_i,
+    // Performance counters
+    output logic                            itlb_miss_o,
+    output logic                            dtlb_miss_o,
+    // PTW memory interface
+    input  dcache_req_o_t                   req_port_i,
+    output dcache_req_i_t                   req_port_o,
+    // PMP
+    input  riscv::pmpcfg_t [15:0]           pmpcfg_i,
+    input  logic [15:0][riscv::PLEN-3:0]    pmpaddr_i
+);
+
+    logic                   iaccess_err;   // insufficient privilege to access this instruction page
+    logic                   i_g_st_access_err;   // insufficient privilege at g stage to access this instruction page
+    logic                   daccess_err;   // insufficient privilege to access this data page
+    logic                   d_g_st_access_err;   // insufficient privilege to access this data page
+    logic                   ptw_active;    // PTW is currently walking a page table
+    logic                   walking_instr; // PTW is walking because of an ITLB miss
+    logic                   ptw_error;     // PTW threw an exception
+    logic                   ptw_error_at_g_st;    // PTW threw an exception at the G-Stage
+    logic                   ptw_err_at_g_int_st;  // PTW threw an exception at the G-Stage during S-Stage translation
+    logic                   ptw_access_exception; // PTW threw an access exception (PMPs)
+    logic [riscv::PLEN-1:0] ptw_bad_paddr; // PTW PMP exception bad physical addr
+    logic [riscv::GPLEN-1:0] ptw_bad_gpaddr; // PTW guest page fault bad guest physical addr
+
+    logic [riscv::VLEN-1:0] update_vaddr;
+    tlb_update_sv39x4_t update_ptw_itlb, update_ptw_dtlb;
+
+    logic        itlb_lu_access;
+    riscv::pte_t itlb_content;
+    logic        itlb_is_2M;
+    logic        itlb_is_1G;
+    // data from G-stage translation
+    riscv::pte_t itlb_g_content;
+    logic        itlb_lu_hit;
+    logic [riscv::GPLEN-1:0]  itlb_gpaddr;
+    logic [ASID_WIDTH-1:0]    itlb_lu_asid;
+
+    logic        dtlb_lu_access;
+    riscv::pte_t dtlb_content;
+    logic        dtlb_is_2M;
+    logic        dtlb_is_1G;
+    logic [ASID_WIDTH-1:0]    dtlb_lu_asid;
+    // data from G-stage translation
+    riscv::pte_t dtlb_g_content;
+    logic        dtlb_lu_hit;
+    logic [riscv::GPLEN-1:0] dtlb_gpaddr;
+
+
+    // Assignments
+    assign itlb_lu_access = icache_areq_i.fetch_req;
+    assign dtlb_lu_access = lsu_req_i;
+    assign itlb_lu_asid = v_i ? vs_asid_i : asid_i;
+    assign dtlb_lu_asid = (ld_st_v_i || flush_tlb_vvma_i) ? vs_asid_i : asid_i;
+
+
+    cva6_tlb_sv39x4 #(
+        .TLB_ENTRIES      ( INSTR_TLB_ENTRIES          ),
+        .ASID_WIDTH       ( ASID_WIDTH                 ),
+        .VMID_WIDTH       ( VMID_WIDTH                 )
+    ) i_itlb (
+        .clk_i            ( clk_i                      ),
+        .rst_ni           ( rst_ni                     ),
+        .flush_i          ( flush_tlb_i                ),
+        .flush_vvma_i     ( flush_tlb_vvma_i           ),
+        .flush_gvma_i     ( flush_tlb_gvma_i           ),
+        .s_st_enbl_i      ( enable_translation_i       ),
+        .g_st_enbl_i      ( enable_g_translation_i     ),
+        .v_i              ( v_i                        ),
+
+        .update_i         ( update_ptw_itlb            ),
+
+        .lu_access_i      ( itlb_lu_access             ),
+        .lu_asid_i        ( itlb_lu_asid               ),
+        .lu_vmid_i        ( vmid_i                     ),
+        .asid_to_be_flushed_i  ( asid_to_be_flushed_i  ),
+        .vmid_to_be_flushed_i  ( vmid_to_be_flushed_i  ),
+        .vaddr_to_be_flushed_i ( vaddr_to_be_flushed_i ),
+        .gpaddr_to_be_flushed_i( gpaddr_to_be_flushed_i),
+        .lu_vaddr_i       ( icache_areq_i.fetch_vaddr  ),
+        .lu_content_o     ( itlb_content               ),
+        .lu_g_content_o   ( itlb_g_content             ),
+        .lu_gpaddr_o      ( itlb_gpaddr                ),
+
+        .lu_is_2M_o       ( itlb_is_2M                 ),
+        .lu_is_1G_o       ( itlb_is_1G                 ),
+        .lu_hit_o         ( itlb_lu_hit                )
+    );
+
+    cva6_tlb_sv39x4 #(
+        .TLB_ENTRIES     ( DATA_TLB_ENTRIES             ),
+        .ASID_WIDTH      ( ASID_WIDTH                   ),
+        .VMID_WIDTH      ( VMID_WIDTH                   )
+    ) i_dtlb (
+        .clk_i            ( clk_i                       ),
+        .rst_ni           ( rst_ni                      ),
+        .flush_i          ( flush_tlb_i                 ),
+        .flush_vvma_i     ( flush_tlb_vvma_i            ),
+        .flush_gvma_i     ( flush_tlb_gvma_i            ),
+        .s_st_enbl_i      ( en_ld_st_translation_i      ),
+        .g_st_enbl_i      ( en_ld_st_g_translation_i    ),
+        .v_i              ( ld_st_v_i                   ),
+
+        .update_i         ( update_ptw_dtlb             ),
+
+        .lu_access_i      ( dtlb_lu_access              ),
+        .lu_asid_i        ( dtlb_lu_asid                ),
+        .lu_vmid_i        ( vmid_i                      ),
+	      .asid_to_be_flushed_i  ( asid_to_be_flushed_i   ),
+        .vmid_to_be_flushed_i  ( vmid_to_be_flushed_i   ),
+	      .vaddr_to_be_flushed_i ( vaddr_to_be_flushed_i  ),
+        .gpaddr_to_be_flushed_i( gpaddr_to_be_flushed_i ),
+        .lu_vaddr_i       ( lsu_vaddr_i                 ),
+        .lu_content_o     ( dtlb_content                ),
+        .lu_g_content_o   ( dtlb_g_content              ),
+        .lu_gpaddr_o      ( dtlb_gpaddr                ),
+
+        .lu_is_2M_o       ( dtlb_is_2M                  ),
+        .lu_is_1G_o       ( dtlb_is_1G                  ),
+        .lu_hit_o         ( dtlb_lu_hit                 )
+    );
+
+
+    cva6_ptw_sv39x4  #(
+        .ASID_WIDTH             ( ASID_WIDTH            ),
+        .VMID_WIDTH             ( VMID_WIDTH            ),
+        .ArianeCfg              ( ArianeCfg             )
+    ) i_ptw (
+        .clk_i                  ( clk_i                 ),
+        .rst_ni                 ( rst_ni                ),
+        .ptw_active_o           ( ptw_active            ),
+        .walking_instr_o        ( walking_instr         ),
+        .ptw_error_o            ( ptw_error             ),
+        .ptw_error_at_g_st_o    ( ptw_error_at_g_st     ),
+        .ptw_err_at_g_int_st_o  ( ptw_err_at_g_int_st   ),
+        .ptw_access_exception_o ( ptw_access_exception  ),
+        .enable_translation_i   ( enable_translation_i  ),
+        .enable_g_translation_i ( enable_g_translation_i),
+
+        .update_vaddr_o         ( update_vaddr          ),
+        .itlb_update_o          ( update_ptw_itlb       ),
+        .dtlb_update_o          ( update_ptw_dtlb       ),
+
+        .itlb_access_i          ( itlb_lu_access        ),
+        .itlb_hit_i             ( itlb_lu_hit           ),
+        .itlb_vaddr_i           ( icache_areq_i.fetch_vaddr ),
+
+        .dtlb_access_i          ( dtlb_lu_access        ),
+        .dtlb_hit_i             ( dtlb_lu_hit           ),
+        .dtlb_vaddr_i           ( lsu_vaddr_i           ),
+        .hlvx_inst_i            ( hlvx_inst_i           ),
+
+        .req_port_i             ( req_port_i            ),
+        .req_port_o             ( req_port_o            ),
+        .pmpcfg_i,
+        .pmpaddr_i,
+        .bad_paddr_o            ( ptw_bad_paddr         ),
+        .bad_gpaddr_o           ( ptw_bad_gpaddr        ),
+        .*
+    );
+
+    // ila_1 i_ila_1 (
+    //     .clk(clk_i), // input wire clk
+    //     .probe0({req_port_o.address_tag, req_port_o.address_index}),
+    //     .probe1(req_port_o.data_req), // input wire [63:0]  probe1
+    //     .probe2(req_port_i.data_gnt), // input wire [0:0]  probe2
+    //     .probe3(req_port_i.data_rdata), // input wire [0:0]  probe3
+    //     .probe4(req_port_i.data_rvalid), // input wire [0:0]  probe4
+    //     .probe5(ptw_error), // input wire [1:0]  probe5
+    //     .probe6(update_vaddr), // input wire [0:0]  probe6
+    //     .probe7(update_ptw_itlb.valid), // input wire [0:0]  probe7
+    //     .probe8(update_ptw_dtlb.valid), // input wire [0:0]  probe8
+    //     .probe9(dtlb_lu_access), // input wire [0:0]  probe9
+    //     .probe10(lsu_vaddr_i), // input wire [0:0]  probe10
+    //     .probe11(dtlb_lu_hit), // input wire [0:0]  probe11
+    //     .probe12(itlb_lu_access), // input wire [0:0]  probe12
+    //     .probe13(icache_areq_i.fetch_vaddr), // input wire [0:0]  probe13
+    //     .probe14(itlb_lu_hit) // input wire [0:0]  probe13
+    // );
+
+    //-----------------------
+    // Instruction Interface
+    //-----------------------
+    logic match_any_execute_region;
+    logic pmp_instr_allow;
+    // The instruction interface is a simple request response interface
+    always_comb begin : instr_interface
+        // MMU disabled: just pass through
+        icache_areq_o.fetch_valid  = icache_areq_i.fetch_req;
+        icache_areq_o.fetch_paddr  = icache_areq_i.fetch_vaddr[riscv::PLEN-1:0]; // play through in case we disabled address translation
+        // two potential exception sources:
+        // 1. HPTW threw an exception -> signal with a page fault exception
+        // 2. We got an access error because of insufficient permissions -> throw an access exception
+        icache_areq_o.fetch_exception      = '0;
+        // Check whether we are allowed to access this memory region from a fetch perspective
+        iaccess_err   = icache_areq_i.fetch_req && enable_translation_i && (((priv_lvl_i == riscv::PRIV_LVL_U) && ~itlb_content.u)
+                                                    || ((priv_lvl_i == riscv::PRIV_LVL_S) && itlb_content.u));
+
+        i_g_st_access_err = icache_areq_i.fetch_req && enable_g_translation_i && !itlb_g_content.u;
+        // MMU enabled: address from TLB, request delayed until hit. Error when TLB
+        // hit and no access right or TLB hit and translated address not valid (e.g.
+        // AXI decode error), or when PTW performs walk due to ITLB miss and raises
+        // an error.
+        if ((enable_translation_i || enable_g_translation_i)) begin
+            // we work with SV39 or SV32, so if VM is enabled, check that all bits [riscv::VLEN-1:riscv::SV-1] are equal
+            if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b1 || (|icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b0)) begin
+                icache_areq_o.fetch_exception = {
+                    riscv::INSTR_ACCESS_FAULT,
+                    {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
+                    {{riscv::XLEN{1'b0}}},
+                    {{riscv::XLEN{1'b0}}},
+                    v_i,
+                    1'b1
+                };
+            end
+
+            icache_areq_o.fetch_valid = 1'b0;
+
+            // 4K page
+            icache_areq_o.fetch_paddr = {enable_g_translation_i ? itlb_g_content.ppn : itlb_content.ppn, icache_areq_i.fetch_vaddr[11:0]};
+            // Mega page
+            if (itlb_is_2M) begin
+                icache_areq_o.fetch_paddr[20:12] = icache_areq_i.fetch_vaddr[20:12];
+            end
+            // Giga page
+            if (itlb_is_1G) begin
+                icache_areq_o.fetch_paddr[29:12] = icache_areq_i.fetch_vaddr[29:12];
+            end
+            // ---------
+            // ITLB Hit
+            // --------
+            // if we hit the ITLB output the request signal immediately
+            if (itlb_lu_hit) begin
+                icache_areq_o.fetch_valid = icache_areq_i.fetch_req;
+                if (i_g_st_access_err) begin
+                    icache_areq_o.fetch_exception = {
+                        riscv::INSTR_GUEST_PAGE_FAULT,
+                        {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
+                        {{riscv::XLEN-riscv::GPLEN{1'b0}},itlb_gpaddr[riscv::GPLEN-1:0]},
+                        {riscv::XLEN{1'b0}},
+                        v_i,
+                        1'b1
+                    };
+                    // we got an access error
+                end else if (iaccess_err) begin
+                    // throw a page fault
+                    icache_areq_o.fetch_exception = {
+                        riscv::INSTR_PAGE_FAULT,
+                        {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
+                        {riscv::XLEN{1'b0}},
+                        {riscv::XLEN{1'b0}},
+                        v_i,
+                        1'b1
+                    };
+                end else if (!pmp_instr_allow) begin
+                    icache_areq_o.fetch_exception = {
+                        riscv::INSTR_ACCESS_FAULT,
+                        {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_i.fetch_vaddr},
+                        {riscv::XLEN{1'b0}},
+                        {riscv::XLEN{1'b0}},
+                        v_i,
+                        1'b1
+                    };
+                end
+            end else
+            // ---------
+            // ITLB Miss
+            // ---------
+            // watch out for exceptions happening during walking the page table
+            if (ptw_active && walking_instr) begin
+                icache_areq_o.fetch_valid = ptw_error | ptw_access_exception;
+                if (ptw_error) begin
+                    if (ptw_error_at_g_st) begin
+                        icache_areq_o.fetch_exception = {
+                            riscv::INSTR_GUEST_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
+                            {{riscv::XLEN-riscv::GPLEN{1'b0}},ptw_bad_gpaddr},
+                            (ptw_err_at_g_int_st ? (riscv::IS_XLEN64 ? riscv::READ_64_PSEUDOINSTRUCTION : riscv::READ_32_PSEUDOINSTRUCTION) : {riscv::XLEN{1'b0}}),
+                            v_i,
+                            1'b1
+                        };
+                    end else begin
+                        icache_areq_o.fetch_exception = {
+                            riscv::INSTR_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
+                            {riscv::XLEN{1'b0}},
+                            {riscv::XLEN{1'b0}},
+                            v_i,
+                            1'b1
+                        };
+                    end
+                end
+                // TODO(moschn,zarubaf): What should the value of tval be in this case?
+                else  icache_areq_o.fetch_exception = {
+                          riscv::INSTR_ACCESS_FAULT,
+                          {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
+                          {riscv::XLEN{1'b0}},
+                          {riscv::XLEN{1'b0}},
+                          v_i,
+                          1'b1
+                      };
+            end
+        end
+        // if it didn't match any execute region throw an `Instruction Access Fault`
+        // or: if we are not translating, check PMPs immediately on the paddr
+        if ((!match_any_execute_region && !ptw_error) || (!(enable_translation_i || enable_g_translation_i) && !pmp_instr_allow)) begin
+          icache_areq_o.fetch_exception = {
+              riscv::INSTR_ACCESS_FAULT,
+              {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr},
+              {riscv::XLEN{1'b0}},
+              {riscv::XLEN{1'b0}},
+              v_i,
+              1'b1
+          };
+        end
+    end
+
+    // check for execute flag on memory
+    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(ArianeCfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
+
+    // Instruction fetch
+    pmp #(
+        .PLEN       ( riscv::PLEN            ),
+        .PMP_LEN    ( riscv::PLEN - 2        ),
+        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+    ) i_pmp_if (
+        .addr_i        ( icache_areq_o.fetch_paddr ),
+        .priv_lvl_i,
+        // we will always execute on the instruction fetch port
+        .access_type_i ( riscv::ACCESS_EXEC        ),
+        // Configuration
+        .conf_addr_i   ( pmpaddr_i                 ),
+        .conf_i        ( pmpcfg_i                  ),
+        .allow_o       ( pmp_instr_allow           )
+    );
+
+    //-----------------------
+    // Data Interface
+    //-----------------------
+    logic [riscv::VLEN-1:0] lsu_vaddr_n,     lsu_vaddr_q;
+    logic [riscv::VLEN-1:0] lsu_gpaddr_n,    lsu_gpaddr_q;
+    logic [riscv::XLEN-1:0] lsu_tinst_n,     lsu_tinst_q;
+    logic                   hs_ld_st_inst_n, hs_ld_st_inst_q;
+    riscv::pte_t dtlb_pte_n,      dtlb_pte_q;
+    riscv::pte_t dtlb_gpte_n,     dtlb_gpte_q;
+    exception_t  misaligned_ex_n, misaligned_ex_q;
+    logic        lsu_req_n,       lsu_req_q;
+    logic        lsu_is_store_n,  lsu_is_store_q;
+    logic        dtlb_hit_n,      dtlb_hit_q;
+    logic        dtlb_is_2M_n,    dtlb_is_2M_q;
+    logic        dtlb_is_1G_n,    dtlb_is_1G_q;
+
+    // check if we need to do translation or if we are always ready (e.g.: we are not translating anything)
+    assign lsu_dtlb_hit_o = (en_ld_st_translation_i || en_ld_st_g_translation_i) ? dtlb_lu_hit :  1'b1;
+
+    // Wires to PMP checks
+    riscv::pmp_access_t pmp_access_type;
+    logic        pmp_data_allow;
+    localparam   PPNWMin = (riscv::PPNW-1 > 29) ? 29 : riscv::PPNW-1;
+    // The data interface is simpler and only consists of a request/response interface
+    always_comb begin : data_interface
+        // save request and DTLB response
+        lsu_vaddr_n           = lsu_vaddr_i;
+        lsu_tinst_n           = lsu_tinst_i;
+        lsu_gpaddr_n          = dtlb_gpaddr;
+        lsu_req_n             = lsu_req_i;
+        hs_ld_st_inst_n       = hs_ld_st_inst_i;
+        misaligned_ex_n       = misaligned_ex_i;
+        dtlb_pte_n            = dtlb_content;
+        dtlb_gpte_n           = dtlb_g_content;
+        dtlb_hit_n            = dtlb_lu_hit;
+        lsu_is_store_n        = lsu_is_store_i;
+        dtlb_is_2M_n          = dtlb_is_2M;
+        dtlb_is_1G_n          = dtlb_is_1G;
+
+        lsu_paddr_o           = lsu_vaddr_q[riscv::PLEN-1:0];
+        lsu_dtlb_ppn_o        = lsu_vaddr_n[riscv::PLEN-1:12];
+        lsu_valid_o           = lsu_req_q;
+        lsu_exception_o       = misaligned_ex_q;
+        csr_hs_ld_st_inst_o   = hs_ld_st_inst_i || hs_ld_st_inst_q;
+        pmp_access_type       = lsu_is_store_q ? riscv::ACCESS_WRITE : riscv::ACCESS_READ;
+
+        // mute misaligned exceptions if there is no request otherwise they will throw accidental exceptions
+        misaligned_ex_n.valid = misaligned_ex_i.valid & lsu_req_i;
+
+        // Check if the User flag is set, then we may only access it in supervisor mode
+        // if SUM is enabled
+        daccess_err = en_ld_st_translation_i &&
+                        ((ld_st_priv_lvl_i == riscv::PRIV_LVL_S && (ld_st_v_i ? !vs_sum_i : !sum_i ) && dtlb_pte_q.u) || // SUM is not set and we are trying to access a user page in supervisor mode
+                        (ld_st_priv_lvl_i == riscv::PRIV_LVL_U && !dtlb_pte_q.u));
+        d_g_st_access_err = en_ld_st_g_translation_i && !dtlb_gpte_q.u;
+        // translation is enabled and no misaligned exception occurred
+        if ((en_ld_st_translation_i || en_ld_st_g_translation_i) && !misaligned_ex_q.valid) begin
+            lsu_valid_o = 1'b0;
+            // 4K page
+            lsu_paddr_o = {(en_ld_st_g_translation_i) ? dtlb_gpte_q.ppn : dtlb_pte_q.ppn, lsu_vaddr_q[11:0]};
+            lsu_dtlb_ppn_o = (en_ld_st_g_translation_i) ? dtlb_g_content.ppn : dtlb_content.ppn;
+            // Mega page
+            if (dtlb_is_2M_q) begin
+                  lsu_paddr_o[20:12]    = lsu_vaddr_q[20:12];
+                  lsu_dtlb_ppn_o[20:12] =  lsu_vaddr_n[20:12];
+            end
+            // Giga page
+            if (dtlb_is_1G_q) begin
+                  lsu_paddr_o[PPNWMin:12]    = lsu_vaddr_q[PPNWMin:12];
+                  lsu_dtlb_ppn_o[PPNWMin:12] =  lsu_vaddr_n[PPNWMin:12];
+            end
+            // ---------
+            // DTLB Hit
+            // --------
+            if (dtlb_hit_q && lsu_req_q) begin
+                lsu_valid_o = 1'b1;
+                // exception priority:
+                // PAGE_FAULTS have higher priority than ACCESS_FAULTS
+                // virtual memory based exceptions are PAGE_FAULTS
+                // physical memory based exceptions are ACCESS_FAULTS (PMA/PMP)
+
+                // this is a store
+                if (lsu_is_store_q) begin
+                    // check if the page is write-able and we are not violating privileges
+                    // also check if the dirty flag is set
+                    if(en_ld_st_g_translation_i && (!dtlb_gpte_q.w || d_g_st_access_err || !dtlb_gpte_q.d)) begin
+                        lsu_exception_o = {
+                            riscv::STORE_GUEST_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
+                            {{riscv::XLEN-riscv::GPLEN{1'b0}},lsu_gpaddr_q},
+                            {riscv::XLEN{1'b0}},
+                            ld_st_v_i,
+                            1'b1
+                        };
+                    end else if (en_ld_st_translation_i && (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d)) begin
+                        lsu_exception_o = {
+                            riscv::STORE_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
+                            {riscv::XLEN{1'b0}},
+                            lsu_tinst_q,
+                            ld_st_v_i,
+                            1'b1
+                        };
+                    // Check if any PMPs are violated
+                    end else if (!pmp_data_allow) begin
+                        lsu_exception_o = {
+                            riscv::ST_ACCESS_FAULT,
+                            {{riscv::XLEN-riscv::PLEN{1'b0}},lsu_paddr_o},
+                            {riscv::XLEN{1'b0}},
+                            lsu_tinst_q,
+                            ld_st_v_i,
+                            1'b1
+                        };
+                    end
+
+                // this is a load
+                end else begin
+                    if (d_g_st_access_err) begin
+                        lsu_exception_o = {
+                            riscv::LOAD_GUEST_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
+                            {{riscv::XLEN-riscv::GPLEN{1'b0}},lsu_gpaddr_q},
+                            {riscv::XLEN{1'b0}},
+                            ld_st_v_i,
+                            1'b1
+                        };
+                    // check for sufficient access privileges - throw a page fault if necessary
+                    end else if (daccess_err) begin
+                        lsu_exception_o = {
+                            riscv::LOAD_PAGE_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
+                            {riscv::XLEN{1'b0}},
+                            lsu_tinst_q,
+                            ld_st_v_i,
+                            1'b1
+                        };
+                    // Check if any PMPs are violated
+                    end else if (!pmp_data_allow) begin
+                        lsu_exception_o = {
+                            riscv::LD_ACCESS_FAULT,
+                            {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
+                            {riscv::XLEN{1'b0}},
+                            lsu_tinst_q,
+                            ld_st_v_i,
+                            1'b1
+                        };
+                    end
+                end
+            end else
+
+            // ---------
+            // DTLB Miss
+            // ---------
+            // watch out for exceptions
+            if (ptw_active && !walking_instr) begin
+                // page table walker threw an exception
+                if (ptw_error) begin
+                    // an error makes the translation valid
+                    lsu_valid_o = 1'b1;
+                    // the page table walker can only throw page faults
+                    if (lsu_is_store_q) begin
+                        if (ptw_error_at_g_st) begin
+                            lsu_exception_o = {
+                                riscv::STORE_GUEST_PAGE_FAULT,
+                                {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                                {{riscv::XLEN-riscv::GPLEN{1'b0}},ptw_bad_gpaddr},
+                                (ptw_err_at_g_int_st ? (riscv::IS_XLEN64 ? riscv::READ_64_PSEUDOINSTRUCTION : riscv::READ_32_PSEUDOINSTRUCTION) : {riscv::XLEN{1'b0}}),
+                                ld_st_v_i,
+                                1'b1
+                            };
+                        end else begin
+                            lsu_exception_o = {
+                                riscv::STORE_PAGE_FAULT,
+                                {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                                {riscv::XLEN{1'b0}},
+                                lsu_tinst_q,
+                                ld_st_v_i,
+                                1'b1
+                            };
+                        end
+                    end else begin
+                        if (ptw_error_at_g_st) begin
+                            lsu_exception_o = {
+                                riscv::LOAD_GUEST_PAGE_FAULT,
+                                {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                                {{riscv::XLEN-riscv::GPLEN{1'b0}},ptw_bad_gpaddr},
+                                (ptw_err_at_g_int_st ? (riscv::IS_XLEN64 ? riscv::READ_64_PSEUDOINSTRUCTION : riscv::READ_32_PSEUDOINSTRUCTION) : {riscv::XLEN{1'b0}}),
+                                ld_st_v_i,
+                                1'b1
+                            };
+                        end else begin
+                            lsu_exception_o = {
+                                riscv::LOAD_PAGE_FAULT,
+                                {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                                {riscv::XLEN{1'b0}},
+                                lsu_tinst_q,
+                                ld_st_v_i,
+                                1'b1
+                            };
+                        end
+                    end
+                end
+
+                if (ptw_access_exception) begin
+                    // an error makes the translation valid
+                    lsu_valid_o = 1'b1;
+                    // the page table walker can only throw page faults
+                    lsu_exception_o = {
+                        riscv::LD_ACCESS_FAULT,
+                        {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                        {riscv::XLEN{1'b0}},
+                        lsu_tinst_q,
+                        ld_st_v_i,
+                        1'b1
+                    };
+                end
+            end
+        end
+        // If translation is not enabled, check the paddr immediately against PMPs
+        else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow) begin
+            if (lsu_is_store_q) begin
+                lsu_exception_o = {
+                    riscv::ST_ACCESS_FAULT,
+                    {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_tinst_q,
+                    ld_st_v_i,
+                    1'b1
+                };
+            end else begin
+                lsu_exception_o = {
+                    riscv::LD_ACCESS_FAULT,
+                    {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
+                    {riscv::XLEN{1'b0}},
+                    lsu_tinst_q,
+                    ld_st_v_i,
+                    1'b1
+                };
+            end
+        end
+    end
+
+    // Load/store PMP check
+    pmp #(
+        .PLEN       ( riscv::PLEN            ),
+        .PMP_LEN    ( riscv::PLEN - 2        ),
+        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+    ) i_pmp_data (
+        .addr_i        ( lsu_paddr_o         ),
+        .priv_lvl_i    ( ld_st_priv_lvl_i    ),
+        .access_type_i ( pmp_access_type     ),
+        // Configuration
+        .conf_addr_i   ( pmpaddr_i           ),
+        .conf_i        ( pmpcfg_i            ),
+        .allow_o       ( pmp_data_allow      )
+    );
+
+    // ----------
+    // Registers
+    // ----------
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (~rst_ni) begin
+            lsu_vaddr_q      <= '0;
+            lsu_gpaddr_q     <= '0;
+            lsu_tinst_q      <= '0;
+            hs_ld_st_inst_q  <= '0;
+            lsu_req_q        <= '0;
+            misaligned_ex_q  <= '0;
+            dtlb_pte_q       <= '0;
+            dtlb_gpte_q      <= '0;
+            dtlb_hit_q       <= '0;
+            lsu_is_store_q   <= '0;
+            dtlb_is_2M_q     <= '0;
+            dtlb_is_1G_q     <= '0;
+        end else begin
+            lsu_vaddr_q      <=  lsu_vaddr_n;
+            lsu_gpaddr_q     <=  lsu_gpaddr_n;
+            lsu_tinst_q      <=  lsu_tinst_n;
+            hs_ld_st_inst_q  <= hs_ld_st_inst_n;
+            lsu_req_q        <=  lsu_req_n;
+            misaligned_ex_q  <=  misaligned_ex_n;
+            dtlb_pte_q       <=  dtlb_pte_n;
+            dtlb_gpte_q      <=  dtlb_gpte_n;
+            dtlb_hit_q       <=  dtlb_hit_n;
+            lsu_is_store_q   <=  lsu_is_store_n;
+            dtlb_is_2M_q     <=  dtlb_is_2M_n;
+            dtlb_is_1G_q     <=  dtlb_is_1G_n;
+        end
+    end
+endmodule

--- a/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
@@ -284,7 +284,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                 icache_areq_o.fetch_exception = {
                     riscv::INSTR_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                    {{riscv::XLEN{1'b0}}},
+                    {riscv::GPLEN{1'b0}},
                     {{riscv::XLEN{1'b0}}},
                     v_i,
                     1'b1
@@ -313,7 +313,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                     icache_areq_o.fetch_exception = {
                         riscv::INSTR_GUEST_PAGE_FAULT,
                         {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                        {{riscv::XLEN-riscv::GPLEN{1'b0}},itlb_gpaddr[riscv::GPLEN-1:0]},
+                        itlb_gpaddr[riscv::GPLEN-1:0],
                         {riscv::XLEN{1'b0}},
                         v_i,
                         1'b1
@@ -324,7 +324,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                     icache_areq_o.fetch_exception = {
                         riscv::INSTR_PAGE_FAULT,
                         {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         v_i,
                         1'b1
@@ -333,7 +333,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                     icache_areq_o.fetch_exception = {
                         riscv::INSTR_ACCESS_FAULT,
                         {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         {riscv::XLEN{1'b0}},
                         v_i,
                         1'b1
@@ -351,7 +351,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         icache_areq_o.fetch_exception = {
                             riscv::INSTR_GUEST_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
-                            {{riscv::XLEN-riscv::GPLEN{1'b0}},ptw_bad_gpaddr},
+                            ptw_bad_gpaddr[riscv::GPLEN-1:0],
                             (ptw_err_at_g_int_st ? (riscv::IS_XLEN64 ? riscv::READ_64_PSEUDOINSTRUCTION : riscv::READ_32_PSEUDOINSTRUCTION) : {riscv::XLEN{1'b0}}),
                             v_i,
                             1'b1
@@ -360,7 +360,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         icache_areq_o.fetch_exception = {
                             riscv::INSTR_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             {riscv::XLEN{1'b0}},
                             v_i,
                             1'b1
@@ -371,7 +371,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                 else  icache_areq_o.fetch_exception = {
                           riscv::INSTR_ACCESS_FAULT,
                           {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr},
-                          {riscv::XLEN{1'b0}},
+                          {riscv::GPLEN{1'b0}},
                           {riscv::XLEN{1'b0}},
                           v_i,
                           1'b1
@@ -384,7 +384,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
           icache_areq_o.fetch_exception = {
               riscv::INSTR_ACCESS_FAULT,
               {{riscv::XLEN-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr},
-              {riscv::XLEN{1'b0}},
+              {riscv::GPLEN{1'b0}},
               {riscv::XLEN{1'b0}},
               v_i,
               1'b1
@@ -500,7 +500,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::STORE_GUEST_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {{riscv::XLEN-riscv::GPLEN{1'b0}},lsu_gpaddr_q},
+                            lsu_gpaddr_q[riscv::GPLEN-1:0],
                             {riscv::XLEN{1'b0}},
                             ld_st_v_i,
                             1'b1
@@ -509,7 +509,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::STORE_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             lsu_tinst_q,
                             ld_st_v_i,
                             1'b1
@@ -519,7 +519,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::ST_ACCESS_FAULT,
                             {{riscv::XLEN-riscv::PLEN{1'b0}},lsu_paddr_o},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             lsu_tinst_q,
                             ld_st_v_i,
                             1'b1
@@ -532,7 +532,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LOAD_GUEST_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {{riscv::XLEN-riscv::GPLEN{1'b0}},lsu_gpaddr_q},
+                            lsu_gpaddr_q[riscv::GPLEN-1:0],
                             {riscv::XLEN{1'b0}},
                             ld_st_v_i,
                             1'b1
@@ -542,7 +542,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LOAD_PAGE_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             lsu_tinst_q,
                             ld_st_v_i,
                             1'b1
@@ -552,7 +552,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                         lsu_exception_o = {
                             riscv::LD_ACCESS_FAULT,
                             {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q},
-                            {riscv::XLEN{1'b0}},
+                            {riscv::GPLEN{1'b0}},
                             lsu_tinst_q,
                             ld_st_v_i,
                             1'b1
@@ -576,7 +576,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                             lsu_exception_o = {
                                 riscv::STORE_GUEST_PAGE_FAULT,
                                 {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                                {{riscv::XLEN-riscv::GPLEN{1'b0}},ptw_bad_gpaddr},
+                                ptw_bad_gpaddr[riscv::GPLEN-1:0],
                                 (ptw_err_at_g_int_st ? (riscv::IS_XLEN64 ? riscv::READ_64_PSEUDOINSTRUCTION : riscv::READ_32_PSEUDOINSTRUCTION) : {riscv::XLEN{1'b0}}),
                                 ld_st_v_i,
                                 1'b1
@@ -585,7 +585,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                             lsu_exception_o = {
                                 riscv::STORE_PAGE_FAULT,
                                 {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                                {riscv::XLEN{1'b0}},
+                                {riscv::GPLEN{1'b0}},
                                 lsu_tinst_q,
                                 ld_st_v_i,
                                 1'b1
@@ -596,7 +596,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                             lsu_exception_o = {
                                 riscv::LOAD_GUEST_PAGE_FAULT,
                                 {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                                {{riscv::XLEN-riscv::GPLEN{1'b0}},ptw_bad_gpaddr},
+                                ptw_bad_gpaddr[riscv::GPLEN-1:0],
                                 (ptw_err_at_g_int_st ? (riscv::IS_XLEN64 ? riscv::READ_64_PSEUDOINSTRUCTION : riscv::READ_32_PSEUDOINSTRUCTION) : {riscv::XLEN{1'b0}}),
                                 ld_st_v_i,
                                 1'b1
@@ -605,7 +605,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                             lsu_exception_o = {
                                 riscv::LOAD_PAGE_FAULT,
                                 {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                                {riscv::XLEN{1'b0}},
+                                {riscv::GPLEN{1'b0}},
                                 lsu_tinst_q,
                                 ld_st_v_i,
                                 1'b1
@@ -621,7 +621,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                     lsu_exception_o = {
                         riscv::LD_ACCESS_FAULT,
                         {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                        {riscv::XLEN{1'b0}},
+                        {riscv::GPLEN{1'b0}},
                         lsu_tinst_q,
                         ld_st_v_i,
                         1'b1
@@ -635,7 +635,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                 lsu_exception_o = {
                     riscv::ST_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_tinst_q,
                     ld_st_v_i,
                     1'b1
@@ -644,7 +644,7 @@ module cva6_mmu_sv39x4 import ariane_pkg::*; #(
                 lsu_exception_o = {
                     riscv::LD_ACCESS_FAULT,
                     {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr},
-                    {riscv::XLEN{1'b0}},
+                    {riscv::GPLEN{1'b0}},
                     lsu_tinst_q,
                     ld_st_v_i,
                     1'b1

--- a/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
@@ -10,6 +10,7 @@
 //
 // Author: Bruno Sá
 // Date: 14/08/2022
+// Acknowledges: Technology Innovation Institute (TII)
 //
 // Description: Hardware-PTW (Page-Table-Walker) for MMU Sv39x4.
 //              This module is an adaptation of the Sv39 PTW developed

--- a/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
@@ -1,0 +1,615 @@
+// Copyright (c) 2022  Bruno Sá and Zero-Day Labs.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Bruno Sá
+// Date: 14/08/2022
+//
+// Description: Hardware-PTW (Page-Table-Walker) for MMU Sv39x4.
+//              This module is an adaptation of the Sv39 PTW developed
+//              by Florian Zaruba and David Schaffenrath to the Sv39x4 standard.
+//
+
+/* verilator lint_off WIDTH */
+
+module cva6_ptw_sv39x4 import ariane_pkg::*; #(
+        parameter int ASID_WIDTH = 1,
+        parameter int VMID_WIDTH = 1,
+        parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+) (
+    input  logic                    clk_i,                  // Clock
+    input  logic                    rst_ni,                 // Asynchronous reset active low
+    input  logic                    flush_i,                // flush everything, we need to do this because
+                                                            // actually everything we do is speculative at this stage
+                                                            // e.g.: there could be a CSR instruction that changes everything
+    output logic                    ptw_active_o,
+    output logic                    walking_instr_o,        // set when walking for TLB
+    output logic                    ptw_error_o,            // set when an error occurred
+    output logic                    ptw_error_at_g_st_o,    // set when an error occurred at the G-Stage
+    output logic                    ptw_err_at_g_int_st_o,  // set when an error occurred at the G-Stage during S-Stage translation
+    output logic                    ptw_access_exception_o, // set when an PMP access exception occured
+    input  logic                    enable_translation_i,   // CSRs indicate to enable SV39 VS-Stage translation
+    input  logic                    enable_g_translation_i, // CSRs indicate to enable SV39  G-Stage translation
+    input  logic                    en_ld_st_translation_i, // enable virtual memory translation for load/stores
+    input  logic                    en_ld_st_g_translation_i, // enable G-Stage translation for load/stores
+    input  logic                    v_i,
+    input  logic                    ld_st_v_i,
+    input  logic                    hlvx_inst_i,          // is a HLVX load/store instruction
+
+    input  logic                    lsu_is_store_i,         // this translation was triggered by a store
+    // PTW memory interface
+    input  dcache_req_o_t           req_port_i,
+    output dcache_req_i_t           req_port_o,
+
+
+    // to TLBs, update logic
+    output tlb_update_sv39x4_t      itlb_update_o,
+    output tlb_update_sv39x4_t      dtlb_update_o,
+
+    output logic [riscv::VLEN-1:0]  update_vaddr_o,
+
+    input  logic [ASID_WIDTH-1:0]   asid_i,
+    input  logic [ASID_WIDTH-1:0]   vs_asid_i,
+    input  logic [VMID_WIDTH-1:0]   vmid_i,
+    // from TLBs
+    // did we miss?
+    input  logic                    itlb_access_i,
+    input  logic                    itlb_hit_i,
+    input  logic [riscv::VLEN-1:0]  itlb_vaddr_i,
+
+    input  logic                    dtlb_access_i,
+    input  logic                    dtlb_hit_i,
+    input  logic [riscv::VLEN-1:0]  dtlb_vaddr_i,
+    // from CSR file
+    input  logic [riscv::PPNW-1:0]  satp_ppn_i, // ppn from satp
+    input  logic [riscv::PPNW-1:0]  vsatp_ppn_i, // ppn from satp
+    input  logic [riscv::PPNW-1:0]  hgatp_ppn_i,// ppn from hgatp
+    input  logic                    mxr_i,
+    input  logic                    vmxr_i,
+    // Performance counters
+    output logic                    itlb_miss_o,
+    output logic                    dtlb_miss_o,
+    // PMP
+
+    input  riscv::pmpcfg_t [15:0]   pmpcfg_i,
+    input  logic [15:0][riscv::PLEN-3:0] pmpaddr_i,
+    output logic [riscv::PLEN-1:0]  bad_paddr_o,
+    output logic [riscv::GPLEN-1:0] bad_gpaddr_o
+
+);
+
+    // input registers
+    logic data_rvalid_q;
+    logic [63:0] data_rdata_q;
+
+    riscv::pte_t pte;
+    riscv::pte_t gpte_q, gpte_d;
+    assign pte = riscv::pte_t'(data_rdata_q);
+
+    enum logic[2:0] {
+      IDLE,
+      WAIT_GRANT,
+      PTE_LOOKUP,
+      WAIT_RVALID,
+      PROPAGATE_ERROR,
+      PROPAGATE_ACCESS_ERROR
+    } state_q, state_d;
+
+    // SV39 defines three levels of page tables
+    enum logic [1:0] {
+        LVL1, LVL2, LVL3
+    } ptw_lvl_q, ptw_lvl_n, gptw_lvl_q, gptw_lvl_n;
+
+    // ptw stages
+    enum logic [1:0] {
+        S_STAGE,
+        G_INTERMED_STAGE,
+        G_FINAL_STAGE
+    } ptw_stage_q, ptw_stage_d;
+
+    // is this an instruction page table walk?
+    logic is_instr_ptw_q,   is_instr_ptw_n;
+    logic global_mapping_q, global_mapping_n;
+    // latched tag signal
+    logic tag_valid_n,      tag_valid_q;
+    // register the ASID
+    logic [ASID_WIDTH-1:0]  tlb_update_asid_q, tlb_update_asid_n;
+    // register the VMID
+    logic [VMID_WIDTH-1:0]  tlb_update_vmid_q, tlb_update_vmid_n;
+    // register the VPN we need to walk, SV39 defines a 39 bit virtual address
+    logic [riscv::VLEN-1:0] vaddr_q,   vaddr_n;
+    // register the VPN we need to walk, SV39 defines a 41 bit virtual address for the G-Stage
+    logic [riscv::GPLEN-1:0] gpaddr_q, gpaddr_n;
+    // 4 byte aligned physical pointer
+    logic [riscv::PLEN-1:0] ptw_pptr_q, ptw_pptr_n;
+    logic [riscv::PLEN-1:0] gptw_pptr_q, gptw_pptr_n;
+
+    // Assignments
+    assign update_vaddr_o  = vaddr_q;
+
+    assign ptw_active_o    = (state_q != IDLE);
+    assign walking_instr_o = is_instr_ptw_q;
+    // directly output the correct physical address
+    assign req_port_o.address_index = ptw_pptr_q[DCACHE_INDEX_WIDTH-1:0];
+    assign req_port_o.address_tag   = ptw_pptr_q[DCACHE_INDEX_WIDTH+DCACHE_TAG_WIDTH-1:DCACHE_INDEX_WIDTH];
+    // we are never going to kill this request
+    assign req_port_o.kill_req      = '0;
+    // we are never going to write with the HPTW
+    assign req_port_o.data_wdata    = 64'b0;
+    // -----------
+    // TLB Update
+    // -----------
+    assign itlb_update_o.vpn = {{39-riscv::SV{1'b0}}, vaddr_q[riscv::SV-1:12]};
+    assign dtlb_update_o.vpn = {{39-riscv::SV{1'b0}}, vaddr_q[riscv::SV-1:12]};
+    assign itlb_update_o.gppn = {{41-riscv::SVX{1'b0}}, gpaddr_q[riscv::SVX-1:12]};
+    assign dtlb_update_o.gppn = {{41-riscv::SVX{1'b0}}, gpaddr_q[riscv::SVX-1:12]};
+    // update the correct page table level
+    assign itlb_update_o.is_2M = (enable_translation_i && enable_g_translation_i) ?
+                                 ((gptw_lvl_q == LVL2 && ptw_lvl_q != LVL3) || (ptw_lvl_q == LVL2 && gptw_lvl_q != LVL3)) :
+                                 (ptw_lvl_q == LVL2);
+    assign itlb_update_o.is_1G = (enable_translation_i && enable_g_translation_i) ?
+                                 ((gptw_lvl_q == LVL1 && ptw_lvl_q == LVL1)) :
+                                 (ptw_lvl_q == LVL1);
+    assign dtlb_update_o.is_2M = (en_ld_st_translation_i && en_ld_st_g_translation_i) ?
+                                 ((gptw_lvl_q == LVL2 && ptw_lvl_q != LVL3) || (ptw_lvl_q == LVL2 && gptw_lvl_q != LVL3)) :
+                                 (ptw_lvl_q == LVL2);
+    assign dtlb_update_o.is_1G = (en_ld_st_translation_i && en_ld_st_g_translation_i) ?
+                                 ((gptw_lvl_q == LVL1 && ptw_lvl_q == LVL1)) :
+                                 (ptw_lvl_q == LVL1);
+    assign itlb_update_o.is_s_2M  = (enable_g_translation_i && enable_translation_i) ? (gptw_lvl_q == LVL2) : enable_translation_i ? (ptw_lvl_q == LVL2) : 1'b0;
+    assign itlb_update_o.is_s_1G  = (enable_g_translation_i && enable_translation_i) ? (gptw_lvl_q == LVL1) : enable_translation_i ? (ptw_lvl_q == LVL1) : 1'b0;
+    assign dtlb_update_o.is_s_2M  = (en_ld_st_g_translation_i && en_ld_st_translation_i) ? (gptw_lvl_q == LVL2) : en_ld_st_translation_i ? (ptw_lvl_q == LVL2) : 1'b0;
+    assign dtlb_update_o.is_s_1G  = (en_ld_st_g_translation_i && en_ld_st_translation_i) ? (gptw_lvl_q == LVL1) : en_ld_st_translation_i ? (ptw_lvl_q == LVL1) : 1'b0;
+    // update G-Stage with the correct page table level when enabled
+    assign itlb_update_o.is_g_2M = (enable_g_translation_i) ? (ptw_lvl_q == LVL2) : '0;
+    assign itlb_update_o.is_g_1G = (enable_g_translation_i) ? (ptw_lvl_q == LVL1) : '0;
+    assign dtlb_update_o.is_g_2M = (en_ld_st_g_translation_i) ? (ptw_lvl_q == LVL2) : '0;
+    assign dtlb_update_o.is_g_1G = (en_ld_st_g_translation_i) ? (ptw_lvl_q == LVL1) : '0;
+    // output the correct ASID
+    assign itlb_update_o.asid = tlb_update_asid_q;
+    assign dtlb_update_o.asid = tlb_update_asid_q;
+    // output the correct VMID
+    assign itlb_update_o.vmid = tlb_update_vmid_q;
+    assign dtlb_update_o.vmid = tlb_update_vmid_q;
+    // set the global mapping bit
+    assign itlb_update_o.content = (enable_g_translation_i) ? gpte_q | (global_mapping_q << 5) : pte | (global_mapping_q << 5);
+    assign dtlb_update_o.content = (en_ld_st_g_translation_i) ? gpte_q | (global_mapping_q << 5) : pte | (global_mapping_q << 5);
+    assign itlb_update_o.g_content = (enable_g_translation_i) ? pte : '0;
+    assign dtlb_update_o.g_content = (en_ld_st_g_translation_i) ? pte : '0;
+
+    assign req_port_o.tag_valid      = tag_valid_q;
+
+    logic allow_access;
+
+    assign bad_paddr_o = ptw_access_exception_o ? ptw_pptr_q : 'b0;
+    assign bad_gpaddr_o = ptw_error_at_g_st_o ? ((ptw_stage_q == G_INTERMED_STAGE) ? gptw_pptr_q[riscv::GPLEN:0] : gpaddr_q) : 'b0;
+
+    pmp #(
+        .PLEN       ( riscv::PLEN            ),
+        .PMP_LEN    ( riscv::PLEN - 2        ),
+        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+    ) i_pmp_ptw (
+        .addr_i        ( ptw_pptr_q         ),
+        // PTW access are always checked as if in S-Mode...
+        .priv_lvl_i    ( riscv::PRIV_LVL_S  ),
+        // ...and they are always loads
+        .access_type_i ( riscv::ACCESS_READ ),
+        // Configuration
+        .conf_addr_i   ( pmpaddr_i          ),
+        .conf_i        ( pmpcfg_i           ),
+        .allow_o       ( allow_access       )
+    );
+
+    //-------------------
+    // Page table walker
+    //-------------------
+    // A virtual address va is translated into a physical address pa as follows:
+    // 1. Let a be sptbr.ppn × PAGESIZE, and let i = LEVELS-1. (For Sv39,
+    //    PAGESIZE=2^12 and LEVELS=3.)
+    // 2. Let pte be the value of the PTE at address a+va.vpn[i]×PTESIZE. (For
+    //    Sv32, PTESIZE=4.)
+    // 3. If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if any bits or encodings 
+    //    that are reserved for future standard use are set within pte, stop and raise 
+    //    a page-fault exception corresponding to the original access type.
+    // 4. Otherwise, the PTE is valid. If pte.r = 1 or pte.x = 1, go to step 5.
+    //    Otherwise, this PTE is a pointer to the next level of the page table.
+    //    Let i=i-1. If i < 0, stop and raise an access exception. Otherwise, let
+    //    a = pte.ppn × PAGESIZE and go to step 2.
+    // 5. A leaf PTE has been found. Determine if the requested memory access
+    //    is allowed by the pte.r, pte.w, and pte.x bits. If not, stop and
+    //    raise an access exception. Otherwise, the translation is successful.
+    //    Set pte.a to 1, and, if the memory access is a store, set pte.d to 1.
+    //    The translated physical address is given as follows:
+    //      - pa.pgoff = va.pgoff.
+    //      - If i > 0, then this is a superpage translation and
+    //        pa.ppn[i-1:0] = va.vpn[i-1:0].
+    //      - pa.ppn[LEVELS-1:i] = pte.ppn[LEVELS-1:i].
+    always_comb begin : ptw
+        automatic logic [riscv::PLEN-1:0] pptr;
+        automatic logic [riscv::GPLEN-1:0] gpaddr;
+        // default assignments
+        // PTW memory interface
+        tag_valid_n            = 1'b0;
+        req_port_o.data_req    = 1'b0;
+        req_port_o.data_be     = 8'hFF;
+        req_port_o.data_size   = 2'b11;
+        req_port_o.data_we     = 1'b0;
+        ptw_error_o            = 1'b0;
+        ptw_error_at_g_st_o    = 1'b0;
+        ptw_err_at_g_int_st_o  = 1'b0;
+        ptw_access_exception_o = 1'b0;
+        itlb_update_o.valid    = 1'b0;
+        dtlb_update_o.valid    = 1'b0;
+        is_instr_ptw_n         = is_instr_ptw_q;
+        ptw_lvl_n              = ptw_lvl_q;
+        gptw_lvl_n             = gptw_lvl_q;
+        ptw_pptr_n             = ptw_pptr_q;
+        gptw_pptr_n            = gptw_pptr_q;
+        state_d                = state_q;
+        ptw_stage_d            = ptw_stage_q;
+        gpte_d                 = gpte_q;
+        global_mapping_n       = global_mapping_q;
+        // input registers
+        tlb_update_asid_n     = tlb_update_asid_q;
+        tlb_update_vmid_n     = tlb_update_vmid_q;
+        vaddr_n               = vaddr_q;
+        gpaddr_n              = gpaddr_q;
+        pptr                  = ptw_pptr_q;
+        gpaddr                = gpaddr_q;
+
+        itlb_miss_o           = 1'b0;
+        dtlb_miss_o           = 1'b0;
+
+        case (state_q)
+
+            IDLE: begin
+                // by default we start with the top-most page table
+                ptw_lvl_n        = LVL1;
+                gptw_lvl_n       = LVL1;
+                global_mapping_n = 1'b0;
+                is_instr_ptw_n   = 1'b0;
+                gpaddr_n         = '0;
+                gpte_d           = '0;
+                // if we got an ITLB miss
+                if ((enable_translation_i | enable_g_translation_i) & itlb_access_i & ~itlb_hit_i & ~dtlb_access_i) begin
+                    if (enable_translation_i && enable_g_translation_i) begin
+                        ptw_stage_d = G_INTERMED_STAGE;
+                        pptr = {vsatp_ppn_i, itlb_vaddr_i[riscv::SV-1:30], 3'b0};
+                        gptw_pptr_n = pptr;
+                        ptw_pptr_n = {hgatp_ppn_i[riscv::PPNW-1:2], pptr[riscv::SVX-1:30], 3'b0};
+                    end else if (!enable_translation_i && enable_g_translation_i) begin
+                        ptw_stage_d = G_FINAL_STAGE;
+                        gpaddr_n = itlb_vaddr_i[riscv::SVX-1:0];
+                        ptw_pptr_n = {hgatp_ppn_i[riscv::PPNW-1:2], itlb_vaddr_i[riscv::SVX-1:30], 3'b0};
+                    end else begin
+                        ptw_stage_d = S_STAGE;
+                        if(v_i)
+                            ptw_pptr_n  = {vsatp_ppn_i, itlb_vaddr_i[riscv::SV-1:30], 3'b0};
+                        else
+                            ptw_pptr_n  = {satp_ppn_i, itlb_vaddr_i[riscv::SV-1:30], 3'b0};
+                    end
+                    is_instr_ptw_n      = 1'b1;
+                    tlb_update_asid_n   = v_i ? vs_asid_i : asid_i;
+                    tlb_update_vmid_n   = vmid_i;
+                    vaddr_n             = itlb_vaddr_i;
+                    state_d             = WAIT_GRANT;
+                    itlb_miss_o         = 1'b1;
+                // we got an DTLB miss
+                end else if ((en_ld_st_translation_i || en_ld_st_g_translation_i) & dtlb_access_i & ~dtlb_hit_i) begin
+                    if (en_ld_st_translation_i && en_ld_st_g_translation_i) begin
+                        ptw_stage_d = G_INTERMED_STAGE;
+                        pptr = {vsatp_ppn_i, dtlb_vaddr_i[riscv::SV-1:30], 3'b0};
+                        gptw_pptr_n = pptr;
+                        ptw_pptr_n = {hgatp_ppn_i[riscv::PPNW-1:2], pptr[riscv::SVX-1:30], 3'b0};
+                    end else if (!en_ld_st_translation_i && en_ld_st_g_translation_i) begin
+                        ptw_stage_d = G_FINAL_STAGE;
+                        gpaddr_n = dtlb_vaddr_i[riscv::SVX-1:0];
+                        ptw_pptr_n = {hgatp_ppn_i[riscv::PPNW-1:2], dtlb_vaddr_i[riscv::SVX-1:30], 3'b0};
+                    end else begin
+                        ptw_stage_d = S_STAGE;
+                        if(ld_st_v_i)
+                            ptw_pptr_n  = {vsatp_ppn_i, dtlb_vaddr_i[riscv::SV-1:30], 3'b0};
+                        else
+                            ptw_pptr_n  = {satp_ppn_i, dtlb_vaddr_i[riscv::SV-1:30], 3'b0};
+                    end
+                    tlb_update_asid_n   = ld_st_v_i ? vs_asid_i : asid_i;
+                    tlb_update_vmid_n   = vmid_i;
+                    vaddr_n             = dtlb_vaddr_i;
+                    state_d             = WAIT_GRANT;
+                    dtlb_miss_o         = 1'b1;
+                end
+            end
+
+            WAIT_GRANT: begin
+                // send a request out
+                req_port_o.data_req = 1'b1;
+                // wait for the WAIT_GRANT
+                if (req_port_i.data_gnt) begin
+                    // send the tag valid signal one cycle later
+                    tag_valid_n = 1'b1;
+                    state_d     = PTE_LOOKUP;
+                end
+            end
+
+            PTE_LOOKUP: begin
+                // we wait for the valid signal
+                if (data_rvalid_q) begin
+
+                    // check if the global mapping bit is set
+                    if (pte.g && ptw_stage_q == S_STAGE)
+                        global_mapping_n = 1'b1;
+
+                    // -------------
+                    // Invalid PTE
+                    // -------------
+                    // If pte.v = 0, or if pte.r = 0 and pte.w = 1, stop and raise a page-fault exception.
+                    if (!pte.v || (!pte.r && pte.w))
+                        state_d = PROPAGATE_ERROR;
+                    // -----------
+                    // Valid PTE
+                    // -----------
+                    else begin
+                        state_d = IDLE;
+                        // it is a valid PTE
+                        // if pte.r = 1 or pte.x = 1 it is a valid PTE
+                        if (pte.r || pte.x) begin
+                            case (ptw_stage_q)
+                                S_STAGE: begin
+                                        if ((is_instr_ptw_q && enable_g_translation_i) || (!is_instr_ptw_q && en_ld_st_g_translation_i)) begin
+                                            state_d = WAIT_GRANT;
+                                            ptw_stage_d = G_FINAL_STAGE;
+                                            gpte_d = pte;
+                                            gptw_lvl_n = ptw_lvl_q;
+                                            gpaddr = {pte.ppn[riscv::GPPNW-1:0], vaddr_q[11:0]};
+                                            if (ptw_lvl_q == LVL2)
+                                                gpaddr[20:0] = vaddr_q[20:0];
+                                            if(ptw_lvl_q == LVL1)
+                                                gpaddr[29:0] = vaddr_q[29:0];
+                                            gpaddr_n = gpaddr;
+                                            ptw_pptr_n = {hgatp_ppn_i[riscv::PPNW-1:2], gpaddr[riscv::SVX-1:30], 3'b0};
+                                            ptw_lvl_n = LVL1;
+                                        end
+                                end
+                                G_INTERMED_STAGE: begin
+                                            state_d = WAIT_GRANT;
+                                            ptw_stage_d = S_STAGE;
+                                            ptw_lvl_n = gptw_lvl_q;
+                                            pptr = {pte.ppn[riscv::GPPNW-1:0], gptw_pptr_q[11:0]};
+                                            if (ptw_lvl_q == LVL2)
+                                                pptr[20:0] = gptw_pptr_q[20:0];
+                                            if(ptw_lvl_q == LVL1)
+                                                pptr[29:0] = gptw_pptr_q[29:0];
+                                            ptw_pptr_n = pptr;
+                                end
+                                default:;
+                            endcase
+                            // Valid translation found (either 1G, 2M or 4K entry)
+                            if (is_instr_ptw_q) begin
+                                // ------------
+                                // Update ITLB
+                                // ------------
+                                // If page is not executable, we can directly raise an error. This
+                                // doesn't put a useless entry into the TLB. The same idea applies
+                                // to the access flag since we let the access flag be managed by SW.
+                                if (!pte.x || !pte.a) begin
+                                  state_d = PROPAGATE_ERROR;
+                                  ptw_stage_d = ptw_stage_q;
+                                end else if((ptw_stage_q == G_FINAL_STAGE) || !enable_g_translation_i)
+                                  itlb_update_o.valid = 1'b1;
+
+                            end else begin
+                                // ------------
+                                // Update DTLB
+                                // ------------
+                                // Check if the access flag has been set, otherwise throw a page-fault
+                                // and let the software handle those bits.
+                                // If page is not readable (there are no write-only pages)
+                                // we can directly raise an error. This doesn't put a useless
+                                // entry into the TLB.
+                                if (pte.a && ((pte.r && !hlvx_inst_i) || (pte.x && (mxr_i || hlvx_inst_i || (ptw_stage_q == S_STAGE && vmxr_i && ld_st_v_i))))) begin
+                                  if((ptw_stage_q == G_FINAL_STAGE) || !en_ld_st_g_translation_i)
+                                      dtlb_update_o.valid = 1'b1;
+                                end else begin
+                                  state_d   = PROPAGATE_ERROR;
+                                  ptw_stage_d = ptw_stage_q;
+                                end
+                                // Request is a store: perform some additional checks
+                                // If the request was a store and the page is not write-able, raise an error
+                                // the same applies if the dirty flag is not set
+                                if (lsu_is_store_i && (!pte.w || !pte.d)) begin
+                                    dtlb_update_o.valid = 1'b0;
+                                    state_d   = PROPAGATE_ERROR;
+                                    ptw_stage_d = ptw_stage_q;
+                                end
+                            end
+                            // check if the ppn is correctly aligned:
+                            // 6. If i > 0 and pa.ppn[i − 1 : 0] != 0, this is a misaligned superpage; stop and raise a page-fault
+                            // exception.
+                            if (ptw_lvl_q == LVL1 && pte.ppn[17:0] != '0) begin
+                                state_d             = PROPAGATE_ERROR;
+                                ptw_stage_d         = ptw_stage_q;
+                                dtlb_update_o.valid = 1'b0;
+                                itlb_update_o.valid = 1'b0;
+                            end else if (ptw_lvl_q == LVL2 && pte.ppn[8:0] != '0) begin
+                                state_d             = PROPAGATE_ERROR;
+                                ptw_stage_d         = ptw_stage_q;
+                                dtlb_update_o.valid = 1'b0;
+                                itlb_update_o.valid = 1'b0;
+                            end
+                            // check if 63:41 are all zeros
+                            if (((v_i && is_instr_ptw_q) || (ld_st_v_i && !is_instr_ptw_q)) && ptw_stage_q == S_STAGE && !((|pte.ppn[riscv::PPNW-1:riscv::GPPNW]) == 1'b0)) begin
+                                state_d = PROPAGATE_ERROR;
+                                ptw_stage_d = G_FINAL_STAGE;
+                            end
+                        // this is a pointer to the next TLB level
+                        end else begin
+                            // pointer to next level of page table
+                            if (ptw_lvl_q == LVL1) begin
+                                // we are in the second level now
+                                ptw_lvl_n = LVL2;
+                                case (ptw_stage_q)
+                                    S_STAGE: begin
+                                        if ((is_instr_ptw_q && enable_g_translation_i) || (!is_instr_ptw_q && en_ld_st_g_translation_i)) begin
+                                            ptw_stage_d = G_INTERMED_STAGE;
+                                            gpte_d = pte;
+                                            gptw_lvl_n = LVL2;
+                                            pptr = {pte.ppn, vaddr_q[29:21], 3'b0};
+                                            gptw_pptr_n = pptr;
+                                            ptw_pptr_n = {hgatp_ppn_i[riscv::PPNW-1:2], pptr[riscv::SVX-1:30], 3'b0};
+                                            ptw_lvl_n = LVL1;
+                                        end else begin
+                                            ptw_pptr_n = {pte.ppn, vaddr_q[29:21], 3'b0};
+                                        end
+                                    end
+                                    G_INTERMED_STAGE: begin
+                                            ptw_pptr_n = {pte.ppn, gptw_pptr_q[29:21], 3'b0};
+                                    end
+                                    G_FINAL_STAGE: begin
+                                            ptw_pptr_n = {pte.ppn, gpaddr_q[29:21], 3'b0};
+                                    end
+                                endcase
+                            end
+
+                            if (ptw_lvl_q == LVL2) begin
+                                // here we received a pointer to the third level
+                                ptw_lvl_n  = LVL3;
+                                unique case (ptw_stage_q)
+                                    S_STAGE: begin
+                                        if ((is_instr_ptw_q && enable_g_translation_i) || (!is_instr_ptw_q && en_ld_st_g_translation_i)) begin
+                                            ptw_stage_d = G_INTERMED_STAGE;
+                                            gpte_d = pte;
+                                            gptw_lvl_n = LVL3;
+                                            pptr = {pte.ppn, vaddr_q[20:12], 3'b0};
+                                            gptw_pptr_n = pptr;
+                                            ptw_pptr_n = {hgatp_ppn_i[riscv::PPNW-1:2], pptr[riscv::SVX-1:30], 3'b0};
+                                            ptw_lvl_n = LVL1;
+                                        end else begin
+                                            ptw_pptr_n = {pte.ppn, vaddr_q[20:12], 3'b0};
+                                        end
+                                    end
+                                    G_INTERMED_STAGE: begin
+                                            ptw_pptr_n = {pte.ppn, gptw_pptr_q[20:12], 3'b0};
+                                    end
+                                    G_FINAL_STAGE: begin
+                                            ptw_pptr_n = {pte.ppn, gpaddr_q[20:12], 3'b0};
+                                    end
+                                    default:;
+                                endcase
+                            end
+
+                            state_d = WAIT_GRANT;
+                            // check if reserved bits are cleared for non-leaf entries
+                            if(pte.a || pte.d || pte.u) begin
+                                state_d = PROPAGATE_ERROR;
+                                ptw_stage_d = ptw_stage_q;
+                            end
+                            if (ptw_lvl_q == LVL3) begin
+                              // Should already be the last level page table => Error
+                              ptw_lvl_n   = LVL3;
+                              state_d = PROPAGATE_ERROR;
+                              ptw_stage_d = ptw_stage_q;
+                            end
+                            // check if 63:41 are all zeros
+                            if (((v_i && is_instr_ptw_q) || (ld_st_v_i && !is_instr_ptw_q)) && ptw_stage_q == S_STAGE && !((|pte.ppn[riscv::PPNW-1:riscv::GPPNW]) == 1'b0)) begin
+                                state_d = PROPAGATE_ERROR;
+                                ptw_stage_d = ptw_stage_q;
+                            end
+                        end
+                    end
+
+                    // Check if this access was actually allowed from a PMP perspective
+                    if (!allow_access) begin
+                        itlb_update_o.valid = 1'b0;
+                        dtlb_update_o.valid = 1'b0;
+                        // we have to return the failed address in bad_addr
+                        ptw_pptr_n = ptw_pptr_q;
+                        ptw_stage_d = ptw_stage_q;
+                        state_d = PROPAGATE_ACCESS_ERROR;
+                    end
+                end
+                // we've got a data WAIT_GRANT so tell the cache that the tag is valid
+            end
+            // Propagate error to MMU/LSU
+            PROPAGATE_ERROR: begin
+                state_d     = IDLE;
+                ptw_error_o = 1'b1;
+                ptw_error_at_g_st_o = (ptw_stage_q != S_STAGE) ? 1'b1 : 1'b0;
+                ptw_err_at_g_int_st_o = (ptw_stage_q == G_INTERMED_STAGE) ? 1'b1 : 1'b0;
+            end
+            PROPAGATE_ACCESS_ERROR: begin
+                state_d     = IDLE;
+                ptw_access_exception_o = 1'b1;
+            end
+            // wait for the rvalid before going back to IDLE
+            WAIT_RVALID: begin
+                if (data_rvalid_q)
+                    state_d = IDLE;
+            end
+            default: begin
+                state_d = IDLE;
+            end
+        endcase
+
+        // -------
+        // Flush
+        // -------
+        // should we have flushed before we got an rvalid, wait for it until going back to IDLE
+        if (flush_i) begin
+            // on a flush check whether we are
+            // 1. in the PTE Lookup check whether we still need to wait for an rvalid
+            // 2. waiting for a grant, if so: wait for it
+            // if not, go back to idle
+            if ((state_q == PTE_LOOKUP && !data_rvalid_q) || ((state_q == WAIT_GRANT) && req_port_i.data_gnt))
+                state_d = WAIT_RVALID;
+            else
+                state_d = IDLE;
+        end
+    end
+
+    // sequential process
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (~rst_ni) begin
+            state_q            <= IDLE;
+            ptw_stage_q        <= S_STAGE;
+            is_instr_ptw_q     <= 1'b0;
+            ptw_lvl_q          <= LVL1;
+            gptw_lvl_q         <= LVL1;
+            tag_valid_q        <= 1'b0;
+            tlb_update_asid_q  <= '0;
+            tlb_update_vmid_q  <= '0;
+            vaddr_q            <= '0;
+            gpaddr_q           <= '0;
+            ptw_pptr_q         <= '0;
+            gptw_pptr_q        <= '0;
+            global_mapping_q   <= 1'b0;
+            data_rdata_q       <= '0;
+            gpte_q             <= '0;
+            data_rvalid_q      <= 1'b0;
+        end else begin
+            state_q            <= state_d;
+            ptw_stage_q        <= ptw_stage_d;
+            ptw_pptr_q         <= ptw_pptr_n;
+            gptw_pptr_q        <= gptw_pptr_n;
+            is_instr_ptw_q     <= is_instr_ptw_n;
+            ptw_lvl_q          <= ptw_lvl_n;
+            gptw_lvl_q         <= gptw_lvl_n;
+            tag_valid_q        <= tag_valid_n;
+            tlb_update_asid_q  <= tlb_update_asid_n;
+            tlb_update_vmid_q  <= tlb_update_vmid_n;
+            vaddr_q            <= vaddr_n;
+            gpaddr_q           <= gpaddr_n;
+            global_mapping_q   <= global_mapping_n;
+            data_rdata_q       <= req_port_i.data_rdata;
+            gpte_q             <= gpte_d;
+            data_rvalid_q      <= req_port_i.data_rvalid;
+        end
+    end
+
+endmodule
+/* verilator lint_on WIDTH */

--- a/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
@@ -376,7 +376,7 @@ module cva6_ptw_sv39x4 import ariane_pkg::*; #(
                     // Invalid PTE
                     // -------------
                     // If pte.v = 0, or if pte.r = 0 and pte.w = 1, stop and raise a page-fault exception.
-                    if (!pte.v || (!pte.r && pte.w))
+                    if (!pte.v || (!pte.r && pte.w) || (|pte.reserved))
                         state_d = PROPAGATE_ERROR;
                     // -----------
                     // Valid PTE

--- a/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
@@ -10,6 +10,7 @@
 //
 // Author: Bruno Sá
 // Date: 14/08/2022
+// Acknowledges: Technology Innovation Institute (TII)
 //
 // Description: Translation Lookaside Buffer, Sv39x4 , fully set-associative
 //              This module is an adaptation of the Sv39 TLB developed

--- a/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
@@ -52,14 +52,9 @@ module cva6_tlb_sv39x4 import ariane_pkg::*; #(
     struct packed {
       logic [ASID_WIDTH-1:0] asid;
       logic [VMID_WIDTH-1:0] vmid;
-      logic [riscv::VPN2:0]  vpn2;
+      logic [riscv::GPPN2:0] vpn2;
       logic [8:0]            vpn1;
       logic [8:0]            vpn0;
-      logic [riscv::GPPN2:0] gppn2;
-      logic [8:0]            gppn1;
-      logic [8:0]            gppn0;
-      logic                  is_2M;
-      logic                  is_1G;
       logic                  is_s_2M;
       logic                  is_s_1G;
       logic                  is_g_2M;
@@ -76,77 +71,85 @@ module cva6_tlb_sv39x4 import ariane_pkg::*; #(
     } [TLB_ENTRIES-1:0] content_q, content_n;
 
     logic [8:0] vpn0, vpn1;
-    logic [riscv::VPN2:0] vpn2;
-    logic [riscv::GPPN2:0] gppn2;
+    logic [riscv::GPPN2:0] vpn2;
     logic [TLB_ENTRIES-1:0] lu_hit;     // to replacement logic
     logic [TLB_ENTRIES-1:0] replace_en; // replace the following entry, set by replacement strategy
     logic [TLB_ENTRIES-1:0] match_vmid;
     logic [TLB_ENTRIES-1:0] match_asid;
+    logic [TLB_ENTRIES-1:0] is_1G;
+    logic [TLB_ENTRIES-1:0] is_2M;
     logic [TLB_ENTRIES-1:0] match_stage;
-    logic [TLB_ENTRIES-1:0] match_pn;
     riscv::pte_t   g_content;
     //-------------
     // Translation
     //-------------
     always_comb begin : translation
+        automatic logic [riscv::GPPN2:0] mask_pn2;
+        mask_pn2 = s_st_enbl_i ? ((2**(riscv::VPN2+1))-1) : ((2**(riscv::GPPN2+1))-1);
         vpn0 = lu_vaddr_i[20:12];
         vpn1 = lu_vaddr_i[29:21];
-        vpn2 = lu_vaddr_i[30+riscv::VPN2:30];
-        gppn2 = lu_vaddr_i[30+riscv::GPPN2:30];
+        vpn2 = lu_vaddr_i[30+riscv::GPPN2:30] & mask_pn2;
 
         // default assignment
-        lu_hit       = '{default: 0};
-        lu_hit_o     = 1'b0;
-        lu_content_o = '{default: 0};
+        lu_hit         = '{default: 0};
+        lu_hit_o       = 1'b0;
+        lu_content_o   = '{default: 0};
         lu_g_content_o = '{default: 0};
-        lu_gpaddr_o  = '{default: 0};
-        lu_is_1G_o   = 1'b0;
-        lu_is_2M_o   = 1'b0;
-        match_asid   = '{default: 0};
-        match_vmid   = '{default: 0};
-        match_stage  = '{default: 0};
-        match_pn     = '{default: 0};
+        lu_is_1G_o     = 1'b0;
+        lu_is_2M_o     = 1'b0;
+        match_asid     = '{default: 0};
+        match_vmid     = '{default: 0};
+        match_stage    = '{default: 0};
+        is_1G          = '{default: 0};
+        is_2M          = '{default: 0};
+        g_content      = '{default: 0};
+        lu_gpaddr_o    = '{default: 0};
+
 
         for (int unsigned i = 0; i < TLB_ENTRIES; i++) begin
-            // first level match, this may be a giga page, check the ASID and VMID flags as well if needed
+            lu_gpaddr_o = make_gpaddr(s_st_enbl_i, tags_q[i].is_s_1G, tags_q[i].is_s_2M, lu_vaddr_i, content_q[i].pte);
+            // first level match, this may be a giga page, check the ASID flags as well
             // if the entry is associated to a global address, don't match the ASID (ASID is don't care)
             match_asid[i] = (((lu_asid_i == tags_q[i].asid) || content_q[i].pte.g) && s_st_enbl_i) || !s_st_enbl_i;
             match_vmid[i] = (lu_vmid_i == tags_q[i].vmid && g_st_enbl_i) || !g_st_enbl_i;
+            is_1G[i] = is_trans_1G(s_st_enbl_i,
+                                   g_st_enbl_i,
+                                   tags_q[i].is_s_1G,
+                                   tags_q[i].is_g_1G
+                                );
+            is_2M[i] = is_trans_2M(s_st_enbl_i,
+                                   g_st_enbl_i,
+                                   tags_q[i].is_s_1G,
+                                   tags_q[i].is_s_2M,
+                                   tags_q[i].is_g_1G,
+                                   tags_q[i].is_g_2M
+                                );
             // check if translation is a: S-Stage and G-Stage, S-Stage only or G-Stage only translation and virtualization mode is on/off
-            match_stage[i] = tags_q[i].g_st_enbl == g_st_enbl_i && tags_q[i].s_st_enbl == s_st_enbl_i && tags_q[i].v == v_i;
-            match_pn[i] = (vpn2 == tags_q[i].vpn2 && s_st_enbl_i) || (gppn2 == tags_q[i].gppn2 && !s_st_enbl_i);
-            if (tags_q[i].valid && match_asid[i] && match_vmid[i] && match_stage[i] && match_pn[i]) begin
-                if (tags_q[i].is_1G) begin
-                      lu_is_1G_o      = tags_q[i].is_1G;
+            match_stage[i] = (tags_q[i].v == v_i) && (tags_q[i].g_st_enbl == g_st_enbl_i) && (tags_q[i].s_st_enbl == s_st_enbl_i);
+            if (tags_q[i].valid && match_asid[i] && match_vmid[i] && match_stage[i] && (vpn2 == (tags_q[i].vpn2 & mask_pn2))) begin
+                if (is_1G[i]) begin
+                      lu_is_1G_o      = is_1G[i];
                       lu_content_o    = content_q[i].pte;
                       lu_g_content_o  = content_q[i].gpte;
-                      lu_gpaddr_o     = {tags_q[i].gppn2,lu_vaddr_i[29:0]};
                       lu_hit_o        = 1'b1;
                       lu_hit[i]       = 1'b1;
                 // not a giga page hit so check further
                 end else if (vpn1 == tags_q[i].vpn1) begin
                     // this could be a 2 mega page hit or a 4 kB hit
                     // output accordingly
-                    if (tags_q[i].is_2M || vpn0 == tags_q[i].vpn0) begin
-                            lu_is_2M_o     = tags_q[i].is_2M;
-                            lu_gpaddr_o    = {content_q[i].pte.ppn, lu_vaddr_i[11:0]};
-                            // Mega page
-                            if (tags_q[i].is_s_2M) begin
-                                lu_gpaddr_o[20:12] = lu_vaddr_i[20:12];
-                            end
-                            // Giga page
-                            if (tags_q[i].is_s_1G) begin
-                                lu_gpaddr_o[29:12] = lu_vaddr_i[29:12];
-                            end
-                            g_content      = content_q[i].gpte;
+                    if (is_2M[i] || vpn0 == tags_q[i].vpn0) begin
+                            lu_is_2M_o = is_2M[i];
+                            // Compute G-Stage PPN based on the gpaddr
+                            g_content = content_q[i].gpte;
                             if(tags_q[i].is_g_2M)
-                              g_content.ppn[8:0] = lu_gpaddr_o[20:12];
+                                g_content.ppn[8:0] = lu_gpaddr_o[20:12];
                             if(tags_q[i].is_g_1G)
-                              g_content.ppn[17:0] = lu_gpaddr_o[29:12];
-                            lu_content_o   = content_q[i].pte;
-                            lu_g_content_o = g_content;
-                            lu_hit_o       = 1'b1;
-                            lu_hit[i]      = 1'b1;
+                                g_content.ppn[17:0] = lu_gpaddr_o[29:12];
+                            // Output G-stage and S-stage content
+                            lu_g_content_o    = g_content;
+                            lu_content_o      = content_q[i].pte;
+                            lu_hit_o          = 1'b1;
+                            lu_hit[i]         = 1'b1;
                     end
                 end
             end
@@ -156,19 +159,21 @@ module cva6_tlb_sv39x4 import ariane_pkg::*; #(
 
 
     logic asid_to_be_flushed_is0;  // indicates that the ASID provided by SFENCE.VMA (rs2)is 0, active high
-    logic vmid_to_be_flushed_is0;  // indicates that the VMID provided by HFENCE.GVMA (rs2)is 0, active high
     logic vaddr_to_be_flushed_is0;  // indicates that the VADDR provided by SFENCE.VMA (rs1)is 0, active high
-    logic gpaddr_to_be_flushed_is0;  // indicates that the VADDR provided by SFENCE.VMA (rs1)is 0, active high
+    logic vmid_to_be_flushed_is0;  // indicates that the VMID provided is 0, active high
+    logic gpaddr_to_be_flushed_is0;  // indicates that the GPADDR provided is 0, active high
     logic  [TLB_ENTRIES-1:0] vaddr_vpn0_match;
     logic  [TLB_ENTRIES-1:0] vaddr_vpn1_match;
     logic  [TLB_ENTRIES-1:0] vaddr_vpn2_match;
     logic  [TLB_ENTRIES-1:0] gpaddr_gppn0_match;
     logic  [TLB_ENTRIES-1:0] gpaddr_gppn1_match;
     logic  [TLB_ENTRIES-1:0] gpaddr_gppn2_match;
+    logic  [TLB_ENTRIES-1:0] [(riscv::GPPNW-1):0] gppn;
+
 
     assign asid_to_be_flushed_is0 =  ~(|asid_to_be_flushed_i);
-    assign vmid_to_be_flushed_is0 =  ~(|vmid_to_be_flushed_i);
     assign vaddr_to_be_flushed_is0 = ~(|vaddr_to_be_flushed_i);
+    assign vmid_to_be_flushed_is0 =  ~(|vmid_to_be_flushed_i);
     assign gpaddr_to_be_flushed_is0 = ~(|gpaddr_to_be_flushed_i);
 
 	  // ------------------
@@ -182,77 +187,73 @@ module cva6_tlb_sv39x4 import ariane_pkg::*; #(
 
             vaddr_vpn0_match[i] = (vaddr_to_be_flushed_i[20:12] == tags_q[i].vpn0);
             vaddr_vpn1_match[i] = (vaddr_to_be_flushed_i[29:21] == tags_q[i].vpn1);
-            vaddr_vpn2_match[i] = (vaddr_to_be_flushed_i[30+riscv::VPN2:30] == tags_q[i].vpn2);
+            vaddr_vpn2_match[i] = (vaddr_to_be_flushed_i[30+riscv::VPN2:30] == tags_q[i].vpn2[riscv::VPN2:0]);
 
-            gpaddr_gppn0_match[i] = (gpaddr_to_be_flushed_i[20:12] == tags_q[i].gppn0);
-            gpaddr_gppn1_match[i] = (gpaddr_to_be_flushed_i[29:21] == tags_q[i].gppn1);
-            gpaddr_gppn2_match[i] = (gpaddr_to_be_flushed_i[30+riscv::GPPN2:30] == tags_q[i].gppn2);
+            gppn[i] = make_gppn(tags_q[i].s_st_enbl, tags_q[i].is_s_1G, tags_q[i].is_s_2M, {tags_q[i].vpn2,tags_q[i].vpn1,tags_q[i].vpn0}, content_q[i].pte);
+            gpaddr_gppn0_match[i] = (gpaddr_to_be_flushed_i[20:12] == gppn[i][8:0]);
+            gpaddr_gppn1_match[i] = (gpaddr_to_be_flushed_i[29:21] == gppn[i][17:9]);
+            gpaddr_gppn2_match[i] = (gpaddr_to_be_flushed_i[30+riscv::GPPN2:30] == gppn[i][18+riscv::GPPN2:18]);
 
             if (flush_i) begin
-                if(!tags_q[i].v && tags_q[i].s_st_enbl) begin
+                if(!tags_q[i].v) begin
                     // invalidate logic
                     // flush everything if ASID is 0 and vaddr is 0 ("SFENCE.VMA x0 x0" case)
-        				    if (asid_to_be_flushed_is0 && vaddr_to_be_flushed_is0 )
+        			if (asid_to_be_flushed_is0 && vaddr_to_be_flushed_is0 )
                         tags_n[i].valid = 1'b0;
                     // flush vaddr in all addressing space ("SFENCE.VMA vaddr x0" case), it should happen only for leaf pages
-                    else if (asid_to_be_flushed_is0 && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_2M) ) && (~vaddr_to_be_flushed_is0))
+                    else if (asid_to_be_flushed_is0 && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_s_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_s_2M) ) && (~vaddr_to_be_flushed_is0))
                         tags_n[i].valid = 1'b0;
                     // the entry is flushed if it's not global and asid and vaddr both matches with the entry to be flushed ("SFENCE.VMA vaddr asid" case)
-				            else if ((!content_q[i].pte.g) && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_2M)) && (asid_to_be_flushed_i == tags_q[i].asid) && (!vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0))
-				              	tags_n[i].valid = 1'b0;
+				    else if ((!content_q[i].pte.g) && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_s_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_s_2M)) && (asid_to_be_flushed_i == tags_q[i].asid) && (!vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0))
+				        tags_n[i].valid = 1'b0;
                     // the entry is flushed if it's not global, and the asid matches and vaddr is 0. ("SFENCE.VMA 0 asid" case)
-				            else if ((!content_q[i].pte.g) && (vaddr_to_be_flushed_is0) && (asid_to_be_flushed_i == tags_q[i].asid) && (!asid_to_be_flushed_is0))
-				            	  tags_n[i].valid = 1'b0;
+				    else if ((!content_q[i].pte.g) && (vaddr_to_be_flushed_is0) && (asid_to_be_flushed_i == tags_q[i].asid) && (!asid_to_be_flushed_is0))
+				        tags_n[i].valid = 1'b0;
                 end
             end else if (flush_vvma_i) begin
                 if(tags_q[i].v && tags_q[i].s_st_enbl) begin
                     // invalidate logic
-                    // flush everything if ASID is 0 and vaddr is 0 ("SFENCE.VMA x0 x0" case)
-        				    if (asid_to_be_flushed_is0 && vaddr_to_be_flushed_is0 && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl))
+                    // flush everything if current VMID matches and ASID is 0 and vaddr is 0 ("SFENCE.VMA/HFENCE.VVMA x0 x0" case)
+        			if (asid_to_be_flushed_is0 && vaddr_to_be_flushed_is0 && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl))
                         tags_n[i].valid = 1'b0;
-                    // flush vaddr in all addressing space ("SFENCE.VMA vaddr x0" case), it should happen only for leaf pages
+                    // flush vaddr in all addressing space if current VMID matches ("SFENCE.VMA/HFENCE.VVMA vaddr x0" case), it should happen only for leaf pages
                     else if (asid_to_be_flushed_is0 && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_s_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_s_2M) ) && (~vaddr_to_be_flushed_is0) && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl))
                         tags_n[i].valid = 1'b0;
-                    // the entry is flushed if it's not global and asid and vaddr both matches with the entry to be flushed ("SFENCE.VMA vaddr asid" case)
-				            else if ((!content_q[i].pte.g) && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_s_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_s_2M)) && (asid_to_be_flushed_i == tags_q[i].asid && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl)) && (!vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0))
-				              	tags_n[i].valid = 1'b0;
-                    // the entry is flushed if it's not global, and the asid matches and vaddr is 0. ("SFENCE.VMA 0 asid" case)
-				            else if ((!content_q[i].pte.g) && (vaddr_to_be_flushed_is0) && (asid_to_be_flushed_i == tags_q[i].asid && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl)) && (!asid_to_be_flushed_is0))
-				            	  tags_n[i].valid = 1'b0;
+                    // the entry is flushed if it's not global and asid and vaddr and current VMID matches with the entry to be flushed ("SFENCE.VMA/HFENCE.VVMA vaddr asid" case)
+				    else if ((!content_q[i].pte.g) && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_s_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_s_2M)) && (asid_to_be_flushed_i == tags_q[i].asid && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl)) && (!vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0))
+				        tags_n[i].valid = 1'b0;
+                    // the entry is flushed if it's not global, and the asid and the current VMID matches and vaddr is 0. ("SFENCE.VMA/HFENCE.VVMA 0 asid" case)
+				    else if ((!content_q[i].pte.g) && (vaddr_to_be_flushed_is0) && (asid_to_be_flushed_i == tags_q[i].asid && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl)) && (!asid_to_be_flushed_is0))
+				        tags_n[i].valid = 1'b0;
                 end
             end else if (flush_gvma_i) begin
                 if(tags_q[i].g_st_enbl) begin
                     // invalidate logic
-                    // flush everything if VMID is 0 and addr is 0 ("HFENCE.GVMA x0 x0" case)
-        				    if (vmid_to_be_flushed_is0 && gpaddr_to_be_flushed_is0 )
+                    // flush everything if vmid is 0 and addr is 0 ("HFENCE.GVMA x0 x0" case)
+        			if (vmid_to_be_flushed_is0 && gpaddr_to_be_flushed_is0 )
                         tags_n[i].valid = 1'b0;
                     // flush gpaddr in all addressing space ("HFENCE.GVMA gpaddr x0" case), it should happen only for leaf pages
                     else if (vmid_to_be_flushed_is0 && ((gpaddr_gppn0_match[i] && gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i]) || (gpaddr_gppn2_match[i] && tags_q[i].is_g_1G) || (gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i] && tags_q[i].is_g_2M) ) && (~gpaddr_to_be_flushed_is0))
                         tags_n[i].valid = 1'b0;
-                    // the entry asid and gpaddr both matches with the entry to be flushed ("HFENCE.GVMA gpaddr vmid" case)
-				            else if (((gpaddr_gppn0_match[i] && gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i]) || (gpaddr_gppn2_match[i] && tags_q[i].is_g_1G) || (gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i] && tags_q[i].is_g_2M)) && (vmid_to_be_flushed_i == tags_q[i].vmid) && (~gpaddr_to_be_flushed_is0) && (~vmid_to_be_flushed_is0))
-				              	tags_n[i].valid = 1'b0;
-                    // the entry is flushed if it's not global, and the vmid matches and gpaddr is 0. ("HFENCE.GVMA 0 vmid" case)
-				            else if ((gpaddr_to_be_flushed_is0) && (vmid_to_be_flushed_i == tags_q[i].vmid) && (!vmid_to_be_flushed_is0))
-				            	  tags_n[i].valid = 1'b0;
+                    // the entry vmid and gpaddr both matches with the entry to be flushed ("HFENCE.GVMA gpaddr vmid" case)
+				    else if (((gpaddr_gppn0_match[i] && gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i]) || (gpaddr_gppn2_match[i] && tags_q[i].is_g_1G) || (gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i] && tags_q[i].is_g_2M)) && (vmid_to_be_flushed_i == tags_q[i].vmid) && (~gpaddr_to_be_flushed_is0) && (~vmid_to_be_flushed_is0))
+				        tags_n[i].valid = 1'b0;
+                    // the entry is flushed if the vmid matches and gpaddr is 0. ("HFENCE.GVMA 0 vmid" case)
+				    else if ((gpaddr_to_be_flushed_is0) && (vmid_to_be_flushed_i == tags_q[i].vmid) && (!vmid_to_be_flushed_is0))
+				        tags_n[i].valid = 1'b0;
                 end
             // normal replacement
             end else if (update_i.valid & replace_en[i]) begin
                 // update tag array
                 tags_n[i] = '{
-                    asid:  s_st_enbl_i ? update_i.asid : 'b0,
-                    vmid:  g_st_enbl_i ? update_i.vmid : 'b0,
-                    vpn2:  update_i.vpn [18+riscv::VPN2:18],
+                    asid:  update_i.asid,
+                    vmid:  update_i.vmid,
+                    vpn2:  update_i.vpn[18+riscv::GPPN2:18],
                     vpn1:  update_i.vpn [17:9],
                     vpn0:  update_i.vpn [8:0],
-                    gppn2:  update_i.gppn [20+riscv::VPN2:18],
-                    gppn1:  update_i.gppn [17:9],
-                    gppn0:  update_i.gppn [8:0],
                     s_st_enbl:  s_st_enbl_i,
                     g_st_enbl:  g_st_enbl_i,
-                    v:     v_i,
-                    is_1G: update_i.is_1G,
-                    is_2M: update_i.is_2M,
+                    v:  v_i,
                     is_s_1G: update_i.is_s_1G,
                     is_s_2M: update_i.is_s_2M,
                     is_g_1G: update_i.is_g_1G,
@@ -260,7 +261,7 @@ module cva6_tlb_sv39x4 import ariane_pkg::*; #(
                     valid: 1'b1
                 };
                 // and content as well
-                content_n[i].pte  = update_i.content;
+                content_n[i].pte = update_i.content;
                 content_n[i].gpte = update_i.g_content;
             end
         end

--- a/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
@@ -1,0 +1,391 @@
+// Copyright (c) 2022  Bruno Sá and Zero-Day Labs.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Bruno Sá
+// Date: 14/08/2022
+//
+// Description: Translation Lookaside Buffer, Sv39x4 , fully set-associative
+//              This module is an adaptation of the Sv39 TLB developed
+//              by Florian Zaruba and David Schaffenrath to the Sv39x4 standard.
+
+
+module cva6_tlb_sv39x4 import ariane_pkg::*; #(
+      parameter int unsigned TLB_ENTRIES = 4,
+      parameter int unsigned ASID_WIDTH  = 1,
+      parameter int unsigned VMID_WIDTH  = 1
+  )(
+    input  logic                    clk_i,    // Clock
+    input  logic                    rst_ni,   // Asynchronous reset active low
+    input  logic                    flush_i,  // Flush normal translations signal
+    input  logic                    flush_vvma_i,  // Flush vs stage signal
+    input  logic                    flush_gvma_i,  // Flush g stage signal
+    input  logic                    s_st_enbl_i,  // s-stage enabled
+    input  logic                    g_st_enbl_i,  // g-stage enabled
+    input  logic                    v_i,  // virtualization mode
+    // Update TLB
+    input  tlb_update_sv39x4_t      update_i,
+    // Lookup signals
+    input  logic                    lu_access_i,
+    input  logic [ASID_WIDTH-1:0]   lu_asid_i,
+    input  logic [VMID_WIDTH-1:0]   lu_vmid_i,
+    input  logic [riscv::VLEN-1:0]  lu_vaddr_i,
+    output logic [riscv::GPLEN-1:0] lu_gpaddr_o,
+    output riscv::pte_t             lu_content_o,
+    output riscv::pte_t             lu_g_content_o,
+    input  logic [ASID_WIDTH-1:0]   asid_to_be_flushed_i,
+    input  logic [VMID_WIDTH-1:0]   vmid_to_be_flushed_i,
+    input  logic [riscv::VLEN-1:0]  vaddr_to_be_flushed_i,
+    input  logic [riscv::GPLEN-1:0] gpaddr_to_be_flushed_i,
+    output logic                    lu_is_2M_o,
+    output logic                    lu_is_1G_o,
+    output logic                    lu_hit_o
+);
+
+    // SV39 defines three levels of page tables
+    struct packed {
+      logic [ASID_WIDTH-1:0] asid;
+      logic [VMID_WIDTH-1:0] vmid;
+      logic [riscv::VPN2:0]  vpn2;
+      logic [8:0]            vpn1;
+      logic [8:0]            vpn0;
+      logic [riscv::GPPN2:0] gppn2;
+      logic [8:0]            gppn1;
+      logic [8:0]            gppn0;
+      logic                  is_2M;
+      logic                  is_1G;
+      logic                  is_s_2M;
+      logic                  is_s_1G;
+      logic                  is_g_2M;
+      logic                  is_g_1G;
+      logic                  s_st_enbl;   // s-stage translation
+      logic                  g_st_enbl;   // g-stage translation
+      logic                  v;           // virtualization mode
+      logic                  valid;
+    } [TLB_ENTRIES-1:0] tags_q, tags_n;
+
+    struct packed {
+      riscv::pte_t pte;
+      riscv::pte_t gpte;
+    } [TLB_ENTRIES-1:0] content_q, content_n;
+
+    logic [8:0] vpn0, vpn1;
+    logic [riscv::VPN2:0] vpn2;
+    logic [riscv::GPPN2:0] gppn2;
+    logic [TLB_ENTRIES-1:0] lu_hit;     // to replacement logic
+    logic [TLB_ENTRIES-1:0] replace_en; // replace the following entry, set by replacement strategy
+    logic [TLB_ENTRIES-1:0] match_vmid;
+    logic [TLB_ENTRIES-1:0] match_asid;
+    logic [TLB_ENTRIES-1:0] match_stage;
+    logic [TLB_ENTRIES-1:0] match_pn;
+    riscv::pte_t   g_content;
+    //-------------
+    // Translation
+    //-------------
+    always_comb begin : translation
+        vpn0 = lu_vaddr_i[20:12];
+        vpn1 = lu_vaddr_i[29:21];
+        vpn2 = lu_vaddr_i[30+riscv::VPN2:30];
+        gppn2 = lu_vaddr_i[30+riscv::GPPN2:30];
+
+        // default assignment
+        lu_hit       = '{default: 0};
+        lu_hit_o     = 1'b0;
+        lu_content_o = '{default: 0};
+        lu_g_content_o = '{default: 0};
+        lu_gpaddr_o  = '{default: 0};
+        lu_is_1G_o   = 1'b0;
+        lu_is_2M_o   = 1'b0;
+        match_asid   = '{default: 0};
+        match_vmid   = '{default: 0};
+        match_stage  = '{default: 0};
+        match_pn     = '{default: 0};
+
+        for (int unsigned i = 0; i < TLB_ENTRIES; i++) begin
+            // first level match, this may be a giga page, check the ASID and VMID flags as well if needed
+            // if the entry is associated to a global address, don't match the ASID (ASID is don't care)
+            match_asid[i] = (((lu_asid_i == tags_q[i].asid) || content_q[i].pte.g) && s_st_enbl_i) || !s_st_enbl_i;
+            match_vmid[i] = (lu_vmid_i == tags_q[i].vmid && g_st_enbl_i) || !g_st_enbl_i;
+            // check if translation is a: S-Stage and G-Stage, S-Stage only or G-Stage only translation and virtualization mode is on/off
+            match_stage[i] = tags_q[i].g_st_enbl == g_st_enbl_i && tags_q[i].s_st_enbl == s_st_enbl_i && tags_q[i].v == v_i;
+            match_pn[i] = (vpn2 == tags_q[i].vpn2 && s_st_enbl_i) || (gppn2 == tags_q[i].gppn2 && !s_st_enbl_i);
+            if (tags_q[i].valid && match_asid[i] && match_vmid[i] && match_stage[i] && match_pn[i]) begin
+                if (tags_q[i].is_1G) begin
+                      lu_is_1G_o      = tags_q[i].is_1G;
+                      lu_content_o    = content_q[i].pte;
+                      lu_g_content_o  = content_q[i].gpte;
+                      lu_gpaddr_o     = {tags_q[i].gppn2,lu_vaddr_i[29:0]};
+                      lu_hit_o        = 1'b1;
+                      lu_hit[i]       = 1'b1;
+                // not a giga page hit so check further
+                end else if (vpn1 == tags_q[i].vpn1) begin
+                    // this could be a 2 mega page hit or a 4 kB hit
+                    // output accordingly
+                    if (tags_q[i].is_2M || vpn0 == tags_q[i].vpn0) begin
+                            lu_is_2M_o     = tags_q[i].is_2M;
+                            lu_gpaddr_o    = {content_q[i].pte.ppn, lu_vaddr_i[11:0]};
+                            // Mega page
+                            if (tags_q[i].is_s_2M) begin
+                                lu_gpaddr_o[20:12] = lu_vaddr_i[20:12];
+                            end
+                            // Giga page
+                            if (tags_q[i].is_s_1G) begin
+                                lu_gpaddr_o[29:12] = lu_vaddr_i[29:12];
+                            end
+                            g_content      = content_q[i].gpte;
+                            if(tags_q[i].is_g_2M)
+                              g_content.ppn[8:0] = lu_gpaddr_o[20:12];
+                            if(tags_q[i].is_g_1G)
+                              g_content.ppn[17:0] = lu_gpaddr_o[29:12];
+                            lu_content_o   = content_q[i].pte;
+                            lu_g_content_o = g_content;
+                            lu_hit_o       = 1'b1;
+                            lu_hit[i]      = 1'b1;
+                    end
+                end
+            end
+        end
+    end
+
+
+
+    logic asid_to_be_flushed_is0;  // indicates that the ASID provided by SFENCE.VMA (rs2)is 0, active high
+    logic vmid_to_be_flushed_is0;  // indicates that the VMID provided by HFENCE.GVMA (rs2)is 0, active high
+    logic vaddr_to_be_flushed_is0;  // indicates that the VADDR provided by SFENCE.VMA (rs1)is 0, active high
+    logic gpaddr_to_be_flushed_is0;  // indicates that the VADDR provided by SFENCE.VMA (rs1)is 0, active high
+    logic  [TLB_ENTRIES-1:0] vaddr_vpn0_match;
+    logic  [TLB_ENTRIES-1:0] vaddr_vpn1_match;
+    logic  [TLB_ENTRIES-1:0] vaddr_vpn2_match;
+    logic  [TLB_ENTRIES-1:0] gpaddr_gppn0_match;
+    logic  [TLB_ENTRIES-1:0] gpaddr_gppn1_match;
+    logic  [TLB_ENTRIES-1:0] gpaddr_gppn2_match;
+
+    assign asid_to_be_flushed_is0 =  ~(|asid_to_be_flushed_i);
+    assign vmid_to_be_flushed_is0 =  ~(|vmid_to_be_flushed_i);
+    assign vaddr_to_be_flushed_is0 = ~(|vaddr_to_be_flushed_i);
+    assign gpaddr_to_be_flushed_is0 = ~(|gpaddr_to_be_flushed_i);
+
+	  // ------------------
+    // Update and Flush
+    // ------------------
+    always_comb begin : update_flush
+        tags_n    = tags_q;
+        content_n = content_q;
+
+        for (int unsigned i = 0; i < TLB_ENTRIES; i++) begin
+
+            vaddr_vpn0_match[i] = (vaddr_to_be_flushed_i[20:12] == tags_q[i].vpn0);
+            vaddr_vpn1_match[i] = (vaddr_to_be_flushed_i[29:21] == tags_q[i].vpn1);
+            vaddr_vpn2_match[i] = (vaddr_to_be_flushed_i[30+riscv::VPN2:30] == tags_q[i].vpn2);
+
+            gpaddr_gppn0_match[i] = (gpaddr_to_be_flushed_i[20:12] == tags_q[i].gppn0);
+            gpaddr_gppn1_match[i] = (gpaddr_to_be_flushed_i[29:21] == tags_q[i].gppn1);
+            gpaddr_gppn2_match[i] = (gpaddr_to_be_flushed_i[30+riscv::GPPN2:30] == tags_q[i].gppn2);
+
+            if (flush_i) begin
+                if(!tags_q[i].v && tags_q[i].s_st_enbl) begin
+                    // invalidate logic
+                    // flush everything if ASID is 0 and vaddr is 0 ("SFENCE.VMA x0 x0" case)
+        				    if (asid_to_be_flushed_is0 && vaddr_to_be_flushed_is0 )
+                        tags_n[i].valid = 1'b0;
+                    // flush vaddr in all addressing space ("SFENCE.VMA vaddr x0" case), it should happen only for leaf pages
+                    else if (asid_to_be_flushed_is0 && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_2M) ) && (~vaddr_to_be_flushed_is0))
+                        tags_n[i].valid = 1'b0;
+                    // the entry is flushed if it's not global and asid and vaddr both matches with the entry to be flushed ("SFENCE.VMA vaddr asid" case)
+				            else if ((!content_q[i].pte.g) && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_2M)) && (asid_to_be_flushed_i == tags_q[i].asid) && (!vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0))
+				              	tags_n[i].valid = 1'b0;
+                    // the entry is flushed if it's not global, and the asid matches and vaddr is 0. ("SFENCE.VMA 0 asid" case)
+				            else if ((!content_q[i].pte.g) && (vaddr_to_be_flushed_is0) && (asid_to_be_flushed_i == tags_q[i].asid) && (!asid_to_be_flushed_is0))
+				            	  tags_n[i].valid = 1'b0;
+                end
+            end else if (flush_vvma_i) begin
+                if(tags_q[i].v && tags_q[i].s_st_enbl) begin
+                    // invalidate logic
+                    // flush everything if ASID is 0 and vaddr is 0 ("SFENCE.VMA x0 x0" case)
+        				    if (asid_to_be_flushed_is0 && vaddr_to_be_flushed_is0 && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl))
+                        tags_n[i].valid = 1'b0;
+                    // flush vaddr in all addressing space ("SFENCE.VMA vaddr x0" case), it should happen only for leaf pages
+                    else if (asid_to_be_flushed_is0 && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_s_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_s_2M) ) && (~vaddr_to_be_flushed_is0) && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl))
+                        tags_n[i].valid = 1'b0;
+                    // the entry is flushed if it's not global and asid and vaddr both matches with the entry to be flushed ("SFENCE.VMA vaddr asid" case)
+				            else if ((!content_q[i].pte.g) && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i] && vaddr_vpn2_match[i]) || (vaddr_vpn2_match[i] && tags_q[i].is_s_1G) || (vaddr_vpn1_match[i] && vaddr_vpn2_match[i] && tags_q[i].is_s_2M)) && (asid_to_be_flushed_i == tags_q[i].asid && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl)) && (!vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0))
+				              	tags_n[i].valid = 1'b0;
+                    // the entry is flushed if it's not global, and the asid matches and vaddr is 0. ("SFENCE.VMA 0 asid" case)
+				            else if ((!content_q[i].pte.g) && (vaddr_to_be_flushed_is0) && (asid_to_be_flushed_i == tags_q[i].asid && ((tags_q[i].g_st_enbl && lu_vmid_i == tags_q[i].vmid) || !tags_q[i].g_st_enbl)) && (!asid_to_be_flushed_is0))
+				            	  tags_n[i].valid = 1'b0;
+                end
+            end else if (flush_gvma_i) begin
+                if(tags_q[i].g_st_enbl) begin
+                    // invalidate logic
+                    // flush everything if VMID is 0 and addr is 0 ("HFENCE.GVMA x0 x0" case)
+        				    if (vmid_to_be_flushed_is0 && gpaddr_to_be_flushed_is0 )
+                        tags_n[i].valid = 1'b0;
+                    // flush gpaddr in all addressing space ("HFENCE.GVMA gpaddr x0" case), it should happen only for leaf pages
+                    else if (vmid_to_be_flushed_is0 && ((gpaddr_gppn0_match[i] && gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i]) || (gpaddr_gppn2_match[i] && tags_q[i].is_g_1G) || (gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i] && tags_q[i].is_g_2M) ) && (~gpaddr_to_be_flushed_is0))
+                        tags_n[i].valid = 1'b0;
+                    // the entry asid and gpaddr both matches with the entry to be flushed ("HFENCE.GVMA gpaddr vmid" case)
+				            else if (((gpaddr_gppn0_match[i] && gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i]) || (gpaddr_gppn2_match[i] && tags_q[i].is_g_1G) || (gpaddr_gppn1_match[i] && gpaddr_gppn2_match[i] && tags_q[i].is_g_2M)) && (vmid_to_be_flushed_i == tags_q[i].vmid) && (~gpaddr_to_be_flushed_is0) && (~vmid_to_be_flushed_is0))
+				              	tags_n[i].valid = 1'b0;
+                    // the entry is flushed if it's not global, and the vmid matches and gpaddr is 0. ("HFENCE.GVMA 0 vmid" case)
+				            else if ((gpaddr_to_be_flushed_is0) && (vmid_to_be_flushed_i == tags_q[i].vmid) && (!vmid_to_be_flushed_is0))
+				            	  tags_n[i].valid = 1'b0;
+                end
+            // normal replacement
+            end else if (update_i.valid & replace_en[i]) begin
+                // update tag array
+                tags_n[i] = '{
+                    asid:  s_st_enbl_i ? update_i.asid : 'b0,
+                    vmid:  g_st_enbl_i ? update_i.vmid : 'b0,
+                    vpn2:  update_i.vpn [18+riscv::VPN2:18],
+                    vpn1:  update_i.vpn [17:9],
+                    vpn0:  update_i.vpn [8:0],
+                    gppn2:  update_i.gppn [20+riscv::VPN2:18],
+                    gppn1:  update_i.gppn [17:9],
+                    gppn0:  update_i.gppn [8:0],
+                    s_st_enbl:  s_st_enbl_i,
+                    g_st_enbl:  g_st_enbl_i,
+                    v:     v_i,
+                    is_1G: update_i.is_1G,
+                    is_2M: update_i.is_2M,
+                    is_s_1G: update_i.is_s_1G,
+                    is_s_2M: update_i.is_s_2M,
+                    is_g_1G: update_i.is_g_1G,
+                    is_g_2M: update_i.is_g_2M,
+                    valid: 1'b1
+                };
+                // and content as well
+                content_n[i].pte  = update_i.content;
+                content_n[i].gpte = update_i.g_content;
+            end
+        end
+    end
+
+    // -----------------------------------------------
+    // PLRU - Pseudo Least Recently Used Replacement
+    // -----------------------------------------------
+    logic[2*(TLB_ENTRIES-1)-1:0] plru_tree_q, plru_tree_n;
+    always_comb begin : plru_replacement
+        plru_tree_n = plru_tree_q;
+        // The PLRU-tree indexing:
+        // lvl0        0
+        //            / \
+        //           /   \
+        // lvl1     1     2
+        //         / \   / \
+        // lvl2   3   4 5   6
+        //       / \ /\/\  /\
+        //      ... ... ... ...
+        // Just predefine which nodes will be set/cleared
+        // E.g. for a TLB with 8 entries, the for-loop is semantically
+        // equivalent to the following pseudo-code:
+        // unique case (1'b1)
+        // lu_hit[7]: plru_tree_n[0, 2, 6] = {1, 1, 1};
+        // lu_hit[6]: plru_tree_n[0, 2, 6] = {1, 1, 0};
+        // lu_hit[5]: plru_tree_n[0, 2, 5] = {1, 0, 1};
+        // lu_hit[4]: plru_tree_n[0, 2, 5] = {1, 0, 0};
+        // lu_hit[3]: plru_tree_n[0, 1, 4] = {0, 1, 1};
+        // lu_hit[2]: plru_tree_n[0, 1, 4] = {0, 1, 0};
+        // lu_hit[1]: plru_tree_n[0, 1, 3] = {0, 0, 1};
+        // lu_hit[0]: plru_tree_n[0, 1, 3] = {0, 0, 0};
+        // default: begin /* No hit */ end
+        // endcase
+        for (int unsigned i = 0; i < TLB_ENTRIES; i++) begin
+            automatic int unsigned idx_base, shift, new_index;
+            // we got a hit so update the pointer as it was least recently used
+            if (lu_hit[i] & lu_access_i) begin
+                // Set the nodes to the values we would expect
+                for (int unsigned lvl = 0; lvl < $clog2(TLB_ENTRIES); lvl++) begin
+                  idx_base = $unsigned((2**lvl)-1);
+                  // lvl0 <=> MSB, lvl1 <=> MSB-1, ...
+                  shift = $clog2(TLB_ENTRIES) - lvl;
+                  // to circumvent the 32 bit integer arithmetic assignment
+                  new_index =  ~((i >> (shift-1)) & 32'b1);
+                  plru_tree_n[idx_base + (i >> shift)] = new_index[0];
+                end
+            end
+        end
+        // Decode tree to write enable signals
+        // Next for-loop basically creates the following logic for e.g. an 8 entry
+        // TLB (note: pseudo-code obviously):
+        // replace_en[7] = &plru_tree_q[ 6, 2, 0]; //plru_tree_q[0,2,6]=={1,1,1}
+        // replace_en[6] = &plru_tree_q[~6, 2, 0]; //plru_tree_q[0,2,6]=={1,1,0}
+        // replace_en[5] = &plru_tree_q[ 5,~2, 0]; //plru_tree_q[0,2,5]=={1,0,1}
+        // replace_en[4] = &plru_tree_q[~5,~2, 0]; //plru_tree_q[0,2,5]=={1,0,0}
+        // replace_en[3] = &plru_tree_q[ 4, 1,~0]; //plru_tree_q[0,1,4]=={0,1,1}
+        // replace_en[2] = &plru_tree_q[~4, 1,~0]; //plru_tree_q[0,1,4]=={0,1,0}
+        // replace_en[1] = &plru_tree_q[ 3,~1,~0]; //plru_tree_q[0,1,3]=={0,0,1}
+        // replace_en[0] = &plru_tree_q[~3,~1,~0]; //plru_tree_q[0,1,3]=={0,0,0}
+        // For each entry traverse the tree. If every tree-node matches,
+        // the corresponding bit of the entry's index, this is
+        // the next entry to replace.
+        for (int unsigned i = 0; i < TLB_ENTRIES; i += 1) begin
+            automatic logic en;
+            automatic int unsigned idx_base, shift, new_index;
+            en = 1'b1;
+            for (int unsigned lvl = 0; lvl < $clog2(TLB_ENTRIES); lvl++) begin
+                idx_base = $unsigned((2**lvl)-1);
+                // lvl0 <=> MSB, lvl1 <=> MSB-1, ...
+                shift = $clog2(TLB_ENTRIES) - lvl;
+
+                // en &= plru_tree_q[idx_base + (i>>shift)] == ((i >> (shift-1)) & 1'b1);
+                new_index =  (i >> (shift-1)) & 32'b1;
+                if (new_index[0]) begin
+                  en &= plru_tree_q[idx_base + (i>>shift)];
+                end else begin
+                  en &= ~plru_tree_q[idx_base + (i>>shift)];
+                end
+            end
+            replace_en[i] = en;
+        end
+    end
+
+    // sequential process
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(~rst_ni) begin
+            tags_q      <= '{default: 0};
+            content_q   <= '{default: 0};
+            plru_tree_q <= '{default: 0};
+        end else begin
+            tags_q      <= tags_n;
+            content_q   <= content_n;
+            plru_tree_q <= plru_tree_n;
+        end
+    end
+    //--------------
+    // Sanity checks
+    //--------------
+
+    //pragma translate_off
+    `ifndef VERILATOR
+
+    initial begin : p_assertions
+      assert ((TLB_ENTRIES % 2 == 0) && (TLB_ENTRIES > 1))
+        else begin $error("TLB size must be a multiple of 2 and greater than 1"); $stop(); end
+      assert (ASID_WIDTH >= 1)
+        else begin $error("ASID width must be at least 1"); $stop(); end
+    end
+
+    // Just for checking
+    function int countSetBits(logic[TLB_ENTRIES-1:0] vector);
+      automatic int count = 0;
+      foreach (vector[idx]) begin
+        count += vector[idx];
+      end
+      return count;
+    endfunction
+
+    assert property (@(posedge clk_i)(countSetBits(lu_hit) <= 1))
+      else begin $error("More then one hit in TLB!"); $stop(); end
+    assert property (@(posedge clk_i)(countSetBits(replace_en) <= 1))
+      else begin $error("More then one TLB entry selected for next replace!"); $stop(); end
+
+    `endif
+    //pragma translate_on
+
+endmodule

--- a/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
@@ -107,7 +107,6 @@ module cva6_tlb_sv39x4 import ariane_pkg::*; #(
 
 
         for (int unsigned i = 0; i < TLB_ENTRIES; i++) begin
-            lu_gpaddr_o = make_gpaddr(s_st_enbl_i, tags_q[i].is_s_1G, tags_q[i].is_s_2M, lu_vaddr_i, content_q[i].pte);
             // first level match, this may be a giga page, check the ASID flags as well
             // if the entry is associated to a global address, don't match the ASID (ASID is don't care)
             match_asid[i] = (((lu_asid_i == tags_q[i].asid) || content_q[i].pte.g) && s_st_enbl_i) || !s_st_enbl_i;
@@ -127,6 +126,7 @@ module cva6_tlb_sv39x4 import ariane_pkg::*; #(
             // check if translation is a: S-Stage and G-Stage, S-Stage only or G-Stage only translation and virtualization mode is on/off
             match_stage[i] = (tags_q[i].v == v_i) && (tags_q[i].g_st_enbl == g_st_enbl_i) && (tags_q[i].s_st_enbl == s_st_enbl_i);
             if (tags_q[i].valid && match_asid[i] && match_vmid[i] && match_stage[i] && (vpn2 == (tags_q[i].vpn2 & mask_pn2))) begin
+                lu_gpaddr_o = make_gpaddr(s_st_enbl_i, tags_q[i].is_s_1G, tags_q[i].is_s_2M, lu_vaddr_i, content_q[i].pte);
                 if (is_1G[i]) begin
                       lu_is_1G_o      = is_1G[i];
                       lu_content_o    = content_q[i].pte;

--- a/core/store_unit.sv
+++ b/core/store_unit.sv
@@ -35,6 +35,9 @@ module store_unit import ariane_pkg::*; (
     output logic                     translation_req_o, // request address translation
     output logic [riscv::VLEN-1:0]   vaddr_o,           // virtual address out
     output [riscv::PLEN-1:0]         mem_paddr_o,
+    output logic [riscv::VLEN-1:0]   tinst_o,           // transformed instruction out
+    output logic                     hs_ld_st_inst_o,
+    output logic                     hlvx_inst_o,
     input  logic [riscv::PLEN-1:0]   paddr_i,           // physical address in
     input  exception_t               ex_i,
     input  logic                     dtlb_hit_i,       // will be one in the same cycle translation_req was asserted if it hits
@@ -72,8 +75,11 @@ module store_unit import ariane_pkg::*; (
     logic [TRANS_ID_BITS-1:0] trans_id_n, trans_id_q;
 
     // output assignments
-    assign vaddr_o    = lsu_ctrl_i.vaddr; // virtual address
-    assign trans_id_o = trans_id_q; // transaction id from previous cycle
+    assign vaddr_o          = lsu_ctrl_i.vaddr; // virtual address
+    assign hs_ld_st_inst_o  = lsu_ctrl_i.hs_ld_st_inst;
+    assign hlvx_inst_o      = lsu_ctrl_i.hlvx_inst;
+    assign tinst_o          = lsu_ctrl_i.tinst; // transformed instruction
+    assign trans_id_o       = trans_id_q; // transaction id from previous cycle
 
     always_comb begin : store_control
         translation_req_o      = 1'b0;


### PR DESCRIPTION
- RV64 only.
- Enabled using the `cva6_config_pkg::CVA6ConfigHExtEn` param (disabled by default).
- Missing CI tests for the hypervisor extension.