### PR TITLE
ci: reorganize jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ build_tools:
     - mkdir -p artifacts/tools/
     - mv tools/spike artifacts/tools/
 
-.smoke_test:
+.fe_smoke_test:
   stage: light tests
   rules: *on_dev
   before_script:
@@ -116,7 +116,7 @@ build_tools:
 
 smoke:
   extends:
-    - .smoke_test
+    - .fe_smoke_test
   variables:
     DASHBOARD_JOB_TITLE: "Smoke test $DV_SIMULATORS"
     DASHBOARD_JOB_DESCRIPTION: "Short tests to challenge most architectures with most testbenchs configurations"
@@ -136,7 +136,7 @@ smoke:
 
 gen_smoke:
   extends:
-    - .smoke_test
+    - .fe_smoke_test
   variables:
     DASHBOARD_JOB_TITLE: "Smoke Generated test $DV_SIMULATORS"
     DASHBOARD_JOB_DESCRIPTION: "Short generated tests to challenge the CVA6-DV on STEP1 configuration"
@@ -148,7 +148,7 @@ gen_smoke:
 
 coremark:
   extends:
-    - .smoke_test
+    - .fe_smoke_test
   variables:
     DASHBOARD_JOB_TITLE: "CoreMark"
     DASHBOARD_JOB_DESCRIPTION: "Performance indicator"
@@ -158,72 +158,9 @@ coremark:
     - bash verif/regress/coremark.sh --no-print
     - python3 .gitlab-ci/scripts/report_benchmark.py --coremark verif/sim/out_*/veri-testharness_sim/core_main.log
 
-dhrystone:
-  extends:
-    - .smoke_test
-  variables:
-    DASHBOARD_JOB_TITLE: "Dhrystone"
-    DASHBOARD_JOB_DESCRIPTION: "Performance indicator"
-    DASHBOARD_SORT_INDEX: 5
-    DASHBOARD_JOB_CATEGORY: "Performance"
-  script:
-    - bash verif/regress/dhrystone.sh
-    - python3 .gitlab-ci/scripts/report_benchmark.py --dhrystone verif/sim/out_*/veri-testharness_sim/dhrystone_main.log
-
-.regress_test:
-  stage: heavy tests
-  before_script:
-    - !reference [.smoke_test, before_script]
-  rules: &on_regress
-    - if: $CI_KIND == "regress"
-    - if: $CI_KIND == "verif"
-    - when: manual
-      allow_failure: true
-
-riscv_arch_test:
-  extends:
-    - .regress_test
-  variables:
-    DASHBOARD_JOB_TITLE: "arch_test $DV_TARGET"
-    DASHBOARD_JOB_DESCRIPTION: "Compliance regression suite"
-    DASHBOARD_SORT_INDEX: 0
-    DASHBOARD_JOB_CATEGORY: "Test suites"
-    DV_SIMULATORS: "veri-testharness,spike"
-  parallel:
-    matrix:
-      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
-  script: source verif/regress/dv-riscv-arch-test.sh
-  after_script: *simu_after_script
-
-csr_test:
-  extends:
-    - .regress_test
-  variables:
-    DASHBOARD_JOB_TITLE: "csr_test $DV_TARGET"
-    DASHBOARD_JOB_DESCRIPTION: "CSR regression suite"
-    DASHBOARD_SORT_INDEX: 0
-    DASHBOARD_JOB_CATEGORY: "Test suites"
-    DV_SIMULATORS: "veri-testharness,spike"
-    DV_TARGET: cv32a60x
-  script: source verif/regress/dv-riscv-csr-access-test.sh
-  after_script: *simu_after_script
-
-mmu_sv32_tests:
-  extends:
-    - .regress_test
-  variables:
-    DASHBOARD_JOB_TITLE: "mmu_sv32_tests $DV_TARGET"
-    DASHBOARD_JOB_DESCRIPTION: "MMU SV32 regression suite"
-    DASHBOARD_SORT_INDEX: 0
-    DASHBOARD_JOB_CATEGORY: "Test suites"
-    DV_SIMULATORS: "veri-testharness,spike"
-    DV_TARGET: cv32a60x
-  script: source verif/regress/dv-riscv-mmu-sv32-test.sh
-  after_script: *simu_after_script
-
 hwconfig:
   extends:
-    - .regress_test
+    - .fe_smoke_test
   variables:
     DASHBOARD_JOB_TITLE: "HW config $DV_SIMULATORS $DV_HWCONFIG_OPTS"
     DASHBOARD_JOB_DESCRIPTION: "Short tests to challenge target configurations"
@@ -235,62 +172,23 @@ hwconfig:
     - source verif/regress/hwconfig_tests.sh
     - python3 .gitlab-ci/scripts/report_pass.py
 
-compliance:
-  extends:
-    - .regress_test
-  variables:
-    DASHBOARD_JOB_TITLE: "Compliance $DV_TARGET"
-    DASHBOARD_JOB_DESCRIPTION: "Compliance regression suite"
-    DASHBOARD_SORT_INDEX: 2
-    DASHBOARD_JOB_CATEGORY: "Test suites"
-    DV_SIMULATORS: "veri-testharness,spike"
-  parallel:
-    matrix:
-      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
-  script: source verif/regress/dv-riscv-compliance.sh
-  after_script: *simu_after_script
-
-tests-v:
-  extends:
-    - .regress_test
-  variables:
-    DASHBOARD_JOB_TITLE: "Riscv-test $DV_TARGET (virtual)"
-    DASHBOARD_JOB_DESCRIPTION: "Riscv-test regression suite (virtual)"
-    DASHBOARD_SORT_INDEX: 3
-    DASHBOARD_JOB_CATEGORY: "Test suites"
-    DV_SIMULATORS: "veri-testharness,spike"
-    DV_TARGET: cv64a6_imafdc_sv39
-    DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
-  script: source verif/regress/dv-riscv-tests.sh
-  after_script: *simu_after_script
-
-tests-p:
-  extends:
-    - .regress_test
-  variables:
-    DASHBOARD_JOB_TITLE: "Riscv-test $DV_TARGET (physical)"
-    DASHBOARD_JOB_DESCRIPTION: "Riscv-test regression suite (physical)"
-    DASHBOARD_SORT_INDEX: 4
-    DASHBOARD_JOB_CATEGORY: "Test suites"
-    DV_SIMULATORS: "veri-testharness,spike"
-    DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-p.yaml"
-  parallel:
-    matrix:
-      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
-  script: source verif/regress/dv-riscv-tests.sh
-  after_script: *simu_after_script
-
-synthesis:
+.synthesis_test:
+  stage: heavy tests
   timeout: 2 hours
