### PR TITLE
Makefile/questa: Pass elf-bin to fesvr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ generate-trace-vsim:
 sim: build
 	$(VSIM) +permissive $(questa-flags) $(questa-cmd) -lib $(library) +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) \
 	+BASEDIR=$(riscv-test-dir) $(uvm-flags) $(QUESTASIM_FLAGS) -gblso $(SPIKE_ROOT)/lib/libfesvr.so -sv_lib $(dpi-library)/ariane_dpi  \
-	${top_level}_optimized +permissive-off +PRELOAD=$(elf-bin) ++$(target-options) | tee sim.log
+	${top_level}_optimized +permissive-off ++$(elf-bin) ++$(target-options) | tee sim.log
 
 $(riscv-asm-tests): build
 	$(VSIM) +permissive $(questa-flags) $(questa-cmd) -lib $(library) +max-cycles=$(max_cycles) +UVM_TESTNAME=$(test_case) \


### PR DESCRIPTION
`elf-bin` is propagated to fesvr via the plusplus arg. Since #1240, running
```
make sim elf-bin=path/to/elf
```
returns
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  could not open
+PRELOAD=path/to/elf (did you misspell it? If VCS, did you forget +permissive/+permissive-off?)
```

As per the README, if preloading is needed, `make sim preload=path/to/elf` should be used instead (https://github.com/openhwgroup/cva6/tree/master#memory-preloading), which sets `+PRELOAD=path/to/elf`:
https://github.com/openhwgroup/cva6/blob/6c89fda0da14e188c43c818be3af15123c82fc69/Makefile#L249-L253.