### PR TITLE
Code_Coverage: Exclude coverage of assertions, FSM, toggle of internal signals and constants

### DIFF
--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -93,8 +93,8 @@ endif
 cov-exclude-list ?= $(root-dir)/cov-exclude-mod.lst
 
 ifdef cov
-	cov-comp-opt = -cm line+cond+fsm+tgl+assert -cm_hier $(cov-exclude-list)
-	cov-run-opt  = -cm line+cond+fsm+tgl+assert -cm_name $(TESTNAME)
+	cov-comp-opt = -cm line+cond+tgl -cm_hier $(cov-exclude-list)
+	cov-run-opt  = -cm line+cond+tgl -cm_name $(TESTNAME)
 else
 	cov-comp-opt =
 	cov-run-opt  =
@@ -183,7 +183,8 @@ ALL_UVM_FLAGS           = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
 	  $(VCS_HOME)/etc/uvm/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_MEDIUM -ntb_opts uvm-1.2 -timescale=1ns/1ps \
 	  -assert svaext -race=all -ignore unique_checks -full64 -q +incdir+$(VCS_HOME)/etc/uvm/src \
 	  +incdir+$(CVA6_REPO_DIR)/verif/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/tb/uvmt \
-	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon))
+	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon))\
+	  -cm_seqnoconst -diag noconst
 
 ALL_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) \
 		-sv_lib $(CVA6_REPO_DIR)/verif/core-v-verif/lib/dpi_dasm/lib/Linux64/libdpi_dasm +signature=I-ADD-01.signature_output \
@@ -247,7 +248,7 @@ vcs-uvm:
           for i in `ls *.$(SIMV_TRACE_EXTN)` ; do mv $$i `dirname $(log)`/`basename $(log) .log`.$(target).$$i ; done || true
 
 generate_cov_dash:
-	urg -dir $(VCS_WORK_DIR)/simv.vdb -group instcov_for_score
+	urg -dir $(VCS_WORK_DIR)/simv.vdb -group instcov_for_score -tgl portsonly
 
 vcs_clean_all:
 	@echo "[VCS] Cleanup (entire vcs_work dir)"

--- a/verif/tb/uvmt/cva6_tb_wrapper.sv
+++ b/verif/tb/uvmt/cva6_tb_wrapper.sv
@@ -50,7 +50,8 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
   input  cvxif_pkg::cvxif_resp_t       cvxif_resp,
   output cvxif_pkg::cvxif_req_t        cvxif_req,
   uvma_axi_intf                        axi_slave,
-  uvmt_axi_switch_intf                 axi_switch_vif
+  uvmt_axi_switch_intf                 axi_switch_vif,
+  uvmt_default_inputs_intf             default_inputs_vif
 );
 
   ariane_axi::req_t    axi_ariane_req;
@@ -71,11 +72,11 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
     .clk_i                ( clk_i                     ),
     .rst_ni               ( rst_ni                    ),
     .boot_addr_i          ( boot_addr_i               ),//Driving the boot_addr value from the core control agent
