### PR TITLE
Fix reference to ariane.sv in Bender.yml

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -124,7 +124,7 @@ sources:
       #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv
 
       # Top-level source files (not necessarily instantiated at the top of the cva6).
-      - core/ariane.sv
+      - corev_apu/tb/ariane.sv
       - core/cva6.sv
       - core/alu.sv
       # Note: depends on fpnew_pkg, above


### PR DESCRIPTION
Hi there!

It looks like Bender.yml references the wrong path to ariane.sv.
EDIT: Maybe you want to move it to the (commented) test section.

Thanks!
Flavien