### PR TITLE
Hardwire the reserved bits of the PMPCFG CSR to 0

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -908,6 +908,9 @@ module csr_regfile import ariane_pkg::*; #(
         // hardwired extension registers
         mstatus_d.sd   = (mstatus_q.xs == riscv::Dirty) | (mstatus_q.fs == riscv::Dirty);
 
+        // reserve PMPCFG bits 5 and 6 (hardwire to 0)
+        for (int i = 0; i < NrPMPEntries; i++) pmpcfg_d[i].reserved = 2'b0;
+
         // write the floating point status register
         if (csr_write_fflags_i) begin
             fcsr_d.fflags = csr_wdata_i[4:0] | fcsr_q.fflags;


### PR DESCRIPTION
Currently, the PMPCFG CSRs are implemented as a full 8-bit register. However, the bits 5 and 6 are reserved according to the privilege spec. This patch hardwires these two bits to 0. This should also fix the discrepancy between spike and CVA6 for the PMPCFG CSRs (#1346 ). It might also lead to lower area/less luts used.