### PR TITLE
ci: Remove unused `target` matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         testcase: [asm-tests, mul, amo, fp, benchmarks]
-        target: [cv64a6_imafdc_sv39, cv32a60x, cv32a6_imafc_sv32]
     env:
       RISCV: /riscv
     steps:


### PR DESCRIPTION
The value of the `target` matrix is currently not used by the CI. However, it launches a job for each entry (without using it), unnecessarily consuming CI runtime.