### PR TITLE
ci: update expected area

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,6 +1,2 @@
-cv64a6_imafdc_sv39:
-  gates: 545030
-cv32a60x:
-  gates: 160719
 cv32a6_embedded:
-  gates: 129369
+  gates: 128552


### PR DESCRIPTION
The area has changed recently.

This PR also removes other expected areas as they are not asserted anymore.