### PR TITLE
Add AXI parameter in cva6 config, keep AXI master structs in ariane and slave in SOC

### DIFF
--- a/core/include/ariane_axi_pkg.sv
+++ b/core/include/ariane_axi_pkg.sv
@@ -20,13 +20,13 @@ package ariane_axi;
     // used in axi_adapter.sv
     typedef enum logic { SINGLE_REQ, CACHE_LINE_REQ } ad_req_t;
 
-    localparam IdWidth   = 4; // Recommended by AXI standard
+    localparam IdWidth   = ariane_pkg::AXI_ID_WIDTH; // Recommended by AXI standard
     localparam UserWidth = ariane_pkg::AXI_USER_WIDTH;
-    localparam AddrWidth = 64;
-    localparam DataWidth = 64;
+    localparam AddrWidth = ariane_pkg::AXI_ADDR_WIDTH;
+    localparam DataWidth = ariane_pkg::AXI_DATA_WIDTH;
     localparam StrbWidth = DataWidth / 8;
 
-    typedef logic   [IdWidth-1:0]   id_t;
+    typedef logic [IdWidth-1:0]   id_t;
     typedef logic [AddrWidth-1:0] addr_t;
     typedef logic [DataWidth-1:0] data_t;
     typedef logic [StrbWidth-1:0] strb_t;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -285,7 +285,7 @@ package ariane_pkg;
     // AXI
     // ---------------
 
-    localparam AXI_ID_WIDTH = cva6_config_pkg::CVA6ConfigAxiIdWidth;;
+    localparam AXI_ID_WIDTH = cva6_config_pkg::CVA6ConfigAxiIdWidth;
     localparam AXI_ADDR_WIDTH = cva6_config_pkg::CVA6ConfigAxiAddrWidth;
     localparam AXI_DATA_WIDTH = cva6_config_pkg::CVA6ConfigAxiDataWidth;
     localparam FETCH_USER_WIDTH = cva6_config_pkg::CVA6ConfigFetchUserWidth;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -282,9 +282,12 @@ package ariane_pkg;
                                                     | riscv::SSTATUS_SUM
                                                     | riscv::SSTATUS_MXR;
     // ---------------
-    // User bits
+    // AXI
     // ---------------
 
+    localparam AXI_ID_WIDTH = 4;
+    localparam AXI_ADDR_WIDTH = 64;
+    localparam AXI_DATA_WIDTH = 64;
     localparam FETCH_USER_WIDTH = cva6_config_pkg::CVA6ConfigFetchUserWidth;
     localparam DATA_USER_WIDTH = cva6_config_pkg::CVA6ConfigDataUserWidth;
     localparam AXI_USER_EN = cva6_config_pkg::CVA6ConfigDataUserEn | cva6_config_pkg::CVA6ConfigFetchUserEn;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -285,9 +285,9 @@ package ariane_pkg;
     // AXI
     // ---------------
 
-    localparam AXI_ID_WIDTH = 4;
-    localparam AXI_ADDR_WIDTH = 64;
-    localparam AXI_DATA_WIDTH = 64;
+    localparam AXI_ID_WIDTH = cva6_config_pkg::CVA6ConfigAxiIdWidth;;
+    localparam AXI_ADDR_WIDTH = cva6_config_pkg::CVA6ConfigAxiAddrWidth;
+    localparam AXI_DATA_WIDTH = cva6_config_pkg::CVA6ConfigAxiDataWidth;
     localparam FETCH_USER_WIDTH = cva6_config_pkg::CVA6ConfigFetchUserWidth;
     localparam DATA_USER_WIDTH = cva6_config_pkg::CVA6ConfigDataUserWidth;
     localparam AXI_USER_EN = cva6_config_pkg::CVA6ConfigDataUserEn | cva6_config_pkg::CVA6ConfigFetchUserEn;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -28,6 +28,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 0;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -27,6 +27,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -28,6 +28,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -28,6 +28,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -28,6 +28,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -28,6 +28,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -28,6 +28,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -28,6 +28,9 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
 
+    localparam CVA6ConfigAxiIdWidth = 4;
+    localparam CVA6ConfigAxiAddrWidth = 64;
+    localparam CVA6ConfigAxiDataWidth = 64;
     localparam CVA6ConfigFetchUserEn = 0;
     localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
     localparam CVA6ConfigDataUserEn = 0;

