### PR TITLE
Add coverage pragmas to exclude BITMANIP code

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -73,6 +73,7 @@ module alu import ariane_pkg::*;(
     always_comb begin
       operand_a_bitmanip = fu_data_i.operand_a;
 
+      //VCS coverage off
       if (ariane_pkg::BITMANIP) begin
         unique case (fu_data_i.operation)
           SH1ADD   : operand_a_bitmanip = fu_data_i.operand_a << 1;
@@ -87,6 +88,7 @@ module alu import ariane_pkg::*;(
           default  : ;
         endcase
       end
+      //VCS coverage on
     end
 
     // prepare operand a
@@ -187,6 +189,7 @@ module alu import ariane_pkg::*;(
         less = ($signed({sgn & fu_data_i.operand_a[riscv::XLEN-1], fu_data_i.operand_a})  <  $signed({sgn & fu_data_i.operand_b[riscv::XLEN-1], fu_data_i.operand_b}));
     end
 
+    //VCS coverage off
     if (ariane_pkg::BITMANIP) begin : gen_bitmanip
         // Count Population + Count population Word
 
@@ -217,6 +220,7 @@ module alu import ariane_pkg::*;(
           .empty_o (lz_tz_wempty)
         );
     end
+    //VCS coverage on
 
     // -----------
     // Result MUX
@@ -249,6 +253,7 @@ module alu import ariane_pkg::*;(
             default: ; // default case to suppress unique warning
         endcase
 
+        //VCS coverage off
         if (ariane_pkg::BITMANIP) begin
             // Index for Bitwise Rotation
             bit_indx = 1 << (fu_data_i.operand_b & (riscv::XLEN-1));
@@ -295,5 +300,6 @@ module alu import ariane_pkg::*;(
                 default: ; // default case to suppress unique warning
             endcase
         end
+        //VCS coverage on
     end
 endmodule

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -476,8 +476,10 @@ module decoder import ariane_pkg::*; (
                     // Integer Reg-Reg Operations
                     // ---------------------------
                     end else begin
+                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             instruction_o.fu  = (instr.rtype.funct7 == 7'b000_0001 || ((instr.rtype.funct7 == 7'b000_0101) && !(instr.rtype.funct3[14]))) ? MULT : ALU;
+                        //VCS coverage on
                         end else begin
                             instruction_o.fu  = (instr.rtype.funct7 == 7'b000_0001) ? MULT : ALU;
                         end
@@ -509,6 +511,7 @@ module decoder import ariane_pkg::*; (
                                 illegal_instr_non_bm = 1'b1;
                             end
                         endcase
+                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             unique case ({instr.rtype.funct7, instr.rtype.funct3})
                                 //Logical with Negate
@@ -542,8 +545,11 @@ module decoder import ariane_pkg::*; (
                                     illegal_instr_bm = 1'b1;
                                 end
                             endcase
+                            illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
+                        //VCS coverage on
+                        end else begin
+                          illegal_instr = illegal_instr_non_bm;
                         end
-                        illegal_instr = (ariane_pkg::BITMANIP) ? (illegal_instr_non_bm & illegal_instr_bm) : illegal_instr_non_bm;
                     end
                 end
 
@@ -570,6 +576,7 @@ module decoder import ariane_pkg::*; (
                             {7'b000_0001, 3'b111}: instruction_o.op = ariane_pkg::REMUW;
                             default: illegal_instr_non_bm = 1'b1;
                         endcase
+                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             unique case ({instr.rtype.funct7, instr.rtype.funct3})
                                 // Shift with Add (Unsigned Word)
@@ -585,8 +592,11 @@ module decoder import ariane_pkg::*; (
                                 {7'b011_0000, 3'b101}: instruction_o.op = ariane_pkg::RORW;     // rorw
                                 default: illegal_instr_bm = 1'b1;
                             endcase
+                            illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
+                        //VCS coverage on
+                        end else begin
+                          illegal_instr = illegal_instr_non_bm;
                         end
-                        illegal_instr = (ariane_pkg::BITMANIP) ? (illegal_instr_non_bm & illegal_instr_bm) : illegal_instr_non_bm;
                       end else illegal_instr = 1'b1;
                 end
                 // --------------------------------
@@ -622,6 +632,7 @@ module decoder import ariane_pkg::*; (
                             if (instr.instr[25] != 1'b0 && riscv::XLEN==32) illegal_instr_non_bm = 1'b1;
                         end
                     endcase
+                    //VCS coverage off
                     if (ariane_pkg::BITMANIP) begin
                         unique case (instr.itype.funct3)
                             3'b001: begin
@@ -660,8 +671,11 @@ module decoder import ariane_pkg::*; (
                             end
                             default: illegal_instr_bm = 1'b1;
                         endcase
+                        illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
+                    //VCS coverage on
+                    end else begin
+                      illegal_instr = illegal_instr_non_bm;
                     end
-                    illegal_instr = (ariane_pkg::BITMANIP) ? (illegal_instr_non_bm & illegal_instr_bm) : illegal_instr_non_bm;
                 end
 
                 // --------------------------------
@@ -690,6 +704,7 @@ module decoder import ariane_pkg::*; (
                             end
                             default: illegal_instr_non_bm = 1'b1;
                         endcase
+                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             unique case (instr.itype.funct3)
                                 3'b001: begin
@@ -713,8 +728,12 @@ module decoder import ariane_pkg::*; (
                                 end
                                 default: illegal_instr_bm = 1'b1;
                             endcase
+                            illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
+                        //VCS coverage on
+                        end else begin
+                          illegal_instr = illegal_instr_non_bm;
                         end
-                        illegal_instr = (ariane_pkg::BITMANIP) ? (illegal_instr_non_bm & illegal_instr_bm) : illegal_instr_non_bm;
+
                     end else illegal_instr = 1'b1;
                 end
                 // --------------------------------

--- a/core/multiplier.sv
+++ b/core/multiplier.sv
@@ -32,6 +32,7 @@ module multiplier import ariane_pkg::*; (
     logic [riscv::XLEN-1:0] clmul_q, clmul_d, clmulr_q, clmulr_d, operand_a, operand_b, operand_a_rev, operand_b_rev;
     logic clmul_rmode, clmul_hmode;
 
+    //VCS coverage off
     if (ariane_pkg::BITMANIP) begin : gen_bitmanip
         // checking for clmul_rmode and clmul_hmode
         assign clmul_rmode = (operation_i == CLMULR);
@@ -60,6 +61,7 @@ module multiplier import ariane_pkg::*; (
             assign clmulr_d[i] = clmul_d[(riscv::XLEN-1)-i];
         end
     end
+    //VCS coverage on
 
     // Pipeline register
     logic [TRANS_ID_BITS-1:0]    trans_id_q;
@@ -116,6 +118,7 @@ module multiplier import ariane_pkg::*; (
             default:             result_o = mult_result_q[riscv::XLEN-1:0];// including MUL
         endcase
     end
+    //VCS coverage off
     if (ariane_pkg::BITMANIP) begin
         always_ff @(posedge clk_i or negedge rst_ni) begin
             if (~rst_ni) begin
@@ -127,6 +130,7 @@ module multiplier import ariane_pkg::*; (
              end
         end
     end
+    //VCS coverage on
     // -----------------------
     // Output pipeline register
     // -----------------------


### PR DESCRIPTION
To increase the code coverage of CVA6, pragmas are inserted to disable some code lines. Pragmas are related to VCS tool, that is not so nice, but other solutions have been studied wihtout any success (macro approach is complex,  function is not supported by all tools)

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>