### PR TITLE
Fixed and simplified expression for lzc_a_input in serdiv

### DIFF
--- a/core/serdiv.sv
+++ b/core/serdiv.sv
@@ -82,7 +82,7 @@ module serdiv import ariane_pkg::*; #(
   assign op_a_sign = op_a_i[$high(op_a_i)];
   assign op_b_sign = op_b_i[$high(op_b_i)];
 
-  assign lzc_a_input = (opcode_i[0] & op_a_sign & (op_a_i == -$signed(1)))? {~op_a_i, 1'b1} : (opcode_i[0] & op_a_sign) ? {~op_a_i, 1'b0} : op_a_i; 
+  assign lzc_a_input = (opcode_i[0] & op_a_sign) ? {~op_a_i[$high(op_a_i)-1:0], 1'b1} : op_a_i; 
   // This change in lzc_a_input equation helps to fix erronous results for DIV and REM for -1/1.
   assign lzc_b_input = (opcode_i[0] & op_b_sign) ? ~op_b_i         : op_b_i;
 


### PR DESCRIPTION
# Issue
The formal tool OneSpin 360 DV does not correctly handle the unsigned vs. signed comparison in `op_a_i == -$signed(1)`, as it expects a `$signed` keyword for `op_a_i`.
The commit fc2967c added this extra check to correct a bug that occurs when `op_a_i == -1`.
However, I then realized that this expression can be simplified.

# Fix
Instead of appending `1'b1` if `op_a_i == -1` and `0'b0` else, the functionality remains the same if `1'b1` is always added.
The reason for this is that the last bit does not matter in the count leading zero operation whenever `op_a_i != -1`.
I also added `[$high(op_a_i)-1:0]` to avoid the implicit truncation.

# Example
Assume a WIDTH of 8:
If  `op_a_i == -1` (`8'b11111111`) then `lzc_a_input == 8'b00000001` and thus `lzc_a_result == 7`.
If  `op_a_i == -2` (`8'b11111110`) then `lzc_a_input == 8'b0000001X` and thus `lzc_a_result == 6`.
If  `op_a_i == -3` (`8'b11111101`) then `lzc_a_input == 8'b0000010X` and thus `lzc_a_result == 5`.
And so on...