### PR TITLE
Add Direct D$ Access to `acc_dipsatcher`

### DIFF
--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -54,6 +54,8 @@ module acc_dispatcher import ariane_pkg::*; import riscv::*; #(
     input  logic                                  flush_ex_i,
     output logic                                  flush_pipeline_o,
     // Interface with cache subsystem
+    output dcache_req_i_t                   [1:0] acc_dcache_req_ports_o,
+    input  dcache_req_o_t                   [1:0] acc_dcache_req_ports_i,
     input  logic                                  inval_ready_i,
     output logic                                  inval_valid_o,
     output logic                           [63:0] inval_addr_o,
@@ -412,5 +414,6 @@ module acc_dispatcher import ariane_pkg::*; import riscv::*; #(
 
   assign acc_stall_st_pending_o = 1'b0;
   assign flush_pipeline_o       = 1'b0;
+  assign acc_dcache_req_ports_o = '0;
 
 endmodule : acc_dispatcher

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -18,7 +18,7 @@
 
 module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter int unsigned NR_PORTS       = 3,
+    parameter int unsigned NR_PORTS       = 4,
     parameter type axi_req_t = logic,
     parameter type axi_rsp_t = logic
 )(
@@ -524,7 +524,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
             bypass_ports_req[id].req     = miss_req_valid[id] & miss_req_bypass[id];
             bypass_ports_req[id].reqtype = ariane_pkg::SINGLE_REQ;
             bypass_ports_req[id].amo     = AMO_NONE;
-            bypass_ports_req[id].id      = {2'b10, id};
+            bypass_ports_req[id].id      = 4'b1000 | 4'(id);
             bypass_ports_req[id].addr    = miss_req_addr[id];
             bypass_ports_req[id].wdata   = miss_req_wdata[id];
             bypass_ports_req[id].we      = miss_req_we[id];
@@ -619,7 +619,7 @@ module miss_handler import ariane_pkg::*; import std_cache_pkg::*; #(
         .wdata_i             ( req_fsm_miss_wdata ),
         .be_i                ( req_fsm_miss_be    ),
         .size_i              ( req_fsm_miss_size  ),
-        .id_i                ( {{CVA6Cfg.AxiIdWidth-4{1'b0}}, 4'b1100} ),
+        .id_i                ( {{CVA6Cfg.AxiIdWidth-4{1'b0}}, 4'b0111} ),
         .valid_o             ( valid_miss_fsm     ),
         .rdata_o             ( data_miss_fsm      ),
         .id_o                (                    ),

--- a/core/cache_subsystem/wt_dcache.sv
+++ b/core/cache_subsystem/wt_dcache.sv
@@ -15,7 +15,7 @@
 
 module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-  parameter int unsigned                 NumPorts           = 3,    // number of miss ports
+  parameter int unsigned                 NumPorts           = 4,    // number of miss ports
   // ID to be used for read and AMO transactions.
   // note that the write buffer uses all IDs up to DCACHE_MAX_TX-1 for write transactions
   parameter logic [CACHE_ID_WIDTH-1:0]   RdAmoTxId          = 1,
@@ -38,8 +38,8 @@ module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
   output amo_resp_t                      amo_resp_o,
 
   // Request ports
-  input  dcache_req_i_t [2:0]            req_ports_i,
-  output dcache_req_o_t [2:0]            req_ports_o,
+  input  dcache_req_i_t [NumPorts-1:0]   req_ports_i,
+  output dcache_req_o_t [NumPorts-1:0]   req_ports_o,
 
   output logic [NumPorts-1:0][DCACHE_SET_ASSOC-1:0]    miss_vld_bits_o,
 
@@ -217,60 +217,60 @@ module wt_dcache import ariane_pkg::*; import wt_cache_pkg::*; #(
 ///////////////////////////////////////////////////////
 
   // set read port to low priority
-  assign rd_prio[2] = 1'b0;
+  assign rd_prio[NumPorts-1] = 1'b0;
 
   wt_dcache_wbuffer #(
     .CVA6Cfg       ( CVA6Cfg       ),
     .ArianeCfg     ( ArianeCfg     )
   ) i_wt_dcache_wbuffer (
-    .clk_i           ( clk_i               ),
-    .rst_ni          ( rst_ni              ),
-    .empty_o         ( wbuffer_empty_o     ),
-    .not_ni_o        ( wbuffer_not_ni_o    ),
+    .clk_i           ( clk_i                       ),
+    .rst_ni          ( rst_ni                      ),
+    .empty_o         ( wbuffer_empty_o             ),
+    .not_ni_o        ( wbuffer_not_ni_o            ),
     // TODO: fix this
-    .cache_en_i      ( cache_en            ),
+    .cache_en_i      ( cache_en                    ),
     // .cache_en_i      ( '0                  ),
     // request ports from core (store unit)
-    .req_port_i      ( req_ports_i   [2]   ),
-    .req_port_o      ( req_ports_o   [2]   ),
+    .req_port_i      ( req_ports_i    [NumPorts-1] ),
+    .req_port_o      ( req_ports_o    [NumPorts-1] ),
     // miss unit interface
-    .miss_req_o      ( miss_req      [2]   ),
-    .miss_ack_i      ( miss_ack      [2]   ),
-    .miss_we_o       ( miss_we       [2]   ),
-    .miss_wdata_o    ( miss_wdata    [2]   ),
-    .miss_wuser_o    ( miss_wuser    [2]   ),
-    .miss_vld_bits_o ( miss_vld_bits_o[2]  ),
-    .miss_paddr_o    ( miss_paddr    [2]   ),
-    .miss_nc_o       ( miss_nc       [2]   ),
-    .miss_size_o     ( miss_size     [2]   ),
-    .miss_id_o       ( miss_id       [2]   ),
-    .miss_rtrn_vld_i ( miss_rtrn_vld [2]   ),
-    .miss_rtrn_id_i  ( miss_rtrn_id        ),
+    .miss_req_o      ( miss_req       [NumPorts-1] ),
+    .miss_ack_i      ( miss_ack       [NumPorts-1] ),
+    .miss_we_o       ( miss_we        [NumPorts-1] ),
+    .miss_wdata_o    ( miss_wdata     [NumPorts-1] ),
+    .miss_wuser_o    ( miss_wuser     [NumPorts-1] ),
+    .miss_vld_bits_o ( miss_vld_bits_o[NumPorts-1] ),
+    .miss_paddr_o    ( miss_paddr     [NumPorts-1] ),
+    .miss_nc_o       ( miss_nc        [NumPorts-1] ),
+    .miss_size_o     ( miss_size      [NumPorts-1] ),
+    .miss_id_o       ( miss_id        [NumPorts-1] ),
+    .miss_rtrn_vld_i ( miss_rtrn_vld  [NumPorts-1] ),
+    .miss_rtrn_id_i  ( miss_rtrn_id                ),
     // cache read interface
-    .rd_tag_o        ( rd_tag        [2]   ),
-    .rd_idx_o        ( rd_idx        [2]   ),
-    .rd_off_o        ( rd_off        [2]   ),
-    .rd_req_o        ( rd_req        [2]   ),
-    .rd_tag_only_o   ( rd_tag_only   [2]   ),
-    .rd_ack_i        ( rd_ack        [2]   ),
-    .rd_data_i       ( rd_data             ),
-    .rd_vld_bits_i   ( rd_vld_bits         ),
-    .rd_hit_oh_i     ( rd_hit_oh           ),
+    .rd_tag_o        ( rd_tag         [NumPorts-1] ),
+    .rd_idx_o        ( rd_idx         [NumPorts-1] ),
+    .rd_off_o        ( rd_off         [NumPorts-1] ),
+    .rd_req_o        ( rd_req         [NumPorts-1] ),
+    .rd_tag_only_o   ( rd_tag_only    [NumPorts-1] ),
+    .rd_ack_i        ( rd_ack         [NumPorts-1] ),
+    .rd_data_i       ( rd_data                     ),
+    .rd_vld_bits_i   ( rd_vld_bits                 ),
+    .rd_hit_oh_i     ( rd_hit_oh                   ),
      // incoming invalidations/cache refills
-    .wr_cl_vld_i     ( wr_cl_vld           ),
-    .wr_cl_idx_i     ( wr_cl_idx           ),
+    .wr_cl_vld_i     ( wr_cl_vld                   ),
+    .wr_cl_idx_i     ( wr_cl_idx                   ),
     // single word write interface
-    .wr_req_o        ( wr_req              ),
-    .wr_ack_i        ( wr_ack              ),
-    .wr_idx_o        ( wr_idx              ),
-    .wr_off_o        ( wr_off              ),
-    .wr_data_o       ( wr_data             ),
-    .wr_user_o       ( wr_user             ),
-    .wr_data_be_o    ( wr_data_be          ),
+    .wr_req_o        ( wr_req                      ),
+    .wr_ack_i        ( wr_ack                      ),
+    .wr_idx_o        ( wr_idx                      ),
+    .wr_off_o        ( wr_off                      ),
+    .wr_data_o       ( wr_data                     ),
+    .wr_user_o       ( wr_user                     ),
+    .wr_data_be_o    ( wr_data_be                  ),
     // write buffer forwarding
-    .wbuffer_data_o  ( wbuffer_data        ),
-    .tx_paddr_o      ( tx_paddr            ),
-    .tx_vld_o        ( tx_vld              )
+    .wbuffer_data_o  ( wbuffer_data                ),
+    .tx_paddr_o      ( tx_paddr                    ),
+    .tx_vld_o        ( tx_vld                      )
   );
 
 ///////////////////////////////////////////////////////

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -18,7 +18,7 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
   parameter bit                         AxiCompliant  = 1'b0, // set this to 1 when using in conjunction with AXI bus adapter
   parameter logic [CACHE_ID_WIDTH-1:0]  AmoTxId       = 1,    // TX id to be used for AMOs
-  parameter int unsigned                NumPorts      = 3     // number of miss ports
+  parameter int unsigned                NumPorts      = 4     // number of miss ports
 ) (
   input  logic                                       clk_i,       // Clock
   input  logic                                       rst_ni,      // Asynchronous reset active low


### PR DESCRIPTION
This PR adds D$ access to the `acc_dispatcher`. For this, both caches (WT and STD) are adapted to handle a fourth D$ request port. This fourth port is used for issuing loads. Stores will go over the existing store request port. It is shared with the `store_buffer`, though the `store_buffer` always has priority access over the `acc_dispatcher`.

This fourth port is useful for accelerators, that want to access the D$ directly. Eventually it is also needed for the correct implementation of the CV-X-IF, which also has an interface into the memory. So this PR is a precursor to the future work needed for the correct CV-X-IF implementation.