### PR TITLE
ci: use spike from core-v-verif

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,7 @@ build_tools:
   extends:
     - .setup_job
   script:
+    - git submodule update --init verif/core-v-verif
     # ROOT_PROJECT is used by Spike installer and designates the toplevel of core-v-verif tree.
     - 'export ROOT_PROJECT=$(pwd)'
     # If a local build of Spike is requested, clean up build and installation directories.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,7 @@ build_tools:
     - .setup_job
   script:
     - git submodule update --init verif/core-v-verif
+    - source $SYN_VCS_BASHRC
     # ROOT_PROJECT is used by Spike installer and designates the toplevel of core-v-verif tree.
     - 'export ROOT_PROJECT=$(pwd)'
     # If a local build of Spike is requested, clean up build and installation directories.


### PR DESCRIPTION
Spike is being moved back to core-v-verif. So now fetching core-v-verif is needed to build spike in CI.

This PR additionally enables VCS environment to build spike, to prepare the CI for the tandem feature.