### PR TITLE
add tools to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ xrun_results/
 __pycache__
 .bender/
 Bender.lock
+/tools/


### PR DESCRIPTION
The `tools/` folder is generated hence it shall not be under version control.