### PR TITLE
Support multiple outstanding load operations to the Dcache

### DIFF
--- a/core/cache_subsystem/wt_dcache_ctrl.sv
+++ b/core/cache_subsystem/wt_dcache_ctrl.sv
@@ -58,6 +58,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic [DCACHE_TAG_WIDTH-1:0]    address_tag_d, address_tag_q;
   logic [DCACHE_CL_IDX_WIDTH-1:0] address_idx_d, address_idx_q;
   logic [DCACHE_OFFSET_WIDTH-1:0] address_off_d, address_off_q;
+  logic [DCACHE_TID_WIDTH-1:0]    id_d, id_q;
   logic [DCACHE_SET_ASSOC-1:0]    vld_data_d,    vld_data_q;
   logic save_tag, rd_req_d, rd_req_q, rd_ack_d, rd_ack_q;
   logic [1:0] data_size_d, data_size_q;
@@ -71,6 +72,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign address_tag_d = (save_tag)            ? req_port_i.address_tag                                             : address_tag_q;
   assign address_idx_d = (req_port_o.data_gnt) ? req_port_i.address_index[DCACHE_INDEX_WIDTH-1:DCACHE_OFFSET_WIDTH] : address_idx_q;
   assign address_off_d = (req_port_o.data_gnt) ? req_port_i.address_index[DCACHE_OFFSET_WIDTH-1:0]                  : address_off_q;
+  assign id_d          = (req_port_o.data_gnt) ? req_port_i.data_id                                                 : id_q;
   assign data_size_d   = (req_port_o.data_gnt) ? req_port_i.data_size                                               : data_size_q;
   assign rd_tag_o      = address_tag_d;
   assign rd_idx_o      = address_idx_d;
@@ -78,7 +80,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
 
   assign req_port_o.data_rdata = rd_data_i;
   assign req_port_o.data_ruser = rd_user_i;
-  assign req_port_o.data_rid   = '0;
+  assign req_port_o.data_rid   = id_q;
 
   // to miss unit
   assign miss_vld_bits_o       = vld_data_q;
@@ -239,6 +241,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
       address_tag_q    <= '0;
       address_idx_q    <= '0;
       address_off_q    <= '0;
+      id_q             <= '0;
       vld_data_q       <= '0;
       data_size_q      <= '0;
       rd_req_q         <= '0;
@@ -248,6 +251,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
       address_tag_q    <= address_tag_d;
       address_idx_q    <= address_idx_d;
       address_off_q    <= address_off_d;
+      id_q             <= id_d;
       vld_data_q       <= vld_data_d;
       data_size_q      <= data_size_d;
       rd_req_q         <= rd_req_d;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -693,6 +693,9 @@ package ariane_pkg;
 `endif
     } scoreboard_entry_t;
 
+    //  Maximum number of inflight memory load requests
+    localparam int unsigned NR_LOAD_BUFFER_ENTRIES = cva6_config_pkg::CVA6ConfigNrLoadBufEntries;
+
     // ---------------
     // MMU instanciation
     // ---------------

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -54,6 +54,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -54,6 +54,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -49,6 +49,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrCommitPorts = 2;
     localparam CVA6ConfigNrScoreboardEntries = 8;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigFPGAEn = 0;
 

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -54,6 +54,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -54,6 +54,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -54,6 +54,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 16;
     localparam CVA6ConfigDataTlbEntries = 16;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -54,6 +54,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 16;
     localparam CVA6ConfigDataTlbEntries = 16;


### PR DESCRIPTION
The ID in the request from the load/store unit must be mirrored by the Dcache in the response. This allows to match a given response to its corresponding request. Responses can be given (by the Dcache) in a different order that the one of requests.

This modification introduces a pending load table that tracks outstanding load operations to the Dcache. The depth of this table is a parameter in the target configuration package.