### PR TITLE
add dependabot to update verif/core-v-verif

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "verif/core-v-verif"
+    labels:
+      - "Component:Verif"


### PR DESCRIPTION
This PR adds a dependabot configuration file which will have the following behavior:

- Each monday, if the `verif/core-v-verif` submodule hash is outdated (compared to the current `master` branch of core-v-verif), it opens a new PR updating the submodule, with the `Component:Verif` label.
- As a new PR is open, the dashboard will run and tell us in a comment if it breaks things or not.
  - If it passes, we can merge it by simply clicking the green button.
  - If it fails, we know that we have things to get fixed.
- If there was already such a PR which is itself outdated (ie. if we did not take any actions in a week and CVV has changed in the meantime), dependabot closes it and opens a new one.

---

PS: we should maybe introduce this line into the readme:

```sh
git config --global submodule.recurse true
```

So that subsequent `git pull`’s update CVV submodule too.