### PR TITLE
perf: fix too strict restriction on FLU write-back

### DIFF
--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -388,7 +388,7 @@ module issue_read_operands import ariane_pkg::*; #(
         end
         // after a multiplication was issued we can only issue another multiplication
         // otherwise we will get contentions on the fixed latency bus
-        if (mult_valid_q && issue_instr_i.fu != MULT) begin
+        if (mult_valid_q && issue_instr_i.fu inside {ALU, CTRL_FLOW, CSR}) begin
             issue_ack_o = 1'b0;
         end
     end


### PR DESCRIPTION
### Context

This PR modifies a restriction in the issue stage. The role of the restriction is to avoids contentions in the `flu` result bus (functional unit -> scoreboard) as MULT duration is 2 cycles and other `flu` operations are 1 cycle-long (except div which has a stall signal and is not actually fixed latency).

### Issue fixed

While not all functional units use this same result bus, the issue stage was inserting a bubble after each MULT (except if the subsequent instruction is a MULT too) even when not needed. This PR fixes this too restrictive behavior.

### Example

LOAD uses another result bus so there are no contentions with MULT. A bubble was inserted in a `MULT -> LOAD` sequence even if it was not needed.