### PR TITLE
fix prediction shift for BHT and BTB

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -834,7 +834,7 @@ module cva6 import ariane_pkg::*; #(
   // Cache Subsystem
   // -------------------
 
-  if (DCACHE_TYPE == int'(cva6_config_pkg::WT)) begin
+  if (DCACHE_TYPE == int'(cva6_config_pkg::WT)) begin : gen_cache_wt
   // this is a cache subsystem that is compatible with OpenPiton
   wt_cache_subsystem #(
     .CVA6Cfg              ( CVA6Cfg   ),
@@ -876,7 +876,7 @@ module cva6 import ariane_pkg::*; #(
     .inval_valid_i         ( inval_valid                 ),
     .inval_ready_o         ( inval_ready                 )
   );
-  end else begin
+  end else begin : gen_cache_wb
 
   std_cache_subsystem #(
     // note: this only works with one cacheable region

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -126,22 +126,26 @@ module frontend import ariane_pkg::*; #(
       .addr_o              ( addr                  ),
       .instr_o             ( instr                 )
     );
+
     // --------------------
     // Branch Prediction
     // --------------------
     // select the right branch prediction result
     // in case we are serving an unaligned instruction in instr[0] we need to take
     // the prediction we saved from the previous fetch
-    assign bht_prediction_shifted[0] = (serving_unaligned) ? bht_q : bht_prediction[addr[0][1]];
-    assign btb_prediction_shifted[0] = (serving_unaligned) ? btb_q : btb_prediction[addr[0][1]];
-
     if (ariane_pkg::RVC) begin : gen_btb_prediction_shifted
+      assign bht_prediction_shifted[0] = (serving_unaligned) ? bht_q : bht_prediction[addr[0][$clog2(INSTR_PER_FETCH):1]];
+      assign btb_prediction_shifted[0] = (serving_unaligned) ? btb_q : btb_prediction[addr[0][$clog2(INSTR_PER_FETCH):1]];
+
       // for all other predictions we can use the generated address to index
       // into the branch prediction data structures
       for (genvar i = 1; i < INSTR_PER_FETCH; i++) begin : gen_prediction_address
         assign bht_prediction_shifted[i] = bht_prediction[addr[i][$clog2(INSTR_PER_FETCH):1]];
         assign btb_prediction_shifted[i] = btb_prediction[addr[i][$clog2(INSTR_PER_FETCH):1]];
       end
+    end else begin
+      assign bht_prediction_shifted[0] = (serving_unaligned) ? bht_q : bht_prediction[addr[0][1]];
+      assign btb_prediction_shifted[0] = (serving_unaligned) ? btb_q : btb_prediction[addr[0][1]];
     end;
 
     // for the return address stack it doens't matter as we have the

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -394,7 +394,7 @@ module frontend import ariane_pkg::*; #(
 
     if (ArianeCfg.RASDepth == 0) begin
       assign ras_predict = '0;
-    end else begin
+    end else begin : ras_gen
       ras #(
         .DEPTH  ( ArianeCfg.RASDepth  )
       ) i_ras (
@@ -415,7 +415,7 @@ module frontend import ariane_pkg::*; #(
 
     if (ArianeCfg.BTBEntries == 0) begin
       assign btb_prediction = '0;
-    end else begin
+    end else begin : btb_gen
       btb #(
         .NR_ENTRIES       ( ArianeCfg.BTBEntries   )
       ) i_btb (
@@ -431,7 +431,7 @@ module frontend import ariane_pkg::*; #(
 
     if (ArianeCfg.BHTEntries == 0) begin
       assign bht_prediction = '0;
-    end else begin
+    end else begin : bht_gen
       bht #(
         .NR_ENTRIES       ( ArianeCfg.BHTEntries   )
       ) i_bht (


### PR DESCRIPTION
To be able to issue two instructions in the same cycle, fetching 64 bits each cycle is required to feed the instruction queue (there are not enough compressed instructions in usual code).

With compressed instructions, fetching 64 bits might return up to 4 instructions, which requires a change in the BTB and BHT shapes.  
4 columns means an index of two bits.

There is a mechanism to shift predictions when the access is not aligned.  
For the first item of the result, **the index was using a hardcoded number of one bit, so the returned prediction was not the good one**. This PR fixes that.  
For the subsequent items the result was good.

Without C extension and a 32-bits fetch, `INSTR_PER_FETCH = 1` so `(INSTR_PER_FETCH) = 0` which would cause an issue so the `if`/`else` block is used to handle this specific case.

This modification has no impact on area for current configurations.