### PR TITLE
Changing Addresses of custom registers ICACHE and DCACHE.

### DIFF
--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -512,8 +512,8 @@ package riscv;
         CSR_MHPM_COUNTER_30H = 12'hB9E,  // reserved
         CSR_MHPM_COUNTER_31H = 12'hB9F,  // reserved
         // Cache Control (platform specifc)
-        CSR_DCACHE         = 12'h701,
-        CSR_ICACHE         = 12'h700,
+        CSR_DCACHE         = 12'h7C1,
+        CSR_ICACHE         = 12'h7C0,
         // Triggers
         CSR_TSELECT        = 12'h7A0,
         CSR_TDATA1         = 12'h7A1,

--- a/docs/01_cva6_user/ip-xact/cva6_csr.md
+++ b/docs/01_cva6_user/ip-xact/cva6_csr.md
@@ -411,7 +411,7 @@ Address register for Physical Memory Protection.
 | 31:0 | address | Address | read-write  | Address register for Physical Memory Protection\.|
 
 ## Instuction Cache Register 
-### *AddressOffset*: 'h700 
+### *AddressOffset*: 'h7C0 
 ### *Description*:
 Custom Register to enable/disable for Icache [bit 0]
 | BIT |  NAME       | displayName        | RIGHT  | Description                                                          |
@@ -419,7 +419,7 @@ Custom Register to enable/disable for Icache [bit 0]
 | 0 | icache | Instruction cache | read-write  | Custom Register to enable/disable for Icache \[bit 0\]|
 
 ## Data Cache Register 
-### *AddressOffset*: 'h701 
+### *AddressOffset*: 'h7C1 
 ### *Description*:
 Custom Register to enable/disable for Dcache [bit 0]
 | BIT |  NAME       | displayName        | RIGHT  | Description                                                          |

--- a/docs/01_cva6_user/ip-xact/cva6_csr.rst
+++ b/docs/01_cva6_user/ip-xact/cva6_csr.rst
@@ -1350,7 +1350,7 @@ Address register for Physical Memory Protection.
 
 Instuction Cache Register 
 --------------------------
-AddressOffset: 'h700 
+AddressOffset: 'h7C0 
 --------------------------
 Description:
 --------------------------
@@ -1373,7 +1373,7 @@ Custom Register to enable/disable for Icache [bit 0]
 
 Data Cache Register 
 --------------------------
-AddressOffset: 'h701 
+AddressOffset: 'h7C1 
 --------------------------
 Description:
 --------------------------

--- a/docs/01_cva6_user/ip-xact/cva6_csr.xml
+++ b/docs/01_cva6_user/ip-xact/cva6_csr.xml
@@ -2640,7 +2640,7 @@ If ``mtval`` is written with a nonzero value when an instruction access-fault or
                                         <ipxact:name>icache</ipxact:name>
                                         <ipxact:displayName>Instuction Cache</ipxact:displayName>
                                         <ipxact:description>Custom Register to enable/disable for Icache [bit 0]</ipxact:description>
-                                        <ipxact:addressOffset>'h700</ipxact:addressOffset>
+                                        <ipxact:addressOffset>'h7C0</ipxact:addressOffset>
                                         <ipxact:size>32</ipxact:size>
                                         <ipxact:access>read-write</ipxact:access>
                                         <ipxact:field>
@@ -2665,7 +2665,7 @@ If ``mtval`` is written with a nonzero value when an instruction access-fault or
                                         <ipxact:name>dcache</ipxact:name>
                                         <ipxact:displayName>Data Cache</ipxact:displayName>
                                         <ipxact:description>Custom Register to enable/disable for Dcache [bit 0]</ipxact:description>
-                                        <ipxact:addressOffset>'h701</ipxact:addressOffset>
+                                        <ipxact:addressOffset>'h7C1</ipxact:addressOffset>
                                         <ipxact:size>32</ipxact:size>
                                         <ipxact:access>read-write</ipxact:access>
                                         <ipxact:field>

--- a/docs/01_cva6_user/ip-xact/cva6_csr.yaml
+++ b/docs/01_cva6_user/ip-xact/cva6_csr.yaml
@@ -1882,7 +1882,7 @@ component:
         - name: icache
           displayName: Instuction Cache
           description: Custom Register to enable/disable for Icache [bit 0]
-          addressOffset: "'h700"
+          addressOffset: "'h7C0"
           size: '32'
           access: read-write
           field:
@@ -1901,7 +1901,7 @@ component:
         - name: dcache
           displayName: Data Cache
           description: Custom Register to enable/disable for Dcache [bit 0]
-          addressOffset: "'h701"
+          addressOffset: "'h7C1"
           size: '32'
           access: read-write
           field:


### PR DESCRIPTION
ICACHE and DCACHE have an address in 0x700-0x77F which is a Standard read/write in M-mode. But ICACHE and DCACHE are Custom registers so they need to be Custom read/write. In fact there is two possibilities 0x7C0-0x7FF and 0xBC0-0xBFF. I chose the first one 0x7C0-0x7FF. 
ICACHE: 0x700==>0x7C0. 
DCACHE: 0X701==>0x7C1.  
RTL and Spec are changed to solve #1202 issue.