### PR TITLE
Make MMU optional

### DIFF
--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -687,7 +687,7 @@ package ariane_pkg;
     // ---------------
     // MMU instanciation
     // ---------------
-     localparam bit MMU_PRESENT = 1'b1;  // MMU is present
+     localparam bit MMU_PRESENT = cva6_config_pkg::CVA6ConfigMmuPresent;
 
      localparam int unsigned INSTR_TLB_ENTRIES = cva6_config_pkg::CVA6ConfigInstrTlbEntries;
      localparam int unsigned DATA_TLB_ENTRIES  = cva6_config_pkg::CVA6ConfigDataTlbEntries;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -66,4 +66,6 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigDcacheType = WT;
 
+    localparam CVA6ConfigMmuPresent = 1;
+
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -66,4 +66,6 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigDcacheType = WT;
 
+    localparam CVA6ConfigMmuPresent = 1;
+
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -66,4 +66,6 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigDcacheType = WT;
 
+    localparam CVA6ConfigMmuPresent = 1;
+
 endpackage

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -66,4 +66,6 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigDcacheType = WT;
 
+    localparam CVA6ConfigMmuPresent = 1;
+
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -66,4 +66,6 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigDcacheType = WB;
 
+    localparam CVA6ConfigMmuPresent = 1;
+
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -66,4 +66,6 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigDcacheType = WT;
 
+    localparam CVA6ConfigMmuPresent = 1;
+
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -66,4 +66,6 @@ package cva6_config_pkg;
 
     localparam cache_type_t CVA6ConfigDcacheType = WT;
 
+    localparam CVA6ConfigMmuPresent = 1;
+
 endpackage

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -274,7 +274,7 @@ package riscv;
     // memory management, pte for sv39
     typedef struct packed {
         logic [9:0]  reserved;
-        logic [44-1:0] ppn; // PPN length for 
+        logic [44-1:0] ppn; // PPN length for
         logic [1:0]  rsw;
         logic d;
         logic a;
@@ -288,7 +288,7 @@ package riscv;
 
     // memory management, pte for sv32
     typedef struct packed {
-        logic [22-1:0] ppn; // PPN length for 
+        logic [22-1:0] ppn; // PPN length for
         logic [1:0]  rsw;
         logic d;
         logic a;


### PR DESCRIPTION
Make MMU configurable from config pkg. 
Today no configuration disables the MMU, but a new configuration dedicated to embedded applications will be defined in next PR.