### PR TITLE
[HOT FIX] Revert "Makefile: Remove duplicate cva6_config_pkg (#1273)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ fpga_src :=  $(wildcard corev_apu/fpga/src/*.sv) $(wildcard corev_apu/fpga/src/b
 fpga_src := $(addprefix $(root-dir), $(fpga_src))
 
 # look for testbenches
-tbs := corev_apu/tb/ariane_tb.sv corev_apu/tb/ariane_testharness.sv
+tbs := core/include/$(target)_config_pkg.sv corev_apu/tb/ariane_tb.sv corev_apu/tb/ariane_testharness.sv
 tbs := $(addprefix $(root-dir), $(tbs))
 
 # RISCV asm tests and benchmark setup (used for CI)


### PR DESCRIPTION
This reverts commit ae97ddb66023b14ddb6e26126d4386c027af2b13.

@niwis. This commit fails CI in target=vcs-testharness configuration. That's why it is an HOT FIX. Let's investigate the fail after fixing the CI. 