+  before_script:
+    - !reference [.fe_smoke_test, before_script]
+  rules: *on_dev
+
+asic-synthesis:
   extends:
-    - .regress_test
+    - .synthesis_test
   variables:
-    INPUT_DELAY: "0.46"
-    OUTPUT_DELAY: "0.11"
     DASHBOARD_JOB_TITLE: "ASIC Synthesis $TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Synthesis indicator with specific Techno"
     DASHBOARD_SORT_INDEX: 5
     DASHBOARD_JOB_CATEGORY: "Synthesis"
+    INPUT_DELAY: "0.46"
+    OUTPUT_DELAY: "0.11"
     TARGET: cv32a6_embedded
     PERIOD: "0.85"
   script:
@@ -308,46 +206,9 @@ synthesis:
     - mv pd/synth/cva6_${TARGET}_synth_modified.v artifacts/cva6_${TARGET}_synth_modified.v
     - python3 .gitlab-ci/scripts/report_synth.py pd/synth/cva6_${TARGET}/reports/$PERIOD/cva6_$(echo $TECH_NAME)_synth_area.rpt pd/synth/synthesis_batch.log
 
-.backend_test:
-  stage: backend tests
-  before_script:
-    - mkdir -p artifacts/{reports,logs}
-    - python3 .gitlab-ci/scripts/report_fail.py
-
-smoke-gate:
-  extends:
-    - .backend_test
-  needs:
-    - build_tools
-    - synthesis
-  rules: *on_regress
-  variables:
-    DASHBOARD_JOB_TITLE: "Smoke Gate $TARGET"
-    DASHBOARD_JOB_DESCRIPTION: "Simple test to check netlist from ASIC synthesis"
-    DASHBOARD_SORT_INDEX: 6
-    DASHBOARD_JOB_CATEGORY: "Post Synthesis"
-    TARGET: cv32a6_embedded
-  script:
-    - mkdir -p tools
-    - mv artifacts/tools/spike tools
-    - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
-    - echo $LIB_VERILOG
-    - echo $FOUNDRY_PATH
-    - echo $PERIOD
-    - echo $TECH_NAME
-    - source verif/regress/install-cva6.sh
-    - source verif/regress/install-riscv-dv.sh
-    - source verif/regress/install-riscv-tests.sh
-    - mv artifacts/cva6_${TARGET}_synth_modified.v pd/synth/cva6_${TARGET}_synth_modified.v
-    - cd verif/sim
-    - make vcs_clean_all
-    - python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-lw --iss_yaml cva6.yaml --target $TARGET --iss=spike,vcs-gate $DV_OPTS
-  after_script: *simu_after_script
-
 fpga-build:
-  timeout: 90 minutes
   extends:
-    - .regress_test
+    - .synthesis_test
   variables:
     DASHBOARD_JOB_TITLE: "FPGA Build $TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Test of FPGA build flow"
@@ -362,6 +223,88 @@ fpga-build:
     - mv corev_apu/fpga/work-fpga/ariane_xilinx.bit artifacts/ariane_xilinx_$TARGET.bit
     - python3 .gitlab-ci/scripts/report_fpga.py corev_apu/fpga/reports/ariane.utilization.rpt
 
+.regress_test:
+  stage: heavy tests
+  before_script:
+    - !reference [.fe_smoke_test, before_script]
+  rules: &on_regress
+    - if: $CI_KIND == "regress"
+    - if: $CI_KIND == "verif"
+    - when: manual
+      allow_failure: true
+
+dhrystone:
+  extends:
+    - .regress_test
+  variables:
+    DASHBOARD_JOB_TITLE: "Dhrystone"
+    DASHBOARD_JOB_DESCRIPTION: "Performance indicator"
+    DASHBOARD_SORT_INDEX: 5
+    DASHBOARD_JOB_CATEGORY: "Performance"
+  script:
+    - bash verif/regress/dhrystone.sh
+    - python3 .gitlab-ci/scripts/report_benchmark.py --dhrystone verif/sim/out_*/veri-testharness_sim/dhrystone_main.log
+
+riscv_arch_test:
+  extends:
+    - .regress_test
+  variables:
+    DASHBOARD_JOB_TITLE: "arch_test $DV_TARGET"
+    DASHBOARD_JOB_DESCRIPTION: "Compliance regression suite"
+    DASHBOARD_SORT_INDEX: 0
+    DASHBOARD_JOB_CATEGORY: "Test suites"
+    DV_SIMULATORS: "veri-testharness,spike"
+  parallel:
+    matrix:
+      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
+  script: source verif/regress/dv-riscv-arch-test.sh
+  after_script: *simu_after_script
+
+compliance:
+  extends:
+    - .regress_test
+  variables:
+    DASHBOARD_JOB_TITLE: "Compliance $DV_TARGET"
+    DASHBOARD_JOB_DESCRIPTION: "Compliance regression suite"
+    DASHBOARD_SORT_INDEX: 2
+    DASHBOARD_JOB_CATEGORY: "Test suites"
+    DV_SIMULATORS: "veri-testharness,spike"
+  parallel:
+    matrix:
+      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
+  script: source verif/regress/dv-riscv-compliance.sh
+  after_script: *simu_after_script
+
+riscv-tests-v:
+  extends:
+    - .regress_test
+  variables:
+    DASHBOARD_JOB_TITLE: "Riscv-test $DV_TARGET (virtual)"
+    DASHBOARD_JOB_DESCRIPTION: "Riscv-test regression suite (virtual)"
+    DASHBOARD_SORT_INDEX: 3
+    DASHBOARD_JOB_CATEGORY: "Test suites"
+    DV_SIMULATORS: "veri-testharness,spike"
+    DV_TARGET: cv64a6_imafdc_sv39
+    DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
+  script: source verif/regress/dv-riscv-tests.sh
+  after_script: *simu_after_script
+
+riscv-tests-p:
+  extends:
+    - .regress_test
+  variables:
+    DASHBOARD_JOB_TITLE: "Riscv-test $DV_TARGET (physical)"
+    DASHBOARD_JOB_DESCRIPTION: "Riscv-test regression suite (physical)"
+    DASHBOARD_SORT_INDEX: 4
+    DASHBOARD_JOB_CATEGORY: "Test suites"
+    DV_SIMULATORS: "veri-testharness,spike"
+    DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-p.yaml"
+  parallel:
+    matrix:
+      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
+  script: source verif/regress/dv-riscv-tests.sh
+  after_script: *simu_after_script
+
 .verif_test:
   extends:
     - .regress_test
