### PR TITLE
Add bit manip in the requirement specification.

### DIFF
--- a/docs/02_cva6_requirements/cva6_requirements_specification.rst
+++ b/docs/02_cva6_requirements/cva6_requirements_specification.rst
@@ -306,6 +306,11 @@ independent requirements.
 |                                   |   run-time (selected through a    |
 |                                   |   register).*                     |
 +-----------------------------------+-----------------------------------+
+| ISA-120                           | CVA6 should support as an         |
+|                                   | **option** the **Zba**, **Zbb**,  |
+|                                   | **Zbc** and **Zbs** extensions    |
+|                                   | (bit manipulation), version 1.0.  |
++-----------------------------------+-----------------------------------+
 
 Note to ISA-60 and ISA-70: CV64A6 cannot support the D extension with
 the F extension.


### PR DESCRIPTION
Even if bitmanip was not in the initial plans, it proves useful for performance and it's time to back-annotate the requirements.
"Should" reflects the fact that it was not in the initial plans.
@fatimasaleem, in addition, can you specifically check the version number? Thanks.