### PR TITLE
Code_coverage: Add conditions for the FPU

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -3,4 +3,4 @@ cv64a6_imafdc_sv39:
 cv32a60x:
   gates: 160719
 cv32a6_embedded:
-  gates: 127763
+  gates: 127388

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -195,32 +195,32 @@ module csr_regfile import ariane_pkg::*; #(
         if (csr_read) begin
             unique case (csr_addr.address)
                 riscv::CSR_FFLAGS: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        read_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         csr_rdata = {{riscv::XLEN-5{1'b0}}, fcsr_q.fflags};
+                    end else begin
+                        read_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_FRM: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        read_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         csr_rdata = {{riscv::XLEN-3{1'b0}}, fcsr_q.frm};
+                    end else begin
+                        read_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_FCSR: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        read_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         csr_rdata = {{riscv::XLEN-8{1'b0}}, fcsr_q.frm, fcsr_q.fflags};
+                    end else begin
+                        read_access_exception = 1'b1;
                     end
                 end
                 // non-standard extension
                 riscv::CSR_FTRAN: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        read_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         csr_rdata = {{riscv::XLEN-7{1'b0}}, fcsr_q.fprec};
+                    end else begin
+                        read_access_exception = 1'b1;
                     end
                 end
                 // debug registers
@@ -574,43 +574,43 @@ module csr_regfile import ariane_pkg::*; #(
             unique case (csr_addr.address)
                 // Floating-Point
                 riscv::CSR_FFLAGS: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        update_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         dirty_fp_state_csr = 1'b1;
                         fcsr_d.fflags = csr_wdata[4:0];
                         // this instruction has side-effects
                         flush_o = 1'b1;
+                    end else begin
+                        update_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_FRM: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        update_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         dirty_fp_state_csr = 1'b1;
                         fcsr_d.frm    = csr_wdata[2:0];
                         // this instruction has side-effects
                         flush_o = 1'b1;
+                    end else begin
+                        update_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_FCSR: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        update_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         dirty_fp_state_csr = 1'b1;
                         fcsr_d[7:0] = csr_wdata[7:0]; // ignore writes to reserved space
                         // this instruction has side-effects
                         flush_o = 1'b1;
+                    end else begin
+                        update_access_exception = 1'b1;
                     end
                 end
                 riscv::CSR_FTRAN: begin
-                    if (mstatus_q.fs == riscv::Off) begin
-                        update_access_exception = 1'b1;
-                    end else begin
+                    if(CVA6Cfg.FpPresent) begin
                         dirty_fp_state_csr = 1'b1;
                         fcsr_d.fprec = csr_wdata[6:0]; // ignore writes to reserved space
                         // this instruction has side-effects
                         flush_o = 1'b1;
+                    end else begin
+                        update_access_exception = 1'b1;
                     end
                 end
                 // debug CSR
@@ -912,7 +912,7 @@ module csr_regfile import ariane_pkg::*; #(
         for (int i = 0; i < NrPMPEntries; i++) pmpcfg_d[i].reserved = 2'b0;
 
         // write the floating point status register
-        if (csr_write_fflags_i) begin
+        if (CVA6Cfg.FpPresent && csr_write_fflags_i) begin
             fcsr_d.fflags = csr_wdata_i[4:0] | fcsr_q.fflags;
         end
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1261,7 +1261,7 @@ module cva6 import ariane_pkg::*; #(
         rvfi_o[i].rs1_addr = commit_instr_id_commit[i].rs1[4:0];
         rvfi_o[i].rs2_addr = commit_instr_id_commit[i].rs2[4:0];
         rvfi_o[i].rd_addr  = commit_instr_id_commit[i].rd[4:0];
-        rvfi_o[i].rd_wdata = ariane_pkg::is_rd_fpr_cfg(commit_instr_id_commit[i].op, CVA6ExtendCfg.FpPresent) == 0 ? wdata_commit_id[i] : commit_instr_id_commit[i].result;
+        rvfi_o[i].rd_wdata = (CVA6ExtendCfg.FpPresent && ariane_pkg::is_rd_fpr(commit_instr_id_commit[i].op)) ? commit_instr_id_commit[i].result : wdata_commit_id[i];
         rvfi_o[i].pc_rdata = commit_instr_id_commit[i].pc;
 
         rvfi_o[i].mem_addr  = commit_instr_id_commit[i].lsu_addr;

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -530,94 +530,62 @@ package ariane_pkg;
     // function used in instr_trace svh
     // is_rs1_fpr function is kept to allow cva6 compilation with instr_trace feature
     function automatic logic is_rs1_fpr (input fu_op op);
-        return is_rs1_fpr_cfg (op, 1);
-    endfunction
-
-    function automatic logic is_rs1_fpr_cfg (input fu_op op, input bit FpPresent);
-        if (FpPresent) begin
-            unique case (op) inside
-                [FMUL:FNMADD],                   // Computational Operations (except ADD/SUB)
-                FCVT_F2I,                        // Float-Int Casts
-                FCVT_F2F,                        // Float-Float Casts
-                FSGNJ,                           // Sign Injections
-                FMV_F2X,                         // FPR-GPR Moves
-                FCMP,                            // Comparisons
-                FCLASS,                          // Classifications
-                [VFMIN:VFCPKCD_D],               // Additional Vectorial FP ops
-                ACCEL_OP_FS1      : return 1'b1; // Accelerator instructions
-                default           : return 1'b0; // all other ops
-            endcase
-        end else begin
-            return 1'b0;
-        end
+        unique case (op) inside
+            [FMUL:FNMADD],                   // Computational Operations (except ADD/SUB)
+            FCVT_F2I,                        // Float-Int Casts
+            FCVT_F2F,                        // Float-Float Casts
+            FSGNJ,                           // Sign Injections
+            FMV_F2X,                         // FPR-GPR Moves
+            FCMP,                            // Comparisons
+            FCLASS,                          // Classifications
+            [VFMIN:VFCPKCD_D],               // Additional Vectorial FP ops
+            ACCEL_OP_FS1      : return 1'b1; // Accelerator instructions
+            default           : return 1'b0; // all other ops
+        endcase
     endfunction
 
     // function used in instr_trace svh
     // is_rs2_fpr function is kept to allow cva6 compilation with instr_trace feature
     function automatic logic is_rs2_fpr (input fu_op op);
-        return is_rs2_fpr_cfg (op, 1);
-    endfunction
-
-    function automatic logic is_rs2_fpr_cfg (input fu_op op, input bit FpPresent);
-        if (FpPresent) begin
-            unique case (op) inside
-                [FSD:FSB],                       // FP Stores
-                [FADD:FMIN_MAX],                 // Computational Operations (no sqrt)
-                [FMADD:FNMADD],                  // Fused Computational Operations
-                FCVT_F2F,                        // Vectorial F2F Conversions requrie target
-                [FSGNJ:FMV_F2X],                 // Sign Injections and moves mapped to SGNJ
-                FCMP,                            // Comparisons
-                [VFMIN:VFCPKCD_D] : return 1'b1; // Additional Vectorial FP ops
-                default           : return 1'b0; // all other ops
-            endcase
-        end else begin
-            return 1'b0;
-        end
+        unique case (op) inside
+            [FSD:FSB],                       // FP Stores
+            [FADD:FMIN_MAX],                 // Computational Operations (no sqrt)
+            [FMADD:FNMADD],                  // Fused Computational Operations
+            FCVT_F2F,                        // Vectorial F2F Conversions requrie target
+            [FSGNJ:FMV_F2X],                 // Sign Injections and moves mapped to SGNJ
+            FCMP,                            // Comparisons
+            [VFMIN:VFCPKCD_D] : return 1'b1; // Additional Vectorial FP ops
+            default           : return 1'b0; // all other ops
+        endcase
     endfunction
 
     // function used in instr_trace svh
     // is_imm_fpr function is kept to allow cva6 compilation with instr_trace feature
     // ternary operations encode the rs3 address in the imm field, also add/sub
     function automatic logic is_imm_fpr (input fu_op op);
-        return is_imm_fpr_cfg (op, 1);
-    endfunction
-
-    function automatic logic is_imm_fpr_cfg (input fu_op op, input bit FpPresent);
-        if (FpPresent) begin
-            unique case (op) inside
-                [FADD:FSUB],                         // ADD/SUB need inputs as Operand B/C
-                [FMADD:FNMADD],                      // Fused Computational Operations
-                [VFCPKAB_S:VFCPKCD_D] : return 1'b1; // Vectorial FP cast and pack ops
-                default               : return 1'b0; // all other ops
-            endcase
-        end else begin
-            return 1'b0;
-        end
+        unique case (op) inside
+            [FADD:FSUB],                         // ADD/SUB need inputs as Operand B/C
+            [FMADD:FNMADD],                      // Fused Computational Operations
+            [VFCPKAB_S:VFCPKCD_D] : return 1'b1; // Vectorial FP cast and pack ops
+            default               : return 1'b0; // all other ops
+        endcase
     endfunction
 
     // function used in instr_trace svh
     // is_rd_fpr function is kept to allow cva6 compilation with instr_trace feature
     function automatic logic is_rd_fpr (input fu_op op);
-        return is_rd_fpr_cfg (op, 1);
-    endfunction
-
-    function automatic logic is_rd_fpr_cfg (input fu_op op, input bit FpPresent);
-        if (FpPresent) begin
-            unique case (op) inside
-                [FLD:FLB],                           // FP Loads
-                [FADD:FNMADD],                       // Computational Operations
-                FCVT_I2F,                            // Int-Float Casts
-                FCVT_F2F,                            // Float-Float Casts
-                FSGNJ,                               // Sign Injections
-                FMV_X2F,                             // GPR-FPR Moves
-                [VFMIN:VFSGNJX],                     // Vectorial MIN/MAX and SGNJ
-                [VFCPKAB_S:VFCPKCD_D],               // Vectorial FP cast and pack ops
-                ACCEL_OP_FD           : return 1'b1; // Accelerator instructions
-                default               : return 1'b0; // all other ops
-            endcase
-        end else begin
-            return 1'b0;
-        end
+        unique case (op) inside
+            [FLD:FLB],                           // FP Loads
+            [FADD:FNMADD],                       // Computational Operations
+            FCVT_I2F,                            // Int-Float Casts
+            FCVT_F2F,                            // Float-Float Casts
+            FSGNJ,                               // Sign Injections
+            FMV_X2F,                             // GPR-FPR Moves
+            [VFMIN:VFSGNJX],                     // Vectorial MIN/MAX and SGNJ
+            [VFCPKAB_S:VFCPKCD_D],               // Vectorial FP cast and pack ops
+            ACCEL_OP_FD           : return 1'b1; // Accelerator instructions
+            default               : return 1'b0; // all other ops
+        endcase
     endfunction
 
     function automatic logic is_amo (fu_op op);

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -455,9 +455,25 @@ module load_unit import ariane_pkg::*; #(
     // result mux
     always_comb begin
         unique case (ldbuf_rdata.operation)
-            ariane_pkg::LW, ariane_pkg::LWU, ariane_pkg::FLW: result_o = {{riscv::XLEN-32{rdata_sign_bit}}, shifted_data[31:0]};
-            ariane_pkg::LH, ariane_pkg::LHU, ariane_pkg::FLH: result_o = {{riscv::XLEN-32+16{rdata_sign_bit}}, shifted_data[15:0]};
-            ariane_pkg::LB, ariane_pkg::LBU, ariane_pkg::FLB: result_o = {{riscv::XLEN-32+24{rdata_sign_bit}}, shifted_data[7:0]};
+            ariane_pkg::LW, ariane_pkg::LWU:    result_o = {{riscv::XLEN-32{rdata_sign_bit}}, shifted_data[31:0]};
+            ariane_pkg::LH, ariane_pkg::LHU:    result_o = {{riscv::XLEN-32+16{rdata_sign_bit}}, shifted_data[15:0]};
+            ariane_pkg::LB, ariane_pkg::LBU:    result_o = {{riscv::XLEN-32+24{rdata_sign_bit}}, shifted_data[7:0]};
+            ariane_pkg::FLW: begin
+                if(CVA6Cfg.FpPresent) begin
+                   result_o = {{riscv::XLEN-32{rdata_sign_bit}}, shifted_data[31:0]};
+                end
+            end
+            ariane_pkg::FLH: begin
+                if(CVA6Cfg.FpPresent) begin
+                   result_o = {{riscv::XLEN-32+16{rdata_sign_bit}}, shifted_data[15:0]};
+                end
+            end
+            ariane_pkg::FLB: begin
+                if(CVA6Cfg.FpPresent) begin
+                   result_o = {{riscv::XLEN-32+24{rdata_sign_bit}}, shifted_data[7:0]};
+                end
+            end
+
             default:                                          result_o = shifted_data[riscv::XLEN-1:0];
         endcase
     end


### PR DESCRIPTION
Condition RTL with FPU parameters to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to reach 100% code coverage.