### PR TITLE
Added ZiCond Extension Support

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -302,6 +302,13 @@ module alu import ariane_pkg::*; #(
                 default: ; // default case to suppress unique warning
             endcase
         end
+
+        if (ariane_pkg::RCONDEXT) begin
+           unique case (fu_data_i.operation)
+           CZERO_EQZ : result_o = (fu_data_i.operand_b) ? (fu_data_i.operand_a) : (0) ; // move zero to rd if rs2 is equal to zero else rs1
+           CZERO_NEZ : result_o = (fu_data_i.operand_b) ? (0) : (fu_data_i.operand_a) ; // move zero to rd if rs2 is nonzero else rs1
+           endcase
+        end
         //VCS coverage on
     end
 endmodule

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -319,6 +319,11 @@ package ariane_pkg;
     // ---------------
     localparam bit BITMANIP = cva6_config_pkg::CVA6ConfigBExtEn;
 
+    // ---------------
+    // Enable ZiCond
+    // ---------------
+    localparam bit RCONDEXT = cva6_config_pkg::CVA6ConfigCondExtEn;
+
     // Only use struct when signals have same direction
     // exception
     typedef struct packed {
@@ -554,7 +559,9 @@ package ariane_pkg;
                                // Shift with Add (Bitmanip)
                                SH1ADD, SH2ADD, SH3ADD,
                                // Bitmanip Logical with negate op (Bitmanip)
-                               ANDN, ORN, XNOR
+                               ANDN, ORN, XNOR,
+                               // Zicond instruction
+                               CZERO_EQZ, CZERO_NEZ
                              } fu_op;
 
     typedef struct packed {

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -322,7 +322,7 @@ package ariane_pkg;
     // ---------------
     // Enable ZiCond
     // ---------------
-    localparam bit RCONDEXT = cva6_config_pkg::CVA6ConfigCondExtEn;
+    localparam bit RCONDEXT = cva6_config_pkg::CVA6ConfigZiCondExtEn;
 
     // Only use struct when signals have same direction
     // exception

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -26,6 +26,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 1;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
-    localparam CVA6ConfigCondExtEn = 1;
+    localparam CVA6ConfigZiCondExtEn = 1;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;


### PR DESCRIPTION

This PR is for implementation of [Zicond](https://github.com/riscv/riscv-zicond/releases/tag/v1.0-rc2) ratified v1.0 (conditional integer operations) extension. As for the verification, I have just verified at the unit level. Currently, Zicond is in progress on the GCC (a patch is available). On LLVM, it is available in the current version(17).

The "Conditional" operations extension provides a simple solution that provides most of the benefits and flexibility one would desire to support conditional arithmetic and conditional-select/move operations while remaining true to the RISC-V design philosophy. The instructions follow the format for R-type instructions with three operands (i.e., two source operands and one destination operand). Using these instructions, branch-less sequences can be implemented (typically in two-instruction sequences) without the need for instruction fusion, special provisions during the decoding of architectural instructions, or other micro-architectural provisions.

Authored by: [Asim Ahsan](https://github.com/asimahsan1990)