### PR TITLE
dont use submodules to merge reports

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -609,6 +609,8 @@ check gitlab jobs status:
 merge reports:
   stage: report
   tags: [$TAGS_RUNNER]
+  variables:
+    GIT_SUBMODULE_STRATEGY: none
   rules:
     - if: '$DASHBOARD_URL'
       when: always


### PR DESCRIPTION
The "merge reports" job does not use submodules.
Not cloning/fetching submodules saves bandwidth.