### PR TITLE
Makefile: Remove duplicate cva6_config_pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ fpga_src :=  $(wildcard corev_apu/fpga/src/*.sv) $(wildcard corev_apu/fpga/src/b
 fpga_src := $(addprefix $(root-dir), $(fpga_src))
 
 # look for testbenches
-tbs := core/include/$(target)_config_pkg.sv corev_apu/tb/ariane_tb.sv corev_apu/tb/ariane_testharness.sv
+tbs := corev_apu/tb/ariane_tb.sv corev_apu/tb/ariane_testharness.sv
 tbs := $(addprefix $(root-dir), $(tbs))
 
 # RISCV asm tests and benchmark setup (used for CI)


### PR DESCRIPTION
`cva6_config_pkg` is currently listed in `tbs` and `src`. Elaborating it twice causes some tools to throw a warning (e.g. verilator) and others to error (e.g. questa). Fix this by removing `cva6_config_pkg` from the testbench file list (it is anyways used by the design and thus a design source).