### PR TITLE
hvp vplan creation and sanity covergroup implementation

### DIFF
--- a/verif/README.md
+++ b/verif/README.md
@@ -3,6 +3,7 @@
 - [Directories](#directories)
 - [Prerequisites](#prerequisites)
 - [Test execution](#test-execution)
+- [Verification plan](#verification-plan)
 - [Environment variables](#environment-variables)
 - [32-bit configuration](#32-bit-configuration)
 
@@ -49,6 +50,20 @@ Run one of the shell scripts:
 
 These tests are using [riscv-dv](https://github.com/google/riscv-dv)
 as environment.
+
+## Verification plan
+Verification plan is available only for vcs tool and located in sim/cva6.hvp, it's used within a modifier to filter out only needed features. Example sim/modifier_embedded.hvp for embedded config.
+
+To generate the coverage database user should run at least a test or regression with coverage enabled by setting:
+- `export cov=1`
+
+To view or edit verification plan use command:
+- `cd sim`
+- `verdi -cov -covdir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -mod modifier_embedded.hvp`
+
+To generate verification plan report in html format use command:
+- `cd sim`
+- `urg -hvp_proj cva6_embedded -group instcov_for_score -hvp_attributes description -dir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -mod modifier_embedded.hvp`
 
 ## Environment variables
 Other environment variables can be set to overload default values

--- a/verif/env/uvme/cov/uvme_cva6_config_covg.sv
+++ b/verif/env/uvme/cov/uvme_cva6_config_covg.sv
@@ -1,8 +1,8 @@
 //
 // Copyright 2020 OpenHW Group
-// Copyright 2021 Thales DIS Design Services SAS
+// Copyright 2023 Thales DIS
 //
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/verif/env/uvme/cov/uvme_cva6_config_covg.sv
+++ b/verif/env/uvme/cov/uvme_cva6_config_covg.sv
@@ -1,0 +1,314 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2021 Thales DIS Design Services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+covergroup cg_cva6_config(string name) with function sample();
+
+   option.per_instance = 1;
+   option.name = name;
+
+   cp_Xlen : coverpoint cva6_config_pkg::CVA6ConfigXlen {
+      bins Xlen ={32};
+   }
+   cp_FpuEn : coverpoint cva6_config_pkg::CVA6ConfigFpuEn {
+      bins FpuEn ={0};
+   }
+   cp_F16En : coverpoint cva6_config_pkg::CVA6ConfigF16En {
+      bins F16En ={0};
+   }
+   cp_F16AltEn : coverpoint cva6_config_pkg::CVA6ConfigF16AltEn {
+      bins F16AltEn ={0};
+   }
+   cp_F8En : coverpoint cva6_config_pkg::CVA6ConfigF8En {
+      bins F8En ={0};
+   }
+   cp_FVecEn : coverpoint cva6_config_pkg::CVA6ConfigFVecEn {
+      bins FVecEn ={0};
+   }
+   cp_CvxifEn : coverpoint cva6_config_pkg::CVA6ConfigCvxifEn {
+      bins CvxifEn ={1};
+   }
+   cp_CExtEn : coverpoint cva6_config_pkg::CVA6ConfigCExtEn {
+      bins CExtEn ={1};
+   }
+   cp_AExtEn : coverpoint cva6_config_pkg::CVA6ConfigAExtEn {
+      bins AExtEn ={0};
+   }
+   cp_BExtEn : coverpoint cva6_config_pkg::CVA6ConfigBExtEn {
+      bins BExtEn ={1};
+   }
+   cp_VExtEn : coverpoint cva6_config_pkg::CVA6ConfigVExtEn {
+      bins VExtEn ={0};
+   }
+   cp_ZiCondExtEn : coverpoint cva6_config_pkg::CVA6ConfigZiCondExtEn {
+      bins ZiCondExtEn ={1};
+   }
+   cp_AxiIdWidth : coverpoint cva6_config_pkg::CVA6ConfigAxiIdWidth {
+      bins AxiIdWidth ={4};
+   }
+   cp_AxiAddrWidth : coverpoint cva6_config_pkg::CVA6ConfigAxiAddrWidth {
+      bins AxiAddrWidth ={64};
+   }
+   cp_AxiDataWidth : coverpoint cva6_config_pkg::CVA6ConfigAxiDataWidth {
+      bins AxiDataWidth ={64};
+   }
+   cp_FetchUserEn : coverpoint cva6_config_pkg::CVA6ConfigFetchUserEn {
+      bins FetchUserEn ={0};
+   }
+   cp_FetchUserWidth : coverpoint cva6_config_pkg::CVA6ConfigFetchUserWidth {
+      bins FetchUserWidth ={32};
+   }
+   cp_DataUserEn : coverpoint cva6_config_pkg::CVA6ConfigDataUserEn {
+      bins DataUserEn ={0};
+   }
+   cp_DataUserWidth : coverpoint cva6_config_pkg::CVA6ConfigDataUserWidth {
+      bins DataUserWidth ={32};
+   }
+   cp_IcacheByteSize : coverpoint cva6_config_pkg::CVA6ConfigIcacheByteSize {
+      bins IcacheByteSize ={16384};
+   }
+   cp_IcacheSetAssoc : coverpoint cva6_config_pkg::CVA6ConfigIcacheSetAssoc {
+      bins IcacheSetAssoc ={4};
+   }
+   cp_IcacheLineWidth : coverpoint cva6_config_pkg::CVA6ConfigIcacheLineWidth {
+      bins IcacheLineWidth ={128};
+   }
+   cp_DcacheByteSize : coverpoint cva6_config_pkg::CVA6ConfigDcacheByteSize {
+      bins DcacheByteSize ={32768};
+   }
+   cp_DcacheSetAssoc : coverpoint cva6_config_pkg::CVA6ConfigDcacheSetAssoc {
+      bins DcacheSetAssoc ={8};
+   }
+   cp_DcacheLineWidth : coverpoint cva6_config_pkg::CVA6ConfigDcacheLineWidth {
+      bins DcacheLineWidth ={128};
+   }
+   cp_DcacheIdWidth : coverpoint cva6_config_pkg::CVA6ConfigDcacheIdWidth {
+      bins DcacheIdWidth ={1};
+   }
+   cp_MemTidWidth : coverpoint cva6_config_pkg::CVA6ConfigMemTidWidth {
+      bins MemTidWidth ={2};
+   }
+   cp_WtDcacheWbufDepth : coverpoint cva6_config_pkg::CVA6ConfigWtDcacheWbufDepth {
+      bins WtDcacheWbufDepth ={2};
+   }
+   cp_NrCommitPorts : coverpoint cva6_config_pkg::CVA6ConfigNrCommitPorts {
+      bins NrCommitPorts ={1};
+   }
+   cp_NrScoreboardEntries : coverpoint cva6_config_pkg::CVA6ConfigNrScoreboardEntries {
+      bins NrScoreboardEntries ={4};
+   }
+   cp_FPGAEn : coverpoint cva6_config_pkg::CVA6ConfigFPGAEn {
+      bins FPGAEn ={0};
+   }
+   cp_NrLoadPipeRegs : coverpoint cva6_config_pkg::CVA6ConfigNrLoadPipeRegs {
+      bins NrLoadPipeRegs ={1};
+   }
+   cp_NrStorePipeRegs : coverpoint cva6_config_pkg::CVA6ConfigNrStorePipeRegs {
+      bins NrStorePipeRegs ={0};
+   }
+   cp_NrLoadBufEntries : coverpoint cva6_config_pkg::CVA6ConfigNrLoadBufEntries {
+      bins NrLoadBufEntries ={2};
+   }
+   cp_InstrTlbEntries : coverpoint cva6_config_pkg::CVA6ConfigInstrTlbEntries {
+      bins InstrTlbEntries ={2};
+   }
+   cp_DataTlbEntries : coverpoint cva6_config_pkg::CVA6ConfigDataTlbEntries {
+      bins DataTlbEntries ={2};
+   }
+   cp_RASDepth : coverpoint cva6_config_pkg::CVA6ConfigRASDepth {
+      bins RASDepth ={0};
+   }
+   cp_BTBEntries : coverpoint cva6_config_pkg::CVA6ConfigBTBEntries {
+      bins BTBEntries ={0};
+   }
+   cp_BHTEntries : coverpoint cva6_config_pkg::CVA6ConfigBHTEntries {
+      bins BHTEntries ={0};
+   }
+   cp_NrPMPEntries : coverpoint cva6_config_pkg::CVA6ConfigNrPMPEntries {
+      bins NrPMPEntries ={8};
+   }
+   cp_PerfCounterEn : coverpoint cva6_config_pkg::CVA6ConfigPerfCounterEn {
+      bins PerfCounterEn ={0};
+   }
+   cp_DcacheType : coverpoint cva6_config_pkg::CVA6ConfigDcacheType {
+      bins DcacheType ={cva6_config_pkg::WT};
+   }
+   cp_MmuPresent : coverpoint cva6_config_pkg::CVA6ConfigMmuPresent {
+      bins MmuPresent ={0};
+   }
+   cp_RvfiTrace : coverpoint cva6_config_pkg::CVA6ConfigRvfiTrace {
+      bins RvfiTrace ={1};
+   }
+   // Extended
+   cp_RVF : coverpoint cva6_config_pkg::cva6_cfg.RVF {
+      bins RVF ={0};
+   }
+   cp_RVD : coverpoint cva6_config_pkg::cva6_cfg.RVD {
+      bins RVD ={0};
+   }
+   cp_FpPresent : coverpoint cva6_config_pkg::cva6_cfg.FpPresent {
+      bins FpPresent ={0};
+   }
+   cp_NSX : coverpoint cva6_config_pkg::cva6_cfg.NSX {
+      bins NSX ={0};
+   }
+   cp_FLen : coverpoint cva6_config_pkg::cva6_cfg.FLen {
+      bins FLen ={0};
+   }
+   cp_RVFVec : coverpoint cva6_config_pkg::cva6_cfg.RVFVec {
+      bins RVFVec ={0};
+   }
+   cp_XF16Vec : coverpoint cva6_config_pkg::cva6_cfg.XF16Vec {
+      bins XF16Vec ={0};
+   }
+   cp_XF16ALTVec : coverpoint cva6_config_pkg::cva6_cfg.XF16ALTVec {
+      bins XF16ALTVec ={0};
+   }
+   cp_XF8Vec : coverpoint cva6_config_pkg::cva6_cfg.XF8Vec {
+      bins XF8Vec ={0};
+   }
+   cp_NrRgprPorts : coverpoint cva6_config_pkg::cva6_cfg.NrRgprPorts {
+      bins NrRgprPorts ={0};
+   }
+   cp_NrWbPorts : coverpoint cva6_config_pkg::cva6_cfg.NrWbPorts {
+      bins NrWbPorts ={0};
+   }
+   cp_EnableAccelerator : coverpoint cva6_config_pkg::cva6_cfg.EnableAccelerator {
+      bins EnableAccelerator ={0};
+   }
+   cp_HaltAddress : coverpoint cva6_config_pkg::cva6_cfg.HaltAddress {
+      bins HaltAddress ={64'h800};
+   }
+   cp_ExceptionAddress : coverpoint cva6_config_pkg::cva6_cfg.ExceptionAddress {
+      bins ExceptionAddress ={64'h808};
+   }
+endgroup: cg_cva6_config
+
+covergroup cg_cva6_boot_addr(string name) with function sample(bit [cva6_config_pkg::CVA6ConfigXlen-1:0] boot_addr);
+   option.per_instance = 1;
+   option.name = name;
+   
+   cp_boot_addr : coverpoint boot_addr {
+      bins BOOT_ADDR_0 ={0};
+      bins BOOT_ADDR_LOW ={[1:'h10000_0000]};
+      bins BOOT_ADDR_HIGH ={['h10000_0000:$]};
+   }
+endgroup: cg_cva6_boot_addr
+
+covergroup cg_cva6_clock_period_cg(string name) with function sample(int clock_period_ps);
+   option.per_instance = 1;
+   option.name = name;
+   
+   cp_clock_period_ps : coverpoint clock_period_ps {
+      bins LOW   = {[0:1500]};
+      bins HIGH  = {[1501:6670]};
+   }
+endgroup: cg_cva6_clock_period_cg
+
+covergroup cg_cva6_reset_cg(string name) with function sample();
+   option.per_instance = 1;
+   option.name = name;
+   
+   cp_reset_assert_time : coverpoint cntxt.clknrst_cntxt.mon_reset_assert_timestamp {
+      bins LOW   = {[0:1500]};
+      bins HIGH  = {[1501:6670]};
+   }
+endgroup: cg_cva6_clock_period_cg
+
+class uvme_cva6_config_covg_c extends uvm_component;
+
+   // Objects
+   uvme_cva6_cfg_c         cfg      ;
+   uvme_cva6_cntxt_c       cntxt    ;
+   
+   `uvm_analysis_imp_decl(_reset)
+   uvm_analysis_imp_reset #(uvma_clknrst_mon_trn_c, uvme_cva6_config_covg_c) reset_imp;
+   
+   `uvm_component_utils_begin(uvme_cva6_config_covg_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   // Covergroups
+   cg_cva6_config          config_cg;
+   cg_cva6_boot_addr       boot_addr_cg;
+   cg_cva6_clock_period_cg clock_period_cg;
+   cg_cva6_reset_cg        reset_cg;
+   
+   extern function new(string name = "uvme_cva6_config_covg_c", uvm_component parent = null);
+   extern function void build_phase(uvm_phase phase);
+   extern task run_phase(uvm_phase phase);
+   extern function void sample_cva6_config();
+   extern function void write_reset();
+
+endclass : uvme_cva6_config_covg_c
+
+function uvme_cva6_config_covg_c::new(string name = "uvme_cva6_config_covg_c", uvm_component parent = null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+function void uvme_cva6_config_covg_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvme_cva6_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   void'(uvm_config_db#(uvme_cva6_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (!cntxt) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+
+   config_cg       = new("config_cg");
+   boot_addr_cg    = new("boot_addr_cg");
+   clock_period_cg = new("clock_period_cg");
+   reset_cg        = new("reset_cg");
+   
+endfunction : build_phase
+
+function void uvme_cva6_config_covg_c::sample_cva6_config();
+
+   config_cg.sample();
+   boot_addr_cg.sample(cfg.boot_addr);
+   clock_period_cg.sample(cfg.sys_clk_period);
+   fork
+      begin
+         bit prev_mon_reset_assert_timestamp = 0;
+         forever begin
+            @(cntxt.vif.reset_n);
+            reset_cg.sample();
+         end
+      end
+   join_none
+   
+endfunction : sample_cva6_config
+
+virtual function void uvme_cva6_config_covg_c::write_reset(seq_item req);
+   $display("OK reset")
+endfunction
+
+task uvme_cva6_config_covg_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+   
+   sample_cva6_config();
+
+endtask : run_phase

--- a/verif/env/uvme/cov/uvme_cva6_cov_model.sv
+++ b/verif/env/uvme/cov/uvme_cva6_cov_model.sv
@@ -30,8 +30,12 @@ class uvme_cva6_cov_model_c extends uvm_component;
    uvme_cva6_cntxt_c  cntxt;
 
    // Components
-   uvme_cvxif_covg_c  cvxif_covg;
-   uvme_isa_cov_model_c isa_covg;
+   uvme_cvxif_covg_c        cvxif_covg;
+   uvme_isa_cov_model_c     isa_covg;
+   uvme_cva6_config_covg_c  config_covg;
+   
+   //
+   uvm_analysis_export#(uvma_clknrst_mon_trn_c)  reset_ae;
 
    `uvm_component_utils_begin(uvme_cva6_cov_model_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -52,6 +56,11 @@ class uvme_cva6_cov_model_c extends uvm_component;
     * Describe uvme_cva6_cov_model_c::run_phase()
     */
    extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * Ensures cfg & cntxt handles are not null.
+    */
+   extern virtual function void connect_phase(uvm_phase phase);
 
    /**
     * TODO Describe uvme_cva6_cov_model_c::sample_cfg()
@@ -99,8 +108,19 @@ function void uvme_cva6_cov_model_c::build_phase(uvm_phase phase);
    end
 
    uvm_config_db#(uvme_cva6_cntxt_c)::set(this, "cvxif_covg", "cntxt", cntxt);
+   
+   config_covg = uvme_cva6_config_covg_c::type_id::create("config_covg", this);
+   uvm_config_db#(uvme_cva6_cfg_c)::set(this, "config_covg", "cfg", cfg);
+   uvm_config_db#(uvme_cva6_cntxt_c)::set(this, "config_covg", "cntxt", cntxt);
 
 endfunction : build_phase
+
+function void uvme_cva6_cov_model_c::connect_phase(uvm_phase phase);
+
+   super.connect_phase(phase);
+   reset_ae.connect(config_covg.reset_imp);
+
+endfunction : connect_phase
 
 
 task uvme_cva6_cov_model_c::run_phase(uvm_phase phase);

--- a/verif/env/uvme/cov/uvme_cva6_cov_model.sv
+++ b/verif/env/uvme/cov/uvme_cva6_cov_model.sv
@@ -35,7 +35,7 @@ class uvme_cva6_cov_model_c extends uvm_component;
    uvme_cva6_config_covg_c  config_covg;
    
    //
-   uvm_analysis_export#(uvma_clknrst_mon_trn_c)  reset_ae;
+   uvm_analysis_export#(uvma_clknrst_mon_trn_c)  reset_export;
 
    `uvm_component_utils_begin(uvme_cva6_cov_model_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -80,7 +80,7 @@ endclass : uvme_cva6_cov_model_c
 function uvme_cva6_cov_model_c::new(string name="uvme_cva6_cov_model", uvm_component parent=null);
 
    super.new(name, parent);
-
+   reset_export = new("reset_export");
 endfunction : new
 
 function void uvme_cva6_cov_model_c::build_phase(uvm_phase phase);
@@ -118,7 +118,7 @@ endfunction : build_phase
 function void uvme_cva6_cov_model_c::connect_phase(uvm_phase phase);
 
    super.connect_phase(phase);
-   reset_ae.connect(config_covg.reset_imp);
+   reset_export.connect(config_covg.reset_imp);
 
 endfunction : connect_phase
 

--- a/verif/env/uvme/reg/cva6_csr_reg_adapter.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_adapter.sv
@@ -1,3 +1,21 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2023 Thales DIS
+//
+// Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
 class cva6_csr_reg_adapter extends uvm_reg_adapter;
 
   `uvm_object_utils (cva6_csr_reg_adapter)

--- a/verif/env/uvme/reg/cva6_csr_reg_adapter.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_adapter.sv
@@ -1,0 +1,55 @@
+class cva6_csr_reg_adapter extends uvm_reg_adapter;
+
+  `uvm_object_utils (cva6_csr_reg_adapter)
+
+  function new (string name = "cva6_csr_reg_adapter");
+      super.new (name);
+   endfunction
+  
+  function uvm_sequence_item reg2bus(const ref uvm_reg_bus_op rw);
+    //uvm_reg in passive mode, no implementation needed
+  endfunction
+
+  bit req_q[uvma_isacov_mon_trn_c]; //Used to store 1rst and 2nd Pass Read->Write
+  
+  function void bus2reg(uvm_sequence_item bus_item, ref uvm_reg_bus_op rw);
+    uvma_isacov_mon_trn_c req;
+    rw.addr = 0; // 0 not mapped addr, safe to use as default
+    
+    if(!$cast(req, bus_item) )
+      `uvm_fatal("CSR_REG_ADAPTER", "Error casting bus request")
+        
+    if (req.instr.group != uvma_isacov_pkg::CSR_GROUP) 
+      return;
+        
+    if (req_q[req] == 0) begin // First pass Read
+      req_q[req]=1;
+      
+      rw.kind = UVM_READ;
+      
+      if ((req.instr.rd==0) && (req.instr.name inside {uvma_isacov_pkg::CSRRW, uvma_isacov_pkg::CSRRWI}))
+         return; //no read when CSRRW/CSRRWI with rd==x0  
+         
+      rw.data = req.instr.rd_value;    
+    
+    end else begin  // Second pass Write
+      req_q.delete(req);
+      
+      rw.kind = UVM_WRITE;
+      if (req.instr.name inside {uvma_isacov_pkg::CSRRWI, uvma_isacov_pkg::CSRRSI, uvma_isacov_pkg::CSRRCI})
+         rw.data = req.instr.rs1;
+      else
+         rw.data = req.instr.rs1_value;
+      
+      if ((req.instr.rs1 == 0) && req.instr.name inside {uvma_isacov_pkg::CSRRS, uvma_isacov_pkg::CSRRC, uvma_isacov_pkg::CSRRSI, uvma_isacov_pkg::CSRRCI})
+         return; //no write when CSRRS/CSRRC with rs1==0x or CSRRSI/CSRRCI with imm==0  
+      
+    end
+        
+    rw.addr   = req.instr.csr_val;
+    rw.status = UVM_IS_OK;
+    
+    `uvm_info("CSR_REG_ADAPTER",$sformatf("Monitored transaction CSR KIND:%s ADDR:0x%0h DATA:0x%0h. Original instruction: INSTR:%s ADDR:0x%0h RS1:0x%0h RD:0x%0h IMMU:0x%0h", rw.kind, rw.addr, rw.data, req.instr.name, req.instr.csr_val,req.instr.rs1_value, req.instr.rd_value, req.instr.immu),UVM_HIGH);
+    
+  endfunction
+endclass

--- a/verif/env/uvme/reg/cva6_csr_reg_block.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_block.sv
@@ -1,0 +1,832 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2023 Thales DIS
+//
+// Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+class cva6_csr_reg_block extends uvm_reg_block;
+  `uvm_object_utils(cva6_csr_reg_block)
+  
+  //---------------------------------------
+  // register instances 
+  //---------------------------------------
+  rand reg_mstatus  mstatus; 
+  rand reg_misa  misa; 
+  rand reg_mie  mie; 
+  rand reg_mtvec  mtvec; 
+  rand reg_mstatush  mstatush; 
+  rand reg_mhpmevent3  mhpmevent3; 
+  rand reg_mhpmevent4  mhpmevent4; 
+  rand reg_mhpmevent5  mhpmevent5; 
+  rand reg_mhpmevent6  mhpmevent6; 
+  rand reg_mhpmevent7  mhpmevent7; 
+  rand reg_mhpmevent8  mhpmevent8; 
+  rand reg_mhpmevent9  mhpmevent9; 
+  rand reg_mhpmevent10  mhpmevent10; 
+  rand reg_mhpmevent11  mhpmevent11; 
+  rand reg_mhpmevent12  mhpmevent12; 
+  rand reg_mhpmevent13  mhpmevent13; 
+  rand reg_mhpmevent14  mhpmevent14; 
+  rand reg_mhpmevent15  mhpmevent15; 
+  rand reg_mhpmevent16  mhpmevent16; 
+  rand reg_mhpmevent17  mhpmevent17; 
+  rand reg_mhpmevent18  mhpmevent18; 
+  rand reg_mhpmevent19  mhpmevent19; 
+  rand reg_mhpmevent20  mhpmevent20; 
+  rand reg_mhpmevent21  mhpmevent21; 
+  rand reg_mhpmevent22  mhpmevent22; 
+  rand reg_mhpmevent23  mhpmevent23; 
+  rand reg_mhpmevent24  mhpmevent24; 
+  rand reg_mhpmevent25  mhpmevent25; 
+  rand reg_mhpmevent26  mhpmevent26; 
+  rand reg_mhpmevent27  mhpmevent27; 
+  rand reg_mhpmevent28  mhpmevent28; 
+  rand reg_mhpmevent29  mhpmevent29; 
+  rand reg_mhpmevent30  mhpmevent30; 
+  rand reg_mhpmevent31  mhpmevent31; 
+  rand reg_mscratch  mscratch; 
+  rand reg_mepc  mepc; 
+  rand reg_mcause  mcause; 
+  rand reg_mtval  mtval; 
+  rand reg_mip  mip; 
+  rand reg_pmpcfg0  pmpcfg0; 
+  rand reg_pmpcfg1  pmpcfg1; 
+  rand reg_pmpcfg2  pmpcfg2; 
+  rand reg_pmpcfg3  pmpcfg3; 
+  rand reg_pmpaddr0  pmpaddr0; 
+  rand reg_pmpaddr1  pmpaddr1; 
+  rand reg_pmpaddr2  pmpaddr2; 
+  rand reg_pmpaddr3  pmpaddr3; 
+  rand reg_pmpaddr4  pmpaddr4; 
+  rand reg_pmpaddr5  pmpaddr5; 
+  rand reg_pmpaddr6  pmpaddr6; 
+  rand reg_pmpaddr7  pmpaddr7; 
+  rand reg_pmpaddr8  pmpaddr8; 
+  rand reg_pmpaddr9  pmpaddr9; 
+  rand reg_pmpaddr10  pmpaddr10; 
+  rand reg_pmpaddr11  pmpaddr11; 
+  rand reg_pmpaddr12  pmpaddr12; 
+  rand reg_pmpaddr13  pmpaddr13; 
+  rand reg_pmpaddr14  pmpaddr14; 
+  rand reg_pmpaddr15  pmpaddr15; 
+  rand reg_icache  icache; 
+  rand reg_mcycle  mcycle; 
+  rand reg_minstret  minstret; 
+  rand reg_mcycleh  mcycleh; 
+  rand reg_minstreth  minstreth; 
+  rand reg_mhpmcounter3  mhpmcounter3; 
+  rand reg_mhpmcounter4  mhpmcounter4; 
+  rand reg_mhpmcounter5  mhpmcounter5; 
+  rand reg_mhpmcounter6  mhpmcounter6; 
+  rand reg_mhpmcounter7  mhpmcounter7; 
+  rand reg_mhpmcounter8  mhpmcounter8; 
+  rand reg_mhpmcounter9  mhpmcounter9; 
+  rand reg_mhpmcounter10  mhpmcounter10; 
+  rand reg_mhpmcounter11  mhpmcounter11; 
+  rand reg_mhpmcounter12  mhpmcounter12; 
+  rand reg_mhpmcounter13  mhpmcounter13; 
+  rand reg_mhpmcounter14  mhpmcounter14; 
+  rand reg_mhpmcounter15  mhpmcounter15; 
+  rand reg_mhpmcounter16  mhpmcounter16; 
+  rand reg_mhpmcounter17  mhpmcounter17; 
+  rand reg_mhpmcounter18  mhpmcounter18; 
+  rand reg_mhpmcounter19  mhpmcounter19; 
+  rand reg_mhpmcounter20  mhpmcounter20; 
+  rand reg_mhpmcounter21  mhpmcounter21; 
+  rand reg_mhpmcounter22  mhpmcounter22; 
+  rand reg_mhpmcounter23  mhpmcounter23; 
+  rand reg_mhpmcounter24  mhpmcounter24; 
+  rand reg_mhpmcounter25  mhpmcounter25; 
+  rand reg_mhpmcounter26  mhpmcounter26; 
+  rand reg_mhpmcounter27  mhpmcounter27; 
+  rand reg_mhpmcounter28  mhpmcounter28; 
+  rand reg_mhpmcounter29  mhpmcounter29; 
+  rand reg_mhpmcounter30  mhpmcounter30; 
+  rand reg_mhpmcounter31  mhpmcounter31; 
+  rand reg_mhpmcounterh3  mhpmcounterh3; 
+  rand reg_mhpmcounterh4  mhpmcounterh4; 
+  rand reg_mhpmcounterh5  mhpmcounterh5; 
+  rand reg_mhpmcounterh6  mhpmcounterh6; 
+  rand reg_mhpmcounterh7  mhpmcounterh7; 
+  rand reg_mhpmcounterh8  mhpmcounterh8; 
+  rand reg_mhpmcounterh9  mhpmcounterh9; 
+  rand reg_mhpmcounterh10  mhpmcounterh10; 
+  rand reg_mhpmcounterh11  mhpmcounterh11; 
+  rand reg_mhpmcounterh12  mhpmcounterh12; 
+  rand reg_mhpmcounterh13  mhpmcounterh13; 
+  rand reg_mhpmcounterh14  mhpmcounterh14; 
+  rand reg_mhpmcounterh15  mhpmcounterh15; 
+  rand reg_mhpmcounterh16  mhpmcounterh16; 
+  rand reg_mhpmcounterh17  mhpmcounterh17; 
+  rand reg_mhpmcounterh18  mhpmcounterh18; 
+  rand reg_mhpmcounterh19  mhpmcounterh19; 
+  rand reg_mhpmcounterh20  mhpmcounterh20; 
+  rand reg_mhpmcounterh21  mhpmcounterh21; 
+  rand reg_mhpmcounterh22  mhpmcounterh22; 
+  rand reg_mhpmcounterh23  mhpmcounterh23; 
+  rand reg_mhpmcounterh24  mhpmcounterh24; 
+  rand reg_mhpmcounterh25  mhpmcounterh25; 
+  rand reg_mhpmcounterh26  mhpmcounterh26; 
+  rand reg_mhpmcounterh27  mhpmcounterh27; 
+  rand reg_mhpmcounterh28  mhpmcounterh28; 
+  rand reg_mhpmcounterh29  mhpmcounterh29; 
+  rand reg_mhpmcounterh30  mhpmcounterh30; 
+  rand reg_mhpmcounterh31  mhpmcounterh31; 
+  rand reg_cycle  cycle; 
+  rand reg_instret  instret; 
+  rand reg_cycleh  cycleh; 
+  rand reg_instreth  instreth; 
+  rand reg_mvendorid  mvendorid; 
+  rand reg_marchid  marchid; 
+  rand reg_mimpid  mimpid; 
+  rand reg_mhartid  mhartid; 
+  
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "");
+    super.new(name, .has_coverage(UVM_CVR_ALL));
+  endfunction
+
+  //---------------------------------------
+  // Build Phase 
+  //---------------------------------------
+  virtual function build();
+    
+    //---------------------------------------
+    //reg creation
+    //---------------------------------------
+    mstatus = reg_mstatus::type_id::create("mstatus", null, get_full_name());
+    mstatus.configure(this, null, "mstatus");
+    mstatus.build();
+
+    misa = reg_misa::type_id::create("misa", null, get_full_name());
+    misa.configure(this, null, "misa");
+    misa.build();
+
+    mie = reg_mie::type_id::create("mie", null, get_full_name());
+    mie.configure(this, null, "mie");
+    mie.build();
+
+    mtvec = reg_mtvec::type_id::create("mtvec", null, get_full_name());
+    mtvec.configure(this, null, "mtvec");
+    mtvec.build();
+
+    mstatush = reg_mstatush::type_id::create("mstatush", null, get_full_name());
+    mstatush.configure(this, null, "mstatush");
+    mstatush.build();
+
+    mhpmevent3 = reg_mhpmevent3::type_id::create("mhpmevent3", null, get_full_name());
+    mhpmevent3.configure(this, null, "mhpmevent3");
+    mhpmevent3.build();
+
+    mhpmevent4 = reg_mhpmevent4::type_id::create("mhpmevent4", null, get_full_name());
+    mhpmevent4.configure(this, null, "mhpmevent4");
+    mhpmevent4.build();
+
+    mhpmevent5 = reg_mhpmevent5::type_id::create("mhpmevent5", null, get_full_name());
+    mhpmevent5.configure(this, null, "mhpmevent5");
+    mhpmevent5.build();
+
+    mhpmevent6 = reg_mhpmevent6::type_id::create("mhpmevent6", null, get_full_name());
+    mhpmevent6.configure(this, null, "mhpmevent6");
+    mhpmevent6.build();
+
+    mhpmevent7 = reg_mhpmevent7::type_id::create("mhpmevent7", null, get_full_name());
+    mhpmevent7.configure(this, null, "mhpmevent7");
+    mhpmevent7.build();
+
+    mhpmevent8 = reg_mhpmevent8::type_id::create("mhpmevent8", null, get_full_name());
+    mhpmevent8.configure(this, null, "mhpmevent8");
+    mhpmevent8.build();
+
+    mhpmevent9 = reg_mhpmevent9::type_id::create("mhpmevent9", null, get_full_name());
+    mhpmevent9.configure(this, null, "mhpmevent9");
+    mhpmevent9.build();
+
+    mhpmevent10 = reg_mhpmevent10::type_id::create("mhpmevent10", null, get_full_name());
+    mhpmevent10.configure(this, null, "mhpmevent10");
+    mhpmevent10.build();
+
+    mhpmevent11 = reg_mhpmevent11::type_id::create("mhpmevent11", null, get_full_name());
+    mhpmevent11.configure(this, null, "mhpmevent11");
+    mhpmevent11.build();
+
+    mhpmevent12 = reg_mhpmevent12::type_id::create("mhpmevent12", null, get_full_name());
+    mhpmevent12.configure(this, null, "mhpmevent12");
+    mhpmevent12.build();
+
+    mhpmevent13 = reg_mhpmevent13::type_id::create("mhpmevent13", null, get_full_name());
+    mhpmevent13.configure(this, null, "mhpmevent13");
+    mhpmevent13.build();
+
+    mhpmevent14 = reg_mhpmevent14::type_id::create("mhpmevent14", null, get_full_name());
+    mhpmevent14.configure(this, null, "mhpmevent14");
+    mhpmevent14.build();
+
+    mhpmevent15 = reg_mhpmevent15::type_id::create("mhpmevent15", null, get_full_name());
+    mhpmevent15.configure(this, null, "mhpmevent15");
+    mhpmevent15.build();
+
+    mhpmevent16 = reg_mhpmevent16::type_id::create("mhpmevent16", null, get_full_name());
+    mhpmevent16.configure(this, null, "mhpmevent16");
+    mhpmevent16.build();
+
+    mhpmevent17 = reg_mhpmevent17::type_id::create("mhpmevent17", null, get_full_name());
+    mhpmevent17.configure(this, null, "mhpmevent17");
+    mhpmevent17.build();
+
+    mhpmevent18 = reg_mhpmevent18::type_id::create("mhpmevent18", null, get_full_name());
+    mhpmevent18.configure(this, null, "mhpmevent18");
+    mhpmevent18.build();
+
+    mhpmevent19 = reg_mhpmevent19::type_id::create("mhpmevent19", null, get_full_name());
+    mhpmevent19.configure(this, null, "mhpmevent19");
+    mhpmevent19.build();
+
+    mhpmevent20 = reg_mhpmevent20::type_id::create("mhpmevent20", null, get_full_name());
+    mhpmevent20.configure(this, null, "mhpmevent20");
+    mhpmevent20.build();
+
+    mhpmevent21 = reg_mhpmevent21::type_id::create("mhpmevent21", null, get_full_name());
+    mhpmevent21.configure(this, null, "mhpmevent21");
+    mhpmevent21.build();
+
+    mhpmevent22 = reg_mhpmevent22::type_id::create("mhpmevent22", null, get_full_name());
+    mhpmevent22.configure(this, null, "mhpmevent22");
+    mhpmevent22.build();
+
+    mhpmevent23 = reg_mhpmevent23::type_id::create("mhpmevent23", null, get_full_name());
+    mhpmevent23.configure(this, null, "mhpmevent23");
+    mhpmevent23.build();
+
+    mhpmevent24 = reg_mhpmevent24::type_id::create("mhpmevent24", null, get_full_name());
+    mhpmevent24.configure(this, null, "mhpmevent24");
+    mhpmevent24.build();
+
+    mhpmevent25 = reg_mhpmevent25::type_id::create("mhpmevent25", null, get_full_name());
+    mhpmevent25.configure(this, null, "mhpmevent25");
+    mhpmevent25.build();
+
+    mhpmevent26 = reg_mhpmevent26::type_id::create("mhpmevent26", null, get_full_name());
+    mhpmevent26.configure(this, null, "mhpmevent26");
+    mhpmevent26.build();
+
+    mhpmevent27 = reg_mhpmevent27::type_id::create("mhpmevent27", null, get_full_name());
+    mhpmevent27.configure(this, null, "mhpmevent27");
+    mhpmevent27.build();
+
+    mhpmevent28 = reg_mhpmevent28::type_id::create("mhpmevent28", null, get_full_name());
+    mhpmevent28.configure(this, null, "mhpmevent28");
+    mhpmevent28.build();
+
+    mhpmevent29 = reg_mhpmevent29::type_id::create("mhpmevent29", null, get_full_name());
+    mhpmevent29.configure(this, null, "mhpmevent29");
+    mhpmevent29.build();
+
+    mhpmevent30 = reg_mhpmevent30::type_id::create("mhpmevent30", null, get_full_name());
+    mhpmevent30.configure(this, null, "mhpmevent30");
+    mhpmevent30.build();
+
+    mhpmevent31 = reg_mhpmevent31::type_id::create("mhpmevent31", null, get_full_name());
+    mhpmevent31.configure(this, null, "mhpmevent31");
+    mhpmevent31.build();
+
+    mscratch = reg_mscratch::type_id::create("mscratch", null, get_full_name());
+    mscratch.configure(this, null, "mscratch");
+    mscratch.build();
+
+    mepc = reg_mepc::type_id::create("mepc", null, get_full_name());
+    mepc.configure(this, null, "mepc");
+    mepc.build();
+
+    mcause = reg_mcause::type_id::create("mcause", null, get_full_name());
+    mcause.configure(this, null, "mcause");
+    mcause.build();
+
+    mtval = reg_mtval::type_id::create("mtval", null, get_full_name());
+    mtval.configure(this, null, "mtval");
+    mtval.build();
+
+    mip = reg_mip::type_id::create("mip", null, get_full_name());
+    mip.configure(this, null, "mip");
+    mip.build();
+
+    pmpcfg0 = reg_pmpcfg0::type_id::create("pmpcfg0", null, get_full_name());
+    pmpcfg0.configure(this, null, "pmpcfg0");
+    pmpcfg0.build();
+
+    pmpcfg1 = reg_pmpcfg1::type_id::create("pmpcfg1", null, get_full_name());
+    pmpcfg1.configure(this, null, "pmpcfg1");
+    pmpcfg1.build();
+
+    pmpcfg2 = reg_pmpcfg2::type_id::create("pmpcfg2", null, get_full_name());
+    pmpcfg2.configure(this, null, "pmpcfg2");
+    pmpcfg2.build();
+
+    pmpcfg3 = reg_pmpcfg3::type_id::create("pmpcfg3", null, get_full_name());
+    pmpcfg3.configure(this, null, "pmpcfg3");
+    pmpcfg3.build();
+
+    pmpaddr0 = reg_pmpaddr0::type_id::create("pmpaddr0", null, get_full_name());
+    pmpaddr0.configure(this, null, "pmpaddr0");
+    pmpaddr0.build();
+
+    pmpaddr1 = reg_pmpaddr1::type_id::create("pmpaddr1", null, get_full_name());
+    pmpaddr1.configure(this, null, "pmpaddr1");
+    pmpaddr1.build();
+
+    pmpaddr2 = reg_pmpaddr2::type_id::create("pmpaddr2", null, get_full_name());
+    pmpaddr2.configure(this, null, "pmpaddr2");
+    pmpaddr2.build();
+
+    pmpaddr3 = reg_pmpaddr3::type_id::create("pmpaddr3", null, get_full_name());
+    pmpaddr3.configure(this, null, "pmpaddr3");
+    pmpaddr3.build();
+
+    pmpaddr4 = reg_pmpaddr4::type_id::create("pmpaddr4", null, get_full_name());
+    pmpaddr4.configure(this, null, "pmpaddr4");
+    pmpaddr4.build();
+
+    pmpaddr5 = reg_pmpaddr5::type_id::create("pmpaddr5", null, get_full_name());
+    pmpaddr5.configure(this, null, "pmpaddr5");
+    pmpaddr5.build();
+
+    pmpaddr6 = reg_pmpaddr6::type_id::create("pmpaddr6", null, get_full_name());
+    pmpaddr6.configure(this, null, "pmpaddr6");
+    pmpaddr6.build();
+
+    pmpaddr7 = reg_pmpaddr7::type_id::create("pmpaddr7", null, get_full_name());
+    pmpaddr7.configure(this, null, "pmpaddr7");
+    pmpaddr7.build();
+
+    pmpaddr8 = reg_pmpaddr8::type_id::create("pmpaddr8", null, get_full_name());
+    pmpaddr8.configure(this, null, "pmpaddr8");
+    pmpaddr8.build();
+
+    pmpaddr9 = reg_pmpaddr9::type_id::create("pmpaddr9", null, get_full_name());
+    pmpaddr9.configure(this, null, "pmpaddr9");
+    pmpaddr9.build();
+
+    pmpaddr10 = reg_pmpaddr10::type_id::create("pmpaddr10", null, get_full_name());
+    pmpaddr10.configure(this, null, "pmpaddr10");
+    pmpaddr10.build();
+
+    pmpaddr11 = reg_pmpaddr11::type_id::create("pmpaddr11", null, get_full_name());
+    pmpaddr11.configure(this, null, "pmpaddr11");
+    pmpaddr11.build();
+
+    pmpaddr12 = reg_pmpaddr12::type_id::create("pmpaddr12", null, get_full_name());
+    pmpaddr12.configure(this, null, "pmpaddr12");
+    pmpaddr12.build();
+
+    pmpaddr13 = reg_pmpaddr13::type_id::create("pmpaddr13", null, get_full_name());
+    pmpaddr13.configure(this, null, "pmpaddr13");
+    pmpaddr13.build();
+
+    pmpaddr14 = reg_pmpaddr14::type_id::create("pmpaddr14", null, get_full_name());
+    pmpaddr14.configure(this, null, "pmpaddr14");
+    pmpaddr14.build();
+
+    pmpaddr15 = reg_pmpaddr15::type_id::create("pmpaddr15", null, get_full_name());
+    pmpaddr15.configure(this, null, "pmpaddr15");
+    pmpaddr15.build();
+
+    icache = reg_icache::type_id::create("icache", null, get_full_name());
+    icache.configure(this, null, "icache");
+    icache.build();
+
+    mcycle = reg_mcycle::type_id::create("mcycle", null, get_full_name());
+    mcycle.configure(this, null, "mcycle");
+    mcycle.build();
+
+    minstret = reg_minstret::type_id::create("minstret", null, get_full_name());
+    minstret.configure(this, null, "minstret");
+    minstret.build();
+
+    mcycleh = reg_mcycleh::type_id::create("mcycleh", null, get_full_name());
+    mcycleh.configure(this, null, "mcycleh");
+    mcycleh.build();
+
+    minstreth = reg_minstreth::type_id::create("minstreth", null, get_full_name());
+    minstreth.configure(this, null, "minstreth");
+    minstreth.build();
+
+    mhpmcounter3 = reg_mhpmcounter3::type_id::create("mhpmcounter3", null, get_full_name());
+    mhpmcounter3.configure(this, null, "mhpmcounter3");
+    mhpmcounter3.build();
+
+    mhpmcounter4 = reg_mhpmcounter4::type_id::create("mhpmcounter4", null, get_full_name());
+    mhpmcounter4.configure(this, null, "mhpmcounter4");
+    mhpmcounter4.build();
+
+    mhpmcounter5 = reg_mhpmcounter5::type_id::create("mhpmcounter5", null, get_full_name());
+    mhpmcounter5.configure(this, null, "mhpmcounter5");
+    mhpmcounter5.build();
+
+    mhpmcounter6 = reg_mhpmcounter6::type_id::create("mhpmcounter6", null, get_full_name());
+    mhpmcounter6.configure(this, null, "mhpmcounter6");
+    mhpmcounter6.build();
+
+    mhpmcounter7 = reg_mhpmcounter7::type_id::create("mhpmcounter7", null, get_full_name());
+    mhpmcounter7.configure(this, null, "mhpmcounter7");
+    mhpmcounter7.build();
+
+    mhpmcounter8 = reg_mhpmcounter8::type_id::create("mhpmcounter8", null, get_full_name());
+    mhpmcounter8.configure(this, null, "mhpmcounter8");
+    mhpmcounter8.build();
+
+    mhpmcounter9 = reg_mhpmcounter9::type_id::create("mhpmcounter9", null, get_full_name());
+    mhpmcounter9.configure(this, null, "mhpmcounter9");
+    mhpmcounter9.build();
+
+    mhpmcounter10 = reg_mhpmcounter10::type_id::create("mhpmcounter10", null, get_full_name());
+    mhpmcounter10.configure(this, null, "mhpmcounter10");
+    mhpmcounter10.build();
+
+    mhpmcounter11 = reg_mhpmcounter11::type_id::create("mhpmcounter11", null, get_full_name());
+    mhpmcounter11.configure(this, null, "mhpmcounter11");
+    mhpmcounter11.build();
+
+    mhpmcounter12 = reg_mhpmcounter12::type_id::create("mhpmcounter12", null, get_full_name());
+    mhpmcounter12.configure(this, null, "mhpmcounter12");
+    mhpmcounter12.build();
+
+    mhpmcounter13 = reg_mhpmcounter13::type_id::create("mhpmcounter13", null, get_full_name());
+    mhpmcounter13.configure(this, null, "mhpmcounter13");
+    mhpmcounter13.build();
+
+    mhpmcounter14 = reg_mhpmcounter14::type_id::create("mhpmcounter14", null, get_full_name());
+    mhpmcounter14.configure(this, null, "mhpmcounter14");
+    mhpmcounter14.build();
+
+    mhpmcounter15 = reg_mhpmcounter15::type_id::create("mhpmcounter15", null, get_full_name());
+    mhpmcounter15.configure(this, null, "mhpmcounter15");
+    mhpmcounter15.build();
+
+    mhpmcounter16 = reg_mhpmcounter16::type_id::create("mhpmcounter16", null, get_full_name());
+    mhpmcounter16.configure(this, null, "mhpmcounter16");
+    mhpmcounter16.build();
+
+    mhpmcounter17 = reg_mhpmcounter17::type_id::create("mhpmcounter17", null, get_full_name());
+    mhpmcounter17.configure(this, null, "mhpmcounter17");
+    mhpmcounter17.build();
+
+    mhpmcounter18 = reg_mhpmcounter18::type_id::create("mhpmcounter18", null, get_full_name());
+    mhpmcounter18.configure(this, null, "mhpmcounter18");
+    mhpmcounter18.build();
+
+    mhpmcounter19 = reg_mhpmcounter19::type_id::create("mhpmcounter19", null, get_full_name());
+    mhpmcounter19.configure(this, null, "mhpmcounter19");
+    mhpmcounter19.build();
+
+    mhpmcounter20 = reg_mhpmcounter20::type_id::create("mhpmcounter20", null, get_full_name());
+    mhpmcounter20.configure(this, null, "mhpmcounter20");
+    mhpmcounter20.build();
+
+    mhpmcounter21 = reg_mhpmcounter21::type_id::create("mhpmcounter21", null, get_full_name());
+    mhpmcounter21.configure(this, null, "mhpmcounter21");
+    mhpmcounter21.build();
+
+    mhpmcounter22 = reg_mhpmcounter22::type_id::create("mhpmcounter22", null, get_full_name());
+    mhpmcounter22.configure(this, null, "mhpmcounter22");
+    mhpmcounter22.build();
+
+    mhpmcounter23 = reg_mhpmcounter23::type_id::create("mhpmcounter23", null, get_full_name());
+    mhpmcounter23.configure(this, null, "mhpmcounter23");
+    mhpmcounter23.build();
+
+    mhpmcounter24 = reg_mhpmcounter24::type_id::create("mhpmcounter24", null, get_full_name());
+    mhpmcounter24.configure(this, null, "mhpmcounter24");
+    mhpmcounter24.build();
+
+    mhpmcounter25 = reg_mhpmcounter25::type_id::create("mhpmcounter25", null, get_full_name());
+    mhpmcounter25.configure(this, null, "mhpmcounter25");
+    mhpmcounter25.build();
+
+    mhpmcounter26 = reg_mhpmcounter26::type_id::create("mhpmcounter26", null, get_full_name());
+    mhpmcounter26.configure(this, null, "mhpmcounter26");
+    mhpmcounter26.build();
+
+    mhpmcounter27 = reg_mhpmcounter27::type_id::create("mhpmcounter27", null, get_full_name());
+    mhpmcounter27.configure(this, null, "mhpmcounter27");
+    mhpmcounter27.build();
+
+    mhpmcounter28 = reg_mhpmcounter28::type_id::create("mhpmcounter28", null, get_full_name());
+    mhpmcounter28.configure(this, null, "mhpmcounter28");
+    mhpmcounter28.build();
+
+    mhpmcounter29 = reg_mhpmcounter29::type_id::create("mhpmcounter29", null, get_full_name());
+    mhpmcounter29.configure(this, null, "mhpmcounter29");
+    mhpmcounter29.build();
+
+    mhpmcounter30 = reg_mhpmcounter30::type_id::create("mhpmcounter30", null, get_full_name());
+    mhpmcounter30.configure(this, null, "mhpmcounter30");
+    mhpmcounter30.build();
+
+    mhpmcounter31 = reg_mhpmcounter31::type_id::create("mhpmcounter31", null, get_full_name());
+    mhpmcounter31.configure(this, null, "mhpmcounter31");
+    mhpmcounter31.build();
+
+    mhpmcounterh3 = reg_mhpmcounterh3::type_id::create("mhpmcounterh3", null, get_full_name());
+    mhpmcounterh3.configure(this, null, "mhpmcounterh3");
+    mhpmcounterh3.build();
+
+    mhpmcounterh4 = reg_mhpmcounterh4::type_id::create("mhpmcounterh4", null, get_full_name());
+    mhpmcounterh4.configure(this, null, "mhpmcounterh4");
+    mhpmcounterh4.build();
+
+    mhpmcounterh5 = reg_mhpmcounterh5::type_id::create("mhpmcounterh5", null, get_full_name());
+    mhpmcounterh5.configure(this, null, "mhpmcounterh5");
+    mhpmcounterh5.build();
+
+    mhpmcounterh6 = reg_mhpmcounterh6::type_id::create("mhpmcounterh6", null, get_full_name());
+    mhpmcounterh6.configure(this, null, "mhpmcounterh6");
+    mhpmcounterh6.build();
+
+    mhpmcounterh7 = reg_mhpmcounterh7::type_id::create("mhpmcounterh7", null, get_full_name());
+    mhpmcounterh7.configure(this, null, "mhpmcounterh7");
+    mhpmcounterh7.build();
+
+    mhpmcounterh8 = reg_mhpmcounterh8::type_id::create("mhpmcounterh8", null, get_full_name());
+    mhpmcounterh8.configure(this, null, "mhpmcounterh8");
+    mhpmcounterh8.build();
+
+    mhpmcounterh9 = reg_mhpmcounterh9::type_id::create("mhpmcounterh9", null, get_full_name());
+    mhpmcounterh9.configure(this, null, "mhpmcounterh9");
+    mhpmcounterh9.build();
+
+    mhpmcounterh10 = reg_mhpmcounterh10::type_id::create("mhpmcounterh10", null, get_full_name());
+    mhpmcounterh10.configure(this, null, "mhpmcounterh10");
+    mhpmcounterh10.build();
+
+    mhpmcounterh11 = reg_mhpmcounterh11::type_id::create("mhpmcounterh11", null, get_full_name());
+    mhpmcounterh11.configure(this, null, "mhpmcounterh11");
+    mhpmcounterh11.build();
+
+    mhpmcounterh12 = reg_mhpmcounterh12::type_id::create("mhpmcounterh12", null, get_full_name());
+    mhpmcounterh12.configure(this, null, "mhpmcounterh12");
+    mhpmcounterh12.build();
+
+    mhpmcounterh13 = reg_mhpmcounterh13::type_id::create("mhpmcounterh13", null, get_full_name());
+    mhpmcounterh13.configure(this, null, "mhpmcounterh13");
+    mhpmcounterh13.build();
+
+    mhpmcounterh14 = reg_mhpmcounterh14::type_id::create("mhpmcounterh14", null, get_full_name());
+    mhpmcounterh14.configure(this, null, "mhpmcounterh14");
+    mhpmcounterh14.build();
+
+    mhpmcounterh15 = reg_mhpmcounterh15::type_id::create("mhpmcounterh15", null, get_full_name());
+    mhpmcounterh15.configure(this, null, "mhpmcounterh15");
+    mhpmcounterh15.build();
+
+    mhpmcounterh16 = reg_mhpmcounterh16::type_id::create("mhpmcounterh16", null, get_full_name());
+    mhpmcounterh16.configure(this, null, "mhpmcounterh16");
+    mhpmcounterh16.build();
+
+    mhpmcounterh17 = reg_mhpmcounterh17::type_id::create("mhpmcounterh17", null, get_full_name());
+    mhpmcounterh17.configure(this, null, "mhpmcounterh17");
+    mhpmcounterh17.build();
+
+    mhpmcounterh18 = reg_mhpmcounterh18::type_id::create("mhpmcounterh18", null, get_full_name());
+    mhpmcounterh18.configure(this, null, "mhpmcounterh18");
+    mhpmcounterh18.build();
+
+    mhpmcounterh19 = reg_mhpmcounterh19::type_id::create("mhpmcounterh19", null, get_full_name());
+    mhpmcounterh19.configure(this, null, "mhpmcounterh19");
+    mhpmcounterh19.build();
+
+    mhpmcounterh20 = reg_mhpmcounterh20::type_id::create("mhpmcounterh20", null, get_full_name());
+    mhpmcounterh20.configure(this, null, "mhpmcounterh20");
+    mhpmcounterh20.build();
+
+    mhpmcounterh21 = reg_mhpmcounterh21::type_id::create("mhpmcounterh21", null, get_full_name());
+    mhpmcounterh21.configure(this, null, "mhpmcounterh21");
+    mhpmcounterh21.build();
+
+    mhpmcounterh22 = reg_mhpmcounterh22::type_id::create("mhpmcounterh22", null, get_full_name());
+    mhpmcounterh22.configure(this, null, "mhpmcounterh22");
+    mhpmcounterh22.build();
+
+    mhpmcounterh23 = reg_mhpmcounterh23::type_id::create("mhpmcounterh23", null, get_full_name());
+    mhpmcounterh23.configure(this, null, "mhpmcounterh23");
+    mhpmcounterh23.build();
+
+    mhpmcounterh24 = reg_mhpmcounterh24::type_id::create("mhpmcounterh24", null, get_full_name());
+    mhpmcounterh24.configure(this, null, "mhpmcounterh24");
+    mhpmcounterh24.build();
+
+    mhpmcounterh25 = reg_mhpmcounterh25::type_id::create("mhpmcounterh25", null, get_full_name());
+    mhpmcounterh25.configure(this, null, "mhpmcounterh25");
+    mhpmcounterh25.build();
+
+    mhpmcounterh26 = reg_mhpmcounterh26::type_id::create("mhpmcounterh26", null, get_full_name());
+    mhpmcounterh26.configure(this, null, "mhpmcounterh26");
+    mhpmcounterh26.build();
+
+    mhpmcounterh27 = reg_mhpmcounterh27::type_id::create("mhpmcounterh27", null, get_full_name());
+    mhpmcounterh27.configure(this, null, "mhpmcounterh27");
+    mhpmcounterh27.build();
+
+    mhpmcounterh28 = reg_mhpmcounterh28::type_id::create("mhpmcounterh28", null, get_full_name());
+    mhpmcounterh28.configure(this, null, "mhpmcounterh28");
+    mhpmcounterh28.build();
+
+    mhpmcounterh29 = reg_mhpmcounterh29::type_id::create("mhpmcounterh29", null, get_full_name());
+    mhpmcounterh29.configure(this, null, "mhpmcounterh29");
+    mhpmcounterh29.build();
+
+    mhpmcounterh30 = reg_mhpmcounterh30::type_id::create("mhpmcounterh30", null, get_full_name());
+    mhpmcounterh30.configure(this, null, "mhpmcounterh30");
+    mhpmcounterh30.build();
+
+    mhpmcounterh31 = reg_mhpmcounterh31::type_id::create("mhpmcounterh31", null, get_full_name());
+    mhpmcounterh31.configure(this, null, "mhpmcounterh31");
+    mhpmcounterh31.build();
+
+    cycle = reg_cycle::type_id::create("cycle", null, get_full_name());
+    cycle.configure(this, null, "cycle");
+    cycle.build();
+
+    instret = reg_instret::type_id::create("instret", null, get_full_name());
+    instret.configure(this, null, "instret");
+    instret.build();
+
+    cycleh = reg_cycleh::type_id::create("cycleh", null, get_full_name());
+    cycleh.configure(this, null, "cycleh");
+    cycleh.build();
+
+    instreth = reg_instreth::type_id::create("instreth", null, get_full_name());
+    instreth.configure(this, null, "instreth");
+    instreth.build();
+
+    mvendorid = reg_mvendorid::type_id::create("mvendorid", null, get_full_name());
+    mvendorid.configure(this, null, "mvendorid");
+    mvendorid.build();
+
+    marchid = reg_marchid::type_id::create("marchid", null, get_full_name());
+    marchid.configure(this, null, "marchid");
+    marchid.build();
+
+    mimpid = reg_mimpid::type_id::create("mimpid", null, get_full_name());
+    mimpid.configure(this, null, "mimpid");
+    mimpid.build();
+
+    mhartid = reg_mhartid::type_id::create("mhartid", null, get_full_name());
+    mhartid.configure(this, null, "mhartid");
+    mhartid.build();
+
+ 
+    
+    //---------------------------------------
+    //Memory map creation and reg map to it
+    //---------------------------------------
+    default_map = create_map(.name("default_map"), .base_addr(0), .n_bytes(4) , .endian(UVM_LITTLE_ENDIAN));
+    default_map.add_reg(mstatus, 'h300, "RW");  
+    default_map.add_reg(misa, 'h301, "RW");  
+    default_map.add_reg(mie, 'h304, "RW");  
+    default_map.add_reg(mtvec, 'h305, "RW");  
+    default_map.add_reg(mstatush, 'h310, "RW");  
+    default_map.add_reg(mhpmevent3, 'h323, "RW");  
+    default_map.add_reg(mhpmevent4, 'h324, "RW");  
+    default_map.add_reg(mhpmevent5, 'h325, "RW");  
+    default_map.add_reg(mhpmevent6, 'h326, "RW");  
+    default_map.add_reg(mhpmevent7, 'h327, "RW");  
+    default_map.add_reg(mhpmevent8, 'h328, "RW");  
+    default_map.add_reg(mhpmevent9, 'h329, "RW");  
+    default_map.add_reg(mhpmevent10, 'h32a, "RW");  
+    default_map.add_reg(mhpmevent11, 'h32b, "RW");  
+    default_map.add_reg(mhpmevent12, 'h32c, "RW");  
+    default_map.add_reg(mhpmevent13, 'h32d, "RW");  
+    default_map.add_reg(mhpmevent14, 'h32e, "RW");  
+    default_map.add_reg(mhpmevent15, 'h32f, "RW");  
+    default_map.add_reg(mhpmevent16, 'h330, "RW");  
+    default_map.add_reg(mhpmevent17, 'h331, "RW");  
+    default_map.add_reg(mhpmevent18, 'h332, "RW");  
+    default_map.add_reg(mhpmevent19, 'h333, "RW");  
+    default_map.add_reg(mhpmevent20, 'h334, "RW");  
+    default_map.add_reg(mhpmevent21, 'h335, "RW");  
+    default_map.add_reg(mhpmevent22, 'h336, "RW");  
+    default_map.add_reg(mhpmevent23, 'h337, "RW");  
+    default_map.add_reg(mhpmevent24, 'h338, "RW");  
+    default_map.add_reg(mhpmevent25, 'h339, "RW");  
+    default_map.add_reg(mhpmevent26, 'h33a, "RW");  
+    default_map.add_reg(mhpmevent27, 'h33b, "RW");  
+    default_map.add_reg(mhpmevent28, 'h33c, "RW");  
+    default_map.add_reg(mhpmevent29, 'h33d, "RW");  
+    default_map.add_reg(mhpmevent30, 'h33e, "RW");  
+    default_map.add_reg(mhpmevent31, 'h33f, "RW");  
+    default_map.add_reg(mscratch, 'h340, "RW");  
+    default_map.add_reg(mepc, 'h341, "RW");  
+    default_map.add_reg(mcause, 'h342, "RW");  
+    default_map.add_reg(mtval, 'h343, "RW");  
+    default_map.add_reg(mip, 'h344, "RW");  
+    default_map.add_reg(pmpcfg0, 'h3a0, "RW");  
+    default_map.add_reg(pmpcfg1, 'h3a1, "RW");  
+    default_map.add_reg(pmpcfg2, 'h3a2, "RW");  
+    default_map.add_reg(pmpcfg3, 'h3a3, "RW");  
+    default_map.add_reg(pmpaddr0, 'h3b0, "RW");  
+    default_map.add_reg(pmpaddr1, 'h3b1, "RW");  
+    default_map.add_reg(pmpaddr2, 'h3b2, "RW");  
+    default_map.add_reg(pmpaddr3, 'h3b3, "RW");  
+    default_map.add_reg(pmpaddr4, 'h3b4, "RW");  
+    default_map.add_reg(pmpaddr5, 'h3b5, "RW");  
+    default_map.add_reg(pmpaddr6, 'h3b6, "RW");  
+    default_map.add_reg(pmpaddr7, 'h3b7, "RW");  
+    default_map.add_reg(pmpaddr8, 'h3b8, "RW");  
+    default_map.add_reg(pmpaddr9, 'h3b9, "RW");  
+    default_map.add_reg(pmpaddr10, 'h3ba, "RW");  
+    default_map.add_reg(pmpaddr11, 'h3bb, "RW");  
+    default_map.add_reg(pmpaddr12, 'h3bc, "RW");  
+    default_map.add_reg(pmpaddr13, 'h3bd, "RW");  
+    default_map.add_reg(pmpaddr14, 'h3be, "RW");  
+    default_map.add_reg(pmpaddr15, 'h3bf, "RW");  
+    default_map.add_reg(icache, 'h7C0, "RW");  
+    default_map.add_reg(mcycle, 'hB00, "RW");  
+    default_map.add_reg(minstret, 'hB02, "RW");  
+    default_map.add_reg(mcycleh, 'hB80, "RW");  
+    default_map.add_reg(minstreth, 'hB82, "RW");  
+    default_map.add_reg(mhpmcounter3, 'hb03, "RW");  
+    default_map.add_reg(mhpmcounter4, 'hb04, "RW");  
+    default_map.add_reg(mhpmcounter5, 'hb05, "RW");  
+    default_map.add_reg(mhpmcounter6, 'hb06, "RW");  
+    default_map.add_reg(mhpmcounter7, 'hb07, "RW");  
+    default_map.add_reg(mhpmcounter8, 'hb08, "RW");  
+    default_map.add_reg(mhpmcounter9, 'hb09, "RW");  
+    default_map.add_reg(mhpmcounter10, 'hb0a, "RW");  
+    default_map.add_reg(mhpmcounter11, 'hb0b, "RW");  
+    default_map.add_reg(mhpmcounter12, 'hb0c, "RW");  
+    default_map.add_reg(mhpmcounter13, 'hb0d, "RW");  
+    default_map.add_reg(mhpmcounter14, 'hb0e, "RW");  
+    default_map.add_reg(mhpmcounter15, 'hb0f, "RW");  
+    default_map.add_reg(mhpmcounter16, 'hb10, "RW");  
+    default_map.add_reg(mhpmcounter17, 'hb11, "RW");  
+    default_map.add_reg(mhpmcounter18, 'hb12, "RW");  
+    default_map.add_reg(mhpmcounter19, 'hb13, "RW");  
+    default_map.add_reg(mhpmcounter20, 'hb14, "RW");  
+    default_map.add_reg(mhpmcounter21, 'hb15, "RW");  
+    default_map.add_reg(mhpmcounter22, 'hb16, "RW");  
+    default_map.add_reg(mhpmcounter23, 'hb17, "RW");  
+    default_map.add_reg(mhpmcounter24, 'hb18, "RW");  
+    default_map.add_reg(mhpmcounter25, 'hb19, "RW");  
+    default_map.add_reg(mhpmcounter26, 'hb1a, "RW");  
+    default_map.add_reg(mhpmcounter27, 'hb1b, "RW");  
+    default_map.add_reg(mhpmcounter28, 'hb1c, "RW");  
+    default_map.add_reg(mhpmcounter29, 'hb1d, "RW");  
+    default_map.add_reg(mhpmcounter30, 'hb1e, "RW");  
+    default_map.add_reg(mhpmcounter31, 'hb1f, "RW");  
+    default_map.add_reg(mhpmcounterh3, 'hb83, "RW");  
+    default_map.add_reg(mhpmcounterh4, 'hb84, "RW");  
+    default_map.add_reg(mhpmcounterh5, 'hb85, "RW");  
+    default_map.add_reg(mhpmcounterh6, 'hb86, "RW");  
+    default_map.add_reg(mhpmcounterh7, 'hb87, "RW");  
+    default_map.add_reg(mhpmcounterh8, 'hb88, "RW");  
+    default_map.add_reg(mhpmcounterh9, 'hb89, "RW");  
+    default_map.add_reg(mhpmcounterh10, 'hb8a, "RW");  
+    default_map.add_reg(mhpmcounterh11, 'hb8b, "RW");  
+    default_map.add_reg(mhpmcounterh12, 'hb8c, "RW");  
+    default_map.add_reg(mhpmcounterh13, 'hb8d, "RW");  
+    default_map.add_reg(mhpmcounterh14, 'hb8e, "RW");  
+    default_map.add_reg(mhpmcounterh15, 'hb8f, "RW");  
+    default_map.add_reg(mhpmcounterh16, 'hb90, "RW");  
+    default_map.add_reg(mhpmcounterh17, 'hb91, "RW");  
+    default_map.add_reg(mhpmcounterh18, 'hb92, "RW");  
+    default_map.add_reg(mhpmcounterh19, 'hb93, "RW");  
+    default_map.add_reg(mhpmcounterh20, 'hb94, "RW");  
+    default_map.add_reg(mhpmcounterh21, 'hb95, "RW");  
+    default_map.add_reg(mhpmcounterh22, 'hb96, "RW");  
+    default_map.add_reg(mhpmcounterh23, 'hb97, "RW");  
+    default_map.add_reg(mhpmcounterh24, 'hb98, "RW");  
+    default_map.add_reg(mhpmcounterh25, 'hb99, "RW");  
+    default_map.add_reg(mhpmcounterh26, 'hb9a, "RW");  
+    default_map.add_reg(mhpmcounterh27, 'hb9b, "RW");  
+    default_map.add_reg(mhpmcounterh28, 'hb9c, "RW");  
+    default_map.add_reg(mhpmcounterh29, 'hb9d, "RW");  
+    default_map.add_reg(mhpmcounterh30, 'hb9e, "RW");  
+    default_map.add_reg(mhpmcounterh31, 'hb9f, "RW");  
+    default_map.add_reg(cycle, 'hC00, "RO");  
+    default_map.add_reg(instret, 'hC02, "RO");  
+    default_map.add_reg(cycleh, 'hC80, "RO");  
+    default_map.add_reg(instreth, 'hC82, "RO");  
+    default_map.add_reg(mvendorid, 'hF11, "RO");  
+    default_map.add_reg(marchid, 'hF12, "RO");  
+    default_map.add_reg(mimpid, 'hF13, "RO");  
+    default_map.add_reg(mhartid, 'hF14, "RO");  
+    //default_map.set_check_on_read(1);
+    this.set_coverage(UVM_CVR_ALL);
+    this.lock_model();
+    reset();
+  endfunction
+endclass

--- a/verif/env/uvme/reg/cva6_csr_reg_file.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_file.sv
@@ -1,0 +1,6040 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2023 Thales DIS
+//
+// Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+typedef enum int {
+   U_LEVEL        = 0,
+   S_LEVEL        = 1,
+   RESERVED_LEVEL = 2,
+   M_LEVEL        = 3,
+   D_LEVEL        = 10
+} privilege_level_t;
+ 
+class csr_reg extends uvm_reg;
+
+  local privilege_level_t privilege_level; //CSR Privilege access level 
+  
+  `uvm_object_utils_begin(csr_reg)
+      `uvm_field_enum(privilege_level_t, privilege_level, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  function new (string name = "csr_reg");
+    super.new(name, .n_bits(32), .has_coverage(UVM_CVR_ALL));
+  endfunction
+  
+  function  int get_privilege_level(); 
+      return privilege_level;
+  endfunction
+
+  function  string get_privilege_level_str(privilege_level_t privilege); 
+   case (privilege)
+      U_LEVEL: return "U";
+      S_LEVEL: return "S";
+      M_LEVEL: return "M";
+      D_LEVEL: return "D";
+   endcase
+   return "?";
+  endfunction
+
+  function void set_privilege_level(privilege_level_t privilege); 
+      privilege_level = privilege;
+  endfunction
+
+  virtual function void sample(uvm_reg_data_t data, uvm_reg_data_t byte_en,bit is_read, uvm_reg_map map);
+     sample_values();
+  endfunction
+
+endclass
+
+class reg_mstatus extends csr_reg;
+  `uvm_object_utils(reg_mstatus)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field SD;
+  rand uvm_reg_field TSR;
+  rand uvm_reg_field TW;
+  rand uvm_reg_field TVM;
+  rand uvm_reg_field MXR;
+  rand uvm_reg_field SUM;
+  rand uvm_reg_field MPRV;
+  rand uvm_reg_field XS;
+  rand uvm_reg_field FS;
+  rand uvm_reg_field MPP;
+  rand uvm_reg_field VS;
+  rand uvm_reg_field SPP;
+  rand uvm_reg_field MPIE;
+  rand uvm_reg_field UBE;
+  rand uvm_reg_field SPIE;
+  rand uvm_reg_field MIE;
+  rand uvm_reg_field SIE;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mstatus";
+      option.per_instance = 1;
+      SD: coverpoint SD.value[0:0];
+      TSR: coverpoint TSR.value[0:0];
+      TW: coverpoint TW.value[0:0];
+      TVM: coverpoint TVM.value[0:0];
+      MXR: coverpoint MXR.value[0:0];
+      SUM: coverpoint SUM.value[0:0];
+      MPRV: coverpoint MPRV.value[0:0];
+      XS: coverpoint XS.value[1:0];
+      FS: coverpoint FS.value[1:0];
+      MPP: coverpoint MPP.value[1:0];
+      VS: coverpoint VS.value[1:0];
+      SPP: coverpoint SPP.value[0:0];
+      MPIE: coverpoint MPIE.value[0:0];
+      UBE: coverpoint UBE.value[0:0];
+      SPIE: coverpoint SPIE.value[0:0];
+      MIE: coverpoint MIE.value[0:0];
+      SIE: coverpoint SIE.value[0:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mstatus");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mstatus");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    SD = uvm_reg_field::type_id::create("SD");   
+    SD.configure(.parent(this), .size(1), .lsb_pos(31), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    TSR = uvm_reg_field::type_id::create("TSR");   
+    TSR.configure(.parent(this), .size(1), .lsb_pos(22), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    TW = uvm_reg_field::type_id::create("TW");   
+    TW.configure(.parent(this), .size(1), .lsb_pos(21), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    TVM = uvm_reg_field::type_id::create("TVM");   
+    TVM.configure(.parent(this), .size(1), .lsb_pos(20), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MXR = uvm_reg_field::type_id::create("MXR");   
+    MXR.configure(.parent(this), .size(1), .lsb_pos(19), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    SUM = uvm_reg_field::type_id::create("SUM");   
+    SUM.configure(.parent(this), .size(1), .lsb_pos(18), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MPRV = uvm_reg_field::type_id::create("MPRV");   
+    MPRV.configure(.parent(this), .size(1), .lsb_pos(17), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    XS = uvm_reg_field::type_id::create("XS");   
+    XS.configure(.parent(this), .size(2), .lsb_pos(15), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    FS = uvm_reg_field::type_id::create("FS");   
+    FS.configure(.parent(this), .size(2), .lsb_pos(13), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MPP = uvm_reg_field::type_id::create("MPP");   
+    MPP.configure(.parent(this), .size(2), .lsb_pos(11), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    VS = uvm_reg_field::type_id::create("VS");   
+    VS.configure(.parent(this), .size(2), .lsb_pos(9), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    SPP = uvm_reg_field::type_id::create("SPP");   
+    SPP.configure(.parent(this), .size(1), .lsb_pos(8), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MPIE = uvm_reg_field::type_id::create("MPIE");   
+    MPIE.configure(.parent(this), .size(1), .lsb_pos(7), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    UBE = uvm_reg_field::type_id::create("UBE");   
+    UBE.configure(.parent(this), .size(1), .lsb_pos(6), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    SPIE = uvm_reg_field::type_id::create("SPIE");   
+    SPIE.configure(.parent(this), .size(1), .lsb_pos(5), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    MIE = uvm_reg_field::type_id::create("MIE");   
+    MIE.configure(.parent(this), .size(1), .lsb_pos(3), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    SIE = uvm_reg_field::type_id::create("SIE");   
+    SIE.configure(.parent(this), .size(1), .lsb_pos(1), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_misa extends csr_reg;
+  `uvm_object_utils(reg_misa)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field MXL;
+  rand uvm_reg_field Extensions;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_misa";
+      option.per_instance = 1;
+      MXL: coverpoint MXL.value[1:0];
+      Extensions: coverpoint Extensions.value[25:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_misa");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.misa");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    MXL = uvm_reg_field::type_id::create("MXL");   
+    MXL.configure(.parent(this), .size(2), .lsb_pos(30), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    Extensions = uvm_reg_field::type_id::create("Extensions");   
+    Extensions.configure(.parent(this), .size(26), .lsb_pos(0), .access("RW"), .volatile(0), .reset(37782532), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mie extends csr_reg;
+  `uvm_object_utils(reg_mie)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field MEIE;
+  rand uvm_reg_field SEIE;
+  rand uvm_reg_field UEIE;
+  rand uvm_reg_field MTIE;
+  rand uvm_reg_field STIE;
+  rand uvm_reg_field UTIE;
+  rand uvm_reg_field MSIE;
+  rand uvm_reg_field SSIE;
+  rand uvm_reg_field USIE;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mie";
+      option.per_instance = 1;
+      MEIE: coverpoint MEIE.value[0:0];
+      SEIE: coverpoint SEIE.value[0:0];
+      UEIE: coverpoint UEIE.value[0:0];
+      MTIE: coverpoint MTIE.value[0:0];
+      STIE: coverpoint STIE.value[0:0];
+      UTIE: coverpoint UTIE.value[0:0];
+      MSIE: coverpoint MSIE.value[0:0];
+      SSIE: coverpoint SSIE.value[0:0];
+      USIE: coverpoint USIE.value[0:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mie");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mie");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+   
+    MEIE = uvm_reg_field::type_id::create("MEIE");   
+    MEIE.configure(.parent(this), .size(1), .lsb_pos(11), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    SEIE = uvm_reg_field::type_id::create("SEIE");   
+    SEIE.configure(.parent(this), .size(1), .lsb_pos(9), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    UEIE = uvm_reg_field::type_id::create("UEIE");   
+    UEIE.configure(.parent(this), .size(1), .lsb_pos(8), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MTIE = uvm_reg_field::type_id::create("MTIE");   
+    MTIE.configure(.parent(this), .size(1), .lsb_pos(7), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    STIE = uvm_reg_field::type_id::create("STIE");   
+    STIE.configure(.parent(this), .size(1), .lsb_pos(5), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    UTIE = uvm_reg_field::type_id::create("UTIE");   
+    UTIE.configure(.parent(this), .size(1), .lsb_pos(4), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MSIE = uvm_reg_field::type_id::create("MSIE");   
+    MSIE.configure(.parent(this), .size(1), .lsb_pos(3), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    SSIE = uvm_reg_field::type_id::create("SSIE");   
+    SSIE.configure(.parent(this), .size(1), .lsb_pos(1), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    USIE = uvm_reg_field::type_id::create("USIE");   
+    USIE.configure(.parent(this), .size(1), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mtvec extends csr_reg;
+  `uvm_object_utils(reg_mtvec)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field BASE;
+  rand uvm_reg_field MODE;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mtvec";
+      option.per_instance = 1;
+      BASE: coverpoint BASE.value[29:0];
+      MODE: coverpoint MODE.value[1:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mtvec");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mtvec");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    BASE = uvm_reg_field::type_id::create("BASE");   
+    BASE.configure(.parent(this), .size(30), .lsb_pos(2), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MODE = uvm_reg_field::type_id::create("MODE");   
+    MODE.configure(.parent(this), .size(2), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mstatush extends csr_reg;
+  `uvm_object_utils(reg_mstatush)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field SBE;
+  rand uvm_reg_field MBE;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mstatush";
+      option.per_instance = 1;
+      SBE: coverpoint SBE.value[0:0];
+      MBE: coverpoint MBE.value[0:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mstatush");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mstatush");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+   
+    SBE = uvm_reg_field::type_id::create("SBE");   
+    SBE.configure(.parent(this), .size(1), .lsb_pos(4), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MBE = uvm_reg_field::type_id::create("MBE");   
+    MBE.configure(.parent(this), .size(1), .lsb_pos(5), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent3 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent3)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent3";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent3");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent3");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent4 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent4)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent4";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent4");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent4");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent5 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent5)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent5";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent5");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent5");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent6 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent6)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent6";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent6");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent6");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent7 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent7)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent7";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent7");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent7");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent8 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent8)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent8";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent8");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent8");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent9 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent9)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent9";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent9");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent9");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent10 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent10)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent10";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent10");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent10");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent11 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent11)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent11";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent11");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent11");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent12 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent12)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent12";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent12");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent12");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent13 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent13)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent13";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent13");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent13");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent14 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent14)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent14";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent14");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent14");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent15 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent15)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent15";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent15");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent15");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent16 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent16)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent16";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent16");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent16");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent17 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent17)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent17";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent17");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent17");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent18 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent18)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent18";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent18");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent18");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent19 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent19)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent19";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent19");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent19");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent20 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent20)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent20";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent20");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent20");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent21 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent21)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent21";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent21");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent21");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent22 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent22)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent22";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent22");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent22");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent23 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent23)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent23";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent23");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent23");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent24 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent24)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent24";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent24");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent24");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent25 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent25)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent25";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent25");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent25");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent26 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent26)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent26";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent26");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent26");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent27 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent27)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent27";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent27");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent27");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent28 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent28)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent28";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent28");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent28");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent29 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent29)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent29";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent29");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent29");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent30 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent30)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent30";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent30");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent30");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmevent31 extends csr_reg;
+  `uvm_object_utils(reg_mhpmevent31)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mhpmevent;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmevent31";
+      option.per_instance = 1;
+      mhpmevent: coverpoint mhpmevent.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmevent31");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmevent31");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mhpmevent = uvm_reg_field::type_id::create("mhpmevent");   
+    mhpmevent.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mscratch extends csr_reg;
+  `uvm_object_utils(reg_mscratch)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mscratch;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mscratch";
+      option.per_instance = 1;
+      mscratch: coverpoint mscratch.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mscratch");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mscratch");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mscratch = uvm_reg_field::type_id::create("mscratch");   
+    mscratch.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mepc extends csr_reg;
+  `uvm_object_utils(reg_mepc)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mepc;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mepc";
+      option.per_instance = 1;
+      mepc: coverpoint mepc.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mepc");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mepc");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mepc = uvm_reg_field::type_id::create("mepc");   
+    mepc.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mcause extends csr_reg;
+  `uvm_object_utils(reg_mcause)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field Interrupt;
+  rand uvm_reg_field exception_code;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mcause";
+      option.per_instance = 1;
+      Interrupt: coverpoint Interrupt.value[0:0];
+      exception_code: coverpoint exception_code.value[30:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mcause");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mcause");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    Interrupt = uvm_reg_field::type_id::create("Interrupt");   
+    Interrupt.configure(.parent(this), .size(1), .lsb_pos(31), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    exception_code = uvm_reg_field::type_id::create("exception_code");   
+    exception_code.configure(.parent(this), .size(31), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mtval extends csr_reg;
+  `uvm_object_utils(reg_mtval)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field mtval;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mtval";
+      option.per_instance = 1;
+      mtval: coverpoint mtval.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mtval");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mtval");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    mtval = uvm_reg_field::type_id::create("mtval");   
+    mtval.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mip extends csr_reg;
+  `uvm_object_utils(reg_mip)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field MEIP;
+  rand uvm_reg_field SEIP;
+  rand uvm_reg_field UEIP;
+  rand uvm_reg_field MTIP;
+  rand uvm_reg_field STIP;
+  rand uvm_reg_field UTIP;
+  rand uvm_reg_field MSIP;
+  rand uvm_reg_field SSIP;
+  rand uvm_reg_field USIP;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mip";
+      option.per_instance = 1;
+      MEIP: coverpoint MEIP.value[0:0];
+      SEIP: coverpoint SEIP.value[0:0];
+      UEIP: coverpoint UEIP.value[0:0];
+      MTIP: coverpoint MTIP.value[0:0];
+      STIP: coverpoint STIP.value[0:0];
+      UTIP: coverpoint UTIP.value[0:0];
+      MSIP: coverpoint MSIP.value[0:0];
+      SSIP: coverpoint SSIP.value[0:0];
+      USIP: coverpoint USIP.value[0:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mip");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mip");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+   
+    MEIP = uvm_reg_field::type_id::create("MEIP");   
+    MEIP.configure(.parent(this), .size(1), .lsb_pos(11), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    SEIP = uvm_reg_field::type_id::create("SEIP");   
+    SEIP.configure(.parent(this), .size(1), .lsb_pos(9), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    UEIP = uvm_reg_field::type_id::create("UEIP");   
+    UEIP.configure(.parent(this), .size(1), .lsb_pos(8), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MTIP = uvm_reg_field::type_id::create("MTIP");   
+    MTIP.configure(.parent(this), .size(1), .lsb_pos(7), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    STIP = uvm_reg_field::type_id::create("STIP");   
+    STIP.configure(.parent(this), .size(1), .lsb_pos(5), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    UTIP = uvm_reg_field::type_id::create("UTIP");   
+    UTIP.configure(.parent(this), .size(1), .lsb_pos(4), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    MSIP = uvm_reg_field::type_id::create("MSIP");   
+    MSIP.configure(.parent(this), .size(1), .lsb_pos(3), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+   
+    SSIP = uvm_reg_field::type_id::create("SSIP");   
+    SSIP.configure(.parent(this), .size(1), .lsb_pos(1), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    USIP = uvm_reg_field::type_id::create("USIP");   
+    USIP.configure(.parent(this), .size(1), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpcfg0 extends csr_reg;
+  `uvm_object_utils(reg_pmpcfg0)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field pmp3cfg;
+  rand uvm_reg_field pmp2cfg;
+  rand uvm_reg_field pmp1cfg;
+  rand uvm_reg_field pmp0cfg;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpcfg0";
+      option.per_instance = 1;
+      pmp3cfg: coverpoint pmp3cfg.value[7:0];
+      pmp2cfg: coverpoint pmp2cfg.value[7:0];
+      pmp1cfg: coverpoint pmp1cfg.value[7:0];
+      pmp0cfg: coverpoint pmp0cfg.value[7:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpcfg0");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpcfg0");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    pmp3cfg = uvm_reg_field::type_id::create("pmp3cfg");   
+    pmp3cfg.configure(.parent(this), .size(8), .lsb_pos(24), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp2cfg = uvm_reg_field::type_id::create("pmp2cfg");   
+    pmp2cfg.configure(.parent(this), .size(8), .lsb_pos(16), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp1cfg = uvm_reg_field::type_id::create("pmp1cfg");   
+    pmp1cfg.configure(.parent(this), .size(8), .lsb_pos(8), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp0cfg = uvm_reg_field::type_id::create("pmp0cfg");   
+    pmp0cfg.configure(.parent(this), .size(8), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpcfg1 extends csr_reg;
+  `uvm_object_utils(reg_pmpcfg1)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field pmp7cfg;
+  rand uvm_reg_field pmp6cfg;
+  rand uvm_reg_field pmp5cfg;
+  rand uvm_reg_field pmp4cfg;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpcfg1";
+      option.per_instance = 1;
+      pmp7cfg: coverpoint pmp7cfg.value[7:0];
+      pmp6cfg: coverpoint pmp6cfg.value[7:0];
+      pmp5cfg: coverpoint pmp5cfg.value[7:0];
+      pmp4cfg: coverpoint pmp4cfg.value[7:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpcfg1");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpcfg1");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    pmp7cfg = uvm_reg_field::type_id::create("pmp7cfg");   
+    pmp7cfg.configure(.parent(this), .size(8), .lsb_pos(24), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp6cfg = uvm_reg_field::type_id::create("pmp6cfg");   
+    pmp6cfg.configure(.parent(this), .size(8), .lsb_pos(16), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp5cfg = uvm_reg_field::type_id::create("pmp5cfg");   
+    pmp5cfg.configure(.parent(this), .size(8), .lsb_pos(8), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp4cfg = uvm_reg_field::type_id::create("pmp4cfg");   
+    pmp4cfg.configure(.parent(this), .size(8), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpcfg2 extends csr_reg;
+  `uvm_object_utils(reg_pmpcfg2)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field pmp11cfg;
+  rand uvm_reg_field pmp10cfg;
+  rand uvm_reg_field pmp9cfg;
+  rand uvm_reg_field pmp8cfg;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpcfg2";
+      option.per_instance = 1;
+      pmp11cfg: coverpoint pmp11cfg.value[7:0];
+      pmp10cfg: coverpoint pmp10cfg.value[7:0];
+      pmp9cfg: coverpoint pmp9cfg.value[7:0];
+      pmp8cfg: coverpoint pmp8cfg.value[7:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpcfg2");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpcfg2");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    pmp11cfg = uvm_reg_field::type_id::create("pmp11cfg");   
+    pmp11cfg.configure(.parent(this), .size(8), .lsb_pos(24), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp10cfg = uvm_reg_field::type_id::create("pmp10cfg");   
+    pmp10cfg.configure(.parent(this), .size(8), .lsb_pos(16), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp9cfg = uvm_reg_field::type_id::create("pmp9cfg");   
+    pmp9cfg.configure(.parent(this), .size(8), .lsb_pos(8), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp8cfg = uvm_reg_field::type_id::create("pmp8cfg");   
+    pmp8cfg.configure(.parent(this), .size(8), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpcfg3 extends csr_reg;
+  `uvm_object_utils(reg_pmpcfg3)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field pmp15cfg;
+  rand uvm_reg_field pmp14cfg;
+  rand uvm_reg_field pmp13cfg;
+  rand uvm_reg_field pmp12cfg;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpcfg3";
+      option.per_instance = 1;
+      pmp15cfg: coverpoint pmp15cfg.value[7:0];
+      pmp14cfg: coverpoint pmp14cfg.value[7:0];
+      pmp13cfg: coverpoint pmp13cfg.value[7:0];
+      pmp12cfg: coverpoint pmp12cfg.value[7:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpcfg3");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpcfg3");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    pmp15cfg = uvm_reg_field::type_id::create("pmp15cfg");   
+    pmp15cfg.configure(.parent(this), .size(8), .lsb_pos(24), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp14cfg = uvm_reg_field::type_id::create("pmp14cfg");   
+    pmp14cfg.configure(.parent(this), .size(8), .lsb_pos(16), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp13cfg = uvm_reg_field::type_id::create("pmp13cfg");   
+    pmp13cfg.configure(.parent(this), .size(8), .lsb_pos(8), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    pmp12cfg = uvm_reg_field::type_id::create("pmp12cfg");   
+    pmp12cfg.configure(.parent(this), .size(8), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr0 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr0)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr0";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr0");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr0");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr1 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr1)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr1";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr1");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr1");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr2 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr2)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr2";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr2");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr2");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr3 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr3)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr3";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr3");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr3");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr4 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr4)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr4";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr4");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr4");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr5 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr5)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr5";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr5");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr5");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr6 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr6)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr6";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr6");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr6");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr7 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr7)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr7";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr7");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr7");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr8 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr8)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr8";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr8");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr8");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr9 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr9)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr9";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr9");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr9");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr10 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr10)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr10";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr10");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr10");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr11 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr11)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr11";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr11");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr11");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr12 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr12)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr12";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr12");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr12");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr13 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr13)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr13";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr13");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr13");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr14 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr14)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr14";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr14");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr14");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_pmpaddr15 extends csr_reg;
+  `uvm_object_utils(reg_pmpaddr15)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field address;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_pmpaddr15";
+      option.per_instance = 1;
+      address: coverpoint address.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_pmpaddr15");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.pmpaddr15");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    address = uvm_reg_field::type_id::create("address");   
+    address.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_icache extends csr_reg;
+  `uvm_object_utils(reg_icache)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field icache;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_icache";
+      option.per_instance = 1;
+      icache: coverpoint icache.value[0:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_icache");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.icache");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+   
+    icache = uvm_reg_field::type_id::create("icache");   
+    icache.configure(.parent(this), .size(1), .lsb_pos(0), .access("RW"), .volatile(0), .reset(1), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mcycle extends csr_reg;
+  `uvm_object_utils(reg_mcycle)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mcycle";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mcycle");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mcycle");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_minstret extends csr_reg;
+  `uvm_object_utils(reg_minstret)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_minstret";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_minstret");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.minstret");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mcycleh extends csr_reg;
+  `uvm_object_utils(reg_mcycleh)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mcycleh";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mcycleh");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mcycleh");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_minstreth extends csr_reg;
+  `uvm_object_utils(reg_minstreth)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_minstreth";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_minstreth");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.minstreth");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter3 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter3)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter3";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter3");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter3");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter4 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter4)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter4";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter4");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter4");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter5 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter5)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter5";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter5");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter5");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter6 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter6)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter6";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter6");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter6");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter7 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter7)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter7";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter7");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter7");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter8 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter8)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter8";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter8");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter8");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter9 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter9)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter9";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter9");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter9");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter10 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter10)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter10";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter10");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter10");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter11 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter11)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter11";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter11");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter11");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter12 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter12)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter12";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter12");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter12");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter13 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter13)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter13";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter13");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter13");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter14 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter14)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter14";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter14");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter14");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter15 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter15)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter15";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter15");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter15");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter16 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter16)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter16";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter16");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter16");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter17 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter17)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter17";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter17");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter17");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter18 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter18)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter18";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter18");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter18");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter19 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter19)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter19";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter19");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter19");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter20 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter20)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter20";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter20");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter20");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter21 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter21)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter21";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter21");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter21");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter22 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter22)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter22";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter22");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter22");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter23 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter23)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter23";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter23");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter23");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter24 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter24)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter24";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter24");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter24");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter25 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter25)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter25";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter25");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter25");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter26 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter26)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter26";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter26");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter26");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter27 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter27)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter27";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter27");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter27");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter28 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter28)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter28";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter28");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter28");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter29 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter29)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter29";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter29");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter29");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter30 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter30)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter30";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter30");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter30");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounter31 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounter31)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounter31";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounter31");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounter31");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh3 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh3)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh3";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh3");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh3");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh4 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh4)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh4";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh4");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh4");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh5 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh5)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh5";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh5");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh5");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh6 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh6)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh6";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh6");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh6");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh7 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh7)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh7";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh7");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh7");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh8 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh8)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh8";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh8");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh8");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh9 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh9)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh9";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh9");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh9");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh10 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh10)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh10";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh10");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh10");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh11 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh11)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh11";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh11");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh11");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh12 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh12)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh12";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh12");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh12");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh13 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh13)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh13";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh13");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh13");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh14 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh14)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh14";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh14");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh14");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh15 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh15)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh15";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh15");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh15");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh16 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh16)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh16";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh16");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh16");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh17 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh17)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh17";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh17");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh17");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh18 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh18)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh18";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh18");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh18");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh19 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh19)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh19";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh19");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh19");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh20 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh20)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh20";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh20");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh20");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh21 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh21)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh21";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh21");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh21");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh22 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh22)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh22";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh22");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh22");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh23 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh23)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh23";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh23");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh23");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh24 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh24)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh24";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh24");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh24");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh25 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh25)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh25";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh25");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh25");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh26 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh26)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh26";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh26");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh26");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh27 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh27)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh27";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh27");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh27");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh28 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh28)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh28";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh28");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh28");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh29 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh29)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh29";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh29");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh29");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh30 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh30)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh30";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh30");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh30");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhpmcounterh31 extends csr_reg;
+  `uvm_object_utils(reg_mhpmcounterh31)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhpmcounterh31";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhpmcounterh31");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhpmcounterh31");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RW"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_cycle extends csr_reg;
+  `uvm_object_utils(reg_cycle)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_cycle";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_cycle");
+    super.new(name);
+    set_privilege_level(U_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.cycle");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_instret extends csr_reg;
+  `uvm_object_utils(reg_instret)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_instret";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_instret");
+    super.new(name);
+    set_privilege_level(U_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.instret");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_cycleh extends csr_reg;
+  `uvm_object_utils(reg_cycleh)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_cycleh";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_cycleh");
+    super.new(name);
+    set_privilege_level(U_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.cycleh");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_instreth extends csr_reg;
+  `uvm_object_utils(reg_instreth)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field count;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_instreth";
+      option.per_instance = 1;
+      count: coverpoint count.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_instreth");
+    super.new(name);
+    set_privilege_level(U_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.instreth");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    count = uvm_reg_field::type_id::create("count");   
+    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mvendorid extends csr_reg;
+  `uvm_object_utils(reg_mvendorid)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field bank;
+  rand uvm_reg_field offset;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mvendorid";
+      option.per_instance = 1;
+      bank: coverpoint bank.value[24:0];
+      offset: coverpoint offset.value[6:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mvendorid");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mvendorid");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    bank = uvm_reg_field::type_id::create("bank");   
+    bank.configure(.parent(this), .size(25), .lsb_pos(7), .access("RO"), .volatile(0), .reset(384), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+   
+    offset = uvm_reg_field::type_id::create("offset");   
+    offset.configure(.parent(this), .size(7), .lsb_pos(0), .access("RO"), .volatile(0), .reset(64), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_marchid extends csr_reg;
+  `uvm_object_utils(reg_marchid)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field architecture_id;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_marchid";
+      option.per_instance = 1;
+      architecture_id: coverpoint architecture_id.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_marchid");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.marchid");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    architecture_id = uvm_reg_field::type_id::create("architecture_id");   
+    architecture_id.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(3), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mimpid extends csr_reg;
+  `uvm_object_utils(reg_mimpid)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field implementation;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mimpid";
+      option.per_instance = 1;
+      implementation: coverpoint implementation.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mimpid");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mimpid");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    implementation = uvm_reg_field::type_id::create("implementation");   
+    implementation.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass
+
+
+class reg_mhartid extends csr_reg;
+  `uvm_object_utils(reg_mhartid)
+
+  //---------------------------------------
+  // fields instance 
+  //--------------------------------------- 
+  rand uvm_reg_field hart_id;
+   
+
+  covergroup cg_vals;
+      option.name = "csr_mhartid";
+      option.per_instance = 1;
+      hart_id: coverpoint hart_id.value[31:0];
+  endgroup
+
+  //---------------------------------------
+  // Constructor 
+  //---------------------------------------
+  function new (string name = "reg_mhartid");
+    super.new(name);
+    set_privilege_level(M_LEVEL);
+    cg_vals = new();
+    cg_vals.set_inst_name("csr_reg_cov.mhartid");
+  endfunction
+
+  //---------------------------------------
+  // build_phase - 
+  // 1. Create the fields
+  // 2. Configure the fields
+  //---------------------------------------  
+  function void build; 
+   
+    hart_id = uvm_reg_field::type_id::create("hart_id");   
+    hart_id.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
+  endfunction
+
+  virtual function void sample_values();
+    if (get_coverage(UVM_CVR_FIELD_VALS))
+      cg_vals.sample();
+  endfunction
+
+endclass

--- a/verif/env/uvme/reg/cva6_csr_reg_predictor.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_predictor.sv
@@ -1,0 +1,64 @@
+class cva6_csr_reg_predictor #(type BUSTYPE=int) extends uvm_reg_predictor #(BUSTYPE);
+
+   `uvm_component_param_utils(cva6_csr_reg_predictor #(BUSTYPE))
+   
+   function new (string name = "cva6_csr_reg_predictor", uvm_component parent);
+      super.new(name, parent);
+   endfunction : new
+   
+   function void connect_phase(uvm_phase phase);
+      super.connect_phase(phase);
+   endfunction: connect_phase
+   
+   virtual function void write(BUSTYPE tr);      
+      uvm_reg_field reg_fields[$];
+      string fields_access[$];
+      csr_reg rg;
+      
+      if (tr.instr.group != uvma_isacov_pkg::CSR_GROUP)
+         return; //Skip non CSR instructions
+      
+      if (!$cast(rg,map.get_reg_by_offset(tr.instr.csr_val)))
+         `uvm_fatal("CSR_REG_PREDICTOR", "Error casting bus request")
+
+      `uvm_info("CSR Predictor",$sformatf("Received CSR %s instruction %p", rg!= null? rg.get_name(): "Null", tr.instr), UVM_HIGH)
+
+      //Check if register exist
+      if (rg == null) begin
+         `uvm_warning("CSR_REG_PREDICTOR", $sformatf("Accessing non-existent CSR with address 0x%0h, Illegal exception should raize", tr.instr.csr_val))
+         return;
+      end
+      
+      //Check if write in read only CSR
+      if (tr.instr.is_csr_write() && rg.Xget_fields_accessX(map) == "RO")
+         `uvm_warning("CSR_REG_PREDICTOR", $sformatf("Write on read-only CSR %s, illegal exception should raize", rg.get_name()))
+      
+      //Split into 2 transactions READ and/or WRITE depending on instruction
+      super.write(tr); //1rst pass: Read operation
+      
+      //Modify access depending on instruction CSRRS/I or CSRRC/I
+      if (tr.instr.name inside {uvma_isacov_pkg::CSRRS, uvma_isacov_pkg::CSRRC, 
+                                uvma_isacov_pkg::CSRRSI,uvma_isacov_pkg::CSRRCI}) begin
+         rg.get_fields(reg_fields);
+         foreach (reg_fields[i]) begin
+            fields_access.push_back(reg_fields[i].get_access(map));
+            if (reg_fields[i].get_access(map) == "RW") begin
+               if (tr.instr.name inside {uvma_isacov_pkg::CSRRS, uvma_isacov_pkg::CSRRSI}) 
+                  reg_fields[i].set_access("W1S");
+               else if (tr.instr.name inside {uvma_isacov_pkg::CSRRC, uvma_isacov_pkg::CSRRCI})
+                  reg_fields[i].set_access("W1C");
+            end
+         end
+      end
+      
+      super.write(tr); //2nd pass: Write operation
+      
+      //Revertback original access for instr CSRRS/I or CSRRC/I
+      foreach (reg_fields[i])
+         reg_fields[i].set_access(fields_access[i]);             
+                                   
+  endfunction
+
+endclass
+
+

--- a/verif/env/uvme/reg/cva6_csr_reg_predictor.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_predictor.sv
@@ -1,3 +1,21 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2023 Thales DIS
+//
+// Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
 class cva6_csr_reg_predictor #(type BUSTYPE=int) extends uvm_reg_predictor #(BUSTYPE);
 
    `uvm_component_param_utils(cva6_csr_reg_predictor #(BUSTYPE))

--- a/verif/env/uvme/uvme_cva6_pkg.sv
+++ b/verif/env/uvme/uvme_cva6_pkg.sv
@@ -61,6 +61,12 @@ package uvme_cva6_pkg;
    // Predictor
    `include "uvme_cva6_prd.sv"
 
+   //CSR REG
+   `include "reg/cva6_csr_reg_file.sv"
+   `include "reg/cva6_csr_reg_block.sv"
+   `include "reg/cva6_csr_reg_adapter.sv"
+   `include "reg/cva6_csr_reg_predictor.sv"
+
    // Environment components
    `include "uvma_cva6_core_cntrl_drv.sv"
    `include "uvma_cva6_core_cntrl_agent.sv"
@@ -68,6 +74,7 @@ package uvme_cva6_pkg;
    `include "uvme_cva6_vsqr.sv"
    `include "uvme_cvxif_covg.sv"
    `include "uvme_isa_covg.sv"
+   `include "uvme_cva6_config_covg.sv"
    `include "uvme_cva6_cov_model.sv"
    `include "uvme_cva6_env.sv"
 

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -3,12 +3,20 @@ plan "CVA6 Plan";
 
     attribute enum{EMBEDDED,STEP1} CVA6_VERSION = EMBEDDED;
     attribute integer ISA_M_EXTENSION = 0;
+    ISA_M_EXTENSION.description = "M extension support";
     attribute integer ISA_C_EXTENSION = 0;
+    ISA_C_EXTENSION.description = "C extension support";
     attribute integer ISA_ZICSR_EXTENSION = 0;
+    ISA_ZICSR_EXTENSION.description = "ZICSR extension support";
     attribute integer ISA_ZIFENCEI_EXTENSION = 0;
+    ISA_ZIFENCEI_EXTENSION.description = "ZIFENCEI extension support";
     attribute integer MMU_ENABLED = 0;
     attribute integer FPU_ENABLED = 0;
     attribute integer PMP_ENABLED = 0;
+    attribute integer ISA_ZICOND_EXTENSION = 0;
+    ISA_ZICOND_EXTENSION.description = "ZICOND extension support";
+    attribute integer ISA_ZCB_EXTENSION = 0;
+    ISA_ZCB_EXTENSION.description = "ZCB extension support";
 
     description = "CVA6 features";
     feature "Sanity features";
@@ -232,7 +240,7 @@ plan "CVA6 Plan";
     feature "Functional features";
         description = "CVA6 Functional features";
         feature "RSIC-V standard instructions";
-            description = "Compliance RISC-V Instruction Set Manual, Volume I and Volume 2:\nExtensions: RV32I + M + A + C + Zicsr + Zifencei";
+            description = "Compliance RISC-V Instruction Set Manual, Volume I and Volume 2:\nExtensions: RV32I + M + A + C + Zicsr + Zifencei + Zicond + Zcb";
             feature RV32I;
                 description = "I extension";
                 feature ADD;
@@ -693,6 +701,34 @@ plan "CVA6 Plan";
                 ISA_ZIFENCEI_EXTENSION = 1;
                 measure Group FEINCE_I;
                     source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zifencei_fence_i_cg";
+                endmeasure
+            endfeature
+            feature RV32ZICOND;
+                description = "ZICOND extension";
+                ISA_ZICOND_EXTENSION = 1;
+                measure Group CZERO_EQZ;
+                    source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.rv32zicond_czero_eqz_cg";
+                endmeasure
+                measure Group CZERO_NEZ;
+                    source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.rv32zicond_czero_nez_cg";
+                endmeasure
+            endfeature
+            feature RV32ZCB;
+                description = "ZB extension";
+                ISA_ZCB_EXTENSION = 1;
+                measure Group C_MUL;
+                endmeasure
+                measure Group C_ZEXT_B;
+                endmeasure
+                measure Group C_SEXT_B;
+                endmeasure
+                measure Group C_ZEXT_H;
+                endmeasure
+                measure Group C_SEXT_H;
+                endmeasure
+                measure Group C_ZEXT_W;
+                endmeasure
+                measure Group C_NOT;
                 endmeasure
             endfeature
             feature "Instructions sequences";

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -1,0 +1,1489 @@
+
+plan "CVA6 Plan";
+
+    attribute enum{EMBEDDED,STEP1} CVA6_VERSION = EMBEDDED;
+    attribute integer ISA_M_EXTENSION = 0;
+    attribute integer ISA_C_EXTENSION = 0;
+    attribute integer ISA_ZICSR_EXTENSION = 0;
+    attribute integer ISA_ZIFENCEI_EXTENSION = 0;
+    attribute integer MMU_ENABLED = 0;
+    attribute integer FPU_ENABLED = 0;
+    attribute integer PMP_ENABLED = 0;
+
+    description = "CVA6 features";
+    feature "Sanity features";
+        description = "CVA6 Sanity features";
+        feature Configuration;
+            description = "RTL configuration";
+            measure Group AExtEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_AExtEn";
+            endmeasure
+            measure Group AxiAddrWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_AxiAddrWidth";
+            endmeasure
+            measure Group AxiDataWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_AxiDataWidth";
+            endmeasure
+            measure Group AxiIdWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_AxiIdWidth";
+            endmeasure
+            measure Group BExtEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_BExtEn";
+            endmeasure
+            measure Group BHTEntries;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_BHTEntries";
+            endmeasure
+            measure Group BTBEntries;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_BTBEntries";
+            endmeasure
+            measure Group CExtEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_CExtEn";
+            endmeasure
+            measure Group CvxifEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_CvxifEn";
+            endmeasure
+            measure Group DataTlbEntries;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DataTlbEntries";
+            endmeasure
+            measure Group DataUserEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DataUserEn";
+            endmeasure
+            measure Group DataUserWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DataUserWidth";
+            endmeasure
+            measure Group DcacheByteSize;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DcacheByteSize";
+            endmeasure
+            measure Group DcacheIdWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DcacheIdWidth";
+            endmeasure
+            measure Group DcacheLineWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DcacheLineWidth";
+            endmeasure
+            measure Group DcacheSetAssoc;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DcacheSetAssoc";
+            endmeasure
+            measure Group DcacheType;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_DcacheType";
+            endmeasure
+            measure Group EnableAccelerator;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_EnableAccelerator";
+            endmeasure
+            measure Group ExceptionAddress;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_ExceptionAddress";
+            endmeasure
+            measure Group F8En;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_F8En";
+            endmeasure
+            measure Group F16AltEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_F16AltEn";
+            endmeasure
+            measure Group F16En;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_F16En";
+            endmeasure
+            measure Group FLen;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FLen";
+            endmeasure
+            measure Group FPGAEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FPGAEn";
+            endmeasure
+            measure Group FVecEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FVecEn";
+            endmeasure
+            measure Group FetchUserEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FetchUserEn";
+            endmeasure
+            measure Group FetchUserWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FetchUserWidth";
+            endmeasure
+            measure Group FpPresent;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FpPresent";
+            endmeasure
+            measure Group FpuEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FpuEn";
+            endmeasure
+            measure Group HaltAddress;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_HaltAddress";
+            endmeasure
+            measure Group IcacheByteSize;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_IcacheByteSize";
+            endmeasure
+            measure Group IcacheLineWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_IcacheLineWidth";
+            endmeasure
+            measure Group IcacheSetAssoc;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_IcacheSetAssoc";
+            endmeasure
+            measure Group InstrTlbEntries;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_InstrTlbEntries";
+            endmeasure
+            measure Group MemTidWidth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_MemTidWidth";
+            endmeasure
+            measure Group MmuPresent;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_MmuPresent";
+            endmeasure
+            measure Group NSX;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NSX";
+            endmeasure
+            measure Group NrCommitPorts;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrCommitPorts";
+            endmeasure
+            measure Group NrLoadBufEntries;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrLoadBufEntries";
+            endmeasure
+            measure Group NrLoadPipeRegs;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrLoadPipeRegs";
+            endmeasure
+            measure Group NrPMPEntries;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrPMPEntries";
+            endmeasure
+            measure Group NrRgprPorts;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrRgprPorts";
+            endmeasure
+            measure Group NrScoreboardEntries;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrScoreboardEntries";
+            endmeasure
+            measure Group NrStorePipeRegs;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrStorePipeRegs";
+            endmeasure
+            measure Group NrWbPorts;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_NrWbPorts";
+            endmeasure
+            measure Group PerfCounterEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_PerfCounterEn";
+            endmeasure
+            measure Group RASDepth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_RASDepth";
+            endmeasure
+            measure Group RVD;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_RVD";
+            endmeasure
+            measure Group RVF;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_RVF";
+            endmeasure
+            measure Group RVFVec;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_RVFVec";
+            endmeasure
+            measure Group RvfiTrace;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_RvfiTrace";
+            endmeasure
+            measure Group VExtEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_VExtEn";
+            endmeasure
+            measure Group WtDcacheWbufDepth;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_WtDcacheWbufDepth";
+            endmeasure
+            measure Group XF8Vec;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_XF8Vec";
+            endmeasure
+            measure Group XF16ALTVec;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_XF16ALTVec";
+            endmeasure
+            measure Group XF16Vec;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_XF16Vec";
+            endmeasure
+            measure Group Xlen;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_Xlen";
+            endmeasure
+            measure Group ZiCondExtEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_ZiCondExtEn";
+            endmeasure
+        endfeature
+        feature "Hard Reset";
+            description = "Hard reset delay and duration";
+            feature "Startup reset";
+                description = "Hard reset on startup";
+                measure Group reset;
+                endmeasure
+            endfeature
+            feature "On the fly reset";
+                description = "Recover from on the fly reset during simulation";
+                CVA6_VERSION = STEP1;
+                measure Group reset;
+                endmeasure
+            endfeature
+        endfeature
+        feature "Boot Addr";
+            description = "Multiple Boot address Support";
+            measure Group boot_addr;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.boot_addr_cg.cp_boot_addr";
+            endmeasure
+        endfeature
+        feature "Clock period";
+            description = "Multi-frequency support, Min frequency CVA6A32 is 150MHz (PPA-30) and CVA6A64 is 900MHz (PPA-40)";
+            measure Group clock_period;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.clock_period_cg.cp_clock_period_ps";
+            endmeasure
+        endfeature
+        feature "Performance monitor";
+            description = "Monitoring performance per MHz (PPA-20), single precision floating (PPA-50) and double-precision floating (PPA-60)";
+            CVA6_VERSION = STEP1;
+            measure Group general_performance;
+            endmeasure
+            measure Group single_precision_floating;
+            endmeasure
+            measure Group double_precision_floating;
+            endmeasure
+        endfeature
+    endfeature
+    feature "Functional features";
+        description = "CVA6 Functional features";
+        feature "RSIC-V standard instructions";
+            description = "Compliance RISC-V Instruction Set Manual, Volume I and Volume 2:\nExtensions: RV32I + M + A + C + Zicsr + Zifencei";
+            feature RV32I;
+                description = "I extension";
+                feature ADD;
+                    measure Group ADD;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_add_cg";
+                    endmeasure
+                endfeature
+                feature ADDI;
+                    measure Group ADDI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_addi_cg";
+                    endmeasure
+                endfeature
+                feature AND;
+                    measure Group AND;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_and_cg";
+                    endmeasure
+                endfeature
+                feature ANDI;
+                    measure Group ANDI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_andi_cg";
+                    endmeasure
+                endfeature
+                feature AUIPC;
+                    measure Group AUIPC;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_auipc_cg";
+                    endmeasure
+                endfeature
+                feature BEQ;
+                    measure Group BEQ;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_beq_cg";
+                    endmeasure
+                endfeature
+                feature BGE;
+                    measure Group BGE;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_bge_cg";
+                    endmeasure
+                endfeature
+                feature BGEU;
+                    measure Group BGEU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_bgeu_cg";
+                    endmeasure
+                endfeature
+                feature BLT;
+                    measure Group BLT;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_blt_cg";
+                    endmeasure
+                endfeature
+                feature BLTU;
+                    measure Group BLTU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_bltu_cg";
+                    endmeasure
+                endfeature
+                feature BNE;
+                    measure Group BNE;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_bne_cg";
+                    endmeasure
+                endfeature
+                feature DRET;
+                    measure Group DRET;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_dret_cg";
+                    endmeasure
+                endfeature
+                feature EBREAK;
+                    measure Group EBREAK;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_ebreak_cg";
+                    endmeasure
+                endfeature
+                feature ECALL;
+                    measure Group ECALL;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_ecall_cg";
+                    endmeasure
+                endfeature
+                feature FENCE;
+                    measure Group FENCE;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_fence_cg";
+                    endmeasure
+                endfeature
+                feature JAL;
+                    measure Group JAL;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_jal_cg";
+                    endmeasure
+                endfeature
+                feature JALR;
+                    measure Group JALR;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_jalr_cg";
+                    endmeasure
+                endfeature
+                feature LB;
+                    measure Group LB;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_lb_cg";
+                    endmeasure
+                endfeature
+                feature LBU;
+                    measure Group LBU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_lbu_cg";
+                    endmeasure
+                endfeature
+                feature LH;
+                    measure Group LH;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_lh_cg";
+                    endmeasure
+                endfeature
+                feature LHU;
+                    measure Group LHU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_lhu_cg";
+                    endmeasure
+                endfeature
+                feature LUI;
+                    measure Group LUI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_lui_cg";
+                    endmeasure
+                endfeature
+                feature LW;
+                    measure Group LW;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_lw_cg";
+                    endmeasure
+                endfeature
+                feature MRET;
+                    measure Group MRET;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_mret_cg";
+                    endmeasure
+                endfeature
+                feature OR;
+                    measure Group OR;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_or_cg";
+                    endmeasure
+                endfeature
+                feature ORI;
+                    measure Group ORI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_ori_cg";
+                    endmeasure
+                endfeature
+                feature SB;
+                    measure Group SB;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sb_cg";
+                    endmeasure
+                endfeature
+                feature SH;
+                    measure Group SH;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sh_cg";
+                    endmeasure
+                endfeature
+                feature SLL;
+                    measure Group SLL;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sll_cg";
+                    endmeasure
+                endfeature
+                feature SLLI;
+                    measure Group SLLI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_slli_cg";
+                    endmeasure
+                endfeature
+                feature SLT;
+                    measure Group SLT;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_slt_cg";
+                    endmeasure
+                endfeature
+                feature SLTI;
+                    measure Group SLTI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_slti_cg";
+                    endmeasure
+                endfeature
+                feature SLTIU;
+                    measure Group SLTIU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sltiu_cg";
+                    endmeasure
+                endfeature
+                feature SLTU;
+                    measure Group SLTU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sltu_cg";
+                    endmeasure
+                endfeature
+                feature SRA;
+                    measure Group SRA;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sra_cg";
+                    endmeasure
+                endfeature
+                feature SRAI;
+                    measure Group SRAI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_srai_cg";
+                    endmeasure
+                endfeature
+                feature SRL;
+                    measure Group SRL;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_srl_cg";
+                    endmeasure
+                endfeature
+                feature SRLI;
+                    measure Group SRLI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_srli_cg";
+                    endmeasure
+                endfeature
+                feature SUB;
+                    measure Group SUB;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sub_cg";
+                    endmeasure
+                endfeature
+                feature SW;
+                    measure Group SW;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_sw_cg";
+                    endmeasure
+                endfeature
+                feature WFI;
+                    measure Group WFI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_wfi_cg";
+                    endmeasure
+                endfeature
+                feature XOR;
+                    measure Group XOR;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_xor_cg";
+                    endmeasure
+                endfeature
+                feature XORI;
+                    measure Group XORI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32i_xori_cg";
+                    endmeasure
+                endfeature
+            endfeature
+            feature RV32M;
+                description = "M extension";
+                ISA_M_EXTENSION = 1;
+                feature DIV;
+                    measure Group DIV;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_div_cg";
+                    endmeasure
+                endfeature
+                feature DIV_RESULTS;
+                    measure Group DIV_RESULTS;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_div_results_cg";
+                    endmeasure
+                endfeature
+                feature DIVU;
+                    measure Group DIVU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_divu_cg";
+                    endmeasure
+                endfeature
+                feature DIVU_RESULTS;
+                    measure Group DIVU_RESULTS;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_divu_results_cg";
+                    endmeasure
+                endfeature
+                feature MUL;
+                    measure Group MUL;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_mul_cg";
+                    endmeasure
+                endfeature
+                feature MULH;
+                    measure Group MULH;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_mulh_cg";
+                    endmeasure
+                endfeature
+                feature MULHSU;
+                    measure Group MULHSU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_mulhsu_cg";
+                    endmeasure
+                endfeature
+                feature MULHU;
+                    measure Group MULHU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_mulhu_cg";
+                    endmeasure
+                endfeature
+                feature REM;
+                    measure Group REM;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_rem_cg";
+                    endmeasure
+                endfeature
+                feature REM_RESULTS;
+                    measure Group REM_RESULTS;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_rem_results_cg";
+                    endmeasure
+                endfeature
+                feature REMU;
+                    measure Group REMU;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_remu_cg";
+                    endmeasure
+                endfeature
+                feature REMU_RESULTS;
+                    measure Group REMU_RESULTS;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32m_remu_results_cg";
+                    endmeasure
+                endfeature
+            endfeature
+            feature RV32C;
+                description = "C extension";
+                ISA_C_EXTENSION = 1;
+                feature ADD;
+                    measure Group ADD;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_add_cg";
+                    endmeasure
+                endfeature
+                feature ADDI4SPN;
+                    measure Group ADDI4SPN;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_addi4spn_cg";
+                    endmeasure
+                endfeature
+                feature ADDI16SP;
+                    measure Group ADDI16SP;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_addi16sp_cg";
+                    endmeasure
+                endfeature
+                feature ADDI;
+                    measure Group ADDI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_addi_cg";
+                    endmeasure
+                endfeature
+                feature AND;
+                    measure Group AND;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_and_cg";
+                    endmeasure
+                endfeature
+                feature ANDI;
+                    measure Group ANDI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_andi_cg";
+                    endmeasure
+                endfeature
+                feature BEQZ;
+                    measure Group BEQZ;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_beqz_cg";
+                    endmeasure
+                endfeature
+                feature BNEZ;
+                    measure Group BNEZ;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_bnez_cg";
+                    endmeasure
+                endfeature
+                feature EBREAK;
+                    measure Group EBREAK;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_ebreak_cg";
+                    endmeasure
+                endfeature
+                feature J;
+                    measure Group J;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_j_cg";
+                    endmeasure
+                endfeature
+                feature JAL;
+                    measure Group JAL;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_jal_cg";
+                    endmeasure
+                endfeature
+                feature JALR;
+                    measure Group JALR;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_jalr_cg";
+                    endmeasure
+                endfeature
+                feature JR;
+                    measure Group JR;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_jr_cg";
+                    endmeasure
+                endfeature
+                feature LI;
+                    measure Group LI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_li_cg";
+                    endmeasure
+                endfeature
+                feature LUI;
+                    measure Group LUI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_lui_cg";
+                    endmeasure
+                endfeature
+                feature LW;
+                    measure Group LW;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_lw_cg";
+                    endmeasure
+                endfeature
+                feature LWSP;
+                    measure Group LWSP;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_lwsp_cg";
+                    endmeasure
+                endfeature
+                feature MV;
+                    measure Group MV;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_mv_cg";
+                    endmeasure
+                endfeature
+                feature NOP;
+                    measure Group NOP;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_nop_cg";
+                    endmeasure
+                endfeature
+                feature OR;
+                    measure Group OR;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_or_cg";
+                    endmeasure
+                endfeature
+                feature SLLI;
+                    measure Group SLLI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_slli_cg";
+                    endmeasure
+                endfeature
+                feature SRAI;
+                    measure Group SRAI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_srai_cg";
+                    endmeasure
+                endfeature
+                feature SRLI;
+                    measure Group SRLI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_srli_cg";
+                    endmeasure
+                endfeature
+                feature SUB;
+                    measure Group SUB;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_sub_cg";
+                    endmeasure
+                endfeature
+                feature SW;
+                    measure Group SW;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_sw_cg";
+                    endmeasure
+                endfeature
+                feature SWSP;
+                    measure Group SWSP;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_swsp_cg";
+                    endmeasure
+                endfeature
+                feature XOR;
+                    measure Group XOR;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32c_xor_cg";
+                    endmeasure
+                endfeature
+            endfeature
+            feature RV32ZICSR;
+                description = "ZICSR extension";
+                ISA_ZICSR_EXTENSION = 1;
+                feature CSRRC;
+                    measure Group CSRRC;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zicsr_csrrc_cg";
+                    endmeasure
+                endfeature
+                feature CSRRCI;
+                    measure Group CSRRCI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zicsr_csrrci_cg";
+                    endmeasure
+                endfeature
+                feature CSRRS;
+                    measure Group CSRRS;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zicsr_csrrs_cg";
+                    endmeasure
+                endfeature
+                feature CSRRSI;
+                    measure Group CSRRSI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zicsr_csrrsi_cg";
+                    endmeasure
+                endfeature
+                feature CSRRW;
+                    measure Group CSRRW;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zicsr_csrrw_cg";
+                    endmeasure
+                endfeature
+                feature CSRRWI;
+                    measure Group CSRRWI;
+                        source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zicsr_csrrwi_cg";
+                    endmeasure
+                endfeature
+            endfeature
+            feature RV32ZIFENCEI;
+                description = "ZIFENCE.I extension";
+                ISA_ZIFENCEI_EXTENSION = 1;
+                measure Group FEINCE_I;
+                    source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zifencei_fence_i_cg";
+                endmeasure
+            endfeature
+            feature "Instructions sequences";
+                description = "Instructions sequences";
+                measure Group Sequential;
+                    source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rev32_seq_cg";
+                endmeasure
+            endfeature
+            feature "Illegal instructions";
+                measure Group illegal_instructions;
+                endmeasure
+            endfeature
+        endfeature
+        feature Privileges;
+            description = "Support machine, supervisor, user and debug privilege modes (PVL-10)";
+            CVA6_VERSION = STEP1;
+            measure Group privileges;
+            endmeasure
+        endfeature
+        feature CSR;
+            description = "CSR registers Read/write ";
+            feature CYCLE;
+                CVA6_VERSION = STEP1;
+                measure Group CYCLE;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.cycle";
+                endmeasure
+            endfeature
+            feature CYCLEH;
+                measure Group CYCLEH;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.cycleh";
+                endmeasure
+            endfeature
+            feature ICACHE;
+                measure Group ICACHE;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.icache";
+                endmeasure
+            endfeature
+            feature INSTRET;
+                measure Group INSTRET;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.instret";
+                endmeasure
+            endfeature
+            feature INSTRETH;
+                measure Group INSTRETH;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.instreth";
+                endmeasure
+            endfeature
+            feature MARCHID;
+                measure Group MARCHID;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.marchid";
+                endmeasure
+            endfeature
+            feature MCAUSE;
+                measure Group MCAUSE;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mcause";
+                endmeasure
+            endfeature
+            feature MEPC;
+                measure Group MEPC;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mepc";
+                endmeasure
+            endfeature
+            feature MHARTID;
+                measure Group MHARTID;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhartid";
+                endmeasure
+            endfeature
+            feature MIE;
+                measure Group MIE;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mie";
+                endmeasure
+            endfeature
+            feature MIMPID;
+                measure Group MIMPID;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mimpid";
+                endmeasure
+            endfeature
+            feature MIP;
+                measure Group MIP;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mip";
+                endmeasure
+            endfeature
+            feature MISA;
+                measure Group MISA;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.misa";
+                endmeasure
+            endfeature
+            feature MSCRATCH;
+                measure Group MSCRATCH;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mscratch";
+                endmeasure
+            endfeature
+            feature MSTATUS;
+                measure Group MSTATUS;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mstatus";
+                endmeasure
+            endfeature
+            feature MSTATUSH;
+                measure Group MSTATUSH;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mstatush";
+                endmeasure
+            endfeature
+            feature MTVAL;
+                measure Group MTVAL;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mtval";
+                endmeasure
+            endfeature
+            feature MTVEC;
+                measure Group MTVEC;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mtvec";
+                endmeasure
+            endfeature
+            feature MVENDORID;
+                measure Group MVENDORID;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mvendorid";
+                endmeasure
+            endfeature
+            feature PMPADDR0;
+                measure Group PMPADDR0;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr0";
+                endmeasure
+            endfeature
+            feature PMPADDR1;
+                measure Group PMPADDR1;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr1";
+                endmeasure
+            endfeature
+            feature PMPADDR2;
+                measure Group PMPADDR2;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr2";
+                endmeasure
+            endfeature
+            feature PMPADDR3;
+                measure Group PMPADDR3;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr3";
+                endmeasure
+            endfeature
+            feature PMPADDR4;
+                measure Group PMPADDR4;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr4";
+                endmeasure
+            endfeature
+            feature PMPADDR5;
+                measure Group PMPADDR5;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr5";
+                endmeasure
+            endfeature
+            feature PMPADDR6;
+                measure Group PMPADDR6;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr6";
+                endmeasure
+            endfeature
+            feature PMPADDR7;
+                measure Group PMPADDR7;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr7";
+                endmeasure
+            endfeature
+            feature PMPADDR8;
+                measure Group PMPADDR8;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr8";
+                endmeasure
+            endfeature
+            feature PMPADDR9;
+                measure Group PMPADDR9;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr9";
+                endmeasure
+            endfeature
+            feature PMPADDR10;
+                measure Group PMPADDR10;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr10";
+                endmeasure
+            endfeature
+            feature PMPADDR11;
+                measure Group PMPADDR11;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr11";
+                endmeasure
+            endfeature
+            feature PMPADDR12;
+                measure Group PMPADDR12;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr12";
+                endmeasure
+            endfeature
+            feature PMPADDR13;
+                measure Group PMPADDR13;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr13";
+                endmeasure
+            endfeature
+            feature PMPADDR14;
+                measure Group PMPADDR14;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr14";
+                endmeasure
+            endfeature
+            feature PMPADDR15;
+                measure Group PMPADDR15;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpaddr15";
+                endmeasure
+            endfeature
+            feature PMPCFG0;
+                measure Group PMPCFG0;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpcfg0";
+                endmeasure
+            endfeature
+            feature PMPCFG1;
+                measure Group PMPCFG1;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpcfg1";
+                endmeasure
+            endfeature
+            feature PMPCFG2;
+                measure Group PMPCFG2;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpcfg2";
+                endmeasure
+            endfeature
+            feature PMPCFG3;
+                measure Group PMPCFG3;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.pmpcfg3";
+                endmeasure
+            endfeature
+        endfeature
+        feature "Performance counters";
+            description = "Performance counters control CSR registers Read/Write";
+            CVA6_VERSION = STEP1;
+            feature MHPMCOUNTER3;
+                measure Group MHPMCOUNTER3;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter3";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER4;
+                measure Group MHPMCOUNTER4;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter4";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER5;
+                measure Group MHPMCOUNTER5;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter5";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER6;
+                measure Group MHPMCOUNTER6;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter6";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER7;
+                measure Group MHPMCOUNTER7;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter7";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER8;
+                measure Group MHPMCOUNTER8;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter8";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER9;
+                measure Group MHPMCOUNTER9;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter9";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER10;
+                measure Group MHPMCOUNTER10;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter10";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER11;
+                measure Group MHPMCOUNTER11;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter11";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER12;
+                measure Group MHPMCOUNTER12;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter12";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER13;
+                measure Group MHPMCOUNTER13;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter13";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER14;
+                measure Group MHPMCOUNTER14;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter14";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER15;
+                measure Group MHPMCOUNTER15;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter15";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER16;
+                measure Group MHPMCOUNTER16;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter16";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER17;
+                measure Group MHPMCOUNTER17;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter17";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER18;
+                measure Group MHPMCOUNTER18;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter18";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER19;
+                measure Group MHPMCOUNTER19;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter19";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER20;
+                measure Group MHPMCOUNTER20;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter20";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER21;
+                measure Group MHPMCOUNTER21;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter21";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER22;
+                measure Group MHPMCOUNTER22;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter22";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER23;
+                measure Group MHPMCOUNTER23;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter23";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER24;
+                measure Group MHPMCOUNTER24;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter24";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER25;
+                measure Group MHPMCOUNTER25;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter25";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER26;
+                measure Group MHPMCOUNTER26;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter26";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER27;
+                measure Group MHPMCOUNTER27;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter27";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER28;
+                measure Group MHPMCOUNTER28;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter28";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER29;
+                measure Group MHPMCOUNTER29;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter29";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER30;
+                measure Group MHPMCOUNTER30;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter30";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTER31;
+                measure Group MHPMCOUNTER31;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounter31";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH3;
+                measure Group MHPMCOUNTERH3;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh3";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH4;
+                measure Group MHPMCOUNTERH4;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh4";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH5;
+                measure Group MHPMCOUNTERH5;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh5";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH6;
+                measure Group MHPMCOUNTERH6;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh6";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH7;
+                measure Group MHPMCOUNTERH7;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh7";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH8;
+                measure Group MHPMCOUNTERH8;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh8";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH9;
+                measure Group MHPMCOUNTERH9;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh9";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH10;
+                measure Group MHPMCOUNTERH10;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh10";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH11;
+                measure Group MHPMCOUNTERH11;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh11";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH12;
+                measure Group MHPMCOUNTERH12;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh12";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH13;
+                measure Group MHPMCOUNTERH13;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh13";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH14;
+                measure Group MHPMCOUNTERH14;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh14";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH15;
+                measure Group MHPMCOUNTERH15;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh15";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH16;
+                measure Group MHPMCOUNTERH16;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh16";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH17;
+                measure Group MHPMCOUNTERH17;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh17";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH18;
+                measure Group MHPMCOUNTERH18;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh18";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH19;
+                measure Group MHPMCOUNTERH19;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh19";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH20;
+                measure Group MHPMCOUNTERH20;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh20";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH21;
+                measure Group MHPMCOUNTERH21;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh21";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH22;
+                measure Group MHPMCOUNTERH22;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh22";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH23;
+                measure Group MHPMCOUNTERH23;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh23";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH24;
+                measure Group MHPMCOUNTERH24;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh24";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH25;
+                measure Group MHPMCOUNTERH25;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh25";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH26;
+                measure Group MHPMCOUNTERH26;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh26";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH27;
+                measure Group MHPMCOUNTERH27;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh27";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH28;
+                measure Group MHPMCOUNTERH28;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh28";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH29;
+                measure Group MHPMCOUNTERH29;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh29";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH30;
+                measure Group MHPMCOUNTERH30;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh30";
+                endmeasure
+            endfeature
+            feature MHPMCOUNTERH31;
+                measure Group MHPMCOUNTERH31;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmcounterh31";
+                endmeasure
+            endfeature
+            feature MHPMEVENT3;
+                measure Group MHPMEVENT3;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent3";
+                endmeasure
+            endfeature
+            feature MHPMEVENT4;
+                measure Group MHPMEVENT4;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent4";
+                endmeasure
+            endfeature
+            feature MHPMEVENT5;
+                measure Group MHPMEVENT5;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent5";
+                endmeasure
+            endfeature
+            feature MHPMEVENT6;
+                measure Group MHPMEVENT6;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent6";
+                endmeasure
+            endfeature
+            feature MHPMEVENT7;
+                measure Group MHPMEVENT7;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent7";
+                endmeasure
+            endfeature
+            feature MHPMEVENT8;
+                measure Group MHPMEVENT8;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent8";
+                endmeasure
+            endfeature
+            feature MHPMEVENT9;
+                measure Group MHPMEVENT9;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent9";
+                endmeasure
+            endfeature
+            feature MHPMEVENT10;
+                measure Group MHPMEVENT10;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent10";
+                endmeasure
+            endfeature
+            feature MHPMEVENT11;
+                measure Group MHPMEVENT11;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent11";
+                endmeasure
+            endfeature
+            feature MHPMEVENT12;
+                measure Group MHPMEVENT12;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent12";
+                endmeasure
+            endfeature
+            feature MHPMEVENT13;
+                measure Group MHPMEVENT13;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent13";
+                endmeasure
+            endfeature
+            feature MHPMEVENT14;
+                measure Group MHPMEVENT14;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent14";
+                endmeasure
+            endfeature
+            feature MHPMEVENT15;
+                measure Group MHPMEVENT15;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent15";
+                endmeasure
+            endfeature
+            feature MHPMEVENT16;
+                measure Group MHPMEVENT16;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent16";
+                endmeasure
+            endfeature
+            feature MHPMEVENT17;
+                measure Group MHPMEVENT17;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent17";
+                endmeasure
+            endfeature
+            feature MHPMEVENT18;
+                measure Group MHPMEVENT18;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent18";
+                endmeasure
+            endfeature
+            feature MHPMEVENT19;
+                measure Group MHPMEVENT19;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent19";
+                endmeasure
+            endfeature
+            feature MHPMEVENT20;
+                measure Group MHPMEVENT20;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent20";
+                endmeasure
+            endfeature
+            feature MHPMEVENT21;
+                measure Group MHPMEVENT21;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent21";
+                endmeasure
+            endfeature
+            feature MHPMEVENT22;
+                measure Group MHPMEVENT22;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent22";
+                endmeasure
+            endfeature
+            feature MHPMEVENT23;
+                measure Group MHPMEVENT23;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent23";
+                endmeasure
+            endfeature
+            feature MHPMEVENT24;
+                measure Group MHPMEVENT24;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent24";
+                endmeasure
+            endfeature
+            feature MHPMEVENT25;
+                measure Group MHPMEVENT25;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent25";
+                endmeasure
+            endfeature
+            feature MHPMEVENT26;
+                measure Group MHPMEVENT26;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent26";
+                endmeasure
+            endfeature
+            feature MHPMEVENT27;
+                measure Group MHPMEVENT27;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent27";
+                endmeasure
+            endfeature
+            feature MHPMEVENT28;
+                measure Group MHPMEVENT28;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent28";
+                endmeasure
+            endfeature
+            feature MHPMEVENT29;
+                measure Group MHPMEVENT29;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent29";
+                endmeasure
+            endfeature
+            feature MHPMEVENT30;
+                measure Group MHPMEVENT30;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent30";
+                endmeasure
+            endfeature
+            feature MHPMEVENT31;
+                measure Group MHPMEVENT31;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhpmevent31";
+                endmeasure
+            endfeature
+            feature MINSTRET;
+                measure Group MINSTRET;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.minstret";
+                endmeasure
+            endfeature
+            feature MINSTRETH;
+                measure Group MINSTRETH;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.minstreth";
+                endmeasure
+            endfeature
+            feature MCYCLE;
+                measure Group MCYCLE;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mcycle";
+                endmeasure
+            endfeature
+            feature MCYCLEH;
+                measure Group MCYCLEH;
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mcycleh";
+                endmeasure
+            endfeature
+        endfeature
+        feature TRAPS;
+            description = "Interrupts and Exceptions Support";
+            feature Interrupts;
+                measure Group Interrupts;
+                endmeasure
+            endfeature
+            feature Exceptions;
+                measure Group Exceptions;
+                endmeasure
+            endfeature
+        endfeature
+        feature PMA;
+            description = "Physical Memory Attributes support";
+            CVA6_VERSION = EMBEDDED;
+            measure Group PMA;
+            endmeasure
+        endfeature
+        feature Interfaces;
+            description = "CVA6 Interfaces";
+            feature AXI;
+                description = "Support AXI4 features and AXI5 Atomic";
+                feature Features;
+                    measure Group Features;
+                    endmeasure
+                endfeature
+                feature Assertions;
+                    measure Group Measure_1;
+                        source = "property: **.axi_*_assert.*";
+                    endmeasure
+                endfeature
+            endfeature
+            feature XIF;
+                description = "Support co-processor interface";
+                feature PROTOCOL;
+                    description = "XIF protocol checks";
+                    measure Group PROTOCOL;
+                        source = "group instance: uvma_cvxif_pkg.uvma_cvxif_pkg.request_cg", "group instance: uvma_cvxif_pkg.uvma_cvxif_pkg.response_cg", "group instance: uvma_cvxif_pkg.uvma_cvxif_pkg.result_cg";
+                    endmeasure
+                    measure Group Assertions;
+                        source = "property: **.cvxif_assert.*";
+                    endmeasure
+                endfeature
+                feature "Extednded instructions";
+                    description = "XIF extended instructions";
+                    feature Instructions;
+                        description = "Instructions";
+                        feature CUS_ADD;
+                            measure Group CUS_ADD;
+                                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.cus_add_cg";
+                            endmeasure
+                        endfeature
+                        feature CUS_ADD_MULTI;
+                            measure Group CUS_ADD_MULTI;
+                                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.cus_add_multi_cg";
+                            endmeasure
+                        endfeature
+                        feature CUS_ADD_RS3;
+                            measure Group CUS_ADD_RS3;
+                                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.cus_add_rs3_cg";
+                            endmeasure
+                        endfeature
+                        feature CUS_ADD_S;
+                            measure Group CUS_ADD_S;
+                                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.cus_add_s_cg";
+                            endmeasure
+                        endfeature
+                        feature CUS_ADD_U;
+                            measure Group CUS_ADD_U;
+                                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.cus_add_u_cg";
+                            endmeasure
+                        endfeature
+                        feature CUS_EXC;
+                            measure Group CUS_EXC;
+                                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.cus_exc_cg";
+                            endmeasure
+                        endfeature
+                    endfeature
+                    feature "Instruction sequences";
+                        description = "Instructions sequences";
+                        measure Group sequential;
+                            source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.cus_seq_cg";
+                        endmeasure
+                    endfeature
+                endfeature
+            endfeature
+        endfeature
+        feature "CVA6 Optional Features";
+            description = "Optional features support";
+            feature FPU;
+                description = "Floating Point Unit support";
+                CVA6_VERSION = STEP1;
+                FPU_ENABLED = 1;
+                measure Group FPU;
+                endmeasure
+            endfeature
+            feature MMU;
+                description = "Memory Management Unit support";
+                CVA6_VERSION = STEP1;
+                MMU_ENABLED = 1;
+                measure Group MMU;
+                endmeasure
+            endfeature
+            feature PMP;
+                description = "Physical Memory Protection support";
+                CVA6_VERSION = EMBEDDED;
+                PMP_ENABLED = 1;
+                measure Group PMP;
+                endmeasure
+            endfeature
+        endfeature
+    endfeature
+    feature "Code Coverage";
+        description = "CVA6 Design features code coverage";
+        measure Line, Cond, Toggle, Assert, SnpsAvg CVA6;
+            source = "tree: uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6";
+        endmeasure
+    endfeature
+endplan
+

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -195,12 +195,14 @@ plan "CVA6 Plan";
             feature "Startup reset";
                 description = "Hard reset on startup";
                 measure Group reset;
+                    source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.reset_cg.cp_reset", "group instance: uvme_cva6_pkg.uvme_cva6_pkg.reset_cg.cp_reset_duration_ps";
                 endmeasure
             endfeature
             feature "On the fly reset";
                 description = "Recover from on the fly reset during simulation";
                 CVA6_VERSION = STEP1;
-                measure Group reset;
+                measure Group onthefly;
+                    source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.reset_cg.cp_reset_onthefly_assert";
                 endmeasure
             endfeature
         endfeature
@@ -1464,7 +1466,7 @@ plan "CVA6 Plan";
                 endmeasure
             endfeature
             feature MMU;
-                description = "Memory Management Unit support";
+                description = "Memory Management Unit\r support";
                 CVA6_VERSION = STEP1;
                 MMU_ENABLED = 1;
                 measure Group MMU;

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -731,9 +731,9 @@ plan "CVA6 Plan";
                 measure Group C_NOT;
                 endmeasure
             endfeature
-            feature "Instructions sequences";
+            feature "Instructions execution sequences";
                 description = "Instructions sequences";
-                measure Group Sequential;
+                measure Group sequences;
                     source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rev32_seq_cg";
                 endmeasure
             endfeature

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -1432,8 +1432,11 @@ plan "CVA6 Plan";
                     endmeasure
                 endfeature
                 feature Assertions;
-                    measure Group Measure_1;
-                        source = "property: **.axi_*_assert.*";
+                    measure Assert axi_protocol_assertion;
+                        source = "property: **.axi_ar_assert.*", "property: **.axi_aw_assert.*", "property: **.axi_b_assert.*", "property: **.axi_r_assert.*", "tree: **.axi_w_assert.*";
+                    endmeasure
+                    measure Assert cva6_axi_assertions;
+                        source = "property: **.cva6_axi_assert.*";
                     endmeasure
                 endfeature
             endfeature

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -1433,7 +1433,7 @@ plan "CVA6 Plan";
                 endfeature
                 feature Assertions;
                     measure Assert axi_protocol_assertion;
-                        source = "property: **.axi_ar_assert.*", "property: **.axi_aw_assert.*", "property: **.axi_b_assert.*", "property: **.axi_r_assert.*", "tree: **.axi_w_assert.*";
+                        source = "property: **.axi_ar_assert.*", "property: **.axi_aw_assert.*", "property: **.axi_b_assert.*", "property: **.axi_r_assert.*", "property: **.axi_w_assert.*";
                     endmeasure
                     measure Assert cva6_axi_assertions;
                         source = "property: **.cva6_axi_assert.*";

--- a/verif/sim/modifier_embedded.hvp
+++ b/verif/sim/modifier_embedded.hvp
@@ -1,0 +1,3 @@
+filter CVA6_M_C;
+   remove feature where CVA6_VERSION != EMBEDDED;
+endfilter


### PR DESCRIPTION
1- cva6.hvp vplan creation in sim directory including sanity features, mapped all existing covergroups for functional features and code coverage
2- modifier_embedded.hvp creation in sim directory used to filter out hvp for embedded config
3- Implementation of all needed sanity covergroups: RTL Configuration + Hard Reset + Boot Address + clock period
4- Implementation of passive RAL for CSR coverage