### PR TITLE
ADD SUPPORT FOR `Zcb` EXTENSION (from Code Size Reduction, Zce)

### DIFF
--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -75,7 +75,7 @@ module compressed_decoder #(
                     end
 
                     riscv::OpcodeC0Zcb: begin
-                        if (CVA6Cfg.RZCB) begin
+                        if (CVA6Cfg.RVZCB) begin
                             unique case (instr_i[12:10])
                                 3'b000: begin
                                     // c.lbu -> lbu rd', uimm(rs1') 
@@ -231,7 +231,7 @@ module compressed_decoder #(
                                     end
 
                                     3'b110: begin
-                                        if (CVA6Cfg.RZCB) begin
+                                        if (CVA6Cfg.RVZCB) begin
                                             // c.mul -> mul rd', rd', rs2'
                                             instr_o = {6'b0, 1'b1, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b000, 2'b01, instr_i[9:7], riscv::OpcodeOp};
                                         end else begin
@@ -241,7 +241,7 @@ module compressed_decoder #(
                                     end
 
                                     3'b111: begin
-                                        if (CVA6Cfg.RZCB) begin
+                                        if (CVA6Cfg.RVZCB) begin
 
                                             unique case (instr_i[4:2])
                                                 3'b000: begin

--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -74,6 +74,45 @@ module compressed_decoder #(
                         end
                     end
 
+                    riscv::OpcodeC0Zcb: begin
+                        if (ariane_pkg::COMPRESSEDB) begin
+                            unique case (instr_i[12:10])
+                                3'b000: begin
+                                    // c.lbu -> lbu rd', uimm(rs1') 
+                                    instr_o = {10'b0, instr_i[5], instr_i[6], 2'b01, instr_i[9:7], 3'b100, 2'b01, instr_i[4:2], riscv::OpcodeLoad};
+                                end
+                                
+                                3'b001: begin
+                                    if (instr_i[6])begin
+                                        // c.lh -> lh rd', uimm(rs1') 
+                                        instr_o = {10'b0, instr_i[5], 1'b0, 2'b01, instr_i[9:7], 3'b001, 2'b01, instr_i[4:2], riscv::OpcodeLoad};
+                                    end else begin
+                                        // c.lhu -> lhu rd', uimm(rs1')
+                                        instr_o = {10'b0, instr_i[5], 1'b0, 2'b01, instr_i[9:7], 3'b101, 2'b01, instr_i[4:2], riscv::OpcodeLoad};
+                                    end
+                                end
+
+                                3'b010: begin
+                                    // c.sb -> sb rs2', uimm(rs1') 
+                                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b000, 3'b0, instr_i[5], instr_i[6], riscv::OpcodeStore};
+                                end
+
+                                3'b011: begin
+                                    // c.sh -> sh rs2', uimm(rs1')
+                                    instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b001, 3'b0, instr_i[5], 1'b0, riscv::OpcodeStore};
+                                end
+
+                                default: begin
+                                    illegal_instr_o = 1'b1;
+                                end
+                            endcase
+
+                        end else begin
+                            instr_o = instr_i;
+                            illegal_instr_o = 1'b1;
+                        end
+                    end
+
                     riscv::OpcodeC0Fsd: begin
                         // c.fsd -> fsd rs2', imm(rs1')
                         instr_o = {4'b0, instr_i[6:5], instr_i[12], 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b011, instr_i[11:10], 3'b000, riscv::OpcodeStoreFp};

--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -75,7 +75,7 @@ module compressed_decoder #(
                     end
 
                     riscv::OpcodeC0Zcb: begin
-                        if (ariane_pkg::COMPRESSEDB) begin
+                        if (CVA6Cfg.RZCB) begin
                             unique case (instr_i[12:10])
                                 3'b000: begin
                                     // c.lbu -> lbu rd', uimm(rs1') 
@@ -98,7 +98,7 @@ module compressed_decoder #(
                                 end
 
                                 3'b011: begin
-                                    // c.sh -> sb rs2', uimm(rs1')
+                                    // c.sh -> sh rs2', uimm(rs1')
                                     instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b001, 3'b0, instr_i[5], 1'b0, riscv::OpcodeStore};
                                 end
 
@@ -218,7 +218,7 @@ module compressed_decoder #(
 
                                     3'b011: begin
                                         // c.and -> and rd', rd', rs2'
-                                        instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b111, 2'b01, instr_i[9:7], riscv::OpcodeOp};
+                                      instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b111, 2'b01, instr_i[9:7], riscv::OpcodeOp};
                                     end
 
                                     3'b100: begin
@@ -231,7 +231,7 @@ module compressed_decoder #(
                                     end
 
                                     3'b110: begin
-                                        if (ariane_pkg::COMPRESSEDB) begin
+                                        if (CVA6Cfg.RZCB) begin
                                             // c.mul -> mul rd', rd', rs2'
                                             instr_o = {6'b0, 1'b1, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b000, 2'b01, instr_i[9:7], riscv::OpcodeOp};
                                         end else begin
@@ -241,7 +241,7 @@ module compressed_decoder #(
                                     end
 
                                     3'b111: begin
-                                        if (ariane_pkg::COMPRESSEDB) begin
+                                        if (CVA6Cfg.RZCB) begin
 
                                             unique case (instr_i[4:2])
                                                 3'b000: begin

--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -98,7 +98,7 @@ module compressed_decoder #(
                                 end
 
                                 3'b011: begin
-                                    // c.sh -> sh rs2', uimm(rs1')
+                                    // c.sh -> sb rs2', uimm(rs1')
                                     instr_o = {7'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b001, 3'b0, instr_i[5], 1'b0, riscv::OpcodeStore};
                                 end
 
@@ -230,12 +230,72 @@ module compressed_decoder #(
                                         instr_o = {2'b00, 5'b0, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b000, 2'b01, instr_i[9:7], riscv::OpcodeOp32};
                                     end
 
-                                    3'b110,
+                                    3'b110: begin
+                                        if (ariane_pkg::COMPRESSEDB) begin
+                                            // c.mul -> mul rd', rd', rs2'
+                                            instr_o = {6'b0, 1'b1, 2'b01, instr_i[4:2], 2'b01, instr_i[9:7], 3'b000, 2'b01, instr_i[9:7], riscv::OpcodeOp};
+                                        end else begin
+                                            instr_o = instr_i;
+                                            illegal_instr_o = 1'b1;
+                                        end
+                                    end
+
                                     3'b111: begin
-                                        // 100: c.subw
-                                        // 101: c.addw
-                                        illegal_instr_o = 1'b1;
-                                        instr_o = instr_i;
+                                        if (ariane_pkg::COMPRESSEDB) begin
+
+                                            unique case (instr_i[4:2])
+                                                3'b000: begin
+                                                    // c.zext.b -> andi rd', rd', 0xff
+                                                    instr_o = {4'b0, 8'hFF, 2'b01, instr_i[9:7], 3'b111, 2'b01, instr_i[9:7], riscv::OpcodeOpImm};
+                                                end
+
+                                                3'b001: begin
+                                                    if (ariane_pkg::BITMANIP) begin
+                                                        // c.sext.b -> sext.b rd', rd'
+                                                        instr_o = {7'h30, 5'h4, 2'b01, instr_i[9:7], 3'b001, 2'b01, instr_i[9:7], riscv::OpcodeOpImm};
+                                                    end else illegal_instr_o = 1'b1;
+                                                end
+
+                                                3'b010: begin
+                                                    if (ariane_pkg::BITMANIP) begin
+                                                        // c.zext.h -> zext.h rd', rd'
+                                                        if (riscv::XLEN == 64) begin
+                                                            instr_o = {7'h4, 5'h0, 2'b01, instr_i[9:7], 3'b100, 2'b01, instr_i[9:7], riscv::OpcodeOp32};
+                                                        end else begin
+                                                            instr_o = {7'h4, 5'h0, 2'b01, instr_i[9:7], 3'b100, 2'b01, instr_i[9:7], riscv::OpcodeOp};
+                                                        end
+                                                    end else illegal_instr_o = 1'b1;
+                                                end
+
+                                                3'b011: begin
+                                                    if (ariane_pkg::BITMANIP) begin
+                                                        // c.sext.h -> sext.h rd', rd'
+                                                        instr_o = {7'h30, 5'h5, 2'b01, instr_i[9:7], 3'b001, 2'b01, instr_i[9:7], riscv::OpcodeOpImm};
+                                                    end else illegal_instr_o = 1'b1;
+                                                end
+
+                                                3'b100: begin
+                                                    if (ariane_pkg::BITMANIP) begin
+                                                        // c.zext.w -> add.uw
+                                                        if (riscv::XLEN == 64) begin
+                                                            instr_o = {7'h4, 5'h0, 2'b01, instr_i[9:7], 3'b000, 2'b01, instr_i[9:7], riscv::OpcodeOp32};
+                                                        end else begin
+                                                            illegal_instr_o = 1'b1;
+                                                        end
+                                                    end else illegal_instr_o = 1'b1;
+                                                end
+
+                                                3'b101: begin
+                                                    // c.not -> xori rd', rd', -1
+                                                    instr_o = {12'hFFF, 2'b01, instr_i[9:7], 3'b100, 2'b01, instr_i[9:7], riscv::OpcodeOpImm};
+                                                end
+
+                                                default: begin
+                                                    instr_o = instr_i;
+                                                    illegal_instr_o = 1;
+                                                end
+                                            endcase
+                                        end
                                     end
                                 endcase
                             end

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -176,7 +176,7 @@ module cva6 import ariane_pkg::*; #(
     CVA6Cfg.RVA,
     CVA6Cfg.RVV,
     CVA6Cfg.RVC,
-    CVA6Cfg.RZCB,
+    CVA6Cfg.RVZCB,
     CVA6Cfg.XFVec,
     CVA6Cfg.CvxifEn,
     CVA6Cfg.RCONDEXT,

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -176,6 +176,7 @@ module cva6 import ariane_pkg::*; #(
     CVA6Cfg.RVA,
     CVA6Cfg.RVV,
     CVA6Cfg.RVC,
+    CVA6Cfg.RZCB,
     CVA6Cfg.XFVec,
     CVA6Cfg.CvxifEn,
     CVA6Cfg.RCONDEXT,

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -253,6 +253,9 @@ package ariane_pkg;
     // Fetch Stage
     // ---------------
 
+    // Enable Zcb
+    localparam bit COMPRESSEDB = cva6_config_pkg::CVA6ConfigZCbExtEn;
+
     // leave as is (fails with >8 entries and wider fetch width)
     localparam int unsigned FETCH_FIFO_DEPTH  = 4;
     localparam int unsigned FETCH_WIDTH       = 32;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -253,9 +253,6 @@ package ariane_pkg;
     // Fetch Stage
     // ---------------
 
-    // Enable Zcb
-    localparam bit COMPRESSEDB = cva6_config_pkg::CVA6ConfigZCbExtEn;
-
     // leave as is (fails with >8 entries and wider fetch width)
     localparam int unsigned FETCH_FIFO_DEPTH  = 4;
     localparam int unsigned FETCH_WIDTH       = 32;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -29,6 +29,7 @@ package config_pkg;
       bit RVA;
       bit RVV;
       bit RVC;
+      bit RZCB;
       bit XFVec;
       bit CvxifEn;
       bit RCONDEXT;
@@ -65,6 +66,7 @@ package config_pkg;
       bit'(0),           // RVA
       bit'(0),           // RVV
       bit'(1),           // RVC
+      bit'(0),           // RZCB
       bit'(0),           // XFVec
       bit'(1),           // CvxifEn
       bit'(0),           // EnableZiCond
@@ -99,6 +101,7 @@ package config_pkg;
       bit'(0),           // RVA
       bit'(0),           // RVV
       bit'(0),           // RVC
+      bit'(0),           // RZCB
       bit'(0),           // XFVec
       bit'(0),           // CvxifEn
       bit'(0),           // EnableZiCond

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -29,7 +29,7 @@ package config_pkg;
       bit RVA;
       bit RVV;
       bit RVC;
-      bit RZCB;
+      bit RVZCB;
       bit XFVec;
       bit CvxifEn;
       bit RCONDEXT;
@@ -66,7 +66,7 @@ package config_pkg;
       bit'(0),           // RVA
       bit'(0),           // RVV
       bit'(1),           // RVC
-      bit'(0),           // RZCB
+      bit'(0),           // RVZCB
       bit'(0),           // XFVec
       bit'(1),           // CvxifEn
       bit'(0),           // EnableZiCond
@@ -101,7 +101,7 @@ package config_pkg;
       bit'(0),           // RVA
       bit'(0),           // RVV
       bit'(0),           // RVC
-      bit'(0),           // RZCB
+      bit'(0),           // RVZCB
       bit'(0),           // XFVec
       bit'(0),           // CvxifEn
       bit'(0),           // EnableZiCond

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -25,9 +25,9 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZcbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
-    localparam CVA6ConfigBExtEn = 0;
+    localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
     localparam CVA6ConfigZiCondExtEn = 1;
 

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -91,7 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -24,6 +24,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -24,7 +24,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 1;
+    localparam CVA6ConfigZcbExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
@@ -90,6 +90,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -90,7 +90,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 0;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 0;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -91,7 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -91,7 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -91,7 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -91,7 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 1;
@@ -90,6 +90,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 1;

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -90,7 +90,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 1;
+    localparam CVA6ConfigZcbExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // RCONDEXT

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 1;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 1;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -91,7 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // RCONDEXT

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -91,7 +91,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 0;

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
-    localparam CVA6ConfigZCbExtEn = 0;
+    localparam CVA6ConfigZcbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 1;
@@ -90,6 +90,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
+      bit'(CVA6ConfigZcbExtEn),              // RZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -25,6 +25,7 @@ package cva6_config_pkg;
 
     localparam CVA6ConfigCvxifEn = 0;
     localparam CVA6ConfigCExtEn = 1;
+    localparam CVA6ConfigZCbExtEn = 0;
     localparam CVA6ConfigAExtEn = 1;
     localparam CVA6ConfigBExtEn = 0;
     localparam CVA6ConfigVExtEn = 1;

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -90,7 +90,7 @@ package cva6_config_pkg;
       bit'(CVA6ConfigAExtEn),                // RVA
       bit'(CVA6ConfigVExtEn),                // RVV
       bit'(CVA6ConfigCExtEn),                // RVC
-      bit'(CVA6ConfigZcbExtEn),              // RZCB
+      bit'(CVA6ConfigZcbExtEn),              // RVZCB
       bit'(CVA6ConfigFVecEn),                // XFVec
       bit'(CVA6ConfigCvxifEn),               // CvxifEn
       bit'(CVA6ConfigZiCondExtEn),           // ZiCondExtEn

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -263,7 +263,7 @@ package riscv;
     localparam OpcodeC0Fld          = 3'b001;
     localparam OpcodeC0Lw           = 3'b010;
     localparam OpcodeC0Ld           = 3'b011;
-    localparam OpcodeC0Rsrvd        = 3'b100;
+    localparam OpcodeC0Zcb          = 3'b100;
     localparam OpcodeC0Fsd          = 3'b101;
     localparam OpcodeC0Sw           = 3'b110;
     localparam OpcodeC0Sd           = 3'b111;

--- a/util/config_pkg_generator.py
+++ b/util/config_pkg_generator.py
@@ -37,6 +37,8 @@ def setup_parser_config_generator():
                       help="CoreV-X-Interface enable ? 1 : enable, 0 : disable")
   parser.add_argument("--c_ext", type=int, default=None, choices=[0,1],
                       help="C extension enable ? 1 : enable, 0 : disable")
+  parser.add_argument("--zcb_ext", type=int, default=None, choices=[0,1],
+                      help="Zcb extension enable ? 1 : enable, 0 : disable")
   parser.add_argument("--a_ext", type=int, default=None, choices=[0,1],
                       help="A extension enable ? 1 : enable, 0 : disable")
   parser.add_argument("--b_ext", type=int, default=None, choices=[0,1],
@@ -124,6 +126,7 @@ MapArgsToParameter={
   "FVecEn" : "CVA6ConfigFVecEn",
   "cvxif" : "CVA6ConfigCvxifEn",
   "c_ext" : "CVA6ConfigCExtEn",
+  "zcb_ext" : "CVA6ConfigZCbExtEn",
   "a_ext" : "CVA6ConfigAExtEn",
   "b_ext" : "CVA6ConfigBExtEn",
   "AxiIdWidth" : "CVA6ConfigAxiIdWidth",


### PR DESCRIPTION
This PR resolves #1366 

## Description
This PR adds the support `zcb` extension which is one of the sub-extension recently ratified [Code Size Reduction (Zce)](https://github.com/riscv/riscv-code-size-reduction/releases/download/v1.0.4-1/Zc.1.0.4-1.pdf) extension.
This extension adds compressed ops for following instructions. All the `zcb` instructions require the support of at least standard C extension as a pre-requisite in addition to base (I-type) Instructions:

#### Instructions fall in Quadrant 0:
`c.lbu`, `c.lh`, `c.lhu`, `c.sb`, `c.sh`

#### Instructions fall in Quadrant 1:
`c.mul` (M extension is pre-requisite)
`c.zext.b` 
`c.sext.b` (Bitmanip is pre-requisite)
`c.zext.h` (Bitmanip is pre-requisite)
`c.sext.h` (Bitmanip is pre-requisite)
`c.zext.w` (Bitmanip is pre-requisite)
`c.not` 


## Design Changes

1. The Compressed Decoder is updated to produce the corresponding 32-bit instructions.
2. `CVA6ConfigZcbExtEn` parameter is added to config files.
3. `RZCB` parameter is added for the RTL.
4. zcb is enabled for three configs: `cv32a6_embedded`, `cv32a60x` and `cv64a6_imafdc_sv39`.
(bitmanip is also enabled for `cv32a60x`)


## Verification

Architecture tests for zcb instructions are available in the [PR](https://github.com/riscv-non-isa/riscv-arch-test/pull/364) of `riscv-arch-test`. These tests are run under core-v-verif environment for three configs of cva6 mentioned above and the tests are passing. The artifacts collected after running the tests for all three configs are available in [G-drive](https://drive.google.com/file/d/1SSHaauZGpvusG-QHSpGLdx7xZRswfh-n/view?usp=sharing).