### PR TITLE
Enable Bit manipulation in cv64a6_imafdc_sv39 configuration

### DIFF
--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
-    localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigBExtEn = 1;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;


### PR DESCRIPTION
As B extension has demonstrated its effeciency, @jquevremont @fatimasaleem  I have activated the bit manipulation for the 64 bit configuration. Can you approve it ?