@@ -370,6 +313,32 @@ fpga-build:
     - when: manual
       allow_failure: true
   timeout: 4h
+
+csr_test:
+  extends:
+    - .verif_test
+  variables:
+    DASHBOARD_JOB_TITLE: "csr_test $DV_TARGET"
+    DASHBOARD_JOB_DESCRIPTION: "CSR regression suite"
+    DASHBOARD_SORT_INDEX: 0
+    DASHBOARD_JOB_CATEGORY: "Test suites"
+    DV_SIMULATORS: "veri-testharness,spike"
+    DV_TARGET: cv32a60x
+  script: source verif/regress/dv-riscv-csr-access-test.sh
+  after_script: *simu_after_script
+
+mmu_sv32_tests:
+  extends:
+    - .verif_test
+  variables:
+    DASHBOARD_JOB_TITLE: "mmu_sv32_tests $DV_TARGET"
+    DASHBOARD_JOB_DESCRIPTION: "MMU SV32 regression suite"
+    DASHBOARD_SORT_INDEX: 0
+    DASHBOARD_JOB_CATEGORY: "Test suites"
+    DV_SIMULATORS: "veri-testharness,spike"
+    DV_TARGET: cv32a60x
+  script: source verif/regress/dv-riscv-mmu-sv32-test.sh
+  after_script: *simu_after_script
 
 generated_tests:
   extends:
@@ -456,6 +425,42 @@ directed_xif-tests:
     - mv verif/sim/vcs_results/default/vcs.d/simv.vdb artifacts/coverage
     - python3 .gitlab-ci/scripts/report_pass.py
 
+.backend_test:
+  stage: backend tests
+  before_script:
+    - mkdir -p artifacts/{reports,logs}
+    - python3 .gitlab-ci/scripts/report_fail.py
+
+smoke-gate:
+  extends:
+    - .backend_test
+  needs:
+    - build_tools
+    - asic-synthesis
+  rules: *on_dev
+  variables:
+    DASHBOARD_JOB_TITLE: "Smoke Gate $TARGET"
+    DASHBOARD_JOB_DESCRIPTION: "Simple test to check netlist from ASIC synthesis"
+    DASHBOARD_SORT_INDEX: 6
+    DASHBOARD_JOB_CATEGORY: "Post Synthesis"
+    TARGET: cv32a6_embedded
+  script:
+    - mkdir -p tools
+    - mv artifacts/tools/spike tools
+    - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
+    - echo $LIB_VERILOG
+    - echo $FOUNDRY_PATH
+    - echo $PERIOD
+    - echo $TECH_NAME
+    - source verif/regress/install-cva6.sh
+    - source verif/regress/install-riscv-dv.sh
+    - source verif/regress/install-riscv-tests.sh
+    - mv artifacts/cva6_${TARGET}_synth_modified.v pd/synth/cva6_${TARGET}_synth_modified.v
+    - cd verif/sim
+    - make vcs_clean_all
+    - python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-lw --iss_yaml cva6.yaml --target $TARGET --iss=spike,vcs-gate $DV_OPTS
+  after_script: *simu_after_script
+
 fpga-boot:
   extends:
     - .backend_test
@@ -463,7 +468,7 @@ fpga-boot:
   needs:
     - build_tools
     - fpga-build
-  rules: *on_regress
+  rules: *on_dev
   variables:
     DASHBOARD_JOB_TITLE: "FPGA Linux32 Boot "
     DASHBOARD_JOB_DESCRIPTION: "Test of Linux 32 bits boot on FPGA Genesys2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,6 @@ smoke-gate:
   needs:
     - build_tools
     - asic-synthesis
-  rules: *on_dev
   variables:
     DASHBOARD_JOB_TITLE: "Smoke Gate $DV_TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Simple test to check netlist from ASIC synthesis"
@@ -460,7 +459,6 @@ fpga-boot:
   needs:
     - build_tools
     - fpga-build
-  rules: *on_dev
   variables:
     DASHBOARD_JOB_TITLE: "FPGA Linux32 Boot "
     DASHBOARD_JOB_DESCRIPTION: "Test of Linux 32 bits boot on FPGA Genesys2"
@@ -481,7 +479,6 @@ fpga-boot:
 code_coverage-report:
   extends:
     - .backend_test
-  rules: *on_verif
   needs:
     - generated_tests
     - directed_isacov-tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -280,25 +280,20 @@ tests-p:
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script
 
-synthesis_others:
+synthesis:
   timeout: 2 hours
   extends:
-    - .verif_test
-  parallel:
-    matrix:
-      - TARGET: cv64a6_imafdc_sv39
-        PERIOD: "1.1"
-      - TARGET: cv32a60x
-        PERIOD: "0.95"
-  variables: &synth_vars
+    - .regress_test
+  variables:
     INPUT_DELAY: "0.46"
     OUTPUT_DELAY: "0.11"
     DASHBOARD_JOB_TITLE: "ASIC Synthesis $TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Synthesis indicator with specific Techno"
     DASHBOARD_SORT_INDEX: 5
     DASHBOARD_JOB_CATEGORY: "Synthesis"
-  script: &synth_script
-    #ack trick to manage float gitlab-ci variables that seems to support only string or integer
+    TARGET: cv32a6_embedded
+    PERIOD: "0.85"
+  script:
     - echo $SYNTH_PERIOD
     - echo $INPUT_DELAY
     - echo $OUTPUT_DELAY
@@ -312,16 +307,6 @@ synthesis_others:
     - make -C pd/synth cva6_synth
     - mv pd/synth/cva6_${TARGET}_synth_modified.v artifacts/cva6_${TARGET}_synth_modified.v
     - python3 .gitlab-ci/scripts/report_synth.py pd/synth/cva6_${TARGET}/reports/$PERIOD/cva6_$(echo $TECH_NAME)_synth_area.rpt pd/synth/synthesis_batch.log
-
-synthesis:
-  timeout: 2 hours
-  extends:
-    - .regress_test
-  variables:
-    <<: *synth_vars
-    TARGET: cv32a6_embedded
-    PERIOD: "0.85"
-  script: *synth_script
 
 .backend_test:
   stage: backend tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,10 @@ build_tools:
     - python3 .gitlab-ci/scripts/report_fail.py
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
 
