### PR TITLE
ptw: Wait for rvalid on flush

### DIFF
--- a/core/mmu_sv32/cva6_ptw_sv32.sv
+++ b/core/mmu_sv32/cva6_ptw_sv32.sv
@@ -359,7 +359,8 @@ module cva6_ptw_sv32 import ariane_pkg::*; #(
             // 1. in the PTE Lookup check whether we still need to wait for an rvalid
             // 2. waiting for a grant, if so: wait for it
             // if not, go back to idle
-            if ((state_q == PTE_LOOKUP && !data_rvalid_q) || ((state_q == WAIT_GRANT) && req_port_i.data_gnt))
+            if (((state_q inside {PTE_LOOKUP, WAIT_RVALID}) && !data_rvalid_q) ||
+                ((state_q == WAIT_GRANT) && req_port_i.data_gnt))
                 state_d = WAIT_RVALID;
             else
                 state_d = LATENCY;

--- a/core/mmu_sv39/ptw.sv
+++ b/core/mmu_sv39/ptw.sv
@@ -369,7 +369,8 @@ module ptw import ariane_pkg::*; #(
             // 1. in the PTE Lookup check whether we still need to wait for an rvalid
             // 2. waiting for a grant, if so: wait for it
             // if not, go back to idle
-            if ((state_q == PTE_LOOKUP && !data_rvalid_q) || ((state_q == WAIT_GRANT) && req_port_i.data_gnt))
+            if (((state_q inside {PTE_LOOKUP, WAIT_RVALID}) && !data_rvalid_q) ||
+                ((state_q == WAIT_GRANT) && req_port_i.data_gnt))
                 state_d = WAIT_RVALID;
             else
                 state_d = IDLE;


### PR DESCRIPTION
When the PTW is flushed, we need any pending transactions to complete before returning to the `IDLE` state. Currently, the PTW returns to`IDLE` after one cycle. Remain in `WAIT_RVALID` until we have actually received `rvalid`.