### PR TITLE
Code_Coverage: Display the coverage score at the end of the code coverage job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -497,7 +497,7 @@ code_coverage-report:
     - mv artifacts/coverage/seedlist.yaml verif/sim/seedlist.yaml
     - make -C verif/sim generate_cov_dash
     - mv verif/sim/urgReport artifacts/cov_reports/
-    - python3 .gitlab-ci/scripts/report_pass.py
+    - python3 .gitlab-ci/scripts/report_coverage.py artifacts/cov_reports/urgReport/hierarchy.txt
 
 check gitlab jobs status:
   stage: find failures

--- a/.gitlab-ci/scripts/report_coverage.py
+++ b/.gitlab-ci/scripts/report_coverage.py
@@ -1,0 +1,53 @@
+# Copyright 2023 Thales Silicon Security
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Alae Eddine EZ ZEJJARI (alae-eddine.ez-zejjari@external.thalesgroup.com) – sub-contractor MU-Electronics for Thales group
+
+import re
+import sys
+import yaml
+import report_builder as rb
+from pprint import pprint
+
+log_path = str(sys.argv[1])
+with open(log_path, 'r') as f:
+    log = f.read()
+
+pattern = re.compile(r'\S{2,}')
+
+def get_scores(component):
+	for l in log.splitlines():
+		if re.search(r'\b'+component+r'\b', l):
+			line = l
+	scores = pattern.findall(line)
+	return [float(score) for score in scores[0:4]]
+
+components = [
+	"i_cva6",
+	"commit_stage_i",
+	"controller_i",
+	"csr_regfile_i",
+	"ex_stage_i",
+	"gen_cache_wt.i_cache_subsystem",
+	"i_frontend",
+	"id_stage_i",
+	"issue_stage_i",
+]
+
+score_metric = rb.TableMetric('Coverage results')
+score_metric.add_value("COMPONENT", "SCORE", "LINE", "COND", "TOGGLE")
+for component in components:
+	scores = get_scores(component)
+	score_metric.add_value(component, *scores)
+
+coverage_score = int(get_scores("i_cva6")[0])
+report = rb.Report(f'{coverage_score}%')
+report.add_metric(score_metric)
+
+report.dump()
+
+pprint(score_metric.values)

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -248,7 +248,7 @@ vcs-uvm:
           for i in `ls *.$(SIMV_TRACE_EXTN)` ; do mv $$i `dirname $(log)`/`basename $(log) .log`.$(target).$$i ; done || true
 
 generate_cov_dash:
-	urg -dir $(VCS_WORK_DIR)/simv.vdb -group instcov_for_score -tgl portsonly
+	urg -dir $(VCS_WORK_DIR)/simv.vdb -format both -group instcov_for_score -tgl portsonly
 
 vcs_clean_all:
 	@echo "[VCS] Cleanup (entire vcs_work dir)"


### PR DESCRIPTION
We add the "-format" option to the URG command to generate the coverage report in TXT format.
The source file allows you to search from the TXT coverage report and display the coverage score for each desired module.