+.simu_after_script: &simu_after_script
+  - for i in verif/sim/*/v*_sim/*.log.iss ; do head -10000 $i > artifacts/logs/$(basename $i).head ; done
+  - python3 .gitlab-ci/scripts/report_simu.py verif/sim/logfile.log
+
 smoke:
   extends:
     - .fe_smoke_test
@@ -130,9 +134,7 @@ smoke:
         - "vcs-uvm,spike"
   script:
     - source verif/regress/smoke-tests.sh
-  after_script: &simu_after_script
-    - for i in verif/sim/*/v*_sim/*.log.iss ; do head -10000 $i > artifacts/logs/$(basename $i).head ; done
-    - python3 .gitlab-ci/scripts/report_simu.py verif/sim/logfile.log
+    - !reference [.simu_after_script]
 
 gen_smoke:
   extends:
@@ -143,8 +145,9 @@ gen_smoke:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Basic"
     DV_SIMULATORS: "vcs-uvm,spike"
-  script: source verif/regress/smoke-gen_tests.sh
-  after_script: *simu_after_script
+  script:
+    - source verif/regress/smoke-gen_tests.sh
+    - !reference [.simu_after_script]
 
 coremark:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,7 @@ workflow:
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
   DASHBOARD: cva6
+  DV_TARGET: cv32a6_embedded
 
 default:
   tags: [$TAGS_RUNNER]
@@ -186,13 +187,12 @@ asic-synthesis:
   extends:
     - .synthesis_test
   variables:
-    DASHBOARD_JOB_TITLE: "ASIC Synthesis $TARGET"
+    DASHBOARD_JOB_TITLE: "ASIC Synthesis $DV_TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Synthesis indicator with specific Techno"
     DASHBOARD_SORT_INDEX: 5
     DASHBOARD_JOB_CATEGORY: "Synthesis"
     INPUT_DELAY: "0.46"
     OUTPUT_DELAY: "0.11"
-    TARGET: cv32a6_embedded
     PERIOD: "0.85"
   script:
     - echo $SYNTH_PERIOD
@@ -202,12 +202,12 @@ asic-synthesis:
     - echo $FOUNDRY_PATH
     - echo $PERIOD
     - echo $TECH_NAME
-    - echo $TARGET
+    - echo $DV_TARGET
     - source verif/regress/install-cva6.sh
     - echo $SYN_DCSHELL_BASHRC; source $SYN_DCSHELL_BASHRC
-    - make -C pd/synth cva6_synth
-    - mv pd/synth/cva6_${TARGET}_synth_modified.v artifacts/cva6_${TARGET}_synth_modified.v
-    - python3 .gitlab-ci/scripts/report_synth.py pd/synth/cva6_${TARGET}/reports/$PERIOD/cva6_$(echo $TECH_NAME)_synth_area.rpt pd/synth/synthesis_batch.log
+    - make -C pd/synth cva6_synth TARGET="$DV_TARGET"
+    - mv pd/synth/cva6_${DV_TARGET}_synth_modified.v artifacts/cva6_${DV_TARGET}_synth_modified.v
+    - python3 .gitlab-ci/scripts/report_synth.py pd/synth/cva6_${DV_TARGET}/reports/$PERIOD/cva6_$(echo $TECH_NAME)_synth_area.rpt pd/synth/synthesis_batch.log
 
 fpga-build:
   extends:
@@ -257,9 +257,6 @@ riscv_arch_test:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
-  parallel:
-    matrix:
-      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
   script: source verif/regress/dv-riscv-arch-test.sh
   after_script: *simu_after_script
 
@@ -272,9 +269,6 @@ compliance:
     DASHBOARD_SORT_INDEX: 2
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
-  parallel:
-    matrix:
-      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
   script: source verif/regress/dv-riscv-compliance.sh
   after_script: *simu_after_script
 
@@ -302,9 +296,6 @@ riscv-tests-p:
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-p.yaml"
-  parallel:
-    matrix:
-      - DV_TARGET: [cv64a6_imafdc_sv39, cv32a60x]
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script
 
@@ -326,7 +317,6 @@ csr_test:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
-    DV_TARGET: cv32a60x
   script: source verif/regress/dv-riscv-csr-access-test.sh
   after_script: *simu_after_script
 
@@ -442,11 +432,10 @@ smoke-gate:
     - asic-synthesis
   rules: *on_dev
   variables:
-    DASHBOARD_JOB_TITLE: "Smoke Gate $TARGET"
+    DASHBOARD_JOB_TITLE: "Smoke Gate $DV_TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Simple test to check netlist from ASIC synthesis"
     DASHBOARD_SORT_INDEX: 6
     DASHBOARD_JOB_CATEGORY: "Post Synthesis"
-    TARGET: cv32a6_embedded
   script:
     - mkdir -p tools
     - mv artifacts/tools/spike tools
@@ -458,10 +447,10 @@ smoke-gate:
     - source verif/regress/install-cva6.sh
     - source verif/regress/install-riscv-dv.sh
     - source verif/regress/install-riscv-tests.sh
-    - mv artifacts/cva6_${TARGET}_synth_modified.v pd/synth/cva6_${TARGET}_synth_modified.v
+    - mv artifacts/cva6_${DV_TARGET}_synth_modified.v pd/synth/cva6_${DV_TARGET}_synth_modified.v
     - cd verif/sim
     - make vcs_clean_all
-    - python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-lw --iss_yaml cva6.yaml --target $TARGET --iss=spike,vcs-gate $DV_OPTS
+    - python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-lw --iss_yaml cva6.yaml --target $DV_TARGET --iss=spike,vcs-gate $DV_OPTS
   after_script: *simu_after_script
 
 fpga-boot:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,8 +56,8 @@ default:
 
 stages:
   - setup
-  - smoke tests
-  - verif tests
+  - light tests
+  - heavy tests
   - backend tests
   - find failures
   - report
@@ -104,7 +104,7 @@ build_tools:
     - mv tools/spike artifacts/tools/
 
 .smoke_test:
-  stage: smoke tests
+  stage: light tests
   rules: *on_dev
   before_script:
     - mkdir -p tools
@@ -171,7 +171,7 @@ dhrystone:
     - python3 .gitlab-ci/scripts/report_benchmark.py --dhrystone verif/sim/out_*/veri-testharness_sim/dhrystone_main.log
 
 .regress_test:
-  stage: verif tests
+  stage: heavy tests
   before_script:
     - !reference [.smoke_test, before_script]
   rules: &on_regress

--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -63,3 +63,6 @@ if diff != 0:
 report = rb.Report(f'{cycles//1000} kCycles')
 report.add_metric(score_metric)
 report.dump()
+
+if report.failed:
+    sys.exit(1)

