### PR TITLE
[Hotfix] dashboard

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,10 +31,13 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       variables:
         CI_KIND: verif
+    - if: $CI_COMMIT_BRANCH == "master"
+      variables:
+        CI_KIND: regress
     - if: $CI_COMMIT_BRANCH =~ /.*_PR_.*/
       variables:
         CI_KIND: regress
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^dev.*/
+    - if: $CI_COMMIT_BRANCH =~ /^dev.*/
       variables:
         CI_KIND: dev
     - variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,8 @@ check_env:
     GIT_STRATEGY: none
   script:
     - env
+  artifacts:
+    paths: []
 
 build_tools:
   extends:


### PR DESCRIPTION
- In the previous CI PR I forgot to keep running the Dashboard on master branch pushes in regress mode. It was set to run only on schedule (verif mode). This PR enables "regress" Dashboard runs on pushes on master branch
- There was an issue with the check-env: as it was not checking out a repository, it was keeping the files from previous runs in the same runner. These files were matched as artifacts, which was making the `merge reports` job fail.