### PR TITLE
ci: Propagate target to Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Prepare
       run: ci/setup.sh
     - name: run tests
-      run: make run-${{ matrix.testcase}}-verilator defines=${{ matrix.cache }}
+      run: make run-${{ matrix.testcase}}-verilator target=${{ matrix.target }}


### PR DESCRIPTION
The Github ci Matrix defines different CVA6 targets. However, these are currently not propagated to the Makefile, meaning that the Makefile always falls back to the default target (`cv64a6_imafdc_sv39`)