### PR TITLE
Add parameter on config file to define the width of the memory transaction ID

### DIFF
--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -26,7 +26,7 @@
 
 
 module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
-  parameter logic [CACHE_ID_WIDTH-1:0]  RdTxId             = 0,                                  // ID to be used for read transactions
+  parameter logic [MEM_TID_WIDTH-1:0]   RdTxId             = 0,                                  // ID to be used for read transactions
   parameter ariane_pkg::ariane_cfg_t    ArianeCfg          = ariane_pkg::ArianeDefaultConfig     // contains cacheable regions
 ) (
   input  logic                      clk_i,

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -472,10 +472,11 @@ package ariane_pkg;
     localparam int unsigned DCACHE_LINE_WIDTH  = cva6_config_pkg::CVA6ConfigDcacheLineWidth; // in bit
     localparam int unsigned DCACHE_USER_LINE_WIDTH  = (AXI_USER_WIDTH == 1) ? 4 : cva6_config_pkg::CVA6ConfigDcacheLineWidth; // in bit
     localparam int unsigned DCACHE_USER_WIDTH  = DATA_USER_WIDTH;
-    localparam int unsigned DCACHE_TID_WIDTH   = cva6_config_pkg::CVA6ConfigDcacheIdWidth;
 
     localparam int unsigned MEM_TID_WIDTH      = cva6_config_pkg::CVA6ConfigMemTidWidth;
 `endif
+
+    localparam int unsigned DCACHE_TID_WIDTH   = cva6_config_pkg::CVA6ConfigDcacheIdWidth;
 
     localparam int unsigned WT_DCACHE_WBUF_DEPTH   = cva6_config_pkg::CVA6ConfigWtDcacheWbufDepth;
 

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -437,6 +437,10 @@ package ariane_pkg;
     `define CONFIG_L1D_SIZE 32*1024
 `endif
 
+`ifndef L15_THREADID_WIDTH
+    `define L15_THREADID_WIDTH 3
+`endif
+
     // I$
     localparam int unsigned ICACHE_LINE_WIDTH  = `CONFIG_L1I_CACHELINE_WIDTH;
     localparam int unsigned ICACHE_SET_ASSOC   = `CONFIG_L1I_ASSOCIATIVITY;
@@ -450,6 +454,8 @@ package ariane_pkg;
     localparam int unsigned DCACHE_TAG_WIDTH   = riscv::PLEN - DCACHE_INDEX_WIDTH;
     localparam int unsigned DCACHE_USER_LINE_WIDTH  = (AXI_USER_WIDTH == 1) ? 4 : 128; // in bit
     localparam int unsigned DCACHE_USER_WIDTH  = DATA_USER_WIDTH;
+
+    localparam int unsigned MEM_TID_WIDTH      = `L15_THREADID_WIDTH;
 `else
     // I$
     localparam int unsigned CONFIG_L1I_SIZE    = cva6_config_pkg::CVA6ConfigIcacheByteSize; // in byte
@@ -467,6 +473,8 @@ package ariane_pkg;
     localparam int unsigned DCACHE_USER_LINE_WIDTH  = (AXI_USER_WIDTH == 1) ? 4 : cva6_config_pkg::CVA6ConfigDcacheLineWidth; // in bit
     localparam int unsigned DCACHE_USER_WIDTH  = DATA_USER_WIDTH;
     localparam int unsigned DCACHE_TID_WIDTH   = cva6_config_pkg::CVA6ConfigDcacheIdWidth;
+
+    localparam int unsigned MEM_TID_WIDTH      = cva6_config_pkg::CVA6ConfigMemTidWidth;
 `endif
 
     localparam int unsigned WT_DCACHE_WBUF_DEPTH   = cva6_config_pkg::CVA6ConfigWtDcacheWbufDepth;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -42,6 +42,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigDcacheIdWidth = 1;
+    localparam CVA6ConfigMemTidWidth = 2;
 
     localparam CVA6ConfigWtDcacheWbufDepth = 2;
 

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -42,6 +42,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigDcacheIdWidth = 1;
+    localparam CVA6ConfigMemTidWidth = 2;
 
     localparam CVA6ConfigWtDcacheWbufDepth = 2;
 

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -42,6 +42,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigDcacheIdWidth = 1;
+    localparam CVA6ConfigMemTidWidth = 2;
 
     localparam CVA6ConfigWtDcacheWbufDepth = 8;
 

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -42,6 +42,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigDcacheIdWidth = 1;
+    localparam CVA6ConfigMemTidWidth = 2;
 
     localparam CVA6ConfigWtDcacheWbufDepth = 8;
 

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -42,6 +42,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigDcacheIdWidth = 1;
+    localparam CVA6ConfigMemTidWidth = 2;
 
     localparam CVA6ConfigWtDcacheWbufDepth = 8;
 

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -42,6 +42,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigDcacheIdWidth = 1;
+    localparam CVA6ConfigMemTidWidth = 2;
 
     localparam CVA6ConfigWtDcacheWbufDepth = 8;
 

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -42,6 +42,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigDcacheLineWidth = 128;
 
     localparam CVA6ConfigDcacheIdWidth = 1;
+    localparam CVA6ConfigMemTidWidth = 2;
 
     localparam CVA6ConfigWtDcacheWbufDepth = 8;
 

--- a/core/include/wt_cache_pkg.sv
+++ b/core/include/wt_cache_pkg.sv
@@ -30,23 +30,17 @@ package wt_cache_pkg;
     `define CONFIG_L15_ASSOCIATIVITY 4
 `endif
 
-`ifndef L15_THREADID_WIDTH
-    // this results in 8 pending tx slots in the writebuffer
-    `define L15_THREADID_WIDTH 3
-`endif
-
 `ifndef TLB_CSM_WIDTH
     `define TLB_CSM_WIDTH 33
 `endif
 
   localparam L15_SET_ASSOC           = `CONFIG_L15_ASSOCIATIVITY;
-  localparam L15_TID_WIDTH           = `L15_THREADID_WIDTH;
   localparam L15_TLB_CSM_WIDTH       = `TLB_CSM_WIDTH;
 `else
   localparam L15_SET_ASSOC           = ariane_pkg::DCACHE_SET_ASSOC;// align with dcache for compatibility with the standard Ariane setup
-  localparam L15_TID_WIDTH           = 2;
   localparam L15_TLB_CSM_WIDTH       = 33;
 `endif
+  localparam L15_TID_WIDTH           = ariane_pkg::MEM_TID_WIDTH;
   localparam L15_WAY_WIDTH           = $clog2(L15_SET_ASSOC);
   localparam L1I_WAY_WIDTH           = $clog2(ariane_pkg::ICACHE_SET_ASSOC);
   localparam L1D_WAY_WIDTH           = $clog2(ariane_pkg::DCACHE_SET_ASSOC);


### PR DESCRIPTION
This new parameter in the CVA6 configuration packages defines the width of the transaction ID between the I/Dcaches and the interconnection interface.

It should be defined in global CVA6 packages and not in any specific implementation of a cache to ease the integration of different cache subsystems.

Current default value (before this PR) is 2 bits. I kept this value, then no increase in the area is expected.

@JeanRochCoulon, can you review these changes?

Thank you