### PR TITLE
ci: enable job status checker in "dev" pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -504,7 +504,7 @@ code_coverage-report:
 check gitlab jobs status:
   stage: find failures
   rules:
-    - if: $CI_KIND == "regress" || $CI_KIND == "verif"
+    - if: $DASHBOARD_URL && $CI_KIND != "none"
       when: on_failure
   variables:
     DASHBOARD_JOB_TITLE: "Environment check"


### PR DESCRIPTION
"dev" pipeline was initially designed to be reviewed directly in GitLab
where job failures are already reported. Since it is now used to build
the Dashboard, the "check gitlab jobs status" job should be enabled in
this pipeline.