### PR TITLE
[VL waveforms] Fix path to trace support code provided with Verilator v5.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,8 +545,8 @@ verilate_command := $(verilator) verilator_config.vlt                           
                     $(if ($(PRELOAD)!=""), -DPRELOAD=1,)                                                         \
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
                     $(if $(DEBUG), --trace-structs,)                                                             \
-                    $(if $(TRACE_COMPACT), --trace-fst $(VERILATOR_ROOT)/include/verilated_fst_c.cpp)            \
-                    $(if $(TRACE_FAST), --trace $(VERILATOR_ROOT)/include/verilated_vcd_c.cpp,)                  \
+                    $(if $(TRACE_COMPACT), --trace-fst $(VERILATOR_INSTALL_DIR)/share/verilator/include/verilated_fst_c.cpp) \
+                    $(if $(TRACE_FAST), --trace $(VERILATOR_INSTALL_DIR)/share/verilator/include/verilated_vcd_c.cpp,)       \
                     -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) -lpthread $(if $(TRACE_COMPACT), -lz,)" \
                     -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) -DVL_DEBUG"                                      \
                     --cc  --vpi                                                                                  \


### PR DESCRIPTION
## Purpose

This change fixes verilation errors occurring when waveform generation is requested by setting `TRACE_FAST` or `TRACE_COMPACT` with Verilator v5.

## Modifications

* Makefile (verilate_command): Use correct path to the Verilator-supplied source files.