### PR TITLE
Move wt_cache_pkg functions which depend on cva6 input paramaters

### DIFF
--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -49,6 +49,16 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   output icache_req_t               mem_data_o
 );
 
+  // functions
+  function automatic logic [ariane_pkg::ICACHE_SET_ASSOC-1:0] icache_way_bin2oh (
+    input logic [L1I_WAY_WIDTH-1:0] in
+  );
+    logic [ariane_pkg::ICACHE_SET_ASSOC-1:0] out;
+    out     = '0;
+    out[in] = 1'b1;
+    return out;
+  endfunction
+
   // signals
   logic                                 cache_en_d, cache_en_q;       // cache is enabled
   logic [riscv::VLEN-1:0]               vaddr_d, vaddr_q;

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -72,6 +72,16 @@ module wt_dcache_mem import ariane_pkg::*; import wt_cache_pkg::*; #(
   input wbuffer_t             [DCACHE_WBUF_DEPTH-1:0]       wbuffer_data_i
 );
 
+  // functions
+  function automatic logic [DCACHE_NUM_BANKS-1:0] dcache_cl_bin2oh (
+    input logic [DCACHE_NUM_BANKS_WIDTH-1:0] in
+  );
+    logic [DCACHE_NUM_BANKS-1:0] out;
+    out     = '0;
+    out[in] = 1'b1;
+    return out;
+  endfunction
+
   // number of bits needed to address AXI data. If AxiDataWidth equals XLEN this parameter
   // is not needed. Therefore, increment it by one to avoid reverse range select during elaboration.
   localparam AXI_OFFSET_WIDTH = AxiDataWidth == riscv::XLEN ? $clog2(AxiDataWidth/8)+1 : $clog2(AxiDataWidth/8);

--- a/core/include/wt_cache_pkg.sv
+++ b/core/include/wt_cache_pkg.sv
@@ -257,34 +257,6 @@ package wt_cache_pkg;
     return out;
   endfunction
 
-  function automatic logic [ariane_pkg::ICACHE_SET_ASSOC-1:0] icache_way_bin2oh (
-    input logic [L1I_WAY_WIDTH-1:0] in
-  );
-    logic [ariane_pkg::ICACHE_SET_ASSOC-1:0] out;
-    out     = '0;
-    out[in] = 1'b1;
-    return out;
-  endfunction
-
-  function automatic logic [ariane_pkg::DCACHE_SET_ASSOC-1:0] dcache_way_bin2oh (
-    input logic [L1D_WAY_WIDTH-1:0] in
-  );
-    logic [ariane_pkg::DCACHE_SET_ASSOC-1:0] out;
-    out     = '0;
-    out[in] = 1'b1;
-    return out;
-  endfunction
-
-  function automatic logic [DCACHE_NUM_BANKS-1:0] dcache_cl_bin2oh (
-    input logic [DCACHE_NUM_BANKS_WIDTH-1:0] in
-  );
-    logic [DCACHE_NUM_BANKS-1:0] out;
-    out     = '0;
-    out[in] = 1'b1;
-    return out;
-  endfunction
-
-
   function automatic logic [5:0] popcnt64 (
     input logic [63:0] in
   );
@@ -382,27 +354,5 @@ package wt_cache_pkg;
     endcase // be
     return size;
   endfunction : toSize32
-
-  // align the physical address to the specified size:
-  // 000: bytes
-  // 001: hword
-  // 010: word
-  // 011: dword
-  // 111: DCACHE line
-  function automatic logic [riscv::PLEN-1:0] paddrSizeAlign(
-    input logic [riscv::PLEN-1:0] paddr,
-    input logic [2:0]  size
-  );
-    logic [riscv::PLEN-1:0] out;
-    out = paddr;
-    unique case (size)
-      3'b001: out[0:0]                     = '0;
-      3'b010: out[1:0]                     = '0;
-      3'b011: out[2:0]                     = '0;
-      3'b111: out[DCACHE_OFFSET_WIDTH-1:0] = '0;
-      default: ;
-    endcase
-    return out;
-  endfunction : paddrSizeAlign
 
 endpackage


### PR DESCRIPTION
from wt_cache_pkg to dedicated modules.

This will help for the parametrization