### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,10 +4,10 @@
 
 version: 2
 
-#build:
-#  os: "ubuntu-20.04"
-#  tools:
-#    python: "3.9"
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
 
 # Build from the docs directory with Sphinx
 sphinx:


### PR DESCRIPTION
Explicit build.os is now required by RTD.