--- a/corev_apu/tb/ariane_axi_soc_pkg.sv
+++ b/corev_apu/tb/ariane_axi_soc_pkg.sv
@@ -17,15 +17,12 @@
 
 package ariane_axi_soc;
 
-    // used in axi_adapter.sv
-    typedef enum logic { SINGLE_REQ, CACHE_LINE_REQ } ad_req_t;
-
     localparam UserWidth = ariane_pkg::AXI_USER_WIDTH;
-    localparam AddrWidth = 64;
-    localparam DataWidth = 64;
+    localparam AddrWidth = ariane_axi_pkg::AddrWidth;
+    localparam DataWidth = ariane_axi_pkg::DataWidth;
     localparam StrbWidth = DataWidth / 8;
 
-    typedef logic [ariane_soc::IdWidth-1:0]      id_t;
+    typedef logic [ariane_axi_pkg::IdWidth-1:0]  id_t;
     typedef logic [ariane_soc::IdWidthSlave-1:0] id_slv_t;
     typedef logic [AddrWidth-1:0] addr_t;
     typedef logic [DataWidth-1:0] data_t;

--- a/corev_apu/tb/ariane_axi_soc_pkg.sv
+++ b/corev_apu/tb/ariane_axi_soc_pkg.sv
@@ -17,12 +17,12 @@
 
 package ariane_axi_soc;
 
-    localparam UserWidth = ariane_axi_pkg::UserWidth;
-    localparam AddrWidth = ariane_axi_pkg::AddrWidth;
-    localparam DataWidth = ariane_axi_pkg::DataWidth;
+    localparam UserWidth = ariane_axi::UserWidth;
+    localparam AddrWidth = ariane_axi::AddrWidth;
+    localparam DataWidth = ariane_axi::DataWidth;
     localparam StrbWidth = DataWidth / 8;
 
-    typedef logic [ariane_axi_pkg::IdWidth-1:0]  id_t;
+    typedef logic [ariane_axi::IdWidth-1:0]  id_t;
     typedef logic [ariane_soc::IdWidthSlave-1:0] id_slv_t;
     typedef logic [AddrWidth-1:0] addr_t;
     typedef logic [DataWidth-1:0] data_t;
