### PR TITLE
Improved Acronym List in Glossary

### DIFF
--- a/docs/04_cv32a6_design/source/cv32a6_glossary.rst
+++ b/docs/04_cv32a6_design/source/cv32a6_glossary.rst
@@ -20,36 +20,52 @@
 Glossary
 ========
 
-* **VLEN**: Virtual address lengh
-* **XLEN**: RISC-V processor data lengh
 * **ALU**: Arithmetic/Logic Unit
+* **APU**: Application Processing Unit
 * **ASIC**: Application-Specific Integrated Circuit
+* **AXI**: Advanced eXtensible Interface
+* **BHT**: Branch History Table
+* **BTB**: Branch Target Buffer
 * **Byte**: 8-bit data item
 * **CPU**: Central Processing Unit, processor
 * **CSR**: Control and Status Register
 * **Custom extension**: Non-Standard extension to the RISC-V base instruction set (RISC-V Instruction Set Manual, Volume I: User-Level ISA)
-* **EXE**: Instruction Execute
+* **CVA6**: Core-V Application class processor with a 6 stage pipeline
+* **D$**: Data Cache
+* **DPI**: Direct Programming Interface
+* **EX** or **EXE**: Instruction Execute
 * **FPGA**: Field Programmable Gate Array
 * **FPU**: Floating Point Unit
 * **Halfword**: 16-bit data item
 * **Halfword aligned address**: An address is halfword aligned if it is divisible by 2
+* **I$**: Instruction Cache
 * **ID**: Instruction Decode
 * **IF**: Instruction Fetch
 * **ISA**: Instruction Set Architecture
-* **KGE**: kilo gate equivalents (NAND2)
+* **KGE**: Kilo Gate Equivalents (NAND2)
 * **LSU**: Load Store Unit
 * **M-Mode**: Machine Mode (RISC-V Instruction Set Manual, Volume II: Privileged Architecture)
+* **MMU**: Memory Management Unit
+* **NC**: Not Cacheable
 * **OBI**: Open Bus Interface
+* **OoO**: Out Of Order
 * **PC**: Program Counter
+* **PMP**: Physical memory protection (RISC-V Instruction Set Manual, Volume II: Privileged Architecture)
+* **PTW**: Page Table Walker
 * **PULP platform**: Parallel Ultra Low Power Platform (<https://pulp-platform.org>)
+* **RAS**: Return Address Stack
 * **RV32C**: RISC-V Compressed (C extension)
 * **RV32F**: RISC-V Floating Point (F extension)
+* **S-Mode**: Supervisor Mode (RISC-V Instruction Set Manual, Volume II: Privileged Architecture)
 * **SIMD**: Single Instruction/Multiple Data
 * **Standard extension**: Standard extension to the RISC-V base instruction set (RISC-V Instruction Set Manual, Volume I: User-Level ISA)
+* **TLB**: Translation Lookaside Buffer
+* **U-Mode**: User Mode (RISC-V Instruction Set Manual, Volume II: Privileged Architecture)
+* **VLEN**: Virtual address length
 * **WARL**: Write Any Values, Reads Legal Values
 * **WB**: Write Back of instruction results
 * **WLRL**: Write/Read Only Legal Values
 * **Word**: 32-bit data item
 * **Word aligned address**: An address is word aligned if it is divisible by 4
 * **WPRI**: Reserved Writes Preserve Values, Reads Ignore Values
-
+* **XLEN**: RISC-V processor data length


### PR DESCRIPTION
I added a few acronyms and fixed a couple typos. Here is the full changes list:

* Moved `VLEN` and `XLEN` so the list is now fully alphabetical
* Changed all occurrences of "lengh" to "length"
* Added
  * APU
  * AXI
  * BHT
  * BTB
  * CVA6
  * D$
  * DPI
  * EX
  * I$
  * MMU
  * NC
  * OoO
  * PMP
  * PTW
  * RAS
  * S-Mode
  * TLB
  * U-Mode