### PR TITLE
tracer: Use `hart_id` for trace file format

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1198,7 +1198,9 @@ module cva6 import ariane_pkg::*; #(
   logic [63:0] cycles;
 
   initial begin
-    f = $fopen("trace_hart_00.dasm", "w");
+    string fn;
+    $sformat(fn, "trace_hart_%0.0f.dasm", hart_id_i);
+    f = $fopen(fn, "w");
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin


### PR DESCRIPTION
When having multiple CVA6s this was problematic. Legacy code since an early version of verilator had problems with the string manipulation.

This shouldn't have any impact on the existing project since the tracer isn't used anywhere else afaik.

/cc @domenicw 