--- a/.gitlab-ci/scripts/report_simu.py
+++ b/.gitlab-ci/scripts/report_simu.py
@@ -38,3 +38,6 @@ if job_test_total == 0:
 report = rb.Report(f'{job_test_pass}/{job_test_total}')
 report.add_metric(metric)
 report.dump()
+
+if report.failed:
+    sys.exit(1)

--- a/verif/tests/testlist_riscv-arch-test-cv32a6_embedded.yaml
+++ b/verif/tests/testlist_riscv-arch-test-cv32a6_embedded.yaml
@@ -1,0 +1,472 @@
+# Copyright Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+## C
+- test: rv32im-cadd-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cadd-01.S
+  
+- test: rv32im-caddi-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi-01.S
+  
+- test: rv32im-caddi16sp-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi16sp-01.S
+  
+- test: rv32im-caddi4spn-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi4spn-01.S
+
+- test: rv32im-cand-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cand-01.S
+  
+- test: rv32im-candi-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/candi-01.S
+  
+- test: rv32im-cbeqz-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cbeqz-01.S
+  
+- test: rv32im-cbnez-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cbnez-01.S
+
+- test: rv32im-cebreak-01
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cebreak-01.S
+
+- test: rv32im-cj-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cj-01.S
+  
+- test: rv32im-cjal-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjal-01.S
+ 
+- test: rv32im-cjalr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjalr-01.S
+  
+- test: rv32im-cjr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjr-01.S
+
+- test: rv32im-cli-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cli-01.S
+
+- test: rv32im-clui-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/clui-01.S
+
+- test: rv32im-clw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/clw-01.S
+
+- test: rv32im-clwsp-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/clwsp-01.S
+
+- test: rv32im-cmv-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cmv-01.S
+
+- test: rv32im-cnop-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cnop-01.S
+
+- test: rv32im-cor-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cor-01.S
+
+- test: rv32im-cslli-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cslli-01.S
+
+- test: rv32im-csrai-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csrai-01.S
+
+- test: rv32im-csrli-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csrli-01.S
+
+- test: rv32im-csub-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csub-01.S
+
+- test: rv32im-csw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csw-01.S
+
+- test: rv32im-cswsp-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cswsp-01.S
+
+- test: rv32im-cxor-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cxor-01.S
+  
+  # I  
+- test: rv32im-add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/add-01.S
+
+- test: rv32im-addi-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/addi-01.S
+
+- test: rv32im-and-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/and-01.S
+
+- test: rv32im-andi-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/andi-01.S
+
+- test: rv32im-auipc-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/auipc-01.S
+
+- test: rv32im-beq-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/beq-01.S
+
+- test: rv32im-bge-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bge-01.S
+
+- test: rv32im-bgeu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bgeu-01.S
+
+- test: rv32im-blt-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/blt-01.S
+
+- test: rv32im-bltu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bltu-01.S
+
+- test: rv32im-bne-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bne-01.S
+
+- test: rv32im-fence-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/fence-01.S
+ 
+- test: rv32im-jal-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jal-01.S
+ 
+- test: rv32im-jalr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jalr-01.S
+ 
+- test: rv32im-lb-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lb-align-01.S
+ 
+- test: rv32im-lbu-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lbu-align-01.S
+ 
+- test: rv32im-lh-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lh-align-01.S
+
+- test: rv32im-lhu-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lhu-align-01.S
+
+- test: rv32im-lui-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lui-01.S
+
+- test: rv32im-lw-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lw-align-01.S
+
+- test: rv32im-or-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/or-01.S
+
+- test: rv32im-ori-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/ori-01.S
+ 
+- test: rv32im-sb-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sb-align-01.S
+ 
+- test: rv32im-sh-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sh-align-01.S
+ 
+- test: rv32im-sll-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sll-01.S
+ 
+- test: rv32im-slli-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slli-01.S
+ 
+- test: rv32im-slt-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slt-01.S
+ 
+- test: rv32im-slti-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slti-01.S
+ 
+- test: rv32im-sltiu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltiu-01.S
+ 
+- test: rv32im-sltu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltu-01.S
+ 
+- test: rv32im-sra-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sra-01.S
+ 
+- test: rv32im-srai-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srai-01.S
+ 
+- test: rv32im-srl-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srl-01.S
+ 
+- test: rv32im-srli-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srli-01.S
+ 
+- test: rv32im-sub-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sub-01.S
+ 
+- test: rv32im-sw-align-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sw-align-01.S
+ 
+- test: rv32im-xor-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xor-01.S
+ 
+- test: rv32im-xori-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xori-01.S
+ 
+  # M
+- test: rv32im-div-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/div-01.S
+ 
+- test: rv32im-divu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/divu-01.S
+ 
+- test: rv32im-mul-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mul-01.S
+ 
+- test: rv32im-mulh-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulh-01.S
+
+- test: rv32im-mulhsu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhsu-01.S
+ 
+- test: rv32im-mulhu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhu-01.S
+  
+- test: rv32im-rem-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/rem-01.S
+   
+- test: rv32im-remu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/remu-01.S
+

