### PR TITLE
Start populating more CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,16 @@
 # Global Owners
-*  @zarubaf
+*  @JeanRochCoulon @zarubaf
 
-# FPU owners
-src/fpu_wrap.sv @stmach
+# Core
+
+core/mmu_sv39 @sjthales
+core/cvxif_example @Gchauvon
+core/cvxif_fu.sv @Gchauvon
+
+# APU
+
+corev_apu/openpiton @Jbalkind
+
+## Documentation
+
+docs/ @jquevremont


### PR DESCRIPTION
I just figured out that apparently `CODEOWNERS` need to have write permissions to the repository. There are a couple of feature requests on Github to also enable the `triage` group to be listed but that hasn't been implemented yet.

I suggest starting populating it so that we are ready once that feature is implemented. And for all committers @JeanRochCoulon, @jquevremont, and @zarubaf it would already take effect.