### PR TITLE
ci: Add bender-up-to-date action

### DIFF
--- a/.github/workflows/bender-up-to-date.yml
+++ b/.github/workflows/bender-up-to-date.yml
@@ -1,0 +1,16 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Nils Wistoff <nwistoff@iis.ee.ethz.ch>
+
+name: bender-up-to-date
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  bender-up-to-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Bender up-to-date
+        uses: pulp-platform/pulp-actions/bender-up-to-date@v2


### PR DESCRIPTION
To check if `Bender.yml` is up-to-date.

As expected, the workflow fails due to
```
bender-up-to-date: /home/runner/work/cva6/cva6/core/include/ariane_rvfi_pkg.sv not found.
bender-up-to-date: /home/runner/work/cva6/cva6/core/ariane.sv not found.
```

This will be resolved in #1189 and #1190, after which I will rebase and this job should pass.