### PR TITLE
ci: Remove unused `defines` parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Prepare
       run: ci/setup.sh
     - name: run tests
-      run: make run-${{ matrix.testcase}}-verilator defines=${{ matrix.cache }}
+      run: make run-${{ matrix.testcase}}-verilator


### PR DESCRIPTION
The `defines` parameter is no longer used in the CVA6 Makefile. Therefore, remove it.