### PR TITLE
Transparently support Verilator v4 and v5.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ VCOM ?= vcom$(questa_version)
 VLIB ?= vlib$(questa_version)
 VMAP ?= vmap$(questa_version)
 # verilator version
-verilator      ?= verilator
+verilator      ?= verilator --no-timing
 # traget option
 target-options ?=
 # additional definess

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ VCOM ?= vcom$(questa_version)
 VLIB ?= vlib$(questa_version)
 VMAP ?= vmap$(questa_version)
 # verilator version
-verilator      ?= verilator --no-timing
+verilator      ?= verilator
 # traget option
 target-options ?=
 # additional definess

--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "Variane_testharness.h"
+#include "Variane_testharness___024root.h"
 #include "verilator.h"
 #include "verilated.h"
 #if VM_TRACE_FST
@@ -349,7 +350,7 @@ done_processing:
 
   // Preload memory.
   size_t mem_size = 0xFFFFFF;
-  memif.read(0x80000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram);
+  memif.read(0x80000000, mem_size, (void *) top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram.data());
   // memif.read(0x84000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__gen_mem_user__DOT__i_tc_sram_wrapper_user__DOT__i_tc_sram__DOT__sram);
 
 #ifndef DROMAJO

--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -15,10 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "Variane_testharness.h"
-#include "Variane_testharness___024root.h"
 #include "verilator.h"
 #include "verilated.h"
+#include "Variane_testharness.h"
+#if (VERILATOR_VERSION_INTEGER >= 5000000)
+  // Verilator v5 adds $root wrapper that provides rootp pointer.
+  #include "Variane_testharness___024root.h"
+#endif
 #if VM_TRACE_FST
 #include "verilated_fst_c.h"
 #else
@@ -350,7 +353,13 @@ done_processing:
 
   // Preload memory.
   size_t mem_size = 0xFFFFFF;
-  memif.read(0x80000000, mem_size, (void *) top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram.data());
+#if (VERILATOR_VERSION_INTEGER >= 5000000)
+  // Verilator v5: Use rootp pointer and .data() accessor.
+  memif.read(0x80000000, mem_size, (void *)top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram.data());
+#else
+  // Verilator v4
+  memif.read(0x80000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram);
+#endif
   // memif.read(0x84000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__gen_mem_user__DOT__i_tc_sram_wrapper_user__DOT__i_tc_sram__DOT__sram);
 
 #ifndef DROMAJO


### PR DESCRIPTION
This PR provides transparent support for Verilator v4 and v5 at the Verilator C++ testbench level.

Appropriate headers and data structure accesses are selected depending on the value of C++ macro `VERILATOR_VERSION_INTEGER`:
* In Verilator v4 this macro is not defined and therefore, evaluates to 0 if used in arithmetic context.
* In Verilator v5 it takes a value that is greater or equal to 5 million (the formula is "major_version * 1000000 + minor_version * 1000 + patch_level".)

There is no need to force the `--no-timing` option to Verilator in the CVA6 Makefile.  Instead, an appropriate definition of the Makefile variable `verilator` can be provided by the `core-v-verif` infrastructure depending on the Verilator version used.