### PR TITLE
dependabot: run at 19:30 CET

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "19:30"
+      timezone: "Europe/Paris"
     allow:
       - dependency-name: "verif/core-v-verif"
     labels:


### PR DESCRIPTION
The goal is that dependabot opens a PR just before the Dashboard runs.
This way the results will be available on Tuesday mornings, CET.