### PR TITLE
Code_ coverage: Remove VCS coverage pragma for BitManip

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -75,7 +75,6 @@ module alu import ariane_pkg::*; #(
     always_comb begin
       operand_a_bitmanip = fu_data_i.operand_a;
 
-      //VCS coverage off
       if (ariane_pkg::BITMANIP) begin
         unique case (fu_data_i.operation)
           SH1ADD   : operand_a_bitmanip = fu_data_i.operand_a << 1;
@@ -90,7 +89,6 @@ module alu import ariane_pkg::*; #(
           default  : ;
         endcase
       end
-      //VCS coverage on
     end
 
     // prepare operand a
@@ -191,7 +189,6 @@ module alu import ariane_pkg::*; #(
         less = ($signed({sgn & fu_data_i.operand_a[riscv::XLEN-1], fu_data_i.operand_a})  <  $signed({sgn & fu_data_i.operand_b[riscv::XLEN-1], fu_data_i.operand_b}));
     end
 
-    //VCS coverage off
     if (ariane_pkg::BITMANIP) begin : gen_bitmanip
         // Count Population + Count population Word
 
@@ -222,7 +219,6 @@ module alu import ariane_pkg::*; #(
           .empty_o (lz_tz_wempty)
         );
     end
-    //VCS coverage on
 
     // -----------
     // Result MUX
@@ -255,7 +251,6 @@ module alu import ariane_pkg::*; #(
             default: ; // default case to suppress unique warning
         endcase
 
-        //VCS coverage off
         if (ariane_pkg::BITMANIP) begin
             // Index for Bitwise Rotation
             bit_indx = 1 << (fu_data_i.operand_b & (riscv::XLEN-1));
@@ -309,6 +304,5 @@ module alu import ariane_pkg::*; #(
            default: ; // default case to suppress unique warning
            endcase
         end
-        //VCS coverage on
     end
 endmodule

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -510,10 +510,8 @@ module decoder import ariane_pkg::*; #(
                     // Integer Reg-Reg Operations
                     // ---------------------------
                     end else begin
-                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             instruction_o.fu  = (instr.rtype.funct7 == 7'b000_0001 || ((instr.rtype.funct7 == 7'b000_0101) && !(instr.rtype.funct3[14]))) ? MULT : ALU;
-                        //VCS coverage on
                         end else begin
                             instruction_o.fu  = (instr.rtype.funct7 == 7'b000_0001) ? MULT : ALU;
                         end
@@ -545,7 +543,6 @@ module decoder import ariane_pkg::*; #(
                                 illegal_instr_non_bm = 1'b1;
                             end
                         endcase
-                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             unique case ({instr.rtype.funct7, instr.rtype.funct3})
                                 //Logical with Negate
@@ -590,7 +587,6 @@ module decoder import ariane_pkg::*; #(
                                 end
                             endcase
                         end
-                        //VCS coverage on
                         unique case ({ariane_pkg::BITMANIP, CVA6Cfg.RCONDEXT})
                           2'b00 : illegal_instr = illegal_instr_non_bm;
                           2'b01 : illegal_instr = illegal_instr_non_bm & illegal_instr_zic;
@@ -623,7 +619,6 @@ module decoder import ariane_pkg::*; #(
                             {7'b000_0001, 3'b111}: instruction_o.op = ariane_pkg::REMUW;
                             default: illegal_instr_non_bm = 1'b1;
                         endcase
-                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             unique case ({instr.rtype.funct7, instr.rtype.funct3})
                                 // Shift with Add (Unsigned Word)
@@ -640,7 +635,6 @@ module decoder import ariane_pkg::*; #(
                                 default: illegal_instr_bm = 1'b1;
                             endcase
                             illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
-                        //VCS coverage on
                         end else begin
                           illegal_instr = illegal_instr_non_bm;
                         end
@@ -679,7 +673,6 @@ module decoder import ariane_pkg::*; #(
                             if (instr.instr[25] != 1'b0 && riscv::XLEN==32) illegal_instr_non_bm = 1'b1;
                         end
                     endcase
-                    //VCS coverage off
                     if (ariane_pkg::BITMANIP) begin
                         unique case (instr.itype.funct3)
                             3'b001: begin
@@ -719,7 +712,6 @@ module decoder import ariane_pkg::*; #(
                             default: illegal_instr_bm = 1'b1;
                         endcase
                         illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
-                    //VCS coverage on
                     end else begin
                       illegal_instr = illegal_instr_non_bm;
                     end
@@ -751,7 +743,6 @@ module decoder import ariane_pkg::*; #(
                             end
                             default: illegal_instr_non_bm = 1'b1;
                         endcase
-                        //VCS coverage off
                         if (ariane_pkg::BITMANIP) begin
                             unique case (instr.itype.funct3)
                                 3'b001: begin
@@ -776,7 +767,6 @@ module decoder import ariane_pkg::*; #(
                                 default: illegal_instr_bm = 1'b1;
                             endcase
                             illegal_instr = illegal_instr_non_bm & illegal_instr_bm;
-                        //VCS coverage on
                         end else begin
                           illegal_instr = illegal_instr_non_bm;
                         end

--- a/core/multiplier.sv
+++ b/core/multiplier.sv
@@ -34,7 +34,6 @@ module multiplier import ariane_pkg::*; #(
     logic [riscv::XLEN-1:0] clmul_q, clmul_d, clmulr_q, clmulr_d, operand_a, operand_b, operand_a_rev, operand_b_rev;
     logic clmul_rmode, clmul_hmode;
 
-    //VCS coverage off
     if (ariane_pkg::BITMANIP) begin : gen_bitmanip
         // checking for clmul_rmode and clmul_hmode
         assign clmul_rmode = (operation_i == CLMULR);
@@ -63,7 +62,6 @@ module multiplier import ariane_pkg::*; #(
             assign clmulr_d[i] = clmul_d[(riscv::XLEN-1)-i];
         end
     end
-    //VCS coverage on
 
     // Pipeline register
     logic [TRANS_ID_BITS-1:0]    trans_id_q;
@@ -120,7 +118,6 @@ module multiplier import ariane_pkg::*; #(
             default:             result_o = mult_result_q[riscv::XLEN-1:0];// including MUL
         endcase
     end
-    //VCS coverage off
     if (ariane_pkg::BITMANIP) begin
         always_ff @(posedge clk_i or negedge rst_ni) begin
             if (~rst_ni) begin
@@ -132,7 +129,6 @@ module multiplier import ariane_pkg::*; #(
              end
         end
     end
-    //VCS coverage on
     // -----------------------
     // Output pipeline register
     // -----------------------


### PR DESCRIPTION
Remove VCS coverage pragma for BitManip and let only if(ariane_pkg::BITMANIP) in RTL to identify the code related to the BitManip.