### PR TITLE
Zicond

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -302,6 +302,13 @@ module alu import ariane_pkg::*; #(
                 default: ; // default case to suppress unique warning
             endcase
         end
+
+        if (ariane_pkg::RCONDEXT) begin
+           unique case (fu_data_i.operation)
+           CZERO_EQZ : result_o = (fu_data_i.operand_b) ? (fu_data_i.operand_a) : (0) ; // move zero to rd if rs2 is equal to zero else rs1
+           CZERO_NEZ : result_o = (fu_data_i.operand_b) ? (0) : (fu_data_i.operand_a) ; // move zero to rd if rs2 is nonzero else rs1
+           endcase
+        end
         //VCS coverage on
     end
 endmodule

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -46,6 +46,7 @@ module decoder import ariane_pkg::*; #(
 );
     logic illegal_instr;
     logic illegal_instr_bm;
+    logic illegal_instr_zic;
     logic illegal_instr_non_bm;
     // this instruction is an environment call (ecall), it is handled like an exception
     logic ecall;
@@ -104,6 +105,7 @@ module decoder import ariane_pkg::*; #(
         illegal_instr               = 1'b0;
         illegal_instr_non_bm        = 1'b0;
         illegal_instr_bm            = 1'b0;
+        illegal_instr_zic           = 1'b0;
         instruction_o.pc            = pc_i;
         instruction_o.trans_id      = '0;
         instruction_o.fu            = NONE;
@@ -577,11 +579,24 @@ module decoder import ariane_pkg::*; #(
                                     illegal_instr_bm = 1'b1;
                                 end
                             endcase
-                            illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
-                        //VCS coverage on
-                        end else begin
-                          illegal_instr = illegal_instr_non_bm;
                         end
+                        if (ariane_pkg::RCONDEXT) begin
+                            unique case ({instr.rtype.funct7, instr.rtype.funct3})
+                                //Conditional move
+                                {7'b000_0111, 3'b101}: instruction_o.op = ariane_pkg::CZERO_EQZ;     // czero.eqz
+                                {7'b000_0111, 3'b111}: instruction_o.op = ariane_pkg::CZERO_NEZ;      // czero.nez
+                                default: begin
+                                    illegal_instr_zic = 1'b1;
+                                end
+                            endcase
+                        end
+                        //VCS coverage on
+                        unique case ({ariane_pkg::BITMANIP, ariane_pkg::RCONDEXT})
+                          2'b00 : illegal_instr = illegal_instr_non_bm;
+                          2'b01 : illegal_instr = illegal_instr_non_bm & illegal_instr_zic;
+                          2'b10 : illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
+                          2'b11 : illegal_instr = illegal_instr_non_bm & illegal_instr_bm & illegal_instr_zic;
+                        endcase
                     end
                 end
 

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -245,6 +245,11 @@ package ariane_pkg;
     // ---------------
     localparam bit BITMANIP = cva6_config_pkg::CVA6ConfigBExtEn;
 
+    // ---------------
+    // Enable ZiCond
+    // ---------------
+    localparam bit RCONDEXT = cva6_config_pkg::CVA6ConfigCondExtEn;
+
     // Only use struct when signals have same direction
     // exception
     typedef struct packed {
@@ -483,7 +488,9 @@ package ariane_pkg;
                                // Bitmanip Logical with negate op (Bitmanip)
                                ANDN, ORN, XNOR,
                                // Accelerator operations
-                               ACCEL_OP, ACCEL_OP_FS1, ACCEL_OP_FD, ACCEL_OP_LOAD, ACCEL_OP_STORE
+                               ACCEL_OP, ACCEL_OP_FS1, ACCEL_OP_FD, ACCEL_OP_LOAD, ACCEL_OP_STORE,
+                               // Zicond instruction
+                               CZERO_EQZ, CZERO_NEZ
                              } fu_op;
 
     typedef struct packed {

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -248,7 +248,7 @@ package ariane_pkg;
     // ---------------
     // Enable ZiCond
     // ---------------
-    localparam bit RCONDEXT = cva6_config_pkg::CVA6ConfigCondExtEn;
+    localparam bit RCONDEXT = cva6_config_pkg::CVA6ConfigZiCondExtEn;
 
     // Only use struct when signals have same direction
     // exception

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -28,6 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigZiCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 1;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -27,7 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -27,6 +27,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -28,6 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -28,6 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -28,6 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -28,6 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 1;
+    localparam CVA6ConfigZiCondExtEn = 1;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -28,6 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 1;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -28,6 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
+    localparam CVA6ConfigCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -28,7 +28,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigCondExtEn = 0;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;


### PR DESCRIPTION
This PR completes the [Add Zicond Extension support in CVA6](https://github.com/openhwgroup/cva6/issues/1365)
Which is verified using the Architectural tests that are developed by the RISC-V compliance team. Will add those tests in the arch-tests yaml files when we have the upstream support for Zicond extension in toolchain.