### PR TITLE
[C++ TB code] Upgrade C++ standard used.  Clean up Makefile layout.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,10 @@ endif
 dpi_hdr := $(wildcard corev_apu/tb/dpi/*.h)
 dpi_hdr := $(addprefix $(root-dir), $(dpi_hdr))
 CFLAGS += -I$(QUESTASIM_HOME)/include         \
-          -I$(VCS_HOME)/include \
+          -I$(VCS_HOME)/include               \
           -I$(RISCV)/include                  \
           -I$(SPIKE_ROOT)/include             \
-          -std=c++11 -I../corev_apu/tb/dpi -O3
+          -std=c++17 -I../corev_apu/tb/dpi -O3
 
 ifdef XCELIUM_HOME
 CFLAGS += -I$(XCELIUM_HOME)/tools/include
@@ -159,7 +159,7 @@ src :=  core/include/$(target)_config_pkg.sv                                    
         vendor/pulp-platform/common_cells/src/rstgen_bypass.sv                       \
         vendor/pulp-platform/common_cells/src/rstgen.sv                              \
         vendor/pulp-platform/common_cells/src/addr_decode.sv                         \
-				vendor/pulp-platform/common_cells/src/stream_register.sv                     \
+	vendor/pulp-platform/common_cells/src/stream_register.sv                     \
         vendor/pulp-platform/axi/src/axi_cut.sv                                      \
         vendor/pulp-platform/axi/src/axi_join.sv                                     \
         vendor/pulp-platform/axi/src/axi_delayer.sv                                  \
@@ -303,7 +303,7 @@ $(library):
 # compile DPIs
 $(dpi-library)/%.o: corev_apu/tb/dpi/%.cc $(dpi_hdr)
 	mkdir -p $(dpi-library)
-	$(CXX) -shared -fPIC -std=c++0x -Bsymbolic $(CFLAGS) -c $< -o $@
+	$(CXX) -shared -fPIC -Bsymbolic $(CFLAGS) -c $< -o $@
 
 $(dpi-library)/ariane_dpi.so: $(dpi)
 	mkdir -p $(dpi-library)

--- a/ariane.core
+++ b/ariane.core
@@ -69,7 +69,7 @@ targets:
           - -LDFLAGS
           - "-lfesvr"
           - -CFLAGS
-          - "-std=c++11"
+          - "-std=c++17"
           - -Wall
           - --trace
     toplevel : [ariane_wrapped]


### PR DESCRIPTION
This PR uniformizes the handling of command line options that select the C++ standard used for compiling C++ code of the testbench.  With the upcoming upgrade of Spike (vendorization + update to latest upstream), the systematic use of C++ 2017 standard throughout the CVA6 project becomes mandatory. 

* Makefile (CFLAGS): Use C++ 2017 standard.  Fix whitespace.
* (src): Fix whitespace.
* ($(dpi-library)/%.o): Do not add another (potentially conflicting) C++ standard option.
* ariane.core (verilator_options): Use C++ 2017 standard.