### PR TITLE
Update for #1237

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -790,7 +790,9 @@ module cva6 import ariane_pkg::*; #(
     .stall_issue_i       ( stall_issue               ),
     .mcountinhibit_i     ( mcountinhibit_csr_perf    )
   );
- end
+  end : gen_perf_counter else begin: gen_no_perf_counter
+    assign data_perf_csr    = '0;
+  end : gen_no_perf_counter
 
   // ------------
   // Controller


### PR DESCRIPTION
Since the performance counters are implemented as an optional feature, this commit takes into consideration the case when the performance counters are disabled i.e in that case the output data from the performance counter module should read as 0 (which was reading as X's previously **#1237**)
 