### PR TITLE
Disable Zicond in cv32a6_embedded_config_pkg.sv

### DIFF
--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -23,7 +23,7 @@ package cva6_config_pkg;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
     localparam CVA6ConfigVExtEn = 0;
-    localparam CVA6ConfigZiCondExtEn = 1;
+    localparam CVA6ConfigZiCondExtEn = 0;
 
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;


### PR DESCRIPTION
The Zicond extension does not improve performance or code size. To reduce verifiation effort, disable it.