### PR TITLE
Enable A extension

### DIFF
--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigAExtEn = 0;
+    localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
 


### PR DESCRIPTION
A extension was not enabled so far on cv32a60x. With A extension, Linux can run on cv32a60x.

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>