### PR TITLE
Generate illegal opcode when execute LWU with XLEN=32

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -799,7 +799,8 @@ module decoder import ariane_pkg::*; #(
                         3'b010: instruction_o.op  = ariane_pkg::LW;
                         3'b100: instruction_o.op  = ariane_pkg::LBU;
                         3'b101: instruction_o.op  = ariane_pkg::LHU;
-                        3'b110: instruction_o.op  = ariane_pkg::LWU;
+                        3'b110: if (riscv::XLEN==64) instruction_o.op  = ariane_pkg::LWU;
+                                else illegal_instr = 1'b1;
                         3'b011: if (riscv::XLEN==64) instruction_o.op  = ariane_pkg::LD;
                                 else illegal_instr = 1'b1;
                         default: illegal_instr = 1'b1;


### PR DESCRIPTION
LWU was decoded in 32 and 64 bits. As it is a 64 bit instruction, this modification generates an illegal opcode when configuration is 32bit.

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>