### PR TITLE
Fix VCD generation from Verilator model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,8 +547,8 @@ verilate_command := $(verilator) verilator_config.vlt                           
                     $(if ($(PRELOAD)!=""), -DPRELOAD=1,)                                                         \
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \
                     $(if $(DEBUG), --trace-structs,)                                                             \
-                    $(if $(TRACE_COMPACT), --trace-fst $(VERILATOR_INSTALL_DIR)/share/verilator/include/verilated_fst_c.cpp) \
-                    $(if $(TRACE_FAST), --trace $(VERILATOR_INSTALL_DIR)/share/verilator/include/verilated_vcd_c.cpp) \
+                    $(if $(TRACE_COMPACT), --trace-fst $(VERILATOR_ROOT)/include/verilated_fst_c.cpp)             \
+                    $(if $(TRACE_FAST), --trace $(VERILATOR_ROOT)/include/verilated_vcd_c.cpp)                   \
                     -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_ROOT)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_ROOT)/lib -lfesvr$(if $(PROFILE), -g -pg,) -lpthread $(if $(TRACE_COMPACT), -lz,)" \
                     -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) -DVL_DEBUG"                                      \
                     --cc  --vpi                                                                                  \
@@ -563,7 +563,7 @@ verilate_command := $(verilator) verilator_config.vlt                           
 verilate:
 	@echo "[Verilator] Building Model$(if $(PROFILE), for Profiling,)"
 	$(verilate_command)
-	cd $(ver-library) && $(MAKE) -j${NUM_JOBS} -f Variane_testharness.mk
+	cd $(ver-library) && $(MAKE) -f Variane_testharness.mk
 
 sim-verilator: verilate
 	$(ver-library)/Variane_testharness $(elf-bin)

--- a/README.md
+++ b/README.md
@@ -131,20 +131,34 @@ couple of cycles simulation time.)
 
 ### Build Model and Run Simulations
 
+#### Build default model
 Build the Verilator model of CVA6 by using the Makefile:
 ```
 make verilate
 ```
 
-To build the verilator model with support for vcd files run
+#### Build model with VCD support
+To build the verilator model with support for vcd files:
+- Install Verilator from source (tested on v4.110):
+  - https://verilator.org/guide/latest/install.html#run-in-place-from-verilator-root
+  - You can use the [run-in-place feature](https://verilator.org/guide/latest/install.html#run-in-place-from-verilator-root). No need to install the software. Please note that Makefile needs a C++ file from Verilator sources.
+  - Set `VERILATOR_ROOT` to the repository root (for instance `export VERILATOR_ROOT=/opt/<verilator_repo>`).
+
+You can finally generate the model:
 ```
-make verilate DEBUG=1
+make verilate DEBUG=1 TRACE_FAST=1
 ```
 
+#### Run simulations
 This will create a C++ model of the core including a SystemVerilog wrapper and link it against a C++ testbench (in the `tb` subfolder). The binary can be found in the `work-ver` and accepts a RISC-V ELF binary as an argument, e.g.:
 
 ```
 work-ver/Variane_testharness rv64um-v-divuw
+```
+
+**Note:** If you want to generate the VCD for the same software (`-v` to specify the VCD filename):
+```bash
+work-ver/Variane_testharness -v output.vcd rv64um-v-divuw
 ```
 
 The Verilator testbench makes use of the `riscv-fesvr`. This means that you can use the `riscv-tests` repository as well as `riscv-pk` out-of-the-box. As a general rule of thumb the Verilator model will behave like Spike (exception for being orders of magnitudes slower).


### PR DESCRIPTION
This pull request is an answer to my issue described at https://github.com/openhwgroup/cva6/issues/1340
Quick comments:
- I've removed the `-j${NUM_JOBS}` in Verilator generation as it basically shut down my VM (8 cores...).
- Modifications in Readme: I've tested with Verilator v4.110. I assume it should be compatible with other versions as well.