### PR TITLE
ci: move expected results to cva6 repository

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,0 +1,6 @@
+cv64a6_imafdc_sv39:
+  gates: 545030
+cv32a60x:
+  gates: 160467
+cv32a6_embedded:
+  gates: 127410


### PR DESCRIPTION
It makes it possible to perform changes which have an impact on CVA6
area without having to open a second MR on core-v-verif.

It is still needed to "declare" the change of area in a diff which is
reviewed, but now the diff is in the same repository as the
modification.