### PR TITLE
Test termination: Delegate decision to testbench instead of using explicit $finish.

### DIFF
--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -353,7 +353,7 @@ done_processing:
   // memif.read(0x84000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__gen_mem_user__DOT__i_tc_sram_wrapper_user__DOT__i_tc_sram__DOT__sram);
 
 #ifndef DROMAJO
-  while (!dtm->done() && !jtag->done()) {
+  while (!dtm->done() && !jtag->done() && !(top->exit_o & 0x1)) {
 #else
   // the simulation gets killed by dromajo
   while (true) {
@@ -387,13 +387,17 @@ done_processing:
 
 #ifndef DROMAJO
   if (dtm->exit_code()) {
-    fprintf(stderr, "%s *** FAILED *** (code = %d) after %ld cycles\n", htif_argv[1], dtm->exit_code(), main_time);
+    fprintf(stderr, "%s *** FAILED *** (tohost = %d) after %ld cycles\n", htif_argv[1], dtm->exit_code(), main_time);
     ret = dtm->exit_code();
   } else if (jtag->exit_code()) {
-    fprintf(stderr, "%s *** FAILED *** (code = %d, seed %d) after %ld cycles\n", htif_argv[1], jtag->exit_code(), random_seed, main_time);
+    fprintf(stderr, "%s *** FAILED *** (tohost = %d, seed %d) after %ld cycles\n", htif_argv[1], jtag->exit_code(), random_seed, main_time);
     ret = jtag->exit_code();
+  } else if (top->exit_o & 0xFFFFFFFE) {
+    int exitcode = ((unsigned int) top->exit_o) >> 1;
+    fprintf(stderr, "%s *** FAILED *** (tohost = %d) after %ld cycles\n", htif_argv[1], exitcode, main_time);
+    ret = exitcode;
   } else {
-    fprintf(stderr, "%s completed after %ld cycles\n", htif_argv[1], main_time);
+    fprintf(stderr, "%s *** SUCCESS *** (tohost = 0) after %ld cycles\n", htif_argv[1], main_time);
   }
 
   if (dtm) delete dtm;

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -46,6 +46,7 @@ module ariane_testharness #(
   int          jtag_enable;
   logic        init_done;
   logic [31:0] jtag_exit, dmi_exit;
+  logic [31:0] rvfi_exit;
 
   logic        jtag_TCK;
   logic        jtag_TMS;
@@ -116,7 +117,11 @@ module ariane_testharness #(
   assign debug_req_valid     = (jtag_enable[0]) ? jtag_req_valid     : dmi_req_valid;
   assign debug_resp_ready    = (jtag_enable[0]) ? jtag_resp_ready    : dmi_resp_ready;
   assign debug_req           = (jtag_enable[0]) ? jtag_dmi_req       : dmi_req;
+`ifdef RVFI_TRACE
+  assign exit_o              = (jtag_enable[0]) ? jtag_exit          : rvfi_exit;
+`else
   assign exit_o              = (jtag_enable[0]) ? jtag_exit          : dmi_exit;
+`endif
   assign jtag_resp_valid     = (jtag_enable[0]) ? debug_resp_valid   : 1'b0;
   assign dmi_resp_valid      = (jtag_enable[0]) ? 1'b0               : debug_resp_valid;
 
@@ -667,7 +672,8 @@ module ariane_testharness #(
   ) rvfi_tracer_i (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .rvfi_i(rvfi)
+    .rvfi_i(rvfi),
+    .end_of_test_o(rvfi_exit)
   );
 
 `ifdef AXI_SVA

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -104,15 +104,17 @@ module rvfi_tracer #(
         end
       end
     end
-    end_of_test_d <= end_of_test_q;
-    if (cycles > SIM_FINISH) $finish(1);
-  end
 
-  always_ff @(posedge clk_i or negedge rst_ni)
     if (~rst_ni)
       cycles <= 0;
     else
       cycles <= cycles+1;
+    if (cycles > SIM_FINISH)
+      end_of_test_q = 32'hffff_ffff;
+
+    end_of_test_d <= end_of_test_q;
+  end
+
 
   // Trace any custom signals
   // Define signals to be traced by adding them into debug and name arrays

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -15,7 +15,8 @@ module rvfi_tracer #(
 )(
   input logic                           clk_i,
   input logic                           rst_ni,
-  input rvfi_pkg::rvfi_instr_t[NR_COMMIT_PORTS-1:0]           rvfi_i
+  input rvfi_pkg::rvfi_instr_t[NR_COMMIT_PORTS-1:0]           rvfi_i,
+  output logic[31:0]                    end_of_test_o
 );
 
   logic[riscv::PLEN-1:0] TOHOST_ADDR;
@@ -37,7 +38,12 @@ module rvfi_tracer #(
   // Generate the trace based on RVFI
   logic [63:0] pc64;
   string cause;
+  logic[31:0] end_of_test_q;
+  logic[31:0] end_of_test_d;
+
+  assign end_of_test_o = end_of_test_d;
   always_ff @(posedge clk_i) begin
+    end_of_test_q = (rst_ni && (end_of_test_d[0] == 1'b1)) ? end_of_test_d : 0;
     for (int i = 0; i < NR_COMMIT_PORTS; i++) begin
       pc64 = {{riscv::XLEN-riscv::VLEN{rvfi_i[i].pc_rdata[riscv::VLEN-1]}}, rvfi_i[i].pc_rdata};
       // print the instruction information if the instruction is valid or a trap is taken
@@ -77,8 +83,7 @@ module rvfi_tracer #(
             if (TOHOST_ADDR != '0 &&
                 rvfi_i[i].mem_paddr == TOHOST_ADDR &&
                 rvfi_i[i].mem_wdata[0] == 1'b1) begin
-              $finish(1);
-              $finish(1);
+              end_of_test_q = rvfi_i[i].mem_wdata[31:0];
             end
           end
         end
@@ -99,6 +104,7 @@ module rvfi_tracer #(
         end
       end
     end
+    end_of_test_d <= end_of_test_q;
     if (cycles > SIM_FINISH) $finish(1);
   end
 


### PR DESCRIPTION
This PR replaces explicit use of `$finish()` in RVFI tracer with proper propagation of end-of-test information to the verification testbench:
* Instread of executing a `$finish()` statement the RFVI tracer now outputs the end-of-test event and the test exit code on new output `end_of_test_o`.
* The Verilator and VCS C++ testbenches were modified to detect the end-of-test event (write of `1'b1` into bit 0 of memory variable `tohost`) and to report the exit code of the test (bits [31:1] of the word written into `tohost` upon end-of-test).  The Verilator testbench end-of-test messages were aligned on those of the VCS testbench.
* The UVM handling of the end-of-test is implemented in the companion core-v-verif PR https://github.com/openhwgroup/core-v-verif/pull/1729.

Once the end-of-test condition is detected, the `end_of_test_o` output of RVFI tracer is set and held indefinitely.

FORNOW: Upon hitting the programmable timeout, the RVFI tracer raises an end-of-test condition with the test exit code value `31'h7fff_ffff`, equivalent to writing `32'hffff_ffff` into `tohost`.  Once the timeout feature is moved outside of the RVFI tracer, this behavior may be removed.