### PR TITLE
Support multiple outstanding load operations to the Dcache

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -3,4 +3,4 @@ cv64a6_imafdc_sv39:
 cv32a60x:
   gates: 160719
 cv32a6_embedded:
-  gates: 127613
+  gates: 127977

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -74,6 +74,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
     typedef struct packed {
         logic [DCACHE_INDEX_WIDTH-1:0] index;
         logic [DCACHE_TAG_WIDTH-1:0]   tag;
+        logic [DCACHE_TID_WIDTH-1:0]   id;
         logic [7:0]             be;
         logic [1:0]             size;
         logic                   we;
@@ -116,7 +117,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
         req_port_o.data_gnt    = 1'b0;
         req_port_o.data_rvalid = 1'b0;
         req_port_o.data_rdata  = '0;
-        req_port_o.data_rid    = '0;
+        req_port_o.data_rid    = mem_req_q.id;
         miss_req_o    = '0;
         mshr_addr_o   = '0;
         // Memory array communication
@@ -138,6 +139,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
 
                     // save index, be and we
                     mem_req_d.index = req_port_i.address_index;
+                    mem_req_d.id    = req_port_i.data_id;
                     mem_req_d.be    = req_port_i.data_be;
                     mem_req_d.size  = req_port_i.data_size;
                     mem_req_d.we    = req_port_i.data_we;
@@ -186,6 +188,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
                         if (req_port_i.data_req && !mem_req_q.we && !flush_i) begin
                             state_d          = WAIT_TAG; // switch back to WAIT_TAG
                             mem_req_d.index  = req_port_i.address_index;
+                            mem_req_d.id     = req_port_i.data_id;
                             mem_req_d.be     = req_port_i.data_be;
                             mem_req_d.size   = req_port_i.data_size;
                             mem_req_d.we     = req_port_i.data_we;
@@ -391,6 +394,7 @@ module cache_ctrl import ariane_pkg::*; import std_cache_pkg::*; #(
                     if (req_port_i.data_req) begin
                         // save index, be and we
                         mem_req_d.index = req_port_i.address_index;
+                        mem_req_d.id    = req_port_i.data_id;
                         mem_req_d.be    = req_port_i.data_be;
                         mem_req_d.size  = req_port_i.data_size;
                         mem_req_d.we    = req_port_i.data_we;

--- a/core/cache_subsystem/wt_dcache_ctrl.sv
+++ b/core/cache_subsystem/wt_dcache_ctrl.sv
@@ -59,6 +59,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic [DCACHE_TAG_WIDTH-1:0]    address_tag_d, address_tag_q;
   logic [DCACHE_CL_IDX_WIDTH-1:0] address_idx_d, address_idx_q;
   logic [DCACHE_OFFSET_WIDTH-1:0] address_off_d, address_off_q;
+  logic [DCACHE_TID_WIDTH-1:0]    id_d, id_q;
   logic [DCACHE_SET_ASSOC-1:0]    vld_data_d,    vld_data_q;
   logic save_tag, rd_req_d, rd_req_q, rd_ack_d, rd_ack_q;
   logic [1:0] data_size_d, data_size_q;
@@ -72,6 +73,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign address_tag_d = (save_tag)            ? req_port_i.address_tag                                             : address_tag_q;
   assign address_idx_d = (req_port_o.data_gnt) ? req_port_i.address_index[DCACHE_INDEX_WIDTH-1:DCACHE_OFFSET_WIDTH] : address_idx_q;
   assign address_off_d = (req_port_o.data_gnt) ? req_port_i.address_index[DCACHE_OFFSET_WIDTH-1:0]                  : address_off_q;
+  assign id_d          = (req_port_o.data_gnt) ? req_port_i.data_id                                                 : id_q;
   assign data_size_d   = (req_port_o.data_gnt) ? req_port_i.data_size                                               : data_size_q;
   assign rd_tag_o      = address_tag_d;
   assign rd_idx_o      = address_idx_d;
@@ -79,7 +81,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
 
   assign req_port_o.data_rdata = rd_data_i;
   assign req_port_o.data_ruser = rd_user_i;
-  assign req_port_o.data_rid   = '0;
+  assign req_port_o.data_rid   = id_q;
 
   // to miss unit
   assign miss_vld_bits_o       = vld_data_q;
@@ -240,6 +242,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
       address_tag_q    <= '0;
       address_idx_q    <= '0;
       address_off_q    <= '0;
+      id_q             <= '0;
       vld_data_q       <= '0;
       data_size_q      <= '0;
       rd_req_q         <= '0;
@@ -249,6 +252,7 @@ module wt_dcache_ctrl import ariane_pkg::*; import wt_cache_pkg::*; #(
       address_tag_q    <= address_tag_d;
       address_idx_q    <= address_idx_d;
       address_off_q    <= address_off_d;
+      id_q             <= id_d;
       vld_data_q       <= vld_data_d;
       data_size_q      <= data_size_d;
       rd_req_q         <= rd_req_d;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -168,6 +168,7 @@ module cva6 import ariane_pkg::*; #(
     CVA6Cfg.AxiDataWidth,
     CVA6Cfg.AxiIdWidth,
     CVA6Cfg.AxiUserWidth,
+    CVA6Cfg.NrLoadBufEntries,
     CVA6Cfg.FpuEn,
     CVA6Cfg.XF16,
     CVA6Cfg.XF16ALT,

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -21,6 +21,7 @@ package config_pkg;
       int unsigned AxiDataWidth;
       int unsigned AxiIdWidth;
       int unsigned AxiUserWidth;
+      int unsigned NrLoadBufEntries;
       bit FpuEn;
       bit XF16;
       bit XF16ALT;
@@ -51,6 +52,7 @@ package config_pkg;
       unsigned'(64),     // AxiDataWidth
       unsigned'(4),      // AxiIdWidth
       unsigned'(32),     // AxiUserWidth
+      unsigned'(2),      // NrLoadBufEntries
       bit'(0),           // FpuEn
       bit'(0),           // XF16
       bit'(0),           // XF16ALT
@@ -81,6 +83,7 @@ package config_pkg;
       unsigned'(0),      // AxiDataWidth
       unsigned'(0),      // AxiIdWidth
       unsigned'(0),      // AxiUserWidth
+      unsigned'(0),      // NrLoadBufEntries
       bit'(0),           // FpuEn
       bit'(0),           // XF16
       bit'(0),           // XF16ALT

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -57,6 +57,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;
@@ -76,20 +77,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -53,6 +53,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrCommitPorts = 2;
     localparam CVA6ConfigNrScoreboardEntries = 8;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigFPGAEn = 0;
 
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 2;
     localparam CVA6ConfigDataTlbEntries = 2;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 16;
     localparam CVA6ConfigDataTlbEntries = 16;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 16;
     localparam CVA6ConfigDataTlbEntries = 16;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 16;
     localparam CVA6ConfigDataTlbEntries = 16;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -58,6 +58,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigNrLoadPipeRegs = 1;
     localparam CVA6ConfigNrStorePipeRegs = 0;
+    localparam CVA6ConfigNrLoadBufEntries = 2;
 
     localparam CVA6ConfigInstrTlbEntries = 16;
     localparam CVA6ConfigDataTlbEntries = 16;
@@ -77,20 +78,21 @@ package cva6_config_pkg;
     localparam CVA6ConfigRvfiTrace = 1;
 
     localparam config_pkg::cva6_cfg_t cva6_cfg = {
-      unsigned'(CVA6ConfigNrCommitPorts),  // NrCommitPorts
-      unsigned'(CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-      unsigned'(CVA6ConfigAxiDataWidth),   // AxiDataWidth
-      unsigned'(CVA6ConfigAxiIdWidth),     // AxiIdWidth
-      unsigned'(CVA6ConfigDataUserWidth),  // AxiUserWidth
-      bit'(CVA6ConfigFpuEn),               // FpuEn
-      bit'(CVA6ConfigF16En),               // XF16
-      bit'(CVA6ConfigF16AltEn),            // XF16ALT
-      bit'(CVA6ConfigF8En),                // XF8
-      bit'(CVA6ConfigAExtEn),              // RVA
-      bit'(CVA6ConfigVExtEn),              // RVV
-      bit'(CVA6ConfigCExtEn),              // RVC
-      bit'(CVA6ConfigFVecEn),              // XFVec
-      bit'(CVA6ConfigCvxifEn),             // CvxifEn
+      unsigned'(CVA6ConfigNrCommitPorts),    // NrCommitPorts
+      unsigned'(CVA6ConfigAxiAddrWidth),     // AxiAddrWidth
+      unsigned'(CVA6ConfigAxiDataWidth),     // AxiDataWidth
+      unsigned'(CVA6ConfigAxiIdWidth),       // AxiIdWidth
+      unsigned'(CVA6ConfigDataUserWidth),    // AxiUserWidth
+      unsigned'(CVA6ConfigNrLoadBufEntries), // NrLoadBufEntries
+      bit'(CVA6ConfigFpuEn),                 // FpuEn
+      bit'(CVA6ConfigF16En),                 // XF16
+      bit'(CVA6ConfigF16AltEn),              // XF16ALT
+      bit'(CVA6ConfigF8En),                  // XF8
+      bit'(CVA6ConfigAExtEn),                // RVA
+      bit'(CVA6ConfigVExtEn),                // RVV
+      bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigFVecEn),                // XFVec
+      bit'(CVA6ConfigCvxifEn),               // CvxifEn
       // Extended
       bit'(0),           // RVF
       bit'(0),           // RVD

--- a/util/config_pkg_generator.py
+++ b/util/config_pkg_generator.py
@@ -85,6 +85,8 @@ def setup_parser_config_generator():
                       help="Load latency")
   parser.add_argument("--NrStorePipeRegs", type=int, default=None,
                       help="Store latency")