--- a/verif/tests/testlist_riscv-compliance-cv32a6_embedded.yaml
+++ b/verif/tests/testlist_riscv-compliance-cv32a6_embedded.yaml
@@ -1,0 +1,1131 @@
+# Copyright Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+#- import: <riscv_dv_root>/target/rv64imc/testlist.yaml
+
+- test: rv64im-REMUW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64im/src/REMUW.S
+
+- test: rv64im-MULW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64im/src/MULW.S
+
+- test: rv64i-SRAW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRAW.S
+
+- test: rv64i-ADDW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/ADDW.S
+
+- test: rv64i-ADDIW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/ADDIW.S
+
+- test: rv64i-SLLW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SLLW.S
+
+- test: rv64i-SUBW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SUBW.S
+
+- test: rv64i-SRLW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRLW.S
+
+- test: rv64i-SLLIW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SLLIW.S
+
+- test: rv64i-SRLIW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRLIW.S
+
+- test: rv64i-SRAIW
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRAIW.S
+
+- test: rv32uc-rvc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uc/src/rvc.S
+
+- test: rv32Zifencei-I-FENCE.I-01   # FAILED on spike
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S
+
+- test: rv32im-MULHSU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHSU.S
+
+- test: rv32im-DIVU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIVU.S
+
+- test: rv32im-REMU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REMU.S
+
+- test: rv32im-MUL
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MUL.S
+
+- test: rv32im-DIV
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIV.S
+
+- test: rv32im-MULH
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULH.S
+
+- test: rv32im-MULHU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHU.S
+
+- test: rv32im-REM
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REM.S
+
+- test: rv32ui-jal
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/jal.S
+
+- test: rv32ui-bge
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bge.S
+
+- test: rv32ui-blt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/blt.S
+
+- test: rv32ui-bgeu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bgeu.S
+
+- test: rv32ui-sw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sw.S
+  
+- test: rv32ui-lbu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lbu.S
+  
+- test: rv32ui-sb
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sb.S
+  
+- test: rv32ui-sw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/slti.S
+  
+- test: rv32ui-sra
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sra.S
+  
+- test: rv32ui-srl
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/srl.S
+  
+- test: rv32ui-sh
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sh.S
+  
+- test: rv32ui-lw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lw.S
+  
+- test: rv32ui-andi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/andi.S
+  
+- test: rv32ui-srli
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/srli.S
+  
+- test: rv32ui-slli
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/slli.S
+  
+- test: rv32ui-beq
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/beq.S
+  
+- test: rv32ui-sll
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sll.S
+  
+- test: rv32ui-addi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/addi.S
+  
+- test: rv32ui-lh
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lh.S
+  
+- test: rv32ui-and
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/and.S
+  
+- test: rv32ui-xori
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/xori.S
+  
+- test: rv32ui-sub
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sub.S
+  
+- test: rv32ui-slt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/slt.S
+  
+- test: rv32ui-lb
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lb.S
+  
+- test: rv32ui-or
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/or.S
+  
+- test: rv32ui-lui
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lui.S
+  
+- test: rv32ui-ori
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/ori.S
+  
+- test: rv32ui-bltu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bltu.S
+  
+- test: rv32ui-fence_i
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/fence_i.S
+  
+- test: rv32ui-auipc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/auipc.S
+  
+- test: rv32ui-srai
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/srai.S
+  
+- test: rv32ui-jalr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/jalr.S
+  
+- test: rv32ui-xor
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/xor.S
+  
+- test: rv32ui-simple
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/simple.S
+  
+- test: rv32ui-lhu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lhu.S
+  
+- test: rv32ui-bne
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bne.S
+  
+- test: rv32ui-add
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/add.S
+  
+- test: rv32ui-sltiu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sltiu.S
+  
+- test: rv32ui-sltu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sltu.S
+  
+- test: rv32mi-sbreak
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/sbreak.S
+  
+- test: rv32mi-breakpoint
+  iterations: 0  # csrr    a0, tdata1 => 0x20000000 (spike), 0x00000000 (cva6)
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/breakpoint.S
+  
+- test: rv32mi-scall
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/scall.S
+  
+- test: rv32mi-ma_addr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/ma_addr.S
+  
+- test: rv32mi-mcsr
+  iterations: 0 # expected as different marchid
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/mcsr.S
+  
+- test: rv32mi-ma_fetch
+  iterations: 0 # expected as different misa
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/ma_fetch.S
+  
+- test: rv32mi-shamt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/shamt.S
+  
+- test: rv32mi-illegal
+  iterations: 0 # cva6 does not record illegal instructions in log file
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/illegal.S
+  
+- test: rv32mi-csr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/csr.S
+  
+- test: rv32i-I-AND-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-AND-01.S
+  
+- test: rv32i-I-BNE-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BNE-01.S
+  
+- test: rv32i-I-IO
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-IO.S
+  
+- test: rv32i-I-BLT-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BLT-01.S
+  
+- test: rv32i-I-SB-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SB-01.S
+  
+- test: rv32i-I-MISALIGN_LDST-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-MISALIGN_LDST-01.S
+  
+- test: rv32i-I-ECALL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ECALL-01.S
+  
+- test: rv32i-I-LHU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LHU-01.S
+  
+- test: rv32i-I-SRLI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRLI-01.S
+  
+- test: rv32i-I-BLTU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BLTU-01.S
+  
+- test: rv32i-I-LH-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LH-01.S
+  
+- test: rv32i-I-AUIPC-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-AUIPC-01.S
+  
+- test: rv32i-I-ORI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ORI-01.S
+  
+- test: rv32i-I-SLLI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLLI-01.S
+  
+- test: rv32i-I-RF_width-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-RF_width-01.S
+  
+- test: rv32i-I-XOR-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-XOR-01.S
+  
+- test: rv32i-I-DELAY_SLOTS-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-DELAY_SLOTS-01.S
+  
+- test: rv32i-I-EBREAK-01    # infinite loop with spike
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-EBREAK-01.S
+
+- test: rv32i-I-SRAI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRAI-01.S
+  
+- test: rv32i-I-SLTU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLTU-01.S
+  
+- test: rv32i-I-OR-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-OR-01.S
+  
+- test: rv32i-I-MISALIGN_JMP-01   # infinite loop with spike
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-MISALIGN_JMP-01.S
+
+- test: rv32i-I-JALR-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-JALR-01.S
+  
+- test: rv32i-I-XORI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-XORI-01.S
+  
+- test: rv32i-I-ADDI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ADDI-01.S
+  
+- test: rv32i-I-BGE-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BGE-01.S
+  
+- test: rv32i-I-ANDI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ANDI-01.S
+  
+- test: rv32i-I-SH-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SH-01.S
+  
+- test: rv32i-I-SLT-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLT-01.S
+  
+- test: rv32i-I-SLTIU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLTIU-01.S
+  
+- test: rv32i-I-SLL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLL-01.S
+  
+- test: rv32i-I-SRL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRL-01.S
+  
+- test: rv32i-I-LUI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LUI-01.S
+  
+- test: rv32i-I-SUB-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SUB-01.S
+  
+- test: rv32i-I-LB-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LB-01.S
+  
+- test: rv32i-I-LW-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LW-01.S
+  
+- test: rv32i-I-SW-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SW-01.S
+  
+- test: rv32i-I-SLTI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLTI-01.S
+  
+- test: rv32i-I-SRA-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRA-01.S
+  
+- test: rv32i-I-RF_size-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-RF_size-01.S
+  
+- test: rv32i-I-BEQ-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BEQ-01.S
+  
+- test: rv32i-I-BGEU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BGEU-01.S
+  
+- test: rv32i-I-JAL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-JAL-01.S
+  
+- test: rv32i-I-LBU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LBU-01.S
+  
+- test: rv32i-I-ENDIANESS-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ENDIANESS-01.S
+  
+- test: rv32i-I-RF_x0-01     # assembly error
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-RF_x0-01.S
+
+- test: rv32i-I-NOP-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-NOP-01.S
+  
+- test: rv32i-I-ADD-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ADD-01.S
+  
+- test: rv32si-sbreak
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/sbreak.S
+  
+- test: rv32si-scall
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/scall.S
+  
+- test: rv32si-ma_fetch
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/ma_fetch.S
+  
+- test: rv32si-wfi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/wfi.S
+  
+- test: rv32si-dirty
+  iterations: 0 # exception on spike
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/dirty.S
+  
+- test: rv32si-csr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/csr.S
+  
+- test: rv32imc-C-LW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LW.S
+  
+- test: rv32imc-C-LWSP
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LWSP.S
+  
+- test: rv32imc-C-ADD
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADD.S
+  
+- test: rv32imc-C-JAL  # assembly error
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-JAL.S
+
+- test: rv32imc-C-SRAI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SRAI.S
+  
+- test: rv32imc-C-JALR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-JALR.S
+  
+- test: rv32imc-C-XOR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-XOR.S
+  
+- test: rv32imc-C-SUB
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SUB.S
+  
+- test: rv32imc-C-ADDI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADDI.S
+  
+- test: rv32imc-C-BEQZ
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-BEQZ.S
+  
+- test: rv32imc-C-ADDI16SP
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADDI16SP.S
+  
+- test: rv32imc-C-LI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LI.S
+  
+- test: rv32imc-C-SW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SW.S
+  
+- test: rv32imc-C-OR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-OR.S
+  
+- test: rv32imc-C-ADDI4SPN
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADDI4SPN.S
+  
+- test: rv32imc-C-AND
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-AND.S
+  
+- test: rv32imc-C-SRLI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SRLI.S
+  
+- test: rv32imc-C-SWSP
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SWSP.S
+  
+- test: rv32imc-C-SLLI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SLLI.S
+  
+- test: rv32imc-C-JR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-JR.S
+  
+- test: rv32imc-C-BNEZ
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-BNEZ.S
+  
+- test: rv32imc-C-MV
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-MV.S
+  
+- test: rv32imc-C-LUI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LUI.S
+  
+- test: rv32imc-C-J
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-J.S
+  
+- test: rv32imc-C-ANDI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ANDI.S
+  
+- test: rv32Zicsr-I-CSRRC-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRC-01.S
+  
+- test: rv32Zicsr-I-CSRRS-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRS-01.S
+  
+- test: rv32Zicsr-I-CSRRSI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRSI-01.S
+  
+- test: rv32Zicsr-I-CSRRW-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRW-01.S
+  
+- test: rv32Zicsr-I-CSRRCI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRCI-01.S
+  
+- test: rv32Zicsr-I-CSRRWI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRWI-01.S
+  
+- test: rv32ua-amoxor_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoxor_w.S
+  
+- test: rv32ua-amoadd_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoadd_w.S
+  
+- test: rv32ua-amoor_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoor_w.S
+  
+- test: rv32ua-amomin_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amomin_w.S
+  
+- test: rv32ua-amoand_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoand_w.S
+  
+- test: rv32ua-amomaxu_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amomaxu_w.S
+  
+- test: rv32ua-amoswap_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoswap_w.S
+  
+- test: rv32ua-amominu_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amominu_w.S
+  
+- test: rv32ua-amomax_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amomax_w.S
+
+- test: rv32uf-fclass
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fclass.S
+
+- test: rv32uf-ldst
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/ldst.S
+
+- test: rv32uf-fmadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fmadd.S
+
+- test: rv32uf-recoding
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/recoding.S
+
+- test: rv32uf-fcvt
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fcvt.S
+
+- test: rv32uf-fcmp
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fcmp.S
+
+- test: rv32uf-fcvt_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fcvt_w.S
+
+- test: rv32uf-fadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fadd.S
+
+- test: rv32uf-fmin
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fmin.S
+
+- test: rv32uf-move
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/move.S
+
+- test: rv32uf-fdiv
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uf/src/fdiv.S
+
+- test: rv32ud-fclass
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/fclass.S
+  
+- test: rv32ud-ldst
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/ldst.S
+  
+- test: rv32ud-fmadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/fmadd.S
+  
+- test: rv32ud-recoding
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/recoding.S
+  
+- test: rv32ud-fcvt
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/fcvt.S
+  
+- test: rv32ud-fcmp
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/fcmp.S
+  
+- test: rv32ud-fadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/fadd.S
+  
+- test: rv32ud-fmin
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/fmin.S
+  
+- test: rv32ud-fdiv
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ud/src/fdiv.S

