### PR TITLE
pd/synth/Makefile: Enable RVFI_MEM support at gate level.

### DIFF
--- a/pd/synth/Makefile
+++ b/pd/synth/Makefile
@@ -30,7 +30,7 @@ endif
 
 pre_cva6_synth:
 	grep "CVA6_REPO_DIR\}" ../../core/Flist.cva6|grep -v "instr_tracer"|grep -v "incdir" > Flist.cva6_synth
-	sed -i "s/^/analyze -f sverilog -define {WT_DCACHE,RVFI_TRACE} -lib ariane_lib /" Flist.cva6_synth
+	sed -i "s/^/analyze -f sverilog -define {WT_DCACHE,RVFI_TRACE,RVFI_MEM} -lib ariane_lib /" Flist.cva6_synth
 
 cva6_synth: pre_cva6_synth
 	@echo $(PERIOD)


### PR DESCRIPTION
This PR enables the synthesis of RVFI_MEM support which was missing in gate synthesis configuration.  As a consequence, the RVFI tracer module could not see memory-related events when attached to gate-level models.