### PR TITLE
Remove redundant incompatible tech_cells_generic

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -11,11 +11,6 @@ dependencies:
   common_cells:
     { git: "https://github.com/pulp-platform/common_cells", version: 1.23.0 }
   fpnew: { git: "https://github.com/openhwgroup/cvfpu.git", version: 0.7.0 }
-  tech_cells_generic:
-    {
-      git: "https://github.com/pulp-platform/tech_cells_generic.git",
-      rev: b2a68114302af1d8191ddf34ea0e07b471911866,
-    }
 
 frozen: true
 


### PR DESCRIPTION
Hi there!

There's a bender dependency conflict with this repository, which is also provided, but [in another version, by common_cells](https://github.com/pulp-platform/common_cells/blob/4ac82b420e46fd0005513ca2283cb3c905e7599a/Bender.yml#L14).

Thanks!
Flavien