+  parser.add_argument("--NrLoadBufEntries", type=int, default=None,
+                      help="Number of entries in the load buffer")
   parser.add_argument("--InstrTlbEntries", type=int, default=None,
                       help="Number of instruction TLB entries")
   parser.add_argument("--DataTlbEntries", type=int, default=None,
@@ -145,6 +147,7 @@ MapArgsToParameter={
   "FPGAEn" : "CVA6ConfigFPGAEn",
   "NrLoadPipeRegs" : "CVA6ConfigNrLoadPipeRegs",
   "NrStorePipeRegs" : "CVA6ConfigNrStorePipeRegs",
+  "NrLoadBufEntries" : "CVA6ConfigNrLoadBufEntries",
   "InstrTlbEntries" : "CVA6ConfigInstrTlbEntries",
   "DataTlbEntries" : "CVA6ConfigDataTlbEntries",
   "RASDepth": "CVA6ConfigRASDepth",


### PR DESCRIPTION
This modification introduces a pending load table that tracks outstanding load operations to the Dcache. The depth of this table is a parameter in the target configuration package.

The ID in the request from the load/store unit must be mirrored by the Dcache in the response. This allows to match a given response to its corresponding request. Responses can be given (by the Dcache) in a different order that the one of requests.

To be able to send one load request per cycle, the pending load table shall have at least 2 entries. This is to avoid a combinational path between the request and the response interfaces. This has a minor impact in the area anyway because each entry of the buffer has roughly 10 bits (FFs).