### PR TITLE
Fix bytewidth parameter in OpenPiton bootrom AXI-lite bridge

### DIFF
--- a/corev_apu/openpiton/riscv_peripherals.sv
+++ b/corev_apu/openpiton/riscv_peripherals.sv
@@ -396,7 +396,7 @@ module riscv_peripherals #(
   assign rom_rdata = (ariane_boot_sel_i) ? rom_rdata_bm : rom_rdata_linux;
 
   noc_axilite_bridge #(
-    .SLAVE_RESP_BYTEWIDTH   ( 8             ),
+    .SLAVE_RESP_BYTEWIDTH   ( 0             ),
     .SWAP_ENDIANESS         ( SwapEndianess )
   ) i_bootrom_axilite_bridge (
     .clk                    ( clk_i                           ),


### PR DESCRIPTION
The current bootrom in riscv_peripherals.sv has an AXI-lite bridge that assumes 64b alignment, regardless of the request size. This is incompatible with requests of 32b i.e. I$ fetches which do not fill the full bus width. The erroneous behavior is that the 32b request will not be duplicated in the returning P-Mesh request, which violates the protocol.

This PR fixes this parameter to 0, which informs the bridge to consider the request size when packing the bus on request returns.