--- a/verif/tests/testlist_riscv-csr-access-test-cv32a6_embedded.yaml
+++ b/verif/tests/testlist_riscv-csr-access-test-cv32a6_embedded.yaml
@@ -1,0 +1,76 @@
+## // Copyright 2023 Thales 
+## // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+- test: M_RW_CSR
+  iterations: 1
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_m_rw_csr_test_0.S
+  
+- test: S_RW_CSR
+  iterations: 1
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_s_rw_csr_test_0.S
+
+- test: M_RO_CSR
+  iterations: 1
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_m_ro_csr_test_0.S
+
+- test: M_MCYCLE_CSR
+  iterations: 0
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_mcycle_csr_test_0.S
+
+- test: M_MCYCLEH_CSR
+  iterations: 0
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_mcycleh_csr_test_0.S
+
+- test: M_MINSTRET_CSR
+  iterations: 0
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_minstret_csr_test_0.S
+
+- test: M_MINSTRETH_CSR
+  iterations: 0
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_minstreth_csr_test_0.S
+
+- test: U_CYCLE_CSR
+  iterations: 0
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_cycle_csr_test_0.S
+
+- test: U_INSTRET_CSR
+  iterations: 0
+  path_var: TESTS_PATH
+  # Prerequisite: install riscv-arch-test (== run 'cva6/regress/install-riscv-arch-test.sh') first.
+  # It will populate '<path_var>/riscv-arch-test/riscv-target/spike/' using the current Spike installation.
+  gcc_opts: "-DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/custom/CSR/csr_access_tests/riscv_instret_csr_test_0.S
+
+

