### PR TITLE
Add mconfigptr CSR (fix #1480)

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -271,6 +271,7 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MARCHID:            csr_rdata = ARIANE_MARCHID;
                 riscv::CSR_MIMPID:             csr_rdata = '0; // not implemented
                 riscv::CSR_MHARTID:            csr_rdata = hart_id_i;
+                riscv::CSR_MCONFIGPTR:         csr_rdata = '0; // not implemented
                 riscv::CSR_MCOUNTINHIBIT:      csr_rdata = mcountinhibit_q;
                 // Counters and Timers
                 riscv::CSR_MCYCLE:             csr_rdata = cycle_q[riscv::XLEN-1:0];

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -457,6 +457,7 @@ package riscv;
         CSR_MARCHID        = 12'hF12,
         CSR_MIMPID         = 12'hF13,
         CSR_MHARTID        = 12'hF14,
+        CSR_MCONFIGPTR     = 12'hF15,
         CSR_MCYCLE         = 12'hB00,
         CSR_MCYCLEH        = 12'hB80,
         CSR_MINSTRET       = 12'hB02,


### PR DESCRIPTION
In version 1.12 of Machine ISA module (RISC-V privileged architecture
version 20211203), the mandatory CSR mconfigptr is defined.