### PR TITLE
Use CVA6Cfg as cva6 parameter

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -14,10 +14,10 @@
 
 
 module cva6 import ariane_pkg::*; #(
-  // Pipeline
-  parameter int unsigned NrCommitPorts = cva6_config_pkg::CVA6ConfigNrCommitPorts,
-  // RVFI
-  parameter int unsigned IsRVFI = cva6_config_pkg::CVA6ConfigRvfiTrace,
+  parameter ariane_pkg::cva6_cfg_t CVA6Cfg = {
+    int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
+    int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+  },
   parameter type rvfi_instr_t = struct packed {
     logic [ariane_pkg::NRET-1:0]                  valid;
     logic [ariane_pkg::NRET*64-1:0]               order;
@@ -69,7 +69,7 @@ module cva6 import ariane_pkg::*; #(
   input  logic                         debug_req_i,  // debug request (async)
   // RISC-V formal interface port (`rvfi`):
   // Can be left open when formal tracing is not needed.
-  output rvfi_instr_t [NrCommitPorts-1:0] rvfi_o,
+  output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o,
   output cvxif_req_t                   cvxif_req_o,
   input  cvxif_resp_t                  cvxif_resp_i,
   // L15 (memory side)
@@ -79,11 +79,6 @@ module cva6 import ariane_pkg::*; #(
   output axi_req_t                     axi_req_o,
   input  axi_rsp_t                     axi_resp_i
 );
-
-  localparam ariane_pkg::cva6_cfg_t CVA6Cfg = {
-    int'(NrCommitPorts),
-    int'(IsRVFI)
-  };
 
   // ------------------------------------------
   // Global Signals

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -15,8 +15,8 @@
 
 module cva6 import ariane_pkg::*; #(
   parameter ariane_pkg::cva6_cfg_t CVA6Cfg = {
-    int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
-    int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+    int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),  // NrCommitPorts
+    int'(cva6_config_pkg::CVA6ConfigRvfiTrace)       // IsRVFI
   },
   parameter type rvfi_instr_t = struct packed {
     logic [ariane_pkg::NRET-1:0]                  valid;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -40,8 +40,8 @@ package ariane_pkg;
     } cva6_cfg_t;
 
     localparam cva6_cfg_t cva6_cfg_empty = {
-      unsigned'(0),
-      unsigned'(0)
+      unsigned'(0),  // NrCommitPorts
+      unsigned'(0)   // IsRVFI
     };
 
     localparam NrMaxRules = 16;

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -155,10 +155,10 @@ module ariane_xilinx (
 );
 
 // cva6 configuration
-// Pipeline
-localparam int unsigned NrCommitPorts = cva6_config_pkg::CVA6ConfigNrCommitPorts;
-// RVFI
-localparam int unsigned IsRVFI = 0;
+parameter ariane_pkg::cva6_cfg_t CVA6Cfg = {
+  int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
+  int'(0)
+};
 localparam type rvfi_instr_t = logic;
 
 
@@ -707,8 +707,7 @@ ariane_axi::req_t    axi_ariane_req;
 ariane_axi::resp_t   axi_ariane_resp;
 
 ariane #(
