### PR TITLE
Fix infinite loop in std_cache_pkg::one_hot_to_bin (resolves #1301)

### DIFF
--- a/core/include/std_cache_pkg.sv
+++ b/core/include/std_cache_pkg.sv
@@ -78,7 +78,7 @@ package std_cache_pkg;
     function automatic logic [$clog2(ariane_pkg::DCACHE_SET_ASSOC)-1:0] one_hot_to_bin (
         input logic [ariane_pkg::DCACHE_SET_ASSOC-1:0] in
     );
-        for (logic [$clog2(ariane_pkg::DCACHE_SET_ASSOC)-1:0] i = 0; i < ariane_pkg::DCACHE_SET_ASSOC; i++) begin
+        for (int unsigned i = 0; i < ariane_pkg::DCACHE_SET_ASSOC; i++) begin
             if (in[i])
                 return i;
         end


### PR DESCRIPTION
Use `int unsigned` for loop variable `i` to avoid wrapping before loop exit condition is met.

Resolves bug https://github.com/openhwgroup/cva6/issues/1301