### PR TITLE
fix cleaning in coremark and dhrystone

### DIFF
--- a/verif/regress/coremark.sh
+++ b/verif/regress/coremark.sh
@@ -28,10 +28,10 @@ if ! [ -n "$DV_SIMULATORS" ]; then
   DV_SIMULATORS=veri-testharness
 fi
 
-cd verif/sim/
-
 make clean
 make -C verif/sim clean_all
+
+cd verif/sim/
 
 src0=../tests/custom/coremark/core_main.c
 srcA=(

--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -23,10 +23,10 @@ if ! [ -n "$DV_SIMULATORS" ]; then
   DV_SIMULATORS=veri-testharness
 fi
 
-cd verif/sim
-
 make clean
 make -C verif/sim clean_all
+
+cd verif/sim
 
 src0=../tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c
 srcA=(


### PR DESCRIPTION
There was an issue with paths, and as there is no `set -e`, bash ignores them.