### PR TITLE
cva6_icache: Allow one outstanding killed miss

### DIFF
--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -321,7 +321,7 @@ module cva6_icache
               // only write to cache if this address is cacheable
               cache_wren   = ~paddr_is_nc;
             end
-          // bail out if this request is being killed
+            // bail out if this request is being killed
           end else if (dreq_i.kill_s2 || flush_d) begin
             state_d = IDLE;
             // track if there is an outstanding miss,


### PR DESCRIPTION
This PR relates to the following behaviour.

The I$ can receive a speculative request from the instruction fetch unit (e.g. upon a branch). If this instruction is not in the cache we will incur a miss and a refill request will be issued to the memory. If, when the branch is resolved, the speculated instruction is killed, the refill request will be killed (i.e. the speculated instruction will never be loaded into the cache). Despite being killed, the I$ still waits on the request from memory to be back, stalling all other operation. This implies that even with a hot cache, we can still experience cache miss stalls on speculated instructions which will never enter the cache, and hence the cache will never truely be "hot" (in this sense, speculated instructions should be considered part of the working set).

This PR attempts to improve performance in this condition by handling up to one killed refill request asynchronously. A speculated miss will only induce a stall if another miss occurs before the killed refill returns from memory.