### PR TITLE
fix dv for recent python versions

### DIFF
--- a/verif/regress/install-riscv-dv.sh
+++ b/verif/regress/install-riscv-dv.sh
@@ -43,3 +43,4 @@ if ! [ -d verif/sim/dv ]; then
   cd verif/sim/dv; pip3 install -r requirements.txt; cd -
 fi
 
+touch verif/sim/dv/__init__.py


### PR DESCRIPTION
With newest Python versions (Python 3.9), cva6.py cannot find `dv.scripts` module.

This PR adds an empty `__init__.py` in dv so that the modules inside it can be found by Python 3.9.