-    .NrCommitPorts ( NrCommitPorts ),
-    .IsRVFI ( IsRVFI ),
+    .CVA6Cfg ( CVA6Cfg ),
     .rvfi_instr_t ( rvfi_instr_t ),
     .ArianeCfg ( ariane_soc::ArianeSocCfg )
 ) i_ariane (

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -156,8 +156,8 @@ module ariane_xilinx (
 
 // cva6 configuration
 parameter ariane_pkg::cva6_cfg_t CVA6Cfg = {
-  int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
-  int'(0)
+  int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),  // NrCommitPorts
+  int'(0)                                          // IsRVFI
 };
 localparam type rvfi_instr_t = logic;
 

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -14,10 +14,7 @@
 
 
 module ariane import ariane_pkg::*; #(
-  // Pipeline
-  parameter int unsigned NrCommitPorts = 0,
-  // RVFI
-  parameter int unsigned IsRVFI = 0,
+  parameter ariane_pkg::cva6_cfg_t CVA6Cfg = cva6_cfg_empty,
   parameter type rvfi_instr_t = logic,
   //
   parameter ariane_pkg::ariane_cfg_t ArianeCfg     = ariane_pkg::ArianeDefaultConfig,
@@ -44,7 +41,7 @@ module ariane import ariane_pkg::*; #(
   input  logic                         debug_req_i,  // debug request (async)
   // RISC-V formal interface port (`rvfi`):
   // Can be left open when formal tracing is not needed.
-  output rvfi_instr_t [NrCommitPorts-1:0] rvfi_o,
+  output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o,
 `ifdef PITON_ARIANE
   // L15 (memory side)
   output wt_cache_pkg::l15_req_t       l15_req_o,
@@ -60,8 +57,7 @@ module ariane import ariane_pkg::*; #(
   cvxif_pkg::cvxif_resp_t cvxif_resp;
 
   cva6 #(
-    .NrCommitPorts ( NrCommitPorts ),
-    .IsRVFI ( IsRVFI ),
+    .CVA6Cfg ( CVA6Cfg ),
     .rvfi_instr_t ( rvfi_instr_t ),
     //
     .ArianeCfg  ( ArianeCfg ),

--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -28,6 +28,37 @@ import "DPI-C" context function void read_section(input longint address, inout b
 
 module ariane_tb;
 
+    // cva6 configuration
+    localparam ariane_pkg::cva6_cfg_t CVA6Cfg = {
+      int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
+      int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+    };
+    localparam type rvfi_instr_t = struct packed {
+        logic [ariane_pkg::NRET-1:0]                  valid;
+        logic [ariane_pkg::NRET*64-1:0]               order;
+        logic [ariane_pkg::NRET*ariane_pkg::ILEN-1:0] insn;
+        logic [ariane_pkg::NRET-1:0]                  trap;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      cause;
+        logic [ariane_pkg::NRET-1:0]                  halt;
+        logic [ariane_pkg::NRET-1:0]                  intr;
+        logic [ariane_pkg::NRET*2-1:0]                mode;
+        logic [ariane_pkg::NRET*2-1:0]                ixl;
+        logic [ariane_pkg::NRET*5-1:0]                rs1_addr;
+        logic [ariane_pkg::NRET*5-1:0]                rs2_addr;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      rs1_rdata;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      rs2_rdata;
+        logic [ariane_pkg::NRET*5-1:0]                rd_addr;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      rd_wdata;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      pc_rdata;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      pc_wdata;
+        logic [ariane_pkg::NRET*riscv::VLEN-1:0]      mem_addr;
+        logic [ariane_pkg::NRET*riscv::PLEN-1:0]      mem_paddr;
+        logic [ariane_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_rmask;
+        logic [ariane_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_wmask;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      mem_rdata;
+        logic [ariane_pkg::NRET*riscv::XLEN-1:0]      mem_wdata;
+    };
+
     static uvm_cmdline_processor uvcl = uvm_cmdline_processor::get_inst();
 
     localparam int unsigned CLOCK_PERIOD = 20ns;
@@ -47,6 +78,9 @@ module ariane_tb;
     string binary = "";
 
     ariane_testharness #(
+        .CVA6Cfg ( CVA6Cfg ),
+        .rvfi_instr_t ( rvfi_instr_t ),
+        //
         .NUM_WORDS         ( NUM_WORDS ),
         .InclSimDTM        ( 1'b1      ),
         .StallRandomOutput ( 1'b1      ),
@@ -60,6 +94,7 @@ module ariane_tb;
 
 `ifdef SPIKE_TANDEM
     spike #(
+        .CVA6Cfg ( CVA6Cfg ),
         .Size ( NUM_WORDS * 8 )
     ) i_spike (
         .clk_i,

--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -30,8 +30,8 @@ module ariane_tb;
 
     // cva6 configuration
     localparam ariane_pkg::cva6_cfg_t CVA6Cfg = {
-      int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
-      int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+      int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),  // NrCommitPorts
+      int'(cva6_config_pkg::CVA6ConfigRvfiTrace)       // IsRVFI
     };
     localparam type rvfi_instr_t = struct packed {
         logic [ariane_pkg::NRET-1:0]                  valid;

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -17,8 +17,8 @@
 
 module ariane_testharness #(
   parameter ariane_pkg::cva6_cfg_t CVA6Cfg = {
-    int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
-    int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+    int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),  // NrCommitPorts
+    int'(cva6_config_pkg::CVA6ConfigRvfiTrace)       // IsRVFI
   },
   parameter type rvfi_instr_t = struct packed {
     logic [ariane_pkg::NRET-1:0]                  valid;

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -16,10 +16,10 @@
 `include "axi/assign.svh"
 
 module ariane_testharness #(
-  // Pipeline
-  parameter int unsigned NrCommitPorts = cva6_config_pkg::CVA6ConfigNrCommitPorts,
-  // RVFI
-  parameter int unsigned IsRVFI = cva6_config_pkg::CVA6ConfigRvfiTrace,
+  parameter ariane_pkg::cva6_cfg_t CVA6Cfg = {
+    int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
+    int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+  },
   parameter type rvfi_instr_t = struct packed {
     logic [ariane_pkg::NRET-1:0]                  valid;
     logic [ariane_pkg::NRET*64-1:0]               order;
@@ -634,11 +634,10 @@ module ariane_testharness #(
   // ---------------
   ariane_axi::req_t    axi_ariane_req;
   ariane_axi::resp_t   axi_ariane_resp;
-  rvfi_instr_t [NrCommitPorts-1:0] rvfi;
+  rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi;
 
   ariane #(
-    .NrCommitPorts        ( NrCommitPorts       ),
-    .IsRVFI               ( IsRVFI              ),
+    .CVA6Cfg              ( CVA6Cfg             ),
     .rvfi_instr_t         ( rvfi_instr_t        ),
     .ArianeCfg            ( ariane_soc::ArianeSocCfg )
   ) i_ariane (
@@ -681,7 +680,7 @@ module ariane_testharness #(
   end
 
   rvfi_tracer  #(
-    .NrCommitPorts(NrCommitPorts),
+    .CVA6Cfg(CVA6Cfg),
     .rvfi_instr_t(rvfi_instr_t),
     //
     .HART_ID(hart_id),

--- a/corev_apu/tb/common/spike.sv
+++ b/corev_apu/tb/common/spike.sv
@@ -30,12 +30,12 @@ module spike #(
     input logic       clk_i,
     input logic       rst_ni,
     input logic       clint_tick_i,
-    input ariane_pkg::scoreboard_entry_t [ariane_pkg::NR_COMMIT_PORTS-1:0] commit_instr_i,
-    input logic [ariane_pkg::NR_COMMIT_PORTS-1:0]                          commit_ack_i,
-    input ariane_pkg::exception_t                                          exception_i,
-    input logic [ariane_pkg::NR_COMMIT_PORTS-1:0][4:0]                     waddr_i,
-    input logic [ariane_pkg::NR_COMMIT_PORTS-1:0][63:0]                    wdata_i,
-    input riscv::priv_lvl_t                                                priv_lvl_i
+    input ariane_pkg::scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    input logic [CVA6Cfg.NrCommitPorts-1:0]                          commit_ack_i,
+    input ariane_pkg::exception_t                            exception_i,
+    input logic [CVA6Cfg.NrCommitPorts-1:0][4:0]                     waddr_i,
+    input logic [CVA6Cfg.NrCommitPorts-1:0][63:0]                    wdata_i,
+    input riscv::priv_lvl_t                                  priv_lvl_i
 );
     static uvm_cmdline_processor uvcl = uvm_cmdline_processor::get_inst();
 
@@ -57,7 +57,7 @@ module spike #(
     always_ff @(posedge clk_i) begin
         if (rst_ni) begin
 
-            for (int i = 0; i < ariane_pkg::NR_COMMIT_PORTS; i++) begin
+            for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
                 if ((commit_instr_i[i].valid && commit_ack_i[i]) || (commit_instr_i[i].valid && exception_i.valid)) begin
                     spike_tick(commit_log);
                     instr = (commit_log.instr[1:0] != 2'b11) ? {16'b0, commit_log.instr[15:0]} : commit_log.instr;

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -8,9 +8,7 @@
 // Original Author: Jean-Roch COULON - Thales
 
 module rvfi_tracer #(
-  // Pipeline
-  parameter int unsigned NrCommitPorts = 0,
-  // RVFI
+  parameter ariane_pkg::cva6_cfg_t CVA6Cfg = ariane_pkg::cva6_cfg_empty,
   parameter type rvfi_instr_t = logic,
   //
   parameter logic [7:0] HART_ID      = '0,
@@ -19,7 +17,7 @@ module rvfi_tracer #(
 )(
   input logic                           clk_i,
   input logic                           rst_ni,
-  input rvfi_instr_t[NrCommitPorts-1:0] rvfi_i,
+  input rvfi_instr_t[CVA6Cfg.NrCommitPorts-1:0] rvfi_i,
   output logic[31:0]                    end_of_test_o
 );
 
@@ -48,7 +46,7 @@ module rvfi_tracer #(
   assign end_of_test_o = end_of_test_d;
   always_ff @(posedge clk_i) begin
     end_of_test_q = (rst_ni && (end_of_test_d[0] == 1'b1)) ? end_of_test_d : 0;
-    for (int i = 0; i < NrCommitPorts; i++) begin
+    for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
       pc64 = {{riscv::XLEN-riscv::VLEN{rvfi_i[i].pc_rdata[riscv::VLEN-1]}}, rvfi_i[i].pc_rdata};
       // print the instruction information if the instruction is valid or a trap is taken
       if (rvfi_i[i].valid) begin


### PR DESCRIPTION
CVA6Cfg is now a input parameter of CVA6 to gather all the different configuration variables in the same structure.

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>