### PR TITLE
Code_coverage: Add conditions for the MMU

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1084,7 +1084,7 @@ module csr_regfile import ariane_pkg::*; #(
         // ------------------------------
         // Set the address translation at which the load and stores should occur
         // we can use the previous values since changing the address translation will always involve a pipeline flush
-        if (mprv && riscv::vm_mode_t'(satp_q.mode) == riscv::MODE_SV && (mstatus_q.mpp != riscv::PRIV_LVL_M))
+        if (ariane_pkg::MMU_PRESENT && mprv && riscv::vm_mode_t'(satp_q.mode) == riscv::MODE_SV && (mstatus_q.mpp != riscv::PRIV_LVL_M))
             en_ld_st_translation_d = 1'b1;
         else // otherwise we go with the regular settings
             en_ld_st_translation_d = en_translation_o;

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -447,7 +447,7 @@ module load_store_unit import ariane_pkg::*; #(
             end
         end
 
-         if (ariane_pkg::MMU_PRESENT && en_ld_st_translation_i && lsu_ctrl.overflow) begin
+        if (ariane_pkg::MMU_PRESENT && en_ld_st_translation_i && lsu_ctrl.overflow) begin
 
             if (lsu_ctrl.fu == LOAD) begin
                 misaligned_exception = {

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -447,7 +447,7 @@ module load_store_unit import ariane_pkg::*; #(
             end
         end
 
-        if (en_ld_st_translation_i && lsu_ctrl.overflow) begin
+         if (ariane_pkg::MMU_PRESENT && en_ld_st_translation_i && lsu_ctrl.overflow) begin
 
             if (lsu_ctrl.fu == LOAD) begin
                 misaligned_exception = {

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -387,7 +387,7 @@ module load_unit import ariane_pkg::*; #(
             // the output is also valid if we got an exception. An exception arrives one cycle after
             // dtlb_hit_i is asserted, i.e. when we are in SEND_TAG. Otherwise, the exception
             // corresponds to the next request that is already being translated (see below).
-            if(ex_i.valid && (state_q == SEND_TAG)) begin
+            if (ex_i.valid && (state_q == SEND_TAG)) begin
                 valid_o    = 1'b1;
                 ex_o.valid = 1'b1;
             end

--- a/core/store_unit.sv
+++ b/core/store_unit.sv
@@ -124,7 +124,7 @@ module store_unit import ariane_pkg::*; #(
                     state_d = VALID_STORE;
                     pop_st_o = 1'b1;
 
-                    if(ariane_pkg::MMU_PRESENT && !dtlb_hit_i) begin
+                    if (ariane_pkg::MMU_PRESENT && !dtlb_hit_i) begin
                         state_d = WAIT_TRANSLATION;
                         pop_st_o = 1'b0;
                     end

--- a/core/store_unit.sv
+++ b/core/store_unit.sv
@@ -97,7 +97,7 @@ module store_unit import ariane_pkg::*; #(
                     pop_st_o = 1'b1;
                     // check if translation was valid and we have space in the store buffer
                     // otherwise simply stall
-                    if (!dtlb_hit_i) begin
+                    if (ariane_pkg::MMU_PRESENT && !dtlb_hit_i) begin
                         state_d = WAIT_TRANSLATION;
                         pop_st_o = 1'b0;
                     end
@@ -124,7 +124,7 @@ module store_unit import ariane_pkg::*; #(
                     state_d = VALID_STORE;
                     pop_st_o = 1'b1;
 
-                    if (!dtlb_hit_i) begin
+                    if(ariane_pkg::MMU_PRESENT && !dtlb_hit_i) begin
                         state_d = WAIT_TRANSLATION;
                         pop_st_o = 1'b0;
                     end
@@ -153,10 +153,12 @@ module store_unit import ariane_pkg::*; #(
             // but we know that the store queue is not full as we could only have landed here if
             // it wasn't full
             WAIT_TRANSLATION: begin
-                translation_req_o = 1'b1;
+                if(ariane_pkg::MMU_PRESENT) begin
+                    translation_req_o = 1'b1;
 
-                if (dtlb_hit_i) begin
-                    state_d = IDLE;
+                    if (dtlb_hit_i) begin
+                        state_d = IDLE;
+                    end
                 end
             end
         endcase


### PR DESCRIPTION
Condition RTL with MMU parameters to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to reach 100% code coverage.