### PR TITLE
Merge `CVA6Cfg` and `ArianeCfg`

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -297,7 +297,7 @@ module alu import ariane_pkg::*; #(
                 default: ; // default case to suppress unique warning
             endcase
         end
-        if (CVA6Cfg.RCONDEXT) begin
+        if (CVA6Cfg.ZiCondExtEn) begin
            unique case (fu_data_i.operation)
            CZERO_EQZ : result_o = (|fu_data_i.operand_b) ? fu_data_i.operand_a : '0;  // move zero to rd if rs2 is equal to zero else rs1
            CZERO_NEZ : result_o = (|fu_data_i.operand_b) ? '0 : fu_data_i.operand_a; // move zero to rd if rs2 is nonzero else rs1

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -250,7 +250,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
                     // -------------------------
                     // Check for cache-ability
                     // -------------------------
-                    if (!is_inside_cacheable_regions(CVA6Cfg, {{{64-riscv::PLEN}{1'b0}}, tag_o, {DCACHE_INDEX_WIDTH{1'b0}}})) begin
+                    if (!config_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-riscv::PLEN}{1'b0}}, tag_o, {DCACHE_INDEX_WIDTH{1'b0}}})) begin
                         mem_req_d.bypass = 1'b1;
                         state_d = WAIT_REFILL_GNT;
                     end

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -19,8 +19,7 @@
 
 
 module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
-    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter ariane_cfg_t ArianeCfg = ArianeDefaultConfig // contains cacheable regions
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
     input  logic                                 clk_i,     // Clock
     input  logic                                 rst_ni,    // Asynchronous reset active low
@@ -251,7 +250,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
                     // -------------------------
                     // Check for cache-ability
                     // -------------------------