@@ -79,7 +79,7 @@ package ariane_axi_soc;
     typedef struct packed {
         aw_chan_slv_t aw;
         logic         aw_valid;
-        w_chan_t      w;
+        ariane_axi::w_chan_t      w;
         logic         w_valid;
         logic         b_ready;
         ar_chan_slv_t ar;

--- a/corev_apu/tb/ariane_axi_soc_pkg.sv
+++ b/corev_apu/tb/ariane_axi_soc_pkg.sv
@@ -17,7 +17,7 @@
 
 package ariane_axi_soc;
 
-    localparam UserWidth = ariane_pkg::AXI_USER_WIDTH;
+    localparam UserWidth = ariane_axi_pkg::UserWidth;
     localparam AddrWidth = ariane_axi_pkg::AddrWidth;
     localparam DataWidth = ariane_axi_pkg::DataWidth;
     localparam StrbWidth = DataWidth / 8;
@@ -28,22 +28,6 @@ package ariane_axi_soc;
     typedef logic [DataWidth-1:0] data_t;
     typedef logic [StrbWidth-1:0] strb_t;
     typedef logic [UserWidth-1:0] user_t;
-
-    // AW Channel
-    typedef struct packed {
-        id_t              id;
-        addr_t            addr;
-        axi_pkg::len_t    len;
-        axi_pkg::size_t   size;
-        axi_pkg::burst_t  burst;
-        logic             lock;
-        axi_pkg::cache_t  cache;
-        axi_pkg::prot_t   prot;
-        axi_pkg::qos_t    qos;
-        axi_pkg::region_t region;
-        axi_pkg::atop_t   atop;
-        user_t            user;
-    } aw_chan_t;
 
     // AW Channel - Slave
     typedef struct packed {
@@ -61,42 +45,12 @@ package ariane_axi_soc;
         user_t            user;
     } aw_chan_slv_t;
 
-    // W Channel - AXI4 doesn't define a wid
-    typedef struct packed {
-        data_t data;
-        strb_t strb;
-        logic  last;
-        user_t user;
-    } w_chan_t;
-
-    // B Channel
-    typedef struct packed {
-        id_t            id;
-        axi_pkg::resp_t resp;
-        user_t          user;
-    } b_chan_t;
-
     // B Channel - Slave
     typedef struct packed {
         id_slv_t        id;
         axi_pkg::resp_t resp;
         user_t          user;
     } b_chan_slv_t;
-
-    // AR Channel
-    typedef struct packed {
-        id_t             id;
-        addr_t            addr;
-        axi_pkg::len_t    len;
-        axi_pkg::size_t   size;
-        axi_pkg::burst_t  burst;
-        logic             lock;
-        axi_pkg::cache_t  cache;
-        axi_pkg::prot_t   prot;
-        axi_pkg::qos_t    qos;
-        axi_pkg::region_t region;
-        user_t            user;
-    } ar_chan_t;
 
     // AR Channel - Slave
     typedef struct packed {
@@ -113,15 +67,6 @@ package ariane_axi_soc;
         user_t            user;
     } ar_chan_slv_t;
 
-    // R Channel
-    typedef struct packed {
-        id_t            id;
-        data_t          data;
-        axi_pkg::resp_t resp;
-        logic           last;
-        user_t          user;
-    } r_chan_t;
-
     // R Channel - Slave
     typedef struct packed {
         id_slv_t        id;
@@ -130,28 +75,6 @@ package ariane_axi_soc;
         logic           last;
         user_t          user;
     } r_chan_slv_t;
-
-    // Request/Response structs
-    typedef struct packed {
-        aw_chan_t aw;
-        logic     aw_valid;
-        w_chan_t  w;
-        logic     w_valid;
-        logic     b_ready;
-        ar_chan_t ar;
-        logic     ar_valid;
-        logic     r_ready;
-    } req_t;
-
-    typedef struct packed {
-        logic     aw_ready;
-        logic     ar_ready;
-        logic     w_ready;
-        logic     b_valid;
-        b_chan_t  b;
-        logic     r_valid;
-        r_chan_t  r;
-    } resp_t;
 
     typedef struct packed {
         aw_chan_slv_t aw;

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -208,8 +208,8 @@ module ariane_testharness #(
     end
   end
 
-  ariane_axi_soc::req_t    dm_axi_m_req;
-  ariane_axi_soc::resp_t   dm_axi_m_resp;
+  ariane_axi::req_t    dm_axi_m_req;
+  ariane_axi::resp_t   dm_axi_m_resp;
 
   logic                dm_slave_req;
   logic                dm_slave_we;
@@ -292,8 +292,8 @@ module ariane_testharness #(
     .AXI_ADDR_WIDTH        ( ariane_axi_soc::AddrWidth ),
     .AXI_DATA_WIDTH        ( ariane_axi_soc::DataWidth ),
     .AXI_ID_WIDTH          ( ariane_soc::IdWidth       ),
-    .axi_req_t             ( ariane_axi_soc::req_t     ),
-    .axi_rsp_t             ( ariane_axi_soc::resp_t    )
+    .axi_req_t             ( ariane_axi::req_t         ),
+    .axi_rsp_t             ( ariane_axi::resp_t        )
   ) i_dm_axi_master (
     .clk_i                 ( clk_i                     ),
     .rst_ni                ( rst_ni                    ),
@@ -618,8 +618,8 @@ module ariane_testharness #(
   // ---------------
   // Core
   // ---------------
-  ariane_axi_soc::req_t    axi_ariane_req;
-  ariane_axi_soc::resp_t   axi_ariane_resp;
+  ariane_axi::req_t    axi_ariane_req;
+  ariane_axi::resp_t   axi_ariane_resp;
   ariane_pkg::rvfi_port_t  rvfi;
 
   ariane #(


### PR DESCRIPTION
The axi stuctures were declared twice in the RTL. This PR declare master structures in ariane_axi package and slave structures in ariane_axi_soc package. In parallel, the Ariane AXI configuration is done thanks to parameters declared in cva6 config. 