### PR TITLE
[SkipCI] CONTRIBUTING.md: replace emoji with GitHub labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Contributors are encouraged, but not required, to be a [member](https://www.open
 ### Major evolutions
 
 CVA6 has turned into an industrial project, where the core is being verified to be integrated in production ICs.
-In the same time, we'd like to continue integrating new contributions to keep CVA6 a vivid and innovative ecosystem.
+In the same time, we'd like to continue integrating some new contributions to keep CVA6 a vivid and innovative ecosystem.
 But this comes with constraints to ensure that new contributions do not put the industrial project at risk.
 
 Therefore here are guidelines to help the CVA6 team accept new contributions:
@@ -19,7 +19,7 @@ Therefore here are guidelines to help the CVA6 team accept new contributions:
     * The CVA6 team can provide you recommendations to ease the upcoming contribution.
     * This can help save significant review and overhauling effort for you and us when dealing with the pull request review.
     * Together, we can anticipate specific cases that are not addressed here.
-    * If you do not know how to contact us already, get in touch through info@openhwgroup.org.
+    * If you do not know how to contact us already, get in touch through info@openhwgroup.org or open an issue in GitHub.
     
 - Specific recommendations:
     * Always consider using the CV-X-IF interface if your contribution is an instruction-set extension.
@@ -74,30 +74,7 @@ For RTL coding, the OpenHW Group has adopted the [lowRISC Style Guides](https://
 - Use the present tense ("Add feature" not "Added feature").
 - Wrap the body at 72 characters.
 - Use the body to explain what and why vs. how.
-- Consider starting the commit message with an applicable emoji:
-    * :sparkles: `:sparkles:` When introducing a new feature
-    * :art: `:art:` Improving the format/structure of the code
-    * :zap: `:zap:` When improving performance
-    * :fire: `:fire` Removing code or files.
-    * :memo: `:memo:` When writing docs
-    * :bug: `:bug:` When fixing a bug
-    * :fire: `:fire:` When removing code or files
-    * :wastebasket: `:wastebasket:` When removing code or files
-    * :green_heart: `:green_heart:` When fixing the CI build
-    * :construction_worker: `:construction_worker:` Adding CI build system
-    * :white_check_mark: `:white_check_mark:` When adding tests
-    * :lock: `:lock:` When dealing with security
-    * :arrow_up: `:arrow_up:` When upgrading dependencies
-    * :arrow_down: `:arrow_down:` When downgrading dependencies
-    * :rotating_light: `:rotating_light:` When removing linter warnings
-    * :pencil2: `pencil2:` Fixing typos
-    * :recycle: `:scisccor:` Refactoring code.
-    * :boom: `:boom:` Introducing breaking changes
-    * :truck: `truck` Moving or renaming files.
-    * :space_invader: `:space_invader:` When fixing something synthesis related
-    * :beers: `:beer:` Writing code drunkenly.
-    * :ok_hand: `:ok_hand` Updating code due to code review changes
-    * :building_construction: `:building_construction:` Making architectural changes.
+- Select relevant GitHub labels (e.g. ``Component:Doc``, ``Type:Bug``...)
 
 For a detailed why and how please refer to one of the multiple [resources](https://chris.beams.io/posts/git-commit/) regarding git commit messages.
 


### PR DESCRIPTION
This update follows the CVA6 meeting on 2023-04-18. We thought the emoji tagging was deprecated and labels should be emphasized.