-                    if (!is_inside_cacheable_regions(ArianeCfg, {{{64-riscv::PLEN}{1'b0}}, tag_o, {DCACHE_INDEX_WIDTH{1'b0}}})) begin
+                    if (!is_inside_cacheable_regions(CVA6Cfg, {{{64-riscv::PLEN}{1'b0}}, tag_o, {DCACHE_INDEX_WIDTH{1'b0}}})) begin
                         mem_req_d.bypass = 1'b1;
                         state_d = WAIT_REFILL_GNT;
                     end

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -116,7 +116,7 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign cl_tag_d  = (areq_i.fetch_valid) ? areq_i.fetch_paddr[ICACHE_TAG_WIDTH+ICACHE_INDEX_WIDTH-1:ICACHE_INDEX_WIDTH] : cl_tag_q;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign paddr_is_nc = (~cache_en_q) | (~ariane_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-riscv::PLEN}{1'b0}}, cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
+  assign paddr_is_nc = (~cache_en_q) | (~config_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-riscv::PLEN}{1'b0}}, cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
 
   // pass exception through
   assign dreq_o.ex = areq_i.fetch_exception;
@@ -130,7 +130,7 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign cl_index    = vaddr_d[ICACHE_INDEX_WIDTH-1:ICACHE_OFFSET_WIDTH];
 
 
-  if (CVA6Cfg.BusType == ariane_pkg::BUS_TYPE_AXI4_ATOP) begin : gen_axi_offset
+  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_offset
     // if we generate a noncacheable access, the word will be at offset 0 or 4 in the cl coming from memory
     assign cl_offset_d = ( dreq_o.ready & dreq_i.req)      ? {dreq_i.vaddr>>2, 2'b0} :
                          ( paddr_is_nc  & mem_data_req_o ) ? cl_offset_q[2]<<2 : // needed since we transfer 32bit over a 64bit AXI bus in this case
@@ -164,7 +164,7 @@ end else begin : gen_piton_offset
 // main control logic
 ///////////////////////////////////////////////////////
   logic addr_ni;
-  assign addr_ni = is_inside_nonidempotent_regions(CVA6Cfg, areq_i.fetch_paddr);
+  assign addr_ni = config_pkg::is_inside_nonidempotent_regions(CVA6Cfg, areq_i.fetch_paddr);
   always_comb begin : p_fsm
     // default assignment
     state_d      = state_q;

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -130,7 +130,7 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign cl_index    = vaddr_d[ICACHE_INDEX_WIDTH-1:ICACHE_OFFSET_WIDTH];
 
 
-  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_offset
+  if (CVA6Cfg.NOCType == config_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_offset
     // if we generate a noncacheable access, the word will be at offset 0 or 4 in the cl coming from memory
     assign cl_offset_d = ( dreq_o.ready & dreq_i.req)      ? {dreq_i.vaddr>>2, 2'b0} :
                          ( paddr_is_nc  & mem_data_req_o ) ? cl_offset_q[2]<<2 : // needed since we transfer 32bit over a 64bit AXI bus in this case

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -28,9 +28,7 @@
 module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
   /// ID to be used for read transactions
-  parameter logic [MEM_TID_WIDTH-1:0]   RdTxId = 0,
-  /// Contains cacheable regions
-  parameter ariane_pkg::ariane_cfg_t    ArianeCfg = ariane_pkg::ArianeDefaultConfig
+  parameter logic [MEM_TID_WIDTH-1:0]   RdTxId = 0
 ) (
   input  logic                      clk_i,
   input  logic                      rst_ni,
@@ -118,7 +116,7 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign cl_tag_d  = (areq_i.fetch_valid) ? areq_i.fetch_paddr[ICACHE_TAG_WIDTH+ICACHE_INDEX_WIDTH-1:ICACHE_INDEX_WIDTH] : cl_tag_q;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign paddr_is_nc = (~cache_en_q) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{{64-riscv::PLEN}{1'b0}}, cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
+  assign paddr_is_nc = (~cache_en_q) | (~ariane_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-riscv::PLEN}{1'b0}}, cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
 
   // pass exception through
   assign dreq_o.ex = areq_i.fetch_exception;
@@ -132,7 +130,7 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign cl_index    = vaddr_d[ICACHE_INDEX_WIDTH-1:ICACHE_OFFSET_WIDTH];
 
 
-  if (ArianeCfg.AxiCompliant) begin : gen_axi_offset
+  if (CVA6Cfg.BusType == ariane_pkg::BUS_TYPE_AXI4_ATOP) begin : gen_axi_offset
     // if we generate a noncacheable access, the word will be at offset 0 or 4 in the cl coming from memory
     assign cl_offset_d = ( dreq_o.ready & dreq_i.req)      ? {dreq_i.vaddr>>2, 2'b0} :
                          ( paddr_is_nc  & mem_data_req_o ) ? cl_offset_q[2]<<2 : // needed since we transfer 32bit over a 64bit AXI bus in this case
@@ -166,7 +164,7 @@ end else begin : gen_piton_offset
 // main control logic
 ///////////////////////////////////////////////////////
   logic addr_ni;
-  assign addr_ni = is_inside_nonidempotent_regions(ArianeCfg, areq_i.fetch_paddr);
+  assign addr_ni = is_inside_nonidempotent_regions(CVA6Cfg, areq_i.fetch_paddr);
   always_comb begin : p_fsm
     // default assignment
     state_d      = state_q;

--- a/core/cache_subsystem/cva6_icache_axi_wrapper.sv
+++ b/core/cache_subsystem/cva6_icache_axi_wrapper.sv
@@ -15,7 +15,6 @@
 
 module cva6_icache_axi_wrapper import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter ariane_cfg_t ArianeCfg = ArianeDefaultConfig,  // contains cacheable regions
   parameter type axi_req_t = logic,
   parameter type axi_rsp_t = logic
 ) (
@@ -99,8 +98,7 @@ module cva6_icache_axi_wrapper import ariane_pkg::*; import wt_cache_pkg::*; #(
   cva6_icache #(
     // use ID 0 for icache reads
     .CVA6Cfg            ( CVA6Cfg       ),
-    .RdTxId             ( 0             ),
-    .ArianeCfg          ( ArianeCfg     )
+    .RdTxId             ( 0             )
   ) i_cva6_icache (
     .clk_i              ( clk_i               ),
     .rst_ni             ( rst_ni              ),

--- a/core/cache_subsystem/std_cache_subsystem.sv
+++ b/core/cache_subsystem/std_cache_subsystem.sv
@@ -17,7 +17,6 @@
 
 module std_cache_subsystem import ariane_pkg::*; import std_cache_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter ariane_cfg_t ArianeCfg = ArianeDefaultConfig,  // contains cacheable regions
     parameter int unsigned NumPorts = 4,
     parameter type axi_ar_chan_t = logic,
     parameter type axi_aw_chan_t = logic,
@@ -67,7 +66,6 @@ module std_cache_subsystem import ariane_pkg::*; import std_cache_pkg::*; #(
 
     cva6_icache_axi_wrapper #(
         .CVA6Cfg      ( CVA6Cfg      ),
-        .ArianeCfg    ( ArianeCfg    ),
         .axi_req_t    ( axi_req_t    ),
         .axi_rsp_t    ( axi_rsp_t    )
     ) i_cva6_icache_axi_wrapper (
@@ -92,7 +90,6 @@ module std_cache_subsystem import ariane_pkg::*; import std_cache_pkg::*; #(
    // Port 3: Store Unit
    std_nbdcache #(
       .CVA6Cfg          ( CVA6Cfg      ),
-      .ArianeCfg        ( ArianeCfg    ),
       .NumPorts         ( NumPorts     ),
       .axi_req_t        ( axi_req_t    ),
       .axi_rsp_t        ( axi_rsp_t    )

--- a/core/cache_subsystem/std_nbdcache.sv
+++ b/core/cache_subsystem/std_nbdcache.sv
@@ -15,7 +15,6 @@
 
 module std_nbdcache import std_cache_pkg::*; import ariane_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter ariane_cfg_t ArianeCfg        = ArianeDefaultConfig, // contains cacheable regions
     parameter int unsigned NumPorts = 4,
     parameter type axi_req_t = logic,
     parameter type axi_rsp_t = logic
@@ -93,8 +92,7 @@ import std_cache_pkg::*;
     generate
         for (genvar i = 0; i < NumPorts; i++) begin : master_ports
             cache_ctrl  #(
-                .CVA6Cfg               ( CVA6Cfg              ),
-                .ArianeCfg             ( ArianeCfg            )
+                .CVA6Cfg               ( CVA6Cfg              )
             ) i_cache_ctrl (
                 .bypass_i              ( ~enable_i            ),
                 .busy_o                ( busy            [i]  ),

--- a/core/cache_subsystem/wt_cache_subsystem.sv
+++ b/core/cache_subsystem/wt_cache_subsystem.sv
@@ -21,7 +21,6 @@
 
 module wt_cache_subsystem import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter ariane_pkg::ariane_cfg_t ArianeCfg       = ariane_pkg::ArianeDefaultConfig,  // contains cacheable regions
   parameter int unsigned NumPorts     = 4,
   parameter type noc_req_t = logic,
   parameter type noc_resp_t = logic
@@ -77,8 +76,7 @@ module wt_cache_subsystem import ariane_pkg::*; import wt_cache_pkg::*; #(
   cva6_icache #(
     // use ID 0 for icache reads
     .CVA6Cfg            ( CVA6Cfg       ),
-    .RdTxId             ( 0             ),
-    .ArianeCfg          ( ArianeCfg     )
+    .RdTxId             ( 0             )
   ) i_cva6_icache (
     .clk_i              ( clk_i                   ),
     .rst_ni             ( rst_ni                  ),
@@ -105,8 +103,7 @@ module wt_cache_subsystem import ariane_pkg::*; import wt_cache_pkg::*; #(
     .CVA6Cfg         ( CVA6Cfg       ),
     // use ID 1 for dcache reads and amos. note that the writebuffer
     // uses all IDs up to DCACHE_MAX_TX-1 for write transactions.
-    .RdAmoTxId       ( 1             ),
-    .ArianeCfg       ( ArianeCfg     )
+    .RdAmoTxId       ( 1             )
   ) i_wt_dcache (
     .clk_i           ( clk_i                   ),
     .rst_ni          ( rst_ni                  ),
@@ -137,7 +134,6 @@ module wt_cache_subsystem import ariane_pkg::*; import wt_cache_pkg::*; #(
 `ifdef PITON_ARIANE
   wt_l15_adapter #(
     .CVA6Cfg         ( CVA6Cfg                 ),
-    .SwapEndianess   ( ArianeCfg.SwapEndianess )
   ) i_adapter (
     .clk_i              ( clk_i                   ),
     .rst_ni             ( rst_ni                  ),

--- a/core/cache_subsystem/wt_dcache.sv
+++ b/core/cache_subsystem/wt_dcache.sv
@@ -18,9 +18,7 @@ module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter int unsigned                 NumPorts           = 4,    // number of miss ports
   // ID to be used for read and AMO transactions.
   // note that the write buffer uses all IDs up to DCACHE_MAX_TX-1 for write transactions
-  parameter logic [CACHE_ID_WIDTH-1:0]   RdAmoTxId          = 1,
-  // contains cacheable regions
-  parameter ariane_pkg::ariane_cfg_t     ArianeCfg          = ariane_pkg::ArianeDefaultConfig
+  parameter logic [CACHE_ID_WIDTH-1:0]   RdAmoTxId          = 1
 ) (
   input  logic                           clk_i,       // Clock
   input  logic                           rst_ni,      // Asynchronous reset active low
@@ -113,7 +111,6 @@ module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
 
   wt_dcache_missunit #(
     .CVA6Cfg      ( CVA6Cfg                ),
-    .AxiCompliant ( ArianeCfg.AxiCompliant ),
     .AmoTxId      ( RdAmoTxId              ),
     .NumPorts     ( NumPorts               )
   ) i_wt_dcache_missunit (
@@ -175,8 +172,7 @@ module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
 
     wt_dcache_ctrl #(
       .CVA6Cfg       ( CVA6Cfg       ),
-      .RdTxId        ( RdAmoTxId     ),
-      .ArianeCfg     ( ArianeCfg     )
+      .RdTxId        ( RdAmoTxId     )
     ) i_wt_dcache_ctrl (
       .clk_i           ( clk_i             ),
       .rst_ni          ( rst_ni            ),
@@ -220,8 +216,7 @@ module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign rd_prio[NumPorts-1] = 1'b0;
 
   wt_dcache_wbuffer #(
-    .CVA6Cfg       ( CVA6Cfg       ),
-    .ArianeCfg     ( ArianeCfg     )
+    .CVA6Cfg       ( CVA6Cfg       )
   ) i_wt_dcache_wbuffer (
     .clk_i           ( clk_i                       ),
     .rst_ni          ( rst_ni                      ),
@@ -279,7 +274,6 @@ module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
 
   wt_dcache_mem #(
     .CVA6Cfg      ( CVA6Cfg                ),
-    .AxiCompliant ( ArianeCfg.AxiCompliant ),
     .NumPorts     ( NumPorts               )
   ) i_wt_dcache_mem (
     .clk_i             ( clk_i              ),

--- a/core/cache_subsystem/wt_dcache_ctrl.sv
+++ b/core/cache_subsystem/wt_dcache_ctrl.sv
@@ -15,8 +15,7 @@
 
 module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter logic [CACHE_ID_WIDTH-1:0]  RdTxId    = 1,                              // ID to use for read transactions
-  parameter ariane_pkg::ariane_cfg_t    ArianeCfg = ariane_pkg::ArianeDefaultConfig // contains cacheable regions
+  parameter logic [CACHE_ID_WIDTH-1:0]  RdTxId    = 1
 ) (
   input  logic                            clk_i,          // Clock
   input  logic                            rst_ni,         // Asynchronous reset active low
@@ -89,7 +88,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign miss_size_o           = (miss_nc_o) ? data_size_q : 3'b111;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign miss_nc_o = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH}{1'b0}}, address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
+  assign miss_nc_o = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH}{1'b0}}, address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
 
 
   assign miss_we_o    = '0;

--- a/core/cache_subsystem/wt_dcache_ctrl.sv
+++ b/core/cache_subsystem/wt_dcache_ctrl.sv
@@ -88,7 +88,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign miss_size_o           = (miss_nc_o) ? data_size_q : 3'b111;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign miss_nc_o = (~cache_en_i) | (~ariane_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH}{1'b0}}, address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
+  assign miss_nc_o = (~cache_en_i) | (~config_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH}{1'b0}}, address_tag_q, {DCACHE_INDEX_WIDTH{1'b0}}}));
 
 
   assign miss_we_o    = '0;

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -28,7 +28,6 @@
 
 module wt_dcache_mem import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter bit          AxiCompliant  = 1'b0, // set this to 1 when using in conjunction with AXI bus adapter
   parameter int unsigned NumPorts      = 3
 ) (
   input  logic                                              clk_i,
@@ -256,12 +255,12 @@ module wt_dcache_mem import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign wbuffer_ruser = wbuffer_data_i[wbuffer_hit_idx].user;
   assign wbuffer_be    = (|wbuffer_hit_oh) ? wbuffer_data_i[wbuffer_hit_idx].valid : '0;
 
-  if (AxiCompliant) begin : gen_axi_off
+  if (CVA6Cfg.BusType == ariane_pkg::BUS_TYPE_AXI4_ATOP) begin : gen_axi_offset
       // In case of an uncached read, return the desired XLEN-bit segment of the most recent AXI read
       assign wr_cl_off     = (wr_cl_nc_i) ? (CVA6Cfg.AxiDataWidth == riscv::XLEN) ? '0 :
                               wr_cl_off_i[AXI_OFFSET_WIDTH-1:riscv::XLEN_ALIGN_BYTES] :
                               wr_cl_off_i[DCACHE_OFFSET_WIDTH-1:riscv::XLEN_ALIGN_BYTES];
-  end else begin  : gen_piton_off
+  end else begin  : gen_piton_offset
       assign wr_cl_off     = wr_cl_off_i[DCACHE_OFFSET_WIDTH-1:3];
   end
 

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -255,7 +255,7 @@ module wt_dcache_mem import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign wbuffer_ruser = wbuffer_data_i[wbuffer_hit_idx].user;
   assign wbuffer_be    = (|wbuffer_hit_oh) ? wbuffer_data_i[wbuffer_hit_idx].valid : '0;
 
-  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_offset
+  if (CVA6Cfg.NOCType == config_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_offset
       // In case of an uncached read, return the desired XLEN-bit segment of the most recent AXI read
       assign wr_cl_off     = (wr_cl_nc_i) ? (CVA6Cfg.AxiDataWidth == riscv::XLEN) ? '0 :
                               wr_cl_off_i[AXI_OFFSET_WIDTH-1:riscv::XLEN_ALIGN_BYTES] :

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -255,7 +255,7 @@ module wt_dcache_mem import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign wbuffer_ruser = wbuffer_data_i[wbuffer_hit_idx].user;
   assign wbuffer_be    = (|wbuffer_hit_oh) ? wbuffer_data_i[wbuffer_hit_idx].valid : '0;
 
-  if (CVA6Cfg.BusType == ariane_pkg::BUS_TYPE_AXI4_ATOP) begin : gen_axi_offset
+  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_offset
       // In case of an uncached read, return the desired XLEN-bit segment of the most recent AXI read
       assign wr_cl_off     = (wr_cl_nc_i) ? (CVA6Cfg.AxiDataWidth == riscv::XLEN) ? '0 :
                               wr_cl_off_i[AXI_OFFSET_WIDTH-1:riscv::XLEN_ALIGN_BYTES] :

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -16,7 +16,6 @@
 
 module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter bit                         AxiCompliant  = 1'b0, // set this to 1 when using in conjunction with AXI bus adapter
   parameter logic [CACHE_ID_WIDTH-1:0]  AmoTxId       = 1,    // TX id to be used for AMOs
   parameter int unsigned                NumPorts      = 4     // number of miss ports
 ) (
@@ -255,7 +254,7 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   end
 
   // note: openpiton returns a full cacheline!
-  if (AxiCompliant) begin : gen_axi_rtrn_mux
+  if (CVA6Cfg.BusType == ariane_pkg::BUS_TYPE_AXI4_ATOP) begin : gen_axi_rtrn_mux
     if (CVA6Cfg.AxiDataWidth > 64) begin
       assign amo_rtrn_mux = mem_rtrn_i.data[amo_req_i.operand_a[$clog2(CVA6Cfg.AxiDataWidth/8)-1:3]*64 +: 64];
     end else begin

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -254,7 +254,7 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   end
 
   // note: openpiton returns a full cacheline!
-  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_rtrn_mux
+  if (CVA6Cfg.NOCType == config_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_rtrn_mux
     if (CVA6Cfg.AxiDataWidth > 64) begin
       assign amo_rtrn_mux = mem_rtrn_i.data[amo_req_i.operand_a[$clog2(CVA6Cfg.AxiDataWidth/8)-1:3]*64 +: 64];
     end else begin

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -254,7 +254,7 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   end
 
   // note: openpiton returns a full cacheline!
-  if (CVA6Cfg.BusType == ariane_pkg::BUS_TYPE_AXI4_ATOP) begin : gen_axi_rtrn_mux
+  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_rtrn_mux
     if (CVA6Cfg.AxiDataWidth > 64) begin
       assign amo_rtrn_mux = mem_rtrn_i.data[amo_req_i.operand_a[$clog2(CVA6Cfg.AxiDataWidth/8)-1:3]*64 +: 64];
     end else begin

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -50,8 +50,7 @@
 
 
 module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
-  parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter ariane_pkg::ariane_cfg_t    ArianeCfg          = ariane_pkg::ArianeDefaultConfig     // contains cacheable regions
+  parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
   input  logic                               clk_i,          // Clock
   input  logic                               rst_ni,         // Asynchronous reset active low
@@ -141,10 +140,10 @@ module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic is_nc_miss;
   logic is_ni;
   assign miss_tag = miss_paddr_o[ariane_pkg::DCACHE_INDEX_WIDTH+:ariane_pkg::DCACHE_TAG_WIDTH];
-  assign is_nc_miss = !ariane_pkg::is_inside_cacheable_regions(ArianeCfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, miss_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
+  assign is_nc_miss = !ariane_pkg::is_inside_cacheable_regions(CVA6Cfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, miss_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
   assign miss_nc_o = !cache_en_i || is_nc_miss;
   // Non-idempotent if request goes to NI region
-  assign is_ni = ariane_pkg::is_inside_nonidempotent_regions(ArianeCfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
+  assign is_ni = ariane_pkg::is_inside_nonidempotent_regions(CVA6Cfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
 
   assign miss_we_o       = 1'b1;
   assign miss_vld_bits_o = '0;

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -140,10 +140,10 @@ module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic is_nc_miss;
   logic is_ni;
   assign miss_tag = miss_paddr_o[ariane_pkg::DCACHE_INDEX_WIDTH+:ariane_pkg::DCACHE_TAG_WIDTH];
-  assign is_nc_miss = !ariane_pkg::is_inside_cacheable_regions(CVA6Cfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, miss_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
+  assign is_nc_miss = !config_pkg::is_inside_cacheable_regions(CVA6Cfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, miss_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
   assign miss_nc_o = !cache_en_i || is_nc_miss;
   // Non-idempotent if request goes to NI region
-  assign is_ni = ariane_pkg::is_inside_nonidempotent_regions(CVA6Cfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
+  assign is_ni = config_pkg::is_inside_nonidempotent_regions(CVA6Cfg, {{64-DCACHE_TAG_WIDTH-DCACHE_INDEX_WIDTH{1'b0}}, req_port_i.address_tag, {DCACHE_INDEX_WIDTH{1'b0}}});
 
   assign miss_we_o       = 1'b1;
   assign miss_vld_bits_o = '0;

--- a/core/cache_subsystem/wt_l15_adapter.sv
+++ b/core/cache_subsystem/wt_l15_adapter.sv
@@ -50,8 +50,7 @@
 
 
 module wt_l15_adapter import ariane_pkg::*; import wt_cache_pkg::*; #(
-  parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter bit          SwapEndianess = 1
+  parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
   input logic                  clk_i,
   input logic                  rst_ni,
@@ -133,8 +132,7 @@ l15_rtrn_t rtrn_fifo_data;
 
 
   // openpiton is big endian
-  if (SwapEndianess) assign l15_req_o.l15_data = swendian64(dcache_data.data);
-  else               assign l15_req_o.l15_data = dcache_data.data;
+  assign l15_req_o.l15_data = swendian64(dcache_data.data);
 
   // arbiter
   rrarbiter #(

--- a/core/cache_subsystem/wt_l15_adapter.sv
+++ b/core/cache_subsystem/wt_l15_adapter.sv
@@ -132,7 +132,9 @@ l15_rtrn_t rtrn_fifo_data;
 
 
   // openpiton is big endian
-  assign l15_req_o.l15_data = swendian64(dcache_data.data);
+  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_L15_BIG_ENDIAN) assign l15_req_o.l15_data = swendian64(dcache_data.data);
+  else if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_L15_LITTLE_ENDIAN) assign l15_req_o.l15_data = dcache_data.data;
+  else $fatal(1,"[wt_l15_adapter] Unsupported NOC type");
 
   // arbiter
   rrarbiter #(

--- a/core/cache_subsystem/wt_l15_adapter.sv
+++ b/core/cache_subsystem/wt_l15_adapter.sv
@@ -132,8 +132,8 @@ l15_rtrn_t rtrn_fifo_data;
 
 
   // openpiton is big endian
-  if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_L15_BIG_ENDIAN) assign l15_req_o.l15_data = swendian64(dcache_data.data);
-  else if (CVA6Cfg.NOCType == ariane_pkg::NOC_TYPE_L15_LITTLE_ENDIAN) assign l15_req_o.l15_data = dcache_data.data;
+  if (CVA6Cfg.NOCType == config_pkg::NOC_TYPE_L15_BIG_ENDIAN) assign l15_req_o.l15_data = swendian64(dcache_data.data);
+  else if (CVA6Cfg.NOCType == config_pkg::NOC_TYPE_L15_LITTLE_ENDIAN) assign l15_req_o.l15_data = dcache_data.data;
   else $fatal(1,"[wt_l15_adapter] Unsupported NOC type");
 
   // arbiter

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -15,9 +15,7 @@
 
 module csr_regfile import ariane_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter logic [63:0] DmBaseAddress   = 64'h0, // debug module base address
     parameter int          AsidWidth       = 1,
-    parameter int unsigned NrPMPEntries    = 8,
     parameter int unsigned MHPMCounterNum  = 6
 ) (
     input  logic                  clk_i,                      // Clock
@@ -1269,7 +1267,7 @@ module csr_regfile import ariane_pkg::*; #(
 
         // if we are in debug mode jump to a specific address
         if (debug_mode_q) begin
-            trap_vector_base_o = DmBaseAddress[riscv::VLEN-1:0] + CVA6Cfg.ExceptionAddress[riscv::VLEN-1:0];
+            trap_vector_base_o = CVA6Cfg.DmBaseAddress[riscv::VLEN-1:0] + CVA6Cfg.ExceptionAddress[riscv::VLEN-1:0];
         end
 
         // check if we are in vectored mode, if yes then do BASE + 4 * cause we
@@ -1442,7 +1440,7 @@ module csr_regfile import ariane_pkg::*; #(
             wfi_q                  <= wfi_d;
             // pmp
             for(int i = 0; i < 16; i++) begin
-                if(i < NrPMPEntries) begin
+                if(i < CVA6Cfg.NrPMPEntries) begin
                     // We only support >=8-byte granularity, NA4 is disabled
                     if(pmpcfg_d[i].addr_mode != riscv::NA4 && !(pmpcfg_d[i].access_type.r == '0 && pmpcfg_d[i].access_type.w == '1)) begin
                         pmpcfg_q[i] <= pmpcfg_d[i];

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -907,7 +907,7 @@ module csr_regfile import ariane_pkg::*; #(
         mstatus_d.sd   = (mstatus_q.xs == riscv::Dirty) | (mstatus_q.fs == riscv::Dirty);
 
         // reserve PMPCFG bits 5 and 6 (hardwire to 0)
-        for (int i = 0; i < NrPMPEntries; i++) pmpcfg_d[i].reserved = 2'b0;
+        for (int i = 0; i < CVA6Cfg.NrPMPEntries; i++) pmpcfg_d[i].reserved = 2'b0;
 
         // write the floating point status register
         if (CVA6Cfg.FpPresent && csr_write_fflags_i) begin

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -193,7 +193,22 @@ module cva6 import ariane_pkg::*; #(
     unsigned'(NrWbPorts),
     bit'(EnableAccelerator),
     CVA6Cfg.HaltAddress,
-    CVA6Cfg.ExceptionAddress
+    CVA6Cfg.ExceptionAddress,
+    CVA6Cfg.RASDepth,
+    CVA6Cfg.BTBEntries,
+    CVA6Cfg.BHTEntries,
+    CVA6Cfg.DmBaseAddress,
+    CVA6Cfg.NrPMPEntries,
+    CVA6Cfg.NOCType,
+    CVA6Cfg.NrNonIdempotentRules,
+    CVA6Cfg.NonIdempotentAddrBase,
+    CVA6Cfg.NonIdempotentLength,
+    CVA6Cfg.NrExecuteRegionRules,
+    CVA6Cfg.ExecuteRegionAddrBase,
+    CVA6Cfg.ExecuteRegionLength,
+    CVA6Cfg.NrCachedRegionRules,
+    CVA6Cfg.CachedRegionAddrBase,
+    CVA6Cfg.CachedRegionLength
   };
 
 
@@ -431,7 +446,7 @@ module cva6 import ariane_pkg::*; #(
   // Frontend
   // --------------
   frontend #(
-    .CVA6Cfg   ( CVA6ExtendCfg ),
+    .CVA6Cfg   ( CVA6ExtendCfg )
   ) i_frontend (
     .flush_i             ( flush_ctrl_if                 ), // not entirely correct
     .flush_bp_i          ( 1'b0                          ),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -178,7 +178,7 @@ module cva6 import ariane_pkg::*; #(
     CVA6Cfg.RVZCB,
     CVA6Cfg.XFVec,
     CVA6Cfg.CvxifEn,
-    CVA6Cfg.RCONDEXT,
+    CVA6Cfg.ZiCondExtEn,
     // Extended
     bit'(RVF),
     bit'(RVD),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -109,7 +109,6 @@ module cva6 import ariane_pkg::*; #(
         r_chan_t                     r;
   },
   //
-  parameter ariane_pkg::ariane_cfg_t ArianeCfg     = ariane_pkg::ArianeDefaultConfig,
   parameter type      acc_cfg_t = logic,
   parameter acc_cfg_t AccCfg    = '0,
   parameter type cvxif_req_t  = cvxif_pkg::cvxif_req_t,
@@ -594,8 +593,7 @@ module cva6 import ariane_pkg::*; #(
   // ---------
   ex_stage #(
     .CVA6Cfg    ( CVA6ExtendCfg ),
-    .ASID_WIDTH ( ASID_WIDTH ),
-    .ArianeCfg  ( ArianeCfg  )
+    .ASID_WIDTH ( ASID_WIDTH )
   ) ex_stage_i (
     .clk_i                  ( clk_i                       ),
     .rst_ni                 ( rst_ni                      ),
@@ -920,7 +918,6 @@ module cva6 import ariane_pkg::*; #(
   // this is a cache subsystem that is compatible with OpenPiton
   wt_cache_subsystem #(
     .CVA6Cfg              ( CVA6ExtendCfg ),
-    .ArianeCfg            ( ArianeCfg ),
     .NumPorts             ( NumPorts  ),
     .noc_req_t            ( noc_req_t ),
     .noc_resp_t           ( noc_resp_t )
@@ -965,7 +962,6 @@ module cva6 import ariane_pkg::*; #(
     // not as important since this cache subsystem is about to be
     // deprecated
     .CVA6Cfg               ( CVA6ExtendCfg               ),
-    .ArianeCfg             ( ArianeCfg                   ),
     .NumPorts              ( NumPorts                    ),
     .axi_ar_chan_t         ( axi_ar_chan_t               ),
     .axi_aw_chan_t         ( axi_aw_chan_t               ),
@@ -1083,7 +1079,7 @@ module cva6 import ariane_pkg::*; #(
   // -------------------
   // pragma translate_off
   `ifndef VERILATOR
-  initial ariane_pkg::check_cfg(ArianeCfg, CVA6Cfg);
+  initial ariane_pkg::check_cfg(CVA6Cfg);
   `endif
   // pragma translate_on
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1079,7 +1079,7 @@ module cva6 import ariane_pkg::*; #(
   // -------------------
   // pragma translate_off
   `ifndef VERILATOR
-  initial ariane_pkg::check_cfg(CVA6Cfg);
+  initial config_pkg::check_cfg(CVA6Cfg);
   `endif
   // pragma translate_on
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -433,7 +433,6 @@ module cva6 import ariane_pkg::*; #(
   // --------------
   frontend #(
     .CVA6Cfg   ( CVA6ExtendCfg ),
-    .ArianeCfg ( ArianeCfg )
   ) i_frontend (
     .flush_i             ( flush_ctrl_if                 ), // not entirely correct
     .flush_bp_i          ( 1'b0                          ),
@@ -753,8 +752,6 @@ module cva6 import ariane_pkg::*; #(
   csr_regfile #(
     .CVA6Cfg                ( CVA6ExtendCfg                 ),
     .AsidWidth              ( ASID_WIDTH                    ),
-    .DmBaseAddress          ( ArianeCfg.DmBaseAddress       ),
-    .NrPMPEntries           ( ArianeCfg.NrPMPEntries        ),
     .MHPMCounterNum         ( MHPMCounterNum                )
   ) csr_regfile_i (
     .flush_o                ( flush_csr_ctrl                ),
@@ -1086,7 +1083,7 @@ module cva6 import ariane_pkg::*; #(
   // -------------------
   // pragma translate_off
   `ifndef VERILATOR
-  initial ariane_pkg::check_cfg(ArianeCfg);
+  initial ariane_pkg::check_cfg(ArianeCfg, CVA6Cfg);
   `endif
   // pragma translate_on
 

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -577,7 +577,7 @@ module decoder import ariane_pkg::*; #(
                                 end
                             endcase
                         end
-                        if (CVA6Cfg.RCONDEXT) begin
+                        if (CVA6Cfg.ZiCondExtEn) begin
                             unique case ({instr.rtype.funct7, instr.rtype.funct3})
                                 //Conditional move
                                 {7'b000_0111, 3'b101}: instruction_o.op = ariane_pkg::CZERO_EQZ;     // czero.eqz
@@ -587,7 +587,8 @@ module decoder import ariane_pkg::*; #(
                                 end
                             endcase
                         end
-                        unique case ({ariane_pkg::BITMANIP, CVA6Cfg.RCONDEXT})
+                        //VCS coverage on
+                        unique case ({ariane_pkg::BITMANIP, CVA6Cfg.ZiCondExtEn})
                           2'b00 : illegal_instr = illegal_instr_non_bm;
                           2'b01 : illegal_instr = illegal_instr_non_bm & illegal_instr_zic;
                           2'b10 : illegal_instr = illegal_instr_non_bm & illegal_instr_bm;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -16,8 +16,7 @@
 
 module ex_stage import ariane_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter int unsigned ASID_WIDTH = 1,
-    parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+    parameter int unsigned ASID_WIDTH = 1
 ) (
     input  logic                                   clk_i,    // Clock
     input  logic                                   rst_ni,   // Asynchronous reset active low
@@ -304,8 +303,7 @@ module ex_stage import ariane_pkg::*; #(
 
     load_store_unit #(
         .CVA6Cfg    ( CVA6Cfg    ),
-        .ASID_WIDTH ( ASID_WIDTH ),
-        .ArianeCfg ( ArianeCfg )
+        .ASID_WIDTH ( ASID_WIDTH )
     ) lsu_i (
         .clk_i,
         .rst_ni,

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -16,8 +16,7 @@
 // change request from the back-end and does branch prediction.
 
 module frontend import ariane_pkg::*; #(
-  parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+  parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
   input  logic               clk_i,              // Clock
   input  logic               rst_ni,             // Asynchronous reset active low
@@ -354,7 +353,7 @@ module frontend import ariane_pkg::*; #(
       end
       // 7. Debug
       // enter debug on a hard-coded base-address
-      if (set_debug_pc_i) npc_d = ArianeCfg.DmBaseAddress[riscv::VLEN-1:0] + CVA6Cfg.HaltAddress[riscv::VLEN-1:0];
+      if (set_debug_pc_i) npc_d = CVA6Cfg.DmBaseAddress[riscv::VLEN-1:0] + CVA6Cfg.HaltAddress[riscv::VLEN-1:0];
       icache_dreq_o.vaddr = fetch_address;
     end
 
@@ -396,12 +395,12 @@ module frontend import ariane_pkg::*; #(
       end
     end
 
-    if (ArianeCfg.RASDepth == 0) begin
+    if (CVA6Cfg.RASDepth == 0) begin
       assign ras_predict = '0;
     end else begin : ras_gen
       ras #(
         .CVA6Cfg ( CVA6Cfg ),
-        .DEPTH  ( ArianeCfg.RASDepth  )
+        .DEPTH  ( CVA6Cfg.RASDepth  )
       ) i_ras (
         .clk_i,
         .rst_ni,
@@ -418,12 +417,12 @@ module frontend import ariane_pkg::*; #(
     //and can be read at the same cycle.
     assign vpc_btb = (ariane_pkg::FPGA_EN) ? icache_dreq_i.vaddr : icache_vaddr_q;
 
-    if (ArianeCfg.BTBEntries == 0) begin
+    if (CVA6Cfg.BTBEntries == 0) begin
       assign btb_prediction = '0;
     end else begin : btb_gen
       btb #(
         .CVA6Cfg          ( CVA6Cfg                ),
-        .NR_ENTRIES       ( ArianeCfg.BTBEntries   )
+        .NR_ENTRIES       ( CVA6Cfg.BTBEntries   )
       ) i_btb (
         .clk_i,
         .rst_ni,
@@ -435,12 +434,12 @@ module frontend import ariane_pkg::*; #(
       );
     end
 
-    if (ArianeCfg.BHTEntries == 0) begin
+    if (CVA6Cfg.BHTEntries == 0) begin
       assign bht_prediction = '0;
     end else begin : bht_gen
       bht #(
         .CVA6Cfg          ( CVA6Cfg                ),
-        .NR_ENTRIES       ( ArianeCfg.BHTEntries   )
+        .NR_ENTRIES       ( CVA6Cfg.BHTEntries   )
       ) i_bht (
         .clk_i,
         .rst_ni,

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -27,9 +27,6 @@ package ariane_pkg;
 
     localparam NrMaxRules = 16;
     typedef struct packed {
-      int                               RASDepth;
-      int                               BTBEntries;
-      int                               BHTEntries;
       // PMAs
       int unsigned                      NrNonIdempotentRules;  // Number of non idempotent rules
       logic [NrMaxRules-1:0][63:0]      NonIdempotentAddrBase; // base which needs to match
@@ -43,15 +40,9 @@ package ariane_pkg;
       // cache config
       bit                               AxiCompliant;          // set to 1 when using in conjunction with 64bit AXI bus adapter
       bit                               SwapEndianess;         // set to 1 to swap endianess inside L1.5 openpiton adapter
-      //
-      logic [63:0]                      DmBaseAddress;         // offset of the debug module
-      int unsigned                      NrPMPEntries;          // Number of PMP entries
     } ariane_cfg_t;
 
     localparam ariane_cfg_t ArianeDefaultConfig = '{
-      RASDepth:   int'(cva6_config_pkg::CVA6ConfigRASDepth),
-      BTBEntries: int'(cva6_config_pkg::CVA6ConfigBTBEntries),
-      BHTEntries: int'(cva6_config_pkg::CVA6ConfigBHTEntries),
       // idempotent region
       NrNonIdempotentRules:  unsigned'(2),
       NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
@@ -66,23 +57,34 @@ package ariane_pkg;
       CachedRegionLength:    1024'({64'h40000000}),
       //  cache config
       AxiCompliant:           1'b1,
-      SwapEndianess:          1'b0,
-      // debug
-      DmBaseAddress:          64'h0,
-      NrPMPEntries:           unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries)
+      SwapEndianess:          1'b0
+    };
+
+    localparam cva6_cfg_t CVA6DefaultCfg = '{
+      NrCommitPorts: unsigned'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
+      IsRVFI:        unsigned'(cva6_config_pkg::CVA6ConfigRvfiTrace),
+      AxiAddrWidth:  unsigned'(cva6_config_pkg::CVA6ConfigAxiAddrWidth),
+      AxiDataWidth:  unsigned'(cva6_config_pkg::CVA6ConfigAxiDataWidth),
+      AxiIdWidth:    unsigned'(cva6_config_pkg::CVA6ConfigAxiIdWidth),
+      AxiUserWidth:  unsigned'(cva6_config_pkg::CVA6ConfigDataUserWidth),
+      RASDepth:      unsigned'(cva6_config_pkg::CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries)
     };
 
     // Function being called to check parameters
-    function automatic void check_cfg (ariane_cfg_t Cfg);
+    function automatic void check_cfg (ariane_cfg_t Cfg, cva6_cfg_t CfgCVA6);
       // pragma translate_off
       `ifndef VERILATOR
-        assert(Cfg.RASDepth > 0);
-        assert(2**$clog2(Cfg.BTBEntries)  == Cfg.BTBEntries);
-        assert(2**$clog2(Cfg.BHTEntries)  == Cfg.BHTEntries);
+        assert(CfgCVA6.RASDepth > 0);
+        assert(2**$clog2(CfgCVA6.BTBEntries)  == CfgCVA6.BTBEntries);
+        assert(2**$clog2(CfgCVA6.BHTEntries)  == CfgCVA6.BHTEntries);
         assert(Cfg.NrNonIdempotentRules <= NrMaxRules);
         assert(Cfg.NrExecuteRegionRules <= NrMaxRules);
         assert(Cfg.NrCachedRegionRules  <= NrMaxRules);
-        assert(Cfg.NrPMPEntries <= 16);
+        assert(CfgCVA6.NrPMPEntries <= 16);
       `endif
       // pragma translate_on
     endfunction

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -23,68 +23,23 @@
   `include "l15.tmp.h"
 `endif
 
+/// This package contains `functions` and global defines for CVA6.
+/// *Note*: There are some parameters here as well which will eventually be
+/// moved out to favour a fully parameterizable core.
 package ariane_pkg;
 
-    localparam NrMaxRules = 16;
-    typedef struct packed {
-      // PMAs
-      int unsigned                      NrNonIdempotentRules;  // Number of non idempotent rules
-      logic [NrMaxRules-1:0][63:0]      NonIdempotentAddrBase; // base which needs to match
-      logic [NrMaxRules-1:0][63:0]      NonIdempotentLength;   // bit mask which bits to consider when matching the rule
-      int unsigned                      NrExecuteRegionRules;  // Number of regions which have execute property
-      logic [NrMaxRules-1:0][63:0]      ExecuteRegionAddrBase; // base which needs to match
-      logic [NrMaxRules-1:0][63:0]      ExecuteRegionLength;   // bit mask which bits to consider when matching the rule
-      int unsigned                      NrCachedRegionRules;   // Number of regions which have cached property
-      logic [NrMaxRules-1:0][63:0]      CachedRegionAddrBase;  // base which needs to match
-      logic [NrMaxRules-1:0][63:0]      CachedRegionLength;    // bit mask which bits to consider when matching the rule
-      // cache config
-      bit                               AxiCompliant;          // set to 1 when using in conjunction with 64bit AXI bus adapter
-      bit                               SwapEndianess;         // set to 1 to swap endianess inside L1.5 openpiton adapter
-    } ariane_cfg_t;
-
-    localparam ariane_cfg_t ArianeDefaultConfig = '{
-      // idempotent region
-      NrNonIdempotentRules:  unsigned'(2),
-      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
-      NonIdempotentLength:   1024'({64'b0, 64'b0}),
-      NrExecuteRegionRules:  unsigned'(3),
-      //                      DRAM,          Boot ROM,   Debug Module
-      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
-      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
-      // cached region
-      NrCachedRegionRules:   unsigned'(1),
-      CachedRegionAddrBase:  1024'({64'h8000_0000}),
-      CachedRegionLength:    1024'({64'h40000000}),
-      //  cache config
-      AxiCompliant:           1'b1,
-      SwapEndianess:          1'b0
-    };
-
-    localparam cva6_cfg_t CVA6DefaultCfg = '{
-      NrCommitPorts: unsigned'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
-      IsRVFI:        unsigned'(cva6_config_pkg::CVA6ConfigRvfiTrace),
-      AxiAddrWidth:  unsigned'(cva6_config_pkg::CVA6ConfigAxiAddrWidth),
-      AxiDataWidth:  unsigned'(cva6_config_pkg::CVA6ConfigAxiDataWidth),
-      AxiIdWidth:    unsigned'(cva6_config_pkg::CVA6ConfigAxiIdWidth),
-      AxiUserWidth:  unsigned'(cva6_config_pkg::CVA6ConfigDataUserWidth),
-      RASDepth:      unsigned'(cva6_config_pkg::CVA6ConfigRASDepth),
-      BTBEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBTBEntries),
-      BHTEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBHTEntries),
-      DmBaseAddress: 64'h0,
-      NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries)
-    };
-
-    // Function being called to check parameters
-    function automatic void check_cfg (ariane_cfg_t Cfg, cva6_cfg_t CfgCVA6);
+    /// Utility function being called to check parameters. Not all values make
+    /// sense for all parameters, here is the place to sanity check them.
+    function automatic void check_cfg (cva6_cfg_t Cfg);
       // pragma translate_off
       `ifndef VERILATOR
-        assert(CfgCVA6.RASDepth > 0);
-        assert(2**$clog2(CfgCVA6.BTBEntries)  == CfgCVA6.BTBEntries);
-        assert(2**$clog2(CfgCVA6.BHTEntries)  == CfgCVA6.BHTEntries);
+        assert(Cfg.RASDepth > 0);
+        assert(2**$clog2(Cfg.BTBEntries)  == Cfg.BTBEntries);
+        assert(2**$clog2(Cfg.BHTEntries)  == Cfg.BHTEntries);
         assert(Cfg.NrNonIdempotentRules <= NrMaxRules);
         assert(Cfg.NrExecuteRegionRules <= NrMaxRules);
         assert(Cfg.NrCachedRegionRules  <= NrMaxRules);
-        assert(CfgCVA6.NrPMPEntries <= 16);
+        assert(Cfg.NrPMPEntries <= 16);
       `endif
       // pragma translate_on
     endfunction
@@ -95,7 +50,7 @@ package ariane_pkg;
       return (address >= base) && (({1'b0, address}) < (65'(base)+len));
     endfunction : range_check
 
-    function automatic logic is_inside_nonidempotent_regions (ariane_cfg_t Cfg, logic[63:0] address);
+    function automatic logic is_inside_nonidempotent_regions (cva6_cfg_t Cfg, logic[63:0] address);
       logic[NrMaxRules-1:0] pass;
       pass = '0;
       for (int unsigned k = 0; k < Cfg.NrNonIdempotentRules; k++) begin
@@ -104,7 +59,7 @@ package ariane_pkg;
       return |pass;
     endfunction : is_inside_nonidempotent_regions
 
-    function automatic logic is_inside_execute_regions (ariane_cfg_t Cfg, logic[63:0] address);
+    function automatic logic is_inside_execute_regions (cva6_cfg_t Cfg, logic[63:0] address);
       // if we don't specify any region we assume everything is accessible
       logic[NrMaxRules-1:0] pass;
       pass = '0;
@@ -114,7 +69,7 @@ package ariane_pkg;
       return |pass;
     endfunction : is_inside_execute_regions
 
-    function automatic logic is_inside_cacheable_regions (ariane_cfg_t Cfg, logic[63:0] address);
+    function automatic logic is_inside_cacheable_regions (cva6_cfg_t Cfg, logic[63:0] address);
       automatic logic[NrMaxRules-1:0] pass;
       pass = '0;
       for (int unsigned k = 0; k < Cfg.NrCachedRegionRules; k++) begin

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -28,15 +28,6 @@
 /// moved out to favour a fully parameterizable core.
 package ariane_pkg;
 
-    function automatic logic is_inside_cacheable_regions (cva6_cfg_t Cfg, logic[63:0] address);
-      automatic logic[NrMaxRules-1:0] pass;
-      pass = '0;
-      for (int unsigned k = 0; k < Cfg.NrCachedRegionRules; k++) begin
-        pass[k] = range_check(Cfg.CachedRegionAddrBase[k], Cfg.CachedRegionLength[k], address);
-      end
-      return |pass;
-    endfunction : is_inside_cacheable_regions
-
     // TODO: Slowly move those parameters to the new system.
     localparam NR_SB_ENTRIES = cva6_config_pkg::CVA6ConfigNrScoreboardEntries; // number of scoreboard entries
     localparam TRANS_ID_BITS = $clog2(NR_SB_ENTRIES); // depending on the number of scoreboard entries we need that many bits

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -28,47 +28,6 @@
 /// moved out to favour a fully parameterizable core.
 package ariane_pkg;
 
-    /// Utility function being called to check parameters. Not all values make
-    /// sense for all parameters, here is the place to sanity check them.
-    function automatic void check_cfg (cva6_cfg_t Cfg);
-      // pragma translate_off
-      `ifndef VERILATOR
-        assert(Cfg.RASDepth > 0);
-        assert(2**$clog2(Cfg.BTBEntries)  == Cfg.BTBEntries);
-        assert(2**$clog2(Cfg.BHTEntries)  == Cfg.BHTEntries);
-        assert(Cfg.NrNonIdempotentRules <= NrMaxRules);
-        assert(Cfg.NrExecuteRegionRules <= NrMaxRules);
-        assert(Cfg.NrCachedRegionRules  <= NrMaxRules);
-        assert(Cfg.NrPMPEntries <= 16);
-      `endif
-      // pragma translate_on
-    endfunction
-
-    function automatic logic range_check(logic[63:0] base, logic[63:0] len, logic[63:0] address);
-      // if len is a power of two, and base is properly aligned, this check could be simplified
-      // Extend base by one bit to prevent an overflow.
-      return (address >= base) && (({1'b0, address}) < (65'(base)+len));
-    endfunction : range_check
-
-    function automatic logic is_inside_nonidempotent_regions (cva6_cfg_t Cfg, logic[63:0] address);
-      logic[NrMaxRules-1:0] pass;
-      pass = '0;
-      for (int unsigned k = 0; k < Cfg.NrNonIdempotentRules; k++) begin
-        pass[k] = range_check(Cfg.NonIdempotentAddrBase[k], Cfg.NonIdempotentLength[k], address);
-      end
-      return |pass;
-    endfunction : is_inside_nonidempotent_regions
-
-    function automatic logic is_inside_execute_regions (cva6_cfg_t Cfg, logic[63:0] address);
-      // if we don't specify any region we assume everything is accessible
-      logic[NrMaxRules-1:0] pass;
-      pass = '0;
-      for (int unsigned k = 0; k < Cfg.NrExecuteRegionRules; k++) begin
-        pass[k] = range_check(Cfg.ExecuteRegionAddrBase[k], Cfg.ExecuteRegionLength[k], address);
-      end
-      return |pass;
-    endfunction : is_inside_execute_regions
-
     function automatic logic is_inside_cacheable_regions (cva6_cfg_t Cfg, logic[63:0] address);
       automatic logic[NrMaxRules-1:0] pass;
       pass = '0;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -15,6 +15,8 @@ package config_pkg;
     localparam int unsigned ILEN = 32;
     localparam int unsigned NRET = 1;
 
+    localparam NrMaxRules = 16;
+
     typedef struct packed {
       int unsigned NrCommitPorts;
       int unsigned AxiAddrWidth;
@@ -50,6 +52,19 @@ package config_pkg;
       // address to which a hart should jump when it was requested to halt
       logic [63:0] HaltAddress;
       logic [63:0] ExceptionAddress;
+      // PMAs
+      int unsigned                      NrNonIdempotentRules;  // Number of non idempotent rules
+      logic [NrMaxRules-1:0][63:0]      NonIdempotentAddrBase; // base which needs to match
+      logic [NrMaxRules-1:0][63:0]      NonIdempotentLength;   // bit mask which bits to consider when matching the rule
+      int unsigned                      NrExecuteRegionRules;  // Number of regions which have execute property
+      logic [NrMaxRules-1:0][63:0]      ExecuteRegionAddrBase; // base which needs to match
+      logic [NrMaxRules-1:0][63:0]      ExecuteRegionLength;   // bit mask which bits to consider when matching the rule
+      int unsigned                      NrCachedRegionRules;   // Number of regions which have cached property
+      logic [NrMaxRules-1:0][63:0]      CachedRegionAddrBase;  // base which needs to match
+      logic [NrMaxRules-1:0][63:0]      CachedRegionLength;    // bit mask which bits to consider when matching the rule
+      // cache config
+      bit                               AxiCompliant;          // set to 1 when using in conjunction with 64bit AXI bus adapter
+      bit                               SwapEndianess;         // set to 1 to swap endianess inside L1.5 openpiton adapter
     } cva6_cfg_t;
 
     localparam cva6_cfg_t cva6_cfg_default = {
@@ -87,40 +102,9 @@ package config_pkg;
       64'h808            // ExceptionAddress
     } ;
 
-    localparam cva6_cfg_t cva6_cfg_empty = {
-      unsigned'(0),      // NrCommitPorts
-      unsigned'(0),      // AxiAddrWidth
-      unsigned'(0),      // AxiDataWidth
-      unsigned'(0),      // AxiIdWidth
-      unsigned'(0),      // AxiUserWidth
-      unsigned'(0),      // NrLoadBufEntries
-      bit'(0),           // FpuEn
-      bit'(0),           // XF16
-      bit'(0),           // XF16ALT
-      bit'(0),           // XF8
-      bit'(0),           // RVA
-      bit'(0),           // RVV
-      bit'(0),           // RVC
-      bit'(0),           // RVZCB
-      bit'(0),           // XFVec
-      bit'(0),           // CvxifEn
-      bit'(0),           // EnableZiCond
-      // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h0,             // HaltAddress
-      64'h0              // ExceptionAddress
-    } ;
+    /// Empty configuration to sanity check proper parameter passing. Whenever
+    /// you develop a module that resides within the core, assign this constant.
+    localparam cva6_cfg_t cva6_cfg_empty = '0;
 
 
 endpackage

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -50,7 +50,7 @@ package config_pkg;
       bit RVZCB;
       bit XFVec;
       bit CvxifEn;
-      bit RCONDEXT;
+      bit ZiCondExtEn;
       // Calculated
       bit RVF;
       bit RVD;
@@ -119,7 +119,7 @@ package config_pkg;
       RVZCB: bit'(1),
       XFVec: bit'(0),
       CvxifEn: bit'(1),
-      EnableZiCond: bit'(0),
+      ZiCondExtEn: bit'(0),
       // Extended
       RVF: bit'(0),
       RVD: bit'(0),

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -52,19 +52,38 @@ package config_pkg;
       // address to which a hart should jump when it was requested to halt
       logic [63:0] HaltAddress;
       logic [63:0] ExceptionAddress;
-      // PMAs
-      int unsigned                      NrNonIdempotentRules;  // Number of non idempotent rules
-      logic [NrMaxRules-1:0][63:0]      NonIdempotentAddrBase; // base which needs to match
-      logic [NrMaxRules-1:0][63:0]      NonIdempotentLength;   // bit mask which bits to consider when matching the rule
-      int unsigned                      NrExecuteRegionRules;  // Number of regions which have execute property
-      logic [NrMaxRules-1:0][63:0]      ExecuteRegionAddrBase; // base which needs to match
-      logic [NrMaxRules-1:0][63:0]      ExecuteRegionLength;   // bit mask which bits to consider when matching the rule
-      int unsigned                      NrCachedRegionRules;   // Number of regions which have cached property
-      logic [NrMaxRules-1:0][63:0]      CachedRegionAddrBase;  // base which needs to match
-      logic [NrMaxRules-1:0][63:0]      CachedRegionLength;    // bit mask which bits to consider when matching the rule
-      // cache config
-      bit                               AxiCompliant;          // set to 1 when using in conjunction with 64bit AXI bus adapter
-      bit                               SwapEndianess;         // set to 1 to swap endianess inside L1.5 openpiton adapter
+      /// Return address stack depth, good values are around 2 to 4.
+      int unsigned RASDepth;
+      /// Branch target buffer entries.
+      int unsigned BTBEntries;
+      /// Branch history (2-bit saturation counter) size, to keep track of
+      /// branch otucomes.
+      int unsigned BHTEntries;
+      /// Offset of the debug module.
+      logic [63:0] DmBaseAddress;
+      /// Number of PMP entries.
+      int unsigned NrPMPEntries;
+      /// Set to the bus type in use.
+      bus_type_e   BusType;
+      /// Physical Memory Attributes (PMAs)
+      /// Number of non idempotent rules.
+      int unsigned                      NrNonIdempotentRules;
+      /// Base which needs to match.
+      logic [NrMaxRules-1:0][63:0]      NonIdempotentAddrBase;
+      /// Bit mask which bits to consider when matching the rule.
+      logic [NrMaxRules-1:0][63:0]      NonIdempotentLength;
+      /// Number of regions which have execute property.
+      int unsigned                      NrExecuteRegionRules;
+      /// Base which needs to match.
+      logic [NrMaxRules-1:0][63:0]      ExecuteRegionAddrBase;
+      /// Bit mask which bits to consider when matching the rule.
+      logic [NrMaxRules-1:0][63:0]      ExecuteRegionLength;
+      /// Number of regions which have cached property.
+      int unsigned                      NrCachedRegionRules;
+      /// Base which needs to match.
+      logic [NrMaxRules-1:0][63:0]      CachedRegionAddrBase;
+      /// Bit mask which bits to consider when matching the rule.
+      logic [NrMaxRules-1:0][63:0]      CachedRegionLength;
     } cva6_cfg_t;
 
     localparam cva6_cfg_t cva6_cfg_default = {

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -34,12 +34,12 @@ package config_pkg;
       /// ports than issue ports, for the scoreboard to empty out in case one
       /// instruction stalls a little longer.
       int unsigned NrCommitPorts;
-      int unsigned IsRVFI;
       /// AXI parameters.
       int unsigned AxiAddrWidth;
       int unsigned AxiDataWidth;
       int unsigned AxiIdWidth;
       int unsigned AxiUserWidth;
+      int unsigned NrLoadBufEntries;
       bit FpuEn;
       bit XF16;
       bit XF16ALT;
@@ -135,11 +135,11 @@ package config_pkg;
       EnableAccelerator: bit'(0),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
-      RASDepth:      unsigned'(cva6_config_pkg::CVA6ConfigRASDepth),
-      BTBEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBTBEntries),
-      BHTEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBHTEntries),
+      RASDepth:      2,
+      BTBEntries:    32,
+      BHTEntries:    128,
       DmBaseAddress: 64'h0,
-      NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
+      NrPMPEntries:  8,
       NOCType:       NOC_TYPE_AXI4_ATOP,
       // idempotent region
       NrNonIdempotentRules:  unsigned'(2),

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -15,15 +15,31 @@ package config_pkg;
     localparam int unsigned ILEN = 32;
     localparam int unsigned NRET = 1;
 
+    /// The NoC type is a top-level parameter, hence we need a bit more
+    /// information on what protocol those type parameters are supporting.
+    /// Currently two values are supported"
+    typedef enum {
+      /// The "classic" AXI4 protocol.
+      NOC_TYPE_AXI4_ATOP,
+      /// In the OpenPiton setting the WT cache is connected to the L15.
+      NOC_TYPE_L15_BIG_ENDIAN,
+      NOC_TYPE_L15_LITTLE_ENDIAN
+    } noc_type_e;
+
     localparam NrMaxRules = 16;
 
     typedef struct packed {
+      /// Number of commit ports, i.e., maximum number of instructions that the
+      /// core can retire per cycle. It can be beneficial to have more commit
+      /// ports than issue ports, for the scoreboard to empty out in case one
+      /// instruction stalls a little longer.
       int unsigned NrCommitPorts;
+      int unsigned IsRVFI;
+      /// AXI parameters.
       int unsigned AxiAddrWidth;
       int unsigned AxiDataWidth;
       int unsigned AxiIdWidth;
       int unsigned AxiUserWidth;
-      int unsigned NrLoadBufEntries;
       bit FpuEn;
       bit XF16;
       bit XF16ALT;
@@ -64,7 +80,7 @@ package config_pkg;
       /// Number of PMP entries.
       int unsigned NrPMPEntries;
       /// Set to the bus type in use.
-      bus_type_e   BusType;
+      noc_type_e   NOCType;
       /// Physical Memory Attributes (PMAs)
       /// Number of non idempotent rules.
       int unsigned                      NrNonIdempotentRules;
@@ -86,44 +102,113 @@ package config_pkg;
       logic [NrMaxRules-1:0][63:0]      CachedRegionLength;
     } cva6_cfg_t;
 
-    localparam cva6_cfg_t cva6_cfg_default = {
-      unsigned'(1),      // NrCommitPorts
-      unsigned'(64),     // AxiAddrWidth
-      unsigned'(64),     // AxiDataWidth
-      unsigned'(4),      // AxiIdWidth
-      unsigned'(32),     // AxiUserWidth
-      unsigned'(2),      // NrLoadBufEntries
-      bit'(0),           // FpuEn
-      bit'(0),           // XF16
-      bit'(0),           // XF16ALT
-      bit'(0),           // XF8
-      bit'(0),           // RVA
-      bit'(0),           // RVV
-      bit'(1),           // RVC
-      bit'(0),           // RVZCB
-      bit'(0),           // XFVec
-      bit'(1),           // CvxifEn
-      bit'(0),           // EnableZiCond
+    localparam cva6_cfg_t cva6_cfg_default = '{
+      NrCommitPorts: unsigned'(1),
+      AxiAddrWidth: unsigned'(64),
+      AxiDataWidth: unsigned'(64),
+      AxiIdWidth: unsigned'(4),
+      AxiUserWidth: unsigned'(32),
+      NrLoadBufEntries: unsigned'(2),
+      FpuEn: bit'(0),
+      XF16: bit'(0),
+      XF16ALT: bit'(0),
+      XF8: bit'(0),
+      RVA: bit'(0),
+      RVV: bit'(0),
+      RVC: bit'(1),
+      RVZCB: bit'(1),
+      XFVec: bit'(0),
+      CvxifEn: bit'(1),
+      EnableZiCond: bit'(0),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(cva6_config_pkg::CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(cva6_config_pkg::CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
+      NOCType:       NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
     /// Empty configuration to sanity check proper parameter passing. Whenever
     /// you develop a module that resides within the core, assign this constant.
     localparam cva6_cfg_t cva6_cfg_empty = '0;
 
+
+    /// Utility function being called to check parameters. Not all values make
+    /// sense for all parameters, here is the place to sanity check them.
+    function automatic void check_cfg (cva6_cfg_t Cfg);
+      // pragma translate_off
+      `ifndef VERILATOR
+        assert(Cfg.RASDepth > 0);
+        assert(2**$clog2(Cfg.BTBEntries)  == Cfg.BTBEntries);
+        assert(2**$clog2(Cfg.BHTEntries)  == Cfg.BHTEntries);
+        assert(Cfg.NrNonIdempotentRules <= NrMaxRules);
+        assert(Cfg.NrExecuteRegionRules <= NrMaxRules);
+        assert(Cfg.NrCachedRegionRules  <= NrMaxRules);
+        assert(Cfg.NrPMPEntries <= 16);
+      `endif
+      // pragma translate_on
+    endfunction
+
+    function automatic logic range_check(logic[63:0] base, logic[63:0] len, logic[63:0] address);
+      // if len is a power of two, and base is properly aligned, this check could be simplified
+      // Extend base by one bit to prevent an overflow.
+      return (address >= base) && (({1'b0, address}) < (65'(base)+len));
+    endfunction : range_check
+
+
+    function automatic logic is_inside_nonidempotent_regions (cva6_cfg_t Cfg, logic[63:0] address);
+      logic[NrMaxRules-1:0] pass;
+      pass = '0;
+      for (int unsigned k = 0; k < Cfg.NrNonIdempotentRules; k++) begin
+        pass[k] = range_check(Cfg.NonIdempotentAddrBase[k], Cfg.NonIdempotentLength[k], address);
+      end
+      return |pass;
+    endfunction : is_inside_nonidempotent_regions
+
+    function automatic logic is_inside_execute_regions (cva6_cfg_t Cfg, logic[63:0] address);
+      // if we don't specify any region we assume everything is accessible
+      logic[NrMaxRules-1:0] pass;
+      pass = '0;
+      for (int unsigned k = 0; k < Cfg.NrExecuteRegionRules; k++) begin
+        pass[k] = range_check(Cfg.ExecuteRegionAddrBase[k], Cfg.ExecuteRegionLength[k], address);
+      end
+      return |pass;
+    endfunction : is_inside_execute_regions
+
+    function automatic logic is_inside_cacheable_regions (cva6_cfg_t Cfg, logic[63:0] address);
+      automatic logic[NrMaxRules-1:0] pass;
+      pass = '0;
+      for (int unsigned k = 0; k < Cfg.NrCachedRegionRules; k++) begin
+        pass[k] = range_check(Cfg.CachedRegionAddrBase[k], Cfg.CachedRegionLength[k], address);
+      end
+      return |pass;
+    endfunction : is_inside_cacheable_regions
 
 endpackage

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -77,39 +77,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -76,40 +76,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
-
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -77,39 +77,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -94,7 +94,7 @@ package cva6_config_pkg;
       RVZCB: bit'(CVA6ConfigZcbExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),s)
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
       RVF: bit'(0),
       RVD: bit'(0),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -77,39 +77,56 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),s)
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
-
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 endpackage

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -77,39 +77,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -77,39 +77,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),oblems)
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -94,7 +94,7 @@ package cva6_config_pkg;
       RVZCB: bit'(CVA6ConfigZcbExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),oblems)
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
       RVF: bit'(0),
       RVD: bit'(0),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -76,39 +76,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_L15_BIG_ENDIAN,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -77,39 +77,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // RCONDEXT
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress            // EnableAccelerator
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -77,39 +77,57 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_L15_BIG_ENDIAN,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -76,39 +76,56 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigRvfiTrace = 1;
 
-    localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
-      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
-      bit'(CVA6ConfigFpuEn),                 // FpuEn
-      bit'(CVA6ConfigF16En),                 // XF16
-      bit'(CVA6ConfigF16AltEn),              // XF16ALT
-      bit'(CVA6ConfigF8En),                  // XF8
-      bit'(CVA6ConfigAExtEn),                // RVA
-      bit'(CVA6ConfigVExtEn),                // RVV
-      bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RVZCB
-      bit'(CVA6ConfigFVecEn),                // XFVec
-      bit'(CVA6ConfigCvxifEn),               // CvxifEn
-      bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn
+    localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      bit'(0),           // RVF
-      bit'(0),           // RVD
-      bit'(0),           // FpPresent
-      bit'(0),           // NSX
-      unsigned'(0),      // FLen
-      bit'(0),           // RVFVec
-      bit'(0),           // XF16Vec
-      bit'(0),           // XF16ALTVec
-      bit'(0),           // XF8Vec
-      unsigned'(0),      // NrRgprPorts
-      unsigned'(0),      // NrWbPorts
-      bit'(0),           // EnableAccelerator
-      64'h800,           // HaltAddress
-      64'h808            // ExceptionAddress
-    } ;
-
+      RVF: bit'(0),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth:      unsigned'(CVA6ConfigRASDepth),
+      BTBEntries:    unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries:    unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries:  unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType:       config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:  unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength:   1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules:  unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength:   1024'({64'h40000000,  64'h10000,  64'h1000}),
+      // cached region
+      NrCachedRegionRules:   unsigned'(1),
+      CachedRegionAddrBase:  1024'({64'h8000_0000}),
+      CachedRegionLength:    1024'({64'h40000000})
+    };
 endpackage

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -15,8 +15,7 @@
 
 module load_store_unit import ariane_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter int unsigned ASID_WIDTH = 1,
-    parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+    parameter int unsigned ASID_WIDTH = 1
 )(
     input  logic                     clk_i,
     input  logic                     rst_ni,
@@ -144,8 +143,7 @@ module load_store_unit import ariane_pkg::*; #(
             .CVA6Cfg                ( CVA6Cfg                ),
             .INSTR_TLB_ENTRIES      ( ariane_pkg::INSTR_TLB_ENTRIES ),
             .DATA_TLB_ENTRIES       ( ariane_pkg::DATA_TLB_ENTRIES ),
-            .ASID_WIDTH             ( ASID_WIDTH             ),
-            .ArianeCfg              ( ArianeCfg              )
+            .ASID_WIDTH             ( ASID_WIDTH             )
         ) i_cva6_mmu (
             // misaligned bypass
             .misaligned_ex_i        ( misaligned_exception   ),
@@ -174,8 +172,7 @@ module load_store_unit import ariane_pkg::*; #(
             .CVA6Cfg                ( CVA6Cfg                ),
             .INSTR_TLB_ENTRIES      ( ariane_pkg::INSTR_TLB_ENTRIES ),
             .DATA_TLB_ENTRIES       ( ariane_pkg::DATA_TLB_ENTRIES ),
-            .ASID_WIDTH             ( ASID_WIDTH             ),
-            .ArianeCfg              ( ArianeCfg              )
+            .ASID_WIDTH             ( ASID_WIDTH             )
         ) i_cva6_mmu (
             // misaligned bypass
             .misaligned_ex_i        ( misaligned_exception   ),
@@ -289,8 +286,7 @@ module load_store_unit import ariane_pkg::*; #(
     // Load Unit
     // ------------------
     load_unit #(
-        .CVA6Cfg   ( CVA6Cfg   ),
-        .ArianeCfg ( ArianeCfg )
+        .CVA6Cfg   ( CVA6Cfg   )
     ) i_load_unit (
         .valid_i               ( ld_valid_i           ),
         .lsu_ctrl_i            ( lsu_ctrl             ),

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -19,8 +19,7 @@
 //               to the data cache
 
 module load_unit import ariane_pkg::*; #(
-    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
     input  logic                     clk_i,    // Clock
     input  logic                     rst_ni,   // Asynchronous reset active low
@@ -176,7 +175,7 @@ module load_unit import ariane_pkg::*; #(
     logic not_commit_time;
     logic inflight_stores;
     logic stall_ni;
-    assign paddr_ni = is_inside_nonidempotent_regions(ArianeCfg, {dtlb_ppn_i,12'd0});
+    assign paddr_ni = is_inside_nonidempotent_regions(CVA6Cfg, {dtlb_ppn_i,12'd0});
     assign not_commit_time = commit_tran_id_i != lsu_ctrl_i.trans_id;
     assign inflight_stores = (!dcache_wbuffer_not_ni_i || !store_buffer_empty_i);
     assign stall_ni = (inflight_stores || not_commit_time) && paddr_ni;

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -175,7 +175,7 @@ module load_unit import ariane_pkg::*; #(
     logic not_commit_time;
     logic inflight_stores;
     logic stall_ni;
-    assign paddr_ni = is_inside_nonidempotent_regions(CVA6Cfg, {dtlb_ppn_i,12'd0});
+    assign paddr_ni = config_pkg::is_inside_nonidempotent_regions(CVA6Cfg, {dtlb_ppn_i,12'd0});
     assign not_commit_time = commit_tran_id_i != lsu_ctrl_i.trans_id;
     assign inflight_stores = (!dcache_wbuffer_not_ni_i || !store_buffer_empty_i);
     assign stall_ni = (inflight_stores || not_commit_time) && paddr_ni;

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -30,8 +30,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter int unsigned INSTR_TLB_ENTRIES     = 2,
     parameter int unsigned DATA_TLB_ENTRIES      = 2,
-    parameter int unsigned ASID_WIDTH            = 1,
-    parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+    parameter int unsigned ASID_WIDTH            = 1
 ) (
     input  logic                            clk_i,
     input  logic                            rst_ni,
@@ -198,8 +197,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
 
     cva6_ptw_sv32  #(
         .CVA6Cfg                ( CVA6Cfg               ),
-        .ASID_WIDTH             ( ASID_WIDTH            ),
-        .ArianeCfg              ( ArianeCfg             )
+        .ASID_WIDTH             ( ASID_WIDTH            )
     ) i_ptw (
         .clk_i                  ( clk_i                 ),
         .rst_ni                 ( rst_ni                ),
@@ -338,7 +336,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
     end
 
     // check for execute flag on memory
-    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(ArianeCfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
+    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
 
     // Instruction fetch
     pmp #(
@@ -486,7 +484,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
     pmp #(
         .PLEN       ( riscv::PLEN            ),
         .PMP_LEN    ( riscv::PLEN - 2        ),
-        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+        .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
     ) i_pmp_data (
         .addr_i        ( lsu_paddr_o         ),
         .priv_lvl_i    ( ld_st_priv_lvl_i    ),

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -336,7 +336,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
     end
 
     // check for execute flag on memory
-    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
+    assign match_any_execute_region = config_pkg::is_inside_execute_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
 
     // Instruction fetch
     pmp #(

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -344,7 +344,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
     pmp #(
         .PLEN       ( riscv::PLEN            ),
         .PMP_LEN    ( riscv::PLEN - 2        ),
-        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+        .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
     ) i_pmp_if (
         .addr_i        ( icache_areq_o.fetch_paddr ),
         .priv_lvl_i,

--- a/core/mmu_sv32/cva6_ptw_sv32.sv
+++ b/core/mmu_sv32/cva6_ptw_sv32.sv
@@ -147,7 +147,7 @@ module cva6_ptw_sv32 import ariane_pkg::*; #(
         .CVA6Cfg    ( CVA6Cfg                ),
         .PLEN       ( riscv::PLEN            ),
         .PMP_LEN    ( riscv::PLEN - 2        ),
-        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+        .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
     ) i_pmp_ptw (
         .addr_i        ( ptw_pptr_q         ),
         // PTW access are always checked as if in S-Mode...

--- a/core/mmu_sv32/cva6_ptw_sv32.sv
+++ b/core/mmu_sv32/cva6_ptw_sv32.sv
@@ -28,8 +28,7 @@
 
 module cva6_ptw_sv32 import ariane_pkg::*; #(
         parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-        parameter int ASID_WIDTH = 1,
-        parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+        parameter int ASID_WIDTH = 1
 ) (
     input  logic                    clk_i,                  // Clock
     input  logic                    rst_ni,                 // Asynchronous reset active low

--- a/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_shared_tlb_sv32.sv
@@ -21,8 +21,7 @@ module cva6_shared_tlb_sv32 import ariane_pkg::*; #(
         parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
         parameter int SHARED_TLB_DEPTH = 64,
         parameter int SHARED_TLB_WAYS = 2,
-        parameter int ASID_WIDTH = 1,
-        parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+        parameter int ASID_WIDTH = 1
 ) (
     input  logic                    clk_i,                  // Clock
     input  logic                    rst_ni,                 // Asynchronous reset active low

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -278,7 +278,7 @@ module mmu import ariane_pkg::*; #(
         .CVA6Cfg    ( CVA6Cfg                ),
         .PLEN       ( riscv::PLEN            ),
         .PMP_LEN    ( riscv::PLEN - 2        ),
-        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+        .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
     ) i_pmp_if (
         .addr_i        ( icache_areq_o.fetch_paddr ),
         .priv_lvl_i,
@@ -427,7 +427,7 @@ module mmu import ariane_pkg::*; #(
         .CVA6Cfg    ( CVA6Cfg                ),
         .PLEN       ( riscv::PLEN            ),
         .PMP_LEN    ( riscv::PLEN - 2        ),
-        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+        .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
     ) i_pmp_data (
         .addr_i        ( lsu_paddr_o         ),
         .priv_lvl_i    ( ld_st_priv_lvl_i    ),

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -19,8 +19,7 @@ module mmu import ariane_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter int unsigned INSTR_TLB_ENTRIES     = 4,
     parameter int unsigned DATA_TLB_ENTRIES      = 4,
-    parameter int unsigned ASID_WIDTH            = 1,
-    parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+    parameter int unsigned ASID_WIDTH            = 1
 ) (
     input  logic                            clk_i,
     input  logic                            rst_ni,
@@ -145,8 +144,7 @@ module mmu import ariane_pkg::*; #(
 
     ptw  #(
         .CVA6Cfg                ( CVA6Cfg               ),
-        .ASID_WIDTH             ( ASID_WIDTH            ),
-        .ArianeCfg              ( ArianeCfg             )
+        .ASID_WIDTH             ( ASID_WIDTH            )
     ) i_ptw (
         .clk_i                  ( clk_i                 ),
         .rst_ni                 ( rst_ni                ),
@@ -271,7 +269,7 @@ module mmu import ariane_pkg::*; #(
     end
 
     // check for execute flag on memory
-    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(ArianeCfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
+    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
 
     // Instruction fetch
     pmp #(

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -269,7 +269,7 @@ module mmu import ariane_pkg::*; #(
     end
 
     // check for execute flag on memory
-    assign match_any_execute_region = ariane_pkg::is_inside_execute_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
+    assign match_any_execute_region = config_pkg::is_inside_execute_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
 
     // Instruction fetch
     pmp #(

--- a/core/mmu_sv39/ptw.sv
+++ b/core/mmu_sv39/ptw.sv
@@ -142,7 +142,7 @@ module ptw import ariane_pkg::*; #(
         .CVA6Cfg    ( CVA6Cfg                ),
         .PLEN       ( riscv::PLEN            ),
         .PMP_LEN    ( riscv::PLEN - 2        ),
-        .NR_ENTRIES ( ArianeCfg.NrPMPEntries )
+        .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
     ) i_pmp_ptw (
         .addr_i        ( ptw_pptr_q         ),
         // PTW access are always checked as if in S-Mode...

--- a/core/mmu_sv39/ptw.sv
+++ b/core/mmu_sv39/ptw.sv
@@ -17,8 +17,7 @@
 
 module ptw import ariane_pkg::*; #(
         parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-        parameter int ASID_WIDTH = 1,
-        parameter ariane_pkg::ariane_cfg_t ArianeCfg = ariane_pkg::ArianeDefaultConfig
+        parameter int ASID_WIDTH = 1
 ) (
     input  logic                    clk_i,                  // Clock
     input  logic                    rst_ni,                 // Asynchronous reset active low

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -156,7 +156,55 @@ module ariane_xilinx (
 
 // CVA6 config
 localparam bit IsRVFI = bit'(0);
-localparam config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg;
+// CVA6 Xilinx configuration
+localparam ariane_pkg::cva6_cfg_t CVA6Cfg = '{
+  NrCommitPorts:         cva6_config_pkg::CVA6ConfigNrCommitPorts,
+  AxiAddrWidth:          cva6_config_pkg::CVA6ConfigAxiAddrWidth,
+  AxiDataWidth:          cva6_config_pkg::CVA6ConfigAxiDataWidth,
+  AxiIdWidth:            cva6_config_pkg::CVA6ConfigAxiIdWidth,
+  AxiUserWidth:          cva6_config_pkg::CVA6ConfigDataUserWidth,
+  RASDepth:              cva6_config_pkg::CVA6ConfigRASDepth,
+  BTBEntries:            cva6_config_pkg::CVA6ConfigBTBEntries,
+  BHTEntries:            cva6_config_pkg::CVA6ConfigBHTEntries,
+  FpuEn:                 bit'(cva6_config_pkg::CVA6ConfigFpuEn),
+  XF16:                  bit'(cva6_config_pkg::CVA6ConfigF16En),
+  XF16ALT:               bit'(cva6_config_pkg::CVA6ConfigF16AltEn),
+  XF8:                   bit'(cva6_config_pkg::CVA6ConfigF8En),
+  RVA:                   bit'(cva6_config_pkg::CVA6ConfigAExtEn),
+  RVV:                   bit'(cva6_config_pkg::CVA6ConfigVExtEn),
+  RVC:                   bit'(cva6_config_pkg::CVA6ConfigCExtEn),
+  XFVec:                 bit'(cva6_config_pkg::CVA6ConfigFVecEn),
+  CvxifEn:               bit'(cva6_config_pkg::CVA6ConfigCvxifEn),
+  RVF:                   bit'(0),
+  RVD:                   bit'(0),
+  FpPresent:             bit'(0),
+  NSX:                   bit'(0),
+  FLen:                  unsigned'(0),
+  RVFVec:                bit'(0),
+  XF16Vec:               bit'(0),
+  XF16ALTVec:            bit'(0),
+  XF8Vec:                bit'(0),
+  NrRgprPorts:           unsigned'(0),
+  NrWbPorts:             unsigned'(0),
+  EnableAccelerator:     bit'(0),
+  HaltAddress:           dm::HaltAddress,
+  ExceptionAddress:      dm::ExceptionAddress,
+  DmBaseAddress:         DebugBase,
+  NrPMPEntries:          unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
+  NOCType:               config_pkg::NOC_TYPE_AXI4_ATOP,
+  // idempotent region
+  NrNonIdempotentRules:  unsigned'(1),
+  NonIdempotentAddrBase: 1024'({64'b0}),
+  NonIdempotentLength:   1024'({DRAMBase}),
+  NrExecuteRegionRules:  unsigned'(3),
+  ExecuteRegionAddrBase: 1024'({DRAMBase,   ROMBase,   DebugBase}),
+  ExecuteRegionLength:   1024'({DRAMLength, ROMLength, DebugLength}),
+  // cached region
+  NrCachedRegionRules:   unsigned'(1),
+  CachedRegionAddrBase:  1024'({DRAMBase}),
+  CachedRegionLength:    1024'({DRAMLength})
+};
+
 localparam type rvfi_instr_t = logic;
 
 
@@ -567,7 +615,7 @@ logic [1:0]    axi_adapter_size;
 assign axi_adapter_size = (riscv::XLEN == 64) ? 2'b11 : 2'b10;
 
 axi_adapter #(
-    .CVA6Cfg               ( ariane_soc::CVA6SoCCfg   ),
+    .CVA6Cfg               ( CVA6Cfg                  ),
     .DATA_WIDTH            ( riscv::XLEN              ),
     .axi_req_t             ( ariane_axi::req_t        ),
     .axi_rsp_t             ( ariane_axi::resp_t       )

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -163,6 +163,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   AxiDataWidth:          cva6_config_pkg::CVA6ConfigAxiDataWidth,
   AxiIdWidth:            cva6_config_pkg::CVA6ConfigAxiIdWidth,
   AxiUserWidth:          cva6_config_pkg::CVA6ConfigDataUserWidth,
+  NrLoadBufEntries:      cva6_config_pkg::CVA6ConfigNrLoadBufEntries,
   RASDepth:              cva6_config_pkg::CVA6ConfigRASDepth,
   BTBEntries:            cva6_config_pkg::CVA6ConfigBTBEntries,
   BHTEntries:            cva6_config_pkg::CVA6ConfigBHTEntries,

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -755,7 +755,7 @@ ariane_axi::resp_t   axi_ariane_resp;
 ariane #(
     .CVA6Cfg ( CVA6Cfg ),
     .IsRVFI ( IsRVFI ),
-    .rvfi_instr_t ( rvfi_instr_t ),
+    .rvfi_instr_t ( rvfi_instr_t )
 ) i_ariane (
     .clk_i        ( clk                 ),
     .rst_ni       ( ndmreset_n          ),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -567,7 +567,7 @@ logic [1:0]    axi_adapter_size;
 assign axi_adapter_size = (riscv::XLEN == 64) ? 2'b11 : 2'b10;
 
 axi_adapter #(
-    .CVA6Cfg               ( CVA6Cfg                  ),
+    .CVA6Cfg               ( ariane_soc::CVA6SoCCfg   ),
     .DATA_WIDTH            ( riscv::XLEN              ),
     .axi_req_t             ( ariane_axi::req_t        ),
     .axi_rsp_t             ( ariane_axi::resp_t       )

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -714,6 +714,7 @@ ariane #(
     .irq_i        ( irq                 ),
     .ipi_i        ( ipi                 ),
     .time_irq_i   ( timer_irq           ),
+    .rvfi_o       ( /* open */          ),
     .debug_req_i  ( debug_req_irq       ),
     .noc_req_o    ( axi_ariane_req      ),
     .noc_resp_i   ( axi_ariane_resp     )

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -174,6 +174,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   RVA:                   bit'(cva6_config_pkg::CVA6ConfigAExtEn),
   RVV:                   bit'(cva6_config_pkg::CVA6ConfigVExtEn),
   RVC:                   bit'(cva6_config_pkg::CVA6ConfigCExtEn),
+  RVZCB:                 bit'(cva6_config_pkg::CVA6ConfigZcbExtEn),
   XFVec:                 bit'(cva6_config_pkg::CVA6ConfigFVecEn),
   CvxifEn:               bit'(cva6_config_pkg::CVA6ConfigCvxifEn),
   ZiCondExtEn:           bit'(0),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -190,20 +190,20 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   EnableAccelerator:     bit'(0),
   HaltAddress:           dm::HaltAddress,
   ExceptionAddress:      dm::ExceptionAddress,
-  DmBaseAddress:         DebugBase,
+  DmBaseAddress:         ariane_soc::DebugBase,
   NrPMPEntries:          unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
   NOCType:               config_pkg::NOC_TYPE_AXI4_ATOP,
   // idempotent region
   NrNonIdempotentRules:  unsigned'(1),
   NonIdempotentAddrBase: 1024'({64'b0}),
-  NonIdempotentLength:   1024'({DRAMBase}),
+  NonIdempotentLength:   1024'({ariane_soc::DRAMBase}),
   NrExecuteRegionRules:  unsigned'(3),
-  ExecuteRegionAddrBase: 1024'({DRAMBase,   ROMBase,   DebugBase}),
-  ExecuteRegionLength:   1024'({DRAMLength, ROMLength, DebugLength}),
+  ExecuteRegionAddrBase: 1024'({ariane_soc::DRAMBase,   ariane_soc::ROMBase,   ariane_soc::DebugBase}),
+  ExecuteRegionLength:   1024'({ariane_soc::DRAMLength, ariane_soc::ROMLength, ariane_soc::DebugLength}),
   // cached region
   NrCachedRegionRules:   unsigned'(1),
-  CachedRegionAddrBase:  1024'({DRAMBase}),
-  CachedRegionLength:    1024'({DRAMLength})
+  CachedRegionAddrBase:  1024'({ariane_soc::DRAMBase}),
+  CachedRegionLength:    1024'({ariane_soc::DRAMLength})
 };
 
 localparam type rvfi_instr_t = logic;

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -706,7 +706,6 @@ ariane #(
     .CVA6Cfg ( CVA6Cfg ),
     .IsRVFI ( IsRVFI ),
     .rvfi_instr_t ( rvfi_instr_t ),
-    .ArianeCfg ( ariane_soc::ArianeSocCfg )
 ) i_ariane (
     .clk_i        ( clk                 ),
     .rst_ni       ( ndmreset_n          ),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -157,7 +157,7 @@ module ariane_xilinx (
 // CVA6 config
 localparam bit IsRVFI = bit'(0);
 // CVA6 Xilinx configuration
-localparam ariane_pkg::cva6_cfg_t CVA6Cfg = '{
+localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   NrCommitPorts:         cva6_config_pkg::CVA6ConfigNrCommitPorts,
   AxiAddrWidth:          cva6_config_pkg::CVA6ConfigAxiAddrWidth,
   AxiDataWidth:          cva6_config_pkg::CVA6ConfigAxiDataWidth,
@@ -175,6 +175,7 @@ localparam ariane_pkg::cva6_cfg_t CVA6Cfg = '{
   RVC:                   bit'(cva6_config_pkg::CVA6ConfigCExtEn),
   XFVec:                 bit'(cva6_config_pkg::CVA6ConfigFVecEn),
   CvxifEn:               bit'(cva6_config_pkg::CVA6ConfigCvxifEn),
+  ZiCondExtEn:           bit'(0),
   RVF:                   bit'(0),
   RVD:                   bit'(0),
   FpPresent:             bit'(0),

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -17,8 +17,6 @@ module ariane import ariane_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
   parameter bit IsRVFI = bit'(0),
   parameter type rvfi_instr_t = logic,
-  //
-  parameter ariane_pkg::ariane_cfg_t ArianeCfg     = ariane_pkg::ArianeDefaultConfig,
   parameter int unsigned AxiAddrWidth = ariane_axi::AddrWidth,
   parameter int unsigned AxiDataWidth = ariane_axi::DataWidth,
   parameter int unsigned AxiIdWidth   = ariane_axi::IdWidth,
@@ -55,8 +53,6 @@ module ariane import ariane_pkg::*; #(
     .CVA6Cfg ( CVA6Cfg ),
     .IsRVFI ( IsRVFI ),
     .rvfi_instr_t ( rvfi_instr_t ),
-    //
-    .ArianeCfg  ( ArianeCfg ),
     .axi_ar_chan_t (axi_ar_chan_t),
     .axi_aw_chan_t (axi_aw_chan_t),
     .axi_w_chan_t (axi_w_chan_t),

--- a/corev_apu/tb/ariane_soc_pkg.sv
+++ b/corev_apu/tb/ariane_soc_pkg.sv
@@ -82,7 +82,7 @@ package ariane_soc;
     BHTEntries:    cva6_config_pkg::CVA6ConfigBHTEntries,
     DmBaseAddress: DebugBase,
     NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
-    BusType:       ariane_pkg::BUS_TYPE_AXI4_ATOP,
+    NOCType:       ariane_pkg::NOC_TYPE_AXI4_ATOP,
     // idempotent region
     NrNonIdempotentRules:  unsigned'(1),
     NonIdempotentAddrBase: 1024'({64'b0}),

--- a/corev_apu/tb/ariane_soc_pkg.sv
+++ b/corev_apu/tb/ariane_soc_pkg.sv
@@ -69,31 +69,4 @@ package ariane_soc;
   localparam NrRegion = 1;
   localparam logic [NrRegion-1:0][NB_PERIPHERALS-1:0] ValidRule = {{NrRegion * NB_PERIPHERALS}{1'b1}};
 
-  // cva6 configuration
-  localparam ariane_pkg::cva6_cfg_t CVA6SoCCfg = '{
-    NrCommitPorts: cva6_config_pkg::CVA6ConfigNrCommitPorts,
-    IsRVFI:        cva6_config_pkg::CVA6ConfigRvfiTrace,
-    AxiAddrWidth:  cva6_config_pkg::CVA6ConfigAxiAddrWidth,
-    AxiDataWidth:  cva6_config_pkg::CVA6ConfigAxiDataWidth,
-    AxiIdWidth:    cva6_config_pkg::CVA6ConfigAxiIdWidth,
-    AxiUserWidth:  cva6_config_pkg::CVA6ConfigDataUserWidth,
-    RASDepth:      cva6_config_pkg::CVA6ConfigRASDepth,
-    BTBEntries:    cva6_config_pkg::CVA6ConfigBTBEntries,
-    BHTEntries:    cva6_config_pkg::CVA6ConfigBHTEntries,
-    DmBaseAddress: DebugBase,
-    NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
-    NOCType:       ariane_pkg::NOC_TYPE_AXI4_ATOP,
-    // idempotent region
-    NrNonIdempotentRules:  unsigned'(1),
-    NonIdempotentAddrBase: 1024'({64'b0}),
-    NonIdempotentLength:   1024'({DRAMBase}),
-    NrExecuteRegionRules:  unsigned'(3),
-    ExecuteRegionAddrBase: 1024'({DRAMBase,   ROMBase,   DebugBase}),
-    ExecuteRegionLength:   1024'({DRAMLength, ROMLength, DebugLength}),
-    // cached region
-    NrCachedRegionRules:   unsigned'(1),
-    CachedRegionAddrBase:  1024'({DRAMBase}),
-    CachedRegionLength:    1024'({DRAMLength})
-  };
-
 endpackage

--- a/corev_apu/tb/ariane_soc_pkg.sv
+++ b/corev_apu/tb/ariane_soc_pkg.sv
@@ -69,23 +69,6 @@ package ariane_soc;
   localparam NrRegion = 1;
   localparam logic [NrRegion-1:0][NB_PERIPHERALS-1:0] ValidRule = {{NrRegion * NB_PERIPHERALS}{1'b1}};
 
-  localparam ariane_pkg::ariane_cfg_t ArianeSocCfg = '{
-    // idempotent region
-    NrNonIdempotentRules:  unsigned'(1),
-    NonIdempotentAddrBase: 1024'({64'b0}),
-    NonIdempotentLength:   1024'({DRAMBase}),
-    NrExecuteRegionRules:  unsigned'(3),
-    ExecuteRegionAddrBase: 1024'({DRAMBase,   ROMBase,   DebugBase}),
-    ExecuteRegionLength:   1024'({DRAMLength, ROMLength, DebugLength}),
-    // cached region
-    NrCachedRegionRules:   unsigned'(1),
-    CachedRegionAddrBase:  1024'({DRAMBase}),
-    CachedRegionLength:    1024'({DRAMLength}),
-    //  cache config
-    AxiCompliant:           1'b1,
-    SwapEndianess:          1'b0
-  };
-
   // cva6 configuration
   localparam ariane_pkg::cva6_cfg_t CVA6SoCCfg = '{
     NrCommitPorts: cva6_config_pkg::CVA6ConfigNrCommitPorts,
@@ -98,7 +81,19 @@ package ariane_soc;
     BTBEntries:    cva6_config_pkg::CVA6ConfigBTBEntries,
     BHTEntries:    cva6_config_pkg::CVA6ConfigBHTEntries,
     DmBaseAddress: DebugBase,
-    NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries)
+    NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
+    BusType:       ariane_pkg::BUS_TYPE_AXI4_ATOP,
+    // idempotent region
+    NrNonIdempotentRules:  unsigned'(1),
+    NonIdempotentAddrBase: 1024'({64'b0}),
+    NonIdempotentLength:   1024'({DRAMBase}),
+    NrExecuteRegionRules:  unsigned'(3),
+    ExecuteRegionAddrBase: 1024'({DRAMBase,   ROMBase,   DebugBase}),
+    ExecuteRegionLength:   1024'({DRAMLength, ROMLength, DebugLength}),
+    // cached region
+    NrCachedRegionRules:   unsigned'(1),
+    CachedRegionAddrBase:  1024'({DRAMBase}),
+    CachedRegionLength:    1024'({DRAMLength})
   };
 
 endpackage

--- a/corev_apu/tb/ariane_soc_pkg.sv
+++ b/corev_apu/tb/ariane_soc_pkg.sv
@@ -70,9 +70,6 @@ package ariane_soc;
   localparam logic [NrRegion-1:0][NB_PERIPHERALS-1:0] ValidRule = {{NrRegion * NB_PERIPHERALS}{1'b1}};
 
   localparam ariane_pkg::ariane_cfg_t ArianeSocCfg = '{
-    RASDepth:   int'(cva6_config_pkg::CVA6ConfigRASDepth),
-    BTBEntries: int'(cva6_config_pkg::CVA6ConfigBTBEntries),
-    BHTEntries: int'(cva6_config_pkg::CVA6ConfigBHTEntries),
     // idempotent region
     NrNonIdempotentRules:  unsigned'(1),
     NonIdempotentAddrBase: 1024'({64'b0}),
@@ -86,10 +83,22 @@ package ariane_soc;
     CachedRegionLength:    1024'({DRAMLength}),
     //  cache config
     AxiCompliant:           1'b1,
-    SwapEndianess:          1'b0,
-    // debug
-    DmBaseAddress:          DebugBase,
-    NrPMPEntries:           unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries)
+    SwapEndianess:          1'b0
+  };
+
+  // cva6 configuration
+  localparam ariane_pkg::cva6_cfg_t CVA6SoCCfg = '{
+    NrCommitPorts: cva6_config_pkg::CVA6ConfigNrCommitPorts,
+    IsRVFI:        0,
+    AxiAddrWidth:  cva6_config_pkg::CVA6ConfigAxiAddrWidth,
+    AxiDataWidth:  cva6_config_pkg::CVA6ConfigAxiDataWidth,
+    AxiIdWidth:    cva6_config_pkg::CVA6ConfigAxiIdWidth,
+    AxiUserWidth:  cva6_config_pkg::CVA6ConfigDataUserWidth,
+    RASDepth:      cva6_config_pkg::CVA6ConfigRASDepth,
+    BTBEntries:    cva6_config_pkg::CVA6ConfigBTBEntries,
+    BHTEntries:    cva6_config_pkg::CVA6ConfigBHTEntries,
+    DmBaseAddress: DebugBase,
+    NrPMPEntries:  unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries)
   };
 
 endpackage

--- a/corev_apu/tb/ariane_soc_pkg.sv
+++ b/corev_apu/tb/ariane_soc_pkg.sv
@@ -72,7 +72,7 @@ package ariane_soc;
   // cva6 configuration
   localparam ariane_pkg::cva6_cfg_t CVA6SoCCfg = '{
     NrCommitPorts: cva6_config_pkg::CVA6ConfigNrCommitPorts,
-    IsRVFI:        0,
+    IsRVFI:        cva6_config_pkg::CVA6ConfigRvfiTrace,
     AxiAddrWidth:  cva6_config_pkg::CVA6ConfigAxiAddrWidth,
     AxiDataWidth:  cva6_config_pkg::CVA6ConfigAxiDataWidth,
     AxiIdWidth:    cva6_config_pkg::CVA6ConfigAxiIdWidth,

--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -338,7 +338,7 @@ done_processing:
   size_t mem_size = 0xFFFFFF;
 #if (VERILATOR_VERSION_INTEGER >= 5000000)
   // Verilator v5: Use rootp pointer and .data() accessor.
-  memif.read(0x80000000, mem_size, (void *)top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram.data());
+  memif.read(0x80000000, mem_size, (void *)top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram.m_storage);
 #else
   // Verilator v4
   memif.read(0x80000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram);

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -636,7 +636,6 @@ module ariane_testharness #(
     .CVA6Cfg              ( CVA6Cfg             ),
     .IsRVFI               ( IsRVFI              ),
     .rvfi_instr_t         ( rvfi_instr_t        ),
-    .ArianeCfg            ( ariane_soc::ArianeSocCfg ),
     .noc_req_t            ( ariane_axi::req_t   ),
     .noc_resp_t           ( ariane_axi::resp_t  )
   ) i_ariane (

--- a/corev_apu/tb/tb_cva6_icache/hdl/tb.sv
+++ b/corev_apu/tb/tb_cva6_icache/hdl/tb.sv
@@ -37,30 +37,6 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
   parameter logic [63:0] CachedAddrBeg = MemBytes/4;
   parameter logic [63:0] CachedAddrEnd = MemBytes;
 
-  localparam ariane_cfg_t Cfg = '{
-    RASDepth:              2,
-    BTBEntries:            32,
-    BHTEntries:            128,
-    // idempotent region
-    NrNonIdempotentRules:  0,
-    NonIdempotentAddrBase: {64'b0},
-    NonIdempotentLength:   {64'b0},
-    // executable region
-    NrExecuteRegionRules:  0,
-    ExecuteRegionAddrBase: {64'h0},
-    ExecuteRegionLength:   {64'h0},
-    // cached region
-    NrCachedRegionRules:   1,
-    CachedRegionAddrBase: {CachedAddrBeg},
-    CachedRegionLength:   {CachedAddrEnd-CachedAddrBeg+64'b1},
-    // cache config
-    AxiCompliant:          1'b0,
-    SwapEndianess:         1'b0,
-    // debug
-    DmBaseAddress:         64'h0,
-    NrPMPEntries:          0
-  };
-
   // rates are in percent
   parameter TlbRandHitRate   = 50;
   parameter MemRandHitRate   = 50;
@@ -262,7 +238,7 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
 ///////////////////////////////////////////////////////////////////////////////
 
   cva6_icache  #(
-    .ArianeCfg(Cfg)
+    .CVA6Cfg(ariane_pkg::CVA6DefaultCfg)
     ) dut (
     .clk_i          ( clk_i          ),
     .rst_ni         ( rst_ni         ),

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
@@ -32,9 +32,6 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
   parameter logic [63:0] CachedAddrEnd = 64'hFFFF_FFFF_FFFF_FFFF;
 
   localparam ariane_cfg_t ArianeDefaultConfig = '{
-    RASDepth: 2,
-    BTBEntries: 32,
-    BHTEntries: 128,
     // idempotent region
     NrNonIdempotentRules:  0,
     NonIdempotentAddrBase: {64'b0},
@@ -50,9 +47,6 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
     // cache config
     AxiCompliant:          1'b1,
     SwapEndianess:         1'b0,
-    // debug
-    DmBaseAddress:         64'h0,
-    NrPMPEntries:          0
   };
 
   // contention and invalidation rates (in %)

--- a/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/tb.sv
@@ -31,24 +31,6 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
   parameter logic [63:0] CachedAddrBeg = MemBytes>>3;//1/8th of the memory is NC
   parameter logic [63:0] CachedAddrEnd = 64'hFFFF_FFFF_FFFF_FFFF;
 
-  localparam ariane_cfg_t ArianeDefaultConfig = '{
-    // idempotent region
-    NrNonIdempotentRules:  0,
-    NonIdempotentAddrBase: {64'b0},
-    NonIdempotentLength:   {64'b0},
-    // executable region
-    NrExecuteRegionRules:  0,
-    ExecuteRegionAddrBase: {64'h0},
-    ExecuteRegionLength:   {64'h0},
-    // cached region
-    NrCachedRegionRules:   1,
-    CachedRegionAddrBase:  {CachedAddrBeg},//1/8th of the memory is NC
-    CachedRegionLength:    {CachedAddrEnd-CachedAddrBeg+64'b1},
-    // cache config
-    AxiCompliant:          1'b1,
-    SwapEndianess:         1'b0,
-  };
-
   // contention and invalidation rates (in %)
   parameter MemRandHitRate   = 75;
   parameter MemRandInvRate   = 10;
@@ -412,7 +394,7 @@ module tb import ariane_pkg::*; import std_cache_pkg::*; import tb_pkg::*; #()()
 ///////////////////////////////////////////////////////////////////////////////
 
   std_nbdcache  #(
-    .ArianeCfg      ( ArianeDefaultConfig ),
+    .CVA6Cfg        ( ArianeDefaultConfig ),
     .AXI_ADDR_WIDTH ( TbAxiAddrWidthFull  ),
     .AXI_DATA_WIDTH ( TbAxiDataWidthFull  ),
     .AXI_ID_WIDTH   ( TbAxiIdWidthFull    ),

--- a/corev_apu/tb/tb_wt_axi_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wt_axi_dcache/hdl/tb.sv
@@ -377,9 +377,6 @@ module tb import ariane_pkg::*; import wt_cache_pkg::*; import tb_pkg::*; #()();
 ///////////////////////////////////////////////////////////////////////////////
 
   localparam ariane_cfg_t ArianeDefaultConfig = '{
-    RASDepth: 2,
-    BTBEntries: 32,
-    BHTEntries: 128,
     // idempotent region
     NrNonIdempotentRules:  0,
     NonIdempotentAddrBase: {64'b0},
@@ -395,9 +392,6 @@ module tb import ariane_pkg::*; import wt_cache_pkg::*; import tb_pkg::*; #()();
     // cache config
     AxiCompliant:          1'b1,
     SwapEndianess:         1'b0,
-    // debug
-    DmBaseAddress:         64'h0,
-    NrPMPEntries:          0
   };
 
   wt_cache_subsystem  #(

--- a/corev_apu/tb/tb_wt_axi_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wt_axi_dcache/hdl/tb.sv
@@ -376,26 +376,8 @@ module tb import ariane_pkg::*; import wt_cache_pkg::*; import tb_pkg::*; #()();
 // MUT
 ///////////////////////////////////////////////////////////////////////////////
 
-  localparam ariane_cfg_t ArianeDefaultConfig = '{
-    // idempotent region
-    NrNonIdempotentRules:  0,
-    NonIdempotentAddrBase: {64'b0},
-    NonIdempotentLength:   {64'b0},
-    // executable region
-    NrExecuteRegionRules:  0,
-    ExecuteRegionAddrBase: {64'h0},
-    ExecuteRegionLength:   {64'h0},
-    // cached region
-    NrCachedRegionRules:   1,
-    CachedRegionAddrBase:  {CachedAddrBeg},//1/8th of the memory is NC
-    CachedRegionLength:    {CachedAddrEnd-CachedAddrBeg+64'b1},
-    // cache config
-    AxiCompliant:          1'b1,
-    SwapEndianess:         1'b0,
-  };
-
   wt_cache_subsystem  #(
-    .ArianeCfg    ( ArianeDefaultConfig ),
+    .CVA6Cfg      ( ariane_pkg::CVA6DefaultCfg ),
     .AxiAddrWidth ( TbAxiAddrWidthFull  ),
     .AxiDataWidth ( TbAxiDataWidthFull  ),
     .AxiIdWidth   ( TbAxiIdWidthFull    ),

--- a/corev_apu/tb/tb_wt_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wt_dcache/hdl/tb.sv
@@ -39,9 +39,6 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
   parameter logic [63:0] CachedAddrEnd = 64'hFFFF_FFFF_FFFF_FFFF;
 
   localparam ariane_cfg_t ArianeDefaultConfig = '{
-    RASDepth: 2,
-    BTBEntries: 32,
-    BHTEntries: 128,
     // idempotent region
     NrNonIdempotentRules:  0,
     NonIdempotentAddrBase: {64'b0},
@@ -57,9 +54,6 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
     // cache config
     AxiCompliant:          1'b1,
     SwapEndianess:         1'b0,
-    // debug
-    DmBaseAddress:         64'h0,
-    NrPMPEntries:          0
   };
 
   // contention and invalidation rates (in %)

--- a/corev_apu/tb/tb_wt_dcache/hdl/tb.sv
+++ b/corev_apu/tb/tb_wt_dcache/hdl/tb.sv
@@ -38,24 +38,6 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
   parameter logic [63:0] CachedAddrBeg = MemBytes>>3;//1/8th of the memory is NC
   parameter logic [63:0] CachedAddrEnd = 64'hFFFF_FFFF_FFFF_FFFF;
 
-  localparam ariane_cfg_t ArianeDefaultConfig = '{
-    // idempotent region
-    NrNonIdempotentRules:  0,
-    NonIdempotentAddrBase: {64'b0},
-    NonIdempotentLength:   {64'b0},
-    // executable region
-    NrExecuteRegionRules:  0,
-    ExecuteRegionAddrBase: {64'h0},
-    ExecuteRegionLength:   {64'h0},
-    // cached region
-    NrCachedRegionRules:   1,
-    CachedRegionAddrBase:  {CachedAddrBeg},//1/8th of the memory is NC
-    CachedRegionLength:    {CachedAddrEnd-CachedAddrBeg+64'b1},
-    // cache config
-    AxiCompliant:          1'b1,
-    SwapEndianess:         1'b0,
-  };
-
   // contention and invalidation rates (in %)
   parameter MemRandHitRate   = 75;
   parameter MemRandInvRate   = 10;
@@ -220,7 +202,7 @@ module tb import tb_pkg::*; import ariane_pkg::*; import wt_cache_pkg::*; #()();
 ///////////////////////////////////////////////////////////////////////////////
 
   wt_dcache  #(
-    .ArianeCfg ( ArianeDefaultConfig )
+    .CVA6Cfg ( ariane_pkg::CVA6DefaultCfg )
   ) i_dut (
     .clk_i           ( clk_i           ),
     .rst_ni          ( rst_ni          ),

--- a/docs/01_cva6_user/PMA.rst
+++ b/docs/01_cva6_user/PMA.rst
@@ -39,18 +39,18 @@ supports three main access properties:
   load, and store data from that region.
 
 The regions are instantiation-time parameters, they can not be changed during
-runtime. CVA6 uses the following fields in the ``ariane_cfg_t`` configuration
+runtime. CVA6 uses the following fields in the ``cva6_cfg_t`` configuration
 structure to describe the PMA regions statically:
 
-- ``ArianeCfg.NrNonIdempotentRules``: Number of active non-idempotent regions.
-   - ``ArianeCfg.NonIdempotentAddrBase``: Base address of the non-idempotent region.
-   - ``ArianeCfg.NonIdempotentLength``: Length of the non-idempotent region.
-- ``ArianeCfg.NrExecuteRegionRules``: Number of active executable regions.
-   - ``ArianeCfg.ExecuteRegionAddrBase``: Base address of the executable region.
-   - ``ArianeCfg.ExecuteRegionLength``: Length of the executable region.
-- ``ArianeCfg.NrCachedRegionRules``: Number of active cacheable regions.
-   - ``ArianeCfg.CachedRegionAddrBase``: Base address of the cacheable region.
-   - ``ArianeCfg.CachedRegionLength``: Length of the cacheable region.
+- ``CVA6Cfg.NrNonIdempotentRules``: Number of active non-idempotent regions.
+   - ``CVA6Cfg.NonIdempotentAddrBase``: Base address of the non-idempotent region.
+   - ``CVA6Cfg.NonIdempotentLength``: Length of the non-idempotent region.
+- ``CVA6Cfg.NrExecuteRegionRules``: Number of active executable regions.
+   - ``CVA6Cfg.ExecuteRegionAddrBase``: Base address of the executable region.
+   - ``CVA6Cfg.ExecuteRegionLength``: Length of the executable region.
+- ``CVA6Cfg.NrCachedRegionRules``: Number of active cacheable regions.
+   - ``CVA6Cfg.CachedRegionAddrBase``: Base address of the cacheable region.
+   - ``CVA6Cfg.CachedRegionLength``: Length of the cacheable region.
 
 Unsupported PMAs
 -------

--- a/docs/01_cva6_user/PMP.rst
+++ b/docs/01_cva6_user/PMP.rst
@@ -22,12 +22,12 @@ PMP
 ===
 The CVA6 includes a Physical Memory Protection (PMP) unit. The PMP is both
 statically and dynamically configurable. The static configuration is performed
-through the top level parameters ``ArianeCfg.NrPMPEntries``. The dynamic
+through the top level parameters ``CVA6Cfg.NrPMPEntries``. The dynamic
 configuration is performed through the CSRs described in Control and Status
 Registers. A maximum of 16 PMP entries are supported.
 
 All PMP CSRs are always implemented, but CSRs (or bitfields of CSRs) related to
-PMP entries with number ``ArianeCfg.NrPMPEntries`` and above are hardwired to
+PMP entries with number ``CVA6Cfg.NrPMPEntries`` and above are hardwired to
 zero. All PMPs reset to zero.
 
 When the ``L`` (Lock) bit is set, PMPs are also enforced in M-mode.

--- a/docs/03_cva6_design/ex_stage.md
+++ b/docs/03_cva6_design/ex_stage.md
@@ -291,7 +291,7 @@ checked during the page table walk as well. During a page walk, all
 memory access must pass the PMP rules.
 
 The amount of entries is parametrizable under the
-`ArianeCfg.NrPMPEntries` parameter. However, the core only supports
+`CVA6Cfg.NrPMPEntries` parameter. However, the core only supports
 granularity 8 (G=8). This simplifies the implementation since we do
 not have to worry about any unaligned accesses. There are a total of
 three distinct PMP units in the design. They verify instruction

--- a/docs/04_cv32a6_design/source/cv32a6_subsystem.rst
+++ b/docs/04_cv32a6_design/source/cv32a6_subsystem.rst
@@ -32,8 +32,8 @@ Instantiation
      - Value
      - Description
 
-   * - ``ArianeCfg``
-     - ariane_pkg::ariane_cfg_t
+   * - ``CVA6Cfg``
+     - ariane_pkg::cva6_cfg_t
      - ariane_pkg::v0.1.0_Config
      - CVA6 v0.1.0 configuration
 

--- a/verif/tb/uvmt/cva6_tb_wrapper.sv
+++ b/verif/tb/uvmt/cva6_tb_wrapper.sv
@@ -65,9 +65,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
 
   cva6 #(
      .CVA6Cfg ( CVA6Cfg ),
-     .IsRVFI ( IsRVFI ),
-     //
-    .ArianeCfg  ( ariane_soc::ArianeSocCfg )
+     .IsRVFI ( IsRVFI )
   ) i_cva6 (
     .clk_i                ( clk_i                     ),
     .rst_ni               ( rst_ni                    ),


### PR DESCRIPTION
This commit merges these two similar strategies for parameterization. A further step towards the clean-up.

@Jbalkind I haven't adapted the OpenPiton wrapper so that will break for sure. Not sure how you'd like to proceed but probably it makes the most sense to adapt that once and for all, instead of incremental. Also see the new enum type, ~I also have removed `SwapEndianess` since I haven't seen a use-case for that anymore (it was set to `1` in the OP config). I might have missed the underlying nature, so please do let me know.~


### How has that been tested?

Running `dhrystone` before and after the merge.

Fixes #1319