--- a/verif/tests/testlist_riscv-tests-cv32a6_embedded-p.yaml
+++ b/verif/tests/testlist_riscv-tests-cv32a6_embedded-p.yaml
@@ -1,0 +1,601 @@
+# Copyright Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+#- import: <riscv_dv_root>/target/rv32imc/testlist.yaml
+
+# ISA tests
+- test: rv32ui-p-add
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/add.S
+
+- test: rv32ui-p-addi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/addi.S
+
+- test: rv32ui-p-and
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/and.S
+
+- test: rv32ui-p-andi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/andi.S
+
+- test: rv32ui-p-auipc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/auipc.S
+
+- test: rv32ui-p-beq
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/beq.S
+
+- test: rv32ui-p-bge
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/bge.S
+
+- test: rv32ui-p-bgeu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/bgeu.S
+
+- test: rv32ui-p-blt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/blt.S
+
+- test: rv32ui-p-bltu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/bltu.S
+
+- test: rv32ui-p-bne
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/bne.S
+
+- test: rv32ui-p-simple
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/simple.S
+
+- test: rv32ui-p-fence_i
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/fence_i.S
+
+- test: rv32ui-p-jal
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/jal.S
+
+- test: rv32ui-p-jalr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/jalr.S
+
+- test: rv32ui-p-lb
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/lb.S
+
+- test: rv32ui-p-lbu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/lbu.S
+
+- test: rv32ui-p-lh
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/lh.S
+
+- test: rv32ui-p-lhu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/lhu.S
+
+- test: rv32ui-p-lw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/lw.S
+
+- test: rv32ui-p-lui
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/lui.S
+
+- test: rv32ui-p-or
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/or.S
+
+- test: rv32ui-p-ori
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/ori.S
+
+- test: rv32ui-p-sb
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sb.S
+
+- test: rv32ui-p-sh
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sh.S
+
+- test: rv32ui-p-sw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sw.S
+
+- test: rv32ui-p-sll
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sll.S
+
+- test: rv32ui-p-slli
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/slli.S
+
+- test: rv32ui-p-slt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/slt.S
+
+- test: rv32ui-p-slti
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/slti.S
+
+- test: rv32ui-p-sltiu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sltiu.S
+
+- test: rv32ui-p-sltu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sltu.S
+
+- test: rv32ui-p-sra
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sra.S
+
+- test: rv32ui-p-srai
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/srai.S
+
+- test: rv32ui-p-srl
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/srl.S
+
+- test: rv32ui-p-srli
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/srli.S
+
+- test: rv32ui-p-sub
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/sub.S
+
+- test: rv32ui-p-xor
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/xor.S
+
+- test: rv32ui-p-xori
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ui/xori.S
+
+- test: rv32mi-p-breakpoint
+  iterations: 0 # csrr    a0, tdata1 => 0x20000000 (spike), 0x00000000 (cva6)
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/breakpoint.S
+
+- test: rv32mi-p-csr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/csr.S
+
+- test: rv32mi-p-mcsr
+  iterations: 0 # expected as different marchid
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/mcsr.S
+
+- test: rv32mi-p-illegal
+  iterations: 0 # cva6 does not record illegal instructions in log file
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/illegal.S
+
+- test: rv32mi-p-ma_addr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/ma_addr.S
+
+- test: rv32mi-p-ma_fetch
+  iterations: 0 # expected as different misa
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/ma_fetch.S
+
+- test: rv32mi-p-sbreak
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/sbreak.S
+
+- test: rv32mi-p-scall
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/scall.S
+
+- test: rv32mi-p-shamt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32mi/shamt.S
+
+- test: rv32si-p-csr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32si/csr.S
+
+- test: rv32si-p-ma_fetch
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32si/ma_fetch.S
+
+- test: rv32si-p-scall
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32si/scall.S
+
+- test: rv32si-p-wfi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32si/wfi.S
+
+- test: rv32si-p-sbreak
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32si/sbreak.S
+
+- test: rv32si-p-dirty
+  iterations: 0 # to be explained
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32si/dirty.S
+
+- test: rv32uc-p-rvc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uc/rvc.S
+
+# FPU tests
+- test: rv32uf-p-fadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fadd.S
+
+- test: rv32uf-p-fclass
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fclass.S
+
+- test: rv32uf-p-fcmp
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fcmp.S
+
+- test: rv32uf-p-fcvt
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fcvt.S
+
+- test: rv32uf-p-fcvt_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fcvt_w.S
+
+- test: rv32uf-p-fdiv
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fdiv.S
+
+- test: rv32uf-p-fmadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fmadd.S
+
+- test: rv32uf-p-fmin
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/fmin.S
+
+- test: rv32uf-p-ldst
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/ldst.S
+
+- test: rv32uf-p-move
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/move.S
+
+- test: rv32uf-p-recoding
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32uf/recoding.S
+
+- test: rv32ud-p-fadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fadd.S
+
+- test: rv32ud-p-fclass
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fclass.S
+
+- test: rv32ud-p-fcmp
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fcmp.S
+
+- test: rv32ud-p-fcvt
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fcvt.S
+
+- test: rv32ud-p-fcvt_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fcvt_w.S
+
+- test: rv32ud-p-fdiv
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fdiv.S
+
+- test: rv32ud-p-fmadd
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fmadd.S
+
+- test: rv32ud-p-fmin
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/fmin.S
+
+- test: rv32ud-p-ldst
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/ldst.S
+
+- test: rv32ud-p-recoding
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ud/recoding.S
+
+# MUL/DIV tests
+- test: rv32um-p-div
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/div.S
+
+- test: rv32um-p-divu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/divu.S
+
+- test: rv32um-p-mul
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/mul.S
+
+- test: rv32um-p-mulh
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/mulh.S
+
+- test: rv32um-p-mulhsu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/mulhsu.S
+
+- test: rv32um-p-mulhu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/mulhu.S
+
+- test: rv32um-p-rem
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/rem.S
+
+- test: rv32um-p-remu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32um/remu.S
+
+# AMO tests
+- test: rv32ua-p-amoadd_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amoadd_w.S
+
+- test: rv32ua-p-amoand_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amoand_w.S
+
+- test: rv32ua-p-amomax_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amomax_w.S
+
+- test: rv32ua-p-amomaxu_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amomaxu_w.S
+
+- test: rv32ua-p-amomin_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amomin_w.S
+
+- test: rv32ua-v-amominu_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amominu_w.S
+
+- test: rv32ua-p-amoor_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amoor_w.S
+
+- test: rv32ua-p-amoxor_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amoxor_w.S
+
+- test: rv32ua-p-amoswap_w
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/amoswap_w.S
+
+- test: rv32ua-p-lrsc
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv32ua/lrsc.S


### PR DESCRIPTION
This PR reduces the number of jobs run in a CI pipeline, focusing on the `cv32a6_embedded` configuration.

It reorganizes jobs in categories and in stages to not run the whole pipeline when a smoke test fails.