-    .hart_id_i            ( 64'h0000_0000_0000_0000   ),
-    .irq_i                ( 2'b00 /*irqs*/            ),
-    .ipi_i                ( 1'b0  /*ipi*/             ),
-    .time_irq_i           ( 1'b0  /*timer_irq*/       ),
-    .debug_req_i          ( 1'b0                      ),
+    .hart_id_i            ( default_inputs_vif.hart_id   ),
+    .irq_i                ( default_inputs_vif.irq       ),
+    .ipi_i                ( default_inputs_vif.ipi       ),
+    .time_irq_i           ( default_inputs_vif.time_irq  ),
+    .debug_req_i          ( default_inputs_vif.debug_req ),
     .rvfi_o               ( rvfi                      ),
     .cvxif_req_o          ( cvxif_req                 ),
     .cvxif_resp_i         ( cvxif_resp                ),

--- a/verif/tb/uvmt/uvmt_cva6_dut_wrap.sv
+++ b/verif/tb/uvmt/uvmt_cva6_dut_wrap.sv
@@ -28,6 +28,7 @@ module uvmt_cva6_dut_wrap # (
                             uvma_cvxif_intf                     cvxif_if,
                             uvma_axi_intf                       axi_if,
                             uvmt_axi_switch_intf                axi_switch_vif,
+                            uvmt_default_inputs_intf            default_inputs_vif,
                             uvme_cva6_core_cntrl_if             core_cntrl_if,
                             output logic[31:0]                  tb_exit_o,
                             output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o
@@ -51,6 +52,7 @@ module uvmt_cva6_dut_wrap # (
          .cvxif_req              ( cvxif_if.cvxif_req_i           ),
          .axi_slave              ( axi_if                         ),
          .axi_switch_vif         ( axi_switch_vif                 ),
+         .default_inputs_vif     ( default_inputs_vif             ),
          .tb_exit_o              ( tb_exit_o                      ),
          .rvfi_o                 ( rvfi_o                         )
 );

--- a/verif/tb/uvmt/uvmt_cva6_pkg.sv
+++ b/verif/tb/uvmt/uvmt_cva6_pkg.sv
@@ -28,6 +28,7 @@
 `include "uvmt_cva6_macros.sv"
 
 `include "uvmt_axi_switch_intf.sv"
+`include "uvmt_default_inputs_intf.sv"
 
 /**
  * Encapsulates all the types and test cases for the verification of an

--- a/verif/tb/uvmt/uvmt_cva6_tb.sv
+++ b/verif/tb/uvmt/uvmt_cva6_tb.sv
@@ -86,6 +86,8 @@ module uvmt_cva6_tb;
 
     uvma_rvfi_csr_if#(uvme_cva6_pkg::XLEN)       rvfi_csr_if [uvme_cva6_pkg::RVFI_NRET-1:0]();
 
+   uvmt_default_inputs_intf         default_inputs_vif();
+
    //bind assertion module for cvxif interface
    bind uvmt_cva6_dut_wrap
       uvma_cvxif_assert          cvxif_assert(.cvxif_assert(cvxif_if),
@@ -124,6 +126,7 @@ module uvmt_cva6_tb;
                     .cvxif_if  (cvxif_if),
                     .axi_if    (axi_if),
                     .axi_switch_vif    (axi_switch_vif),
+                    .default_inputs_vif    (default_inputs_vif),
                     .core_cntrl_if(core_cntrl_if),
                     .tb_exit_o(rvfi_if.tb_exit_o),
                     .rvfi_o(rvfi_if.rvfi_o)
@@ -154,6 +157,12 @@ module uvmt_cva6_tb;
       assign  rvfi_instr_if[i].rvfi_mem_wdata = rvfi_if.rvfi_o[i].mem_wdata;
       assign  rvfi_instr_if[i].rvfi_mem_wmask = rvfi_if.rvfi_o[i].mem_wmask;
    end
+
+   assign  default_inputs_vif.hart_id   = 64'h0000_0000_0000_0000;
+   assign  default_inputs_vif.irq       = 2'b00;
+   assign  default_inputs_vif.ipi       = 1'b0;
+   assign  default_inputs_vif.time_irq  = 1'b0;
+   assign  default_inputs_vif.debug_req = 1'b0;
 
 
    for (genvar i = 0; i < uvme_cva6_pkg::RVFI_NRET; i++) begin

--- a/verif/tb/uvmt/uvmt_default_inputs_intf.sv
+++ b/verif/tb/uvmt/uvmt_default_inputs_intf.sv
@@ -1,0 +1,21 @@
+// Copyright 2023 Thales DIS SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Alae Eddine EZ ZEJJARI (alae-eddine.ez-zejjari@external.thalesgroup.com) – sub-contractor MU-Electronics for Thales group
+
+/**** AXI interface to indicate the state of the agent ****/
+
+
+interface uvmt_default_inputs_intf;
+
+   logic [63:0] hart_id;
+   logic [1:0]  irq;
+   logic        ipi;
+   logic        time_irq;
+   logic        debug_req;
+
+endinterface : uvmt_default_inputs_intf


### PR DESCRIPTION
We modify the VCS coverage parameters to disable coverage of assertion , FSM, internal signal toggle and constants.
The default input interface is created to prevent CVA6 inputs from being excluded from coverage.