### PR TITLE
Code_coverage: Add conditions for the AMO Extension

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,2 +1,2 @@
 cv32a6_embedded:
-  gates: 129232
+  gates: 127005

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -106,7 +106,7 @@ module commit_stage
     commit_lsu_o = 1'b0;
     commit_csr_o = 1'b0;
     // amos will commit on port 0
-    wdata_o[0] = (amo_resp_i.ack) ? amo_resp_i.result[riscv::XLEN-1:0] : commit_instr_i[0].result;
+    wdata_o[0] = (CVA6Cfg.RVA && amo_resp_i.ack) ? amo_resp_i.result[riscv::XLEN-1:0] : commit_instr_i[0].result;
     csr_op_o = ADD;  // this corresponds to a CSR NOP
     csr_wdata_o = {riscv::XLEN{1'b0}};
     fence_i_o = 1'b0;

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -136,12 +136,18 @@ module controller
     end
 
     // Set PC to commit stage and flush pipeline
-    if (flush_csr_i || flush_commit_i || flush_acc_i) begin
-      set_pc_commit_o        = 1'b1;
-      flush_if_o             = 1'b1;
-      flush_unissued_instr_o = 1'b1;
-      flush_id_o             = 1'b1;
-      flush_ex_o             = 1'b1;
+    if (flush_csr_i || flush_acc_i) begin
+        set_pc_commit_o        = 1'b1;
+        flush_if_o             = 1'b1;
+        flush_unissued_instr_o = 1'b1;
+        flush_id_o             = 1'b1;
+        flush_ex_o             = 1'b1;
+    end else if (CVA6Cfg.RVA && flush_commit_i) begin
+        set_pc_commit_o        = 1'b1;
+        flush_if_o             = 1'b1;
+        flush_unissued_instr_o = 1'b1;
+        flush_id_o             = 1'b1;
+        flush_ex_o             = 1'b1;
     end
 
     // ---------------------------------


### PR DESCRIPTION
Condition RTL with AMO parameters to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to reach 100% code coverage.