### PR TITLE
[CI] Update Verilator version to v5.008

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ VCOM ?= vcom$(questa_version)
 VLIB ?= vlib$(questa_version)
 VMAP ?= vmap$(questa_version)
 # verilator version
-verilator      ?= verilator
+verilator      ?= $(PWD)/tmp/verilator-v5.008/verilator/bin/verilator
 # traget option
 target-options ?=
 # additional definess
@@ -536,7 +536,7 @@ xrun-check-benchmarks:
 xrun-ci: xrun-asm-tests xrun-amo-tests xrun-mul-tests xrun-fp-tests xrun-benchmarks
 
 # verilator-specific
-verilate_command := $(verilator) verilator_config.vlt                                                            \
+verilate_command := $(verilator) --no-timing verilator_config.vlt                                                            \
                     -f core/Flist.cva6                                                                           \
                     $(filter-out %.vhd, $(ariane_pkg))                                                           \
                     $(filter-out core/fpu_wrap.sv, $(filter-out %.vhd, $(filter-out %_config_pkg.sv, $(src))))   \

--- a/ci/install-verilator.sh
+++ b/ci/install-verilator.sh
@@ -1,24 +1,44 @@
 #!/bin/bash
-set -e
+
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd $ROOT/tmp
 
 if [ -z ${NUM_JOBS} ]; then
-    NUM_JOBS=1
+    NUM_JOBS=4
 fi
 
-if [ ! -e "$VERILATOR_ROOT/bin/verilator" ]; then
-    echo "Installing Verilator"
-    rm -f verilator*.tgz
-    wget https://www.veripool.org/ftp/verilator-4.014.tgz
-    tar xzf verilator*.tgz
-    rm -f verilator*.tgz
-    cd verilator-4.014
-    mkdir -p $VERILATOR_ROOT
-    # copy scripts
-    autoconf && ./configure --prefix="$VERILATOR_ROOT" && make -j${NUM_JOBS}
-    cp -r * $VERILATOR_ROOT/
-    make test
+VERILATOR_REPO="https://github.com/verilator/verilator.git"
+VERILATOR_BRANCH="master"
+# Use the release tag instead of a full SHA1 hash.
+VERILATOR_HASH="v5.008"
+VERILATOR_PATCH="$ROOT/verif/regress/verilator-v5.patch"
+
+VERILATOR_BUILD_DIR=$PWD/verilator-$VERILATOR_HASH/verilator
+VERILATOR_INSTALL_DIR="$(dirname $VERILATOR_BUILD_DIR)"
+
+if [ ! -e "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
+    echo "Building Verilator in $VERILATOR_BUILD_DIR..."
+    echo "Verilator will be installed in $VERILATOR_INSTALL_DIR"
+    echo "VERILATOR_REPO=$VERILATOR_REPO"
+    echo "VERILATOR_BRANCH=$VERILATOR_BRANCH"
+    echo "VERILATOR_HASH=$VERILATOR_HASH"
+    echo "VERILATOR_PATCH=$VERILATOR_PATCH"
+    mkdir -p $VERILATOR_BUILD_DIR
+    cd $VERILATOR_BUILD_DIR
+    sudo apt install libfl-dev help2man
+    [ -d .git ] || git clone $VERILATOR_REPO -b $VERILATOR_BRANCH .
+    git checkout $VERILATOR_HASH
+    if [[ -n "$VERILATOR_PATCH" && -f "$VERILATOR_PATCH" ]] ; then
+      git apply $VERILATOR_PATCH || true
+    fi
+    # Generate the config script and configure Verilator.
+    autoconf && ./configure --prefix="$VERILATOR_INSTALL_DIR" && make -j${NUM_JOBS}
+    # FORNOW: Accept failure in 'make test' (segfault issue on Debian10)
+    make test || true
+    echo "Installing Verilator in $VERILATOR_INSTALL_DIR..."
+    make install
 else
-    echo "Using Verilator from cached directory."
+    echo "Using Verilator from cached directory $VERILATOR_INSTALL_DIR."
 fi
+
+cd $ROOT

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -11,9 +11,12 @@ export CPLUS_INCLUDE_PATH=$RISCV/include
 echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:phiwag:edatools.list
 curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null
 sudo apt update
-sudo apt install verilator-4.110 device-tree-compiler
+sudo apt install device-tree-compiler
 
 ci/make-tmp.sh
+
+ci/install-verilator.sh
+
 sudo mkdir -p $RISCV && sudo chmod 777 $RISCV
 RISCV64_UNKNOWN_ELF_GCC=riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14.tar.gz
 if [ ! -f "$RISCV64_UNKNOWN_ELF_GCC" ]; then

--- a/verif/regress/install-riscv-arch-test.sh
+++ b/verif/regress/install-riscv-arch-test.sh
@@ -17,7 +17,7 @@ fi
 if ! [ -n "$ARCH_TEST_REPO" ]; then
   ARCH_TEST_REPO=https://github.com/riscv-non-isa/riscv-arch-test
   ARCH_TEST_BRANCH=main
-  ARCH_TEST_HASH="46cf99d0e020887e398508fc776928a1adad7c23"
+  ARCH_TEST_HASH="a5a49fc9f244192649e57fe61b4513d9bc39b1e3"
 fi
 echo "Repo:  " $ARCH_TEST_REPO
 echo "Branch:" $ARCH_TEST_BRANCH

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -561,7 +561,7 @@ def run_c(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
          -nostartfiles %s \
          -I%s/dv/user_extension \
           -T%s %s -o %s " % \
-         (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), c_test, cwd, 
+         (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), c_test, cwd,
 					  linker, gcc_opts, elf))
   cmd += (" -march=%s" % isa)
   cmd += (" -mabi=%s" % mabi)
@@ -849,9 +849,9 @@ def load_config(args, cwd):
   Returns:
       Loaded configuration dictionary.
   """
-  
+
   global isa_extension_list
-  isa_extension_list = args.isa_extension.split(",")  
+  isa_extension_list = args.isa_extension.split(",")
   isa_extension_list.append("zicsr")
   isa_extension_list.append("zifencei")
 
@@ -882,13 +882,13 @@ def load_config(args, cwd):
       args.testlist = cwd + "/target/"+ args.target +"/testlist.yaml"
     if args.target == "cv64a6_imafdc_sv39":
       args.mabi = "lp64d"
-      args.isa  = "rv64gc"
+      args.isa  = "rv64gc_zba_zbb_zbs_zbc"
     elif args.target == "cv32a60x": # step1 configuration
       args.mabi = "ilp32"
-      args.isa  = "rv32imac"
+      args.isa  = "rv32imac_zba_zbb_zbs_zbc"
     elif args.target == "cv32a6_embedded":
       args.mabi = "ilp32"
-      args.isa  = "rv32imc"
+      args.isa  = "rv32imc_zba_zbb_zbs_zbc"
     elif args.target == "cv32a6_imac_sv0":
       args.mabi = "ilp32"
       args.isa  = "rv32imac"
@@ -1017,13 +1017,13 @@ def main():
     cfg = load_config(args, cwd)
     # Create output directory
     output_dir = create_output(args.o, args.noclean, cwd+"/out_")
-    
+
     #add z,s,x extensions to the isa if there are some
-    if isa_extension_list !=['']:	
+    if isa_extension_list !=['']:
       for i in isa_extension_list:
         if i!= "":
           args.isa += (f"_{i}")
-        
+
     if args.verilog_style_check:
       logging.debug("Run style check")
       style_err = run_cmd("verilog_style/run.sh")

--- a/verif/tests/testlist_riscv-arch-test-cv32a60x.yaml
+++ b/verif/tests/testlist_riscv-arch-test-cv32a60x.yaml
@@ -35,19 +35,19 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cadd-01.S
-  
+
 - test: rv32im-caddi-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi-01.S
-  
+
 - test: rv32im-caddi16sp-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi16sp-01.S
-  
+
 - test: rv32im-caddi4spn-01
   iterations: 1
   path_var: TESTS_PATH
@@ -59,19 +59,19 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cand-01.S
-  
+
 - test: rv32im-candi-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/candi-01.S
-  
+
 - test: rv32im-cbeqz-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cbeqz-01.S
-  
+
 - test: rv32im-cbnez-01
   iterations: 1
   path_var: TESTS_PATH
@@ -89,19 +89,19 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cj-01.S
-  
+
 - test: rv32im-cjal-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjal-01.S
- 
+
 - test: rv32im-cjalr-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjalr-01.S
-  
+
 - test: rv32im-cjr-01
   iterations: 1
   path_var: TESTS_PATH
@@ -191,8 +191,8 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cxor-01.S
-  
-  # I  
+
+  # I
 - test: rv32im-add-01
   iterations: 1
   path_var: TESTS_PATH
@@ -264,31 +264,31 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/fence-01.S
- 
+
 - test: rv32im-jal-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jal-01.S
- 
+
 - test: rv32im-jalr-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jalr-01.S
- 
+
 - test: rv32im-lb-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lb-align-01.S
- 
+
 - test: rv32im-lbu-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lbu-align-01.S
- 
+
 - test: rv32im-lh-align-01
   iterations: 1
   path_var: TESTS_PATH
@@ -324,122 +324,122 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/ori-01.S
- 
+
 - test: rv32im-sb-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sb-align-01.S
- 
+
 - test: rv32im-sh-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sh-align-01.S
- 
+
 - test: rv32im-sll-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sll-01.S
- 
+
 - test: rv32im-slli-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slli-01.S
- 
+
 - test: rv32im-slt-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slt-01.S
- 
+
 - test: rv32im-slti-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slti-01.S
- 
+
 - test: rv32im-sltiu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltiu-01.S
- 
+
 - test: rv32im-sltu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltu-01.S
- 
+
 - test: rv32im-sra-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sra-01.S
- 
+
 - test: rv32im-srai-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srai-01.S
- 
+
 - test: rv32im-srl-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srl-01.S
- 
+
 - test: rv32im-srli-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srli-01.S
- 
+
 - test: rv32im-sub-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sub-01.S
- 
+
 - test: rv32im-sw-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sw-align-01.S
- 
+
 - test: rv32im-xor-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xor-01.S
- 
+
 - test: rv32im-xori-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xori-01.S
- 
+
   # M
 - test: rv32im-div-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/div-01.S
- 
+
 - test: rv32im-divu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/divu-01.S
- 
+
 - test: rv32im-mul-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mul-01.S
- 
+
 - test: rv32im-mulh-01
   iterations: 1
   path_var: TESTS_PATH
@@ -451,22 +451,268 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhsu-01.S
- 
+
 - test: rv32im-mulhu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhu-01.S
-  
+
 - test: rv32im-rem-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/rem-01.S
-   
+
 - test: rv32im-remu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/remu-01.S
 
+- test: rv32im-andn-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/andn-01.S
+
+- test: rv32im-bclr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bclr-01.S
+
+- test: rv32im-bclri-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bclri-01.S
+
+- test: rv32im-bext-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bext-01.S
+
+- test: rv32im-bexti-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bexti-01.S
+
+- test: rv32im-binv-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/binv-01.S
+
+- test: rv32im-binvi-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/binvi-01.S
+
+- test: rv32im-bset-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bset-01.S
+
+- test: rv32im-bseti-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bseti-01.S
+
+- test: rv32im-clmul-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clmul-01.S
+
+- test: rv32im-clmulh-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clmulh-01.S
+
+- test: rv32im-clmulr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clmulr-01.S
+
+- test: rv32im-clz-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clz-01.S
+
+- test: rv32im-cpop-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/cpop-01.S
+
+- test: rv32im-ctz-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/ctz-01.S
+
+- test: rv32im-max-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/max-01.S
+
+- test: rv32im-maxu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/maxu-01.S
+
+- test: rv32im-min-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/min-01.S
+
+- test: rv32im-minu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/minu-01.S
+
+- test: rv32im-orcb_32-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/orcb_32-01.S
+
+- test: rv32im-orn-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/orn-01.S
+
+- test: rv32im-rev8_32-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/rev8_32-01.S
+
+- test: rv32im-rol-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/rol-01.S
+
+- test: rv32im-ror-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/ror-01.S
+
+- test: rv32im-rori-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/rori-01.S
+
+- test: rv32im-sext.b-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sext.b-01.S
+
+- test: rv32im-sext.h-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sext.h-01.S
+
+- test: rv32im-sh1add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh1add-01.S
+
+- test: rv32im-sh2add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh2add-01.S
+
+- test: rv32im-sh3add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh3add-01.S
+
+- test: rv32im-xnor-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/xnor-01.S
+
+- test: rv32im-zext.h_32-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/zext.h_32-01.S
+
+  ##A
+- test: rv32im-amoadd.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amoadd.w-01.S
+
+- test: rv32im-amoand.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amoand.w-01.S
+
+- test: rv32im-amomax.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amomax.w-01.S
+
+- test: rv32im-amomaxu.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amomaxu.w-01.S
+
+- test: rv32im-amomin.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amomin.w-01.S
+
+- test: rv32im-amominu.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amominu.w-01.S
+
+- test: rv32im-amoor.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amoor.w-01.S
+
+- test: rv32im-amoswap.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amoswap.w-01.S
+
+- test: rv32im-amoxor.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/A/src/amoxor.w-01.S

--- a/verif/tests/testlist_riscv-arch-test-cv32a6_embedded.yaml
+++ b/verif/tests/testlist_riscv-arch-test-cv32a6_embedded.yaml
@@ -35,19 +35,19 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cadd-01.S
-  
+
 - test: rv32im-caddi-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi-01.S
-  
+
 - test: rv32im-caddi16sp-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi16sp-01.S
-  
+
 - test: rv32im-caddi4spn-01
   iterations: 1
   path_var: TESTS_PATH
@@ -59,19 +59,19 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cand-01.S
-  
+
 - test: rv32im-candi-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/candi-01.S
-  
+
 - test: rv32im-cbeqz-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cbeqz-01.S
-  
+
 - test: rv32im-cbnez-01
   iterations: 1
   path_var: TESTS_PATH
@@ -89,19 +89,19 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cj-01.S
-  
+
 - test: rv32im-cjal-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjal-01.S
- 
+
 - test: rv32im-cjalr-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjalr-01.S
-  
+
 - test: rv32im-cjr-01
   iterations: 1
   path_var: TESTS_PATH
@@ -191,8 +191,8 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cxor-01.S
-  
-  # I  
+
+  # I
 - test: rv32im-add-01
   iterations: 1
   path_var: TESTS_PATH
@@ -264,31 +264,31 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/fence-01.S
- 
+
 - test: rv32im-jal-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jal-01.S
- 
+
 - test: rv32im-jalr-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jalr-01.S
- 
+
 - test: rv32im-lb-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lb-align-01.S
- 
+
 - test: rv32im-lbu-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lbu-align-01.S
- 
+
 - test: rv32im-lh-align-01
   iterations: 1
   path_var: TESTS_PATH
@@ -324,122 +324,122 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/ori-01.S
- 
+
 - test: rv32im-sb-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sb-align-01.S
- 
+
 - test: rv32im-sh-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sh-align-01.S
- 
+
 - test: rv32im-sll-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sll-01.S
- 
+
 - test: rv32im-slli-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slli-01.S
- 
+
 - test: rv32im-slt-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slt-01.S
- 
+
 - test: rv32im-slti-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slti-01.S
- 
+
 - test: rv32im-sltiu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltiu-01.S
- 
+
 - test: rv32im-sltu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltu-01.S
- 
+
 - test: rv32im-sra-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sra-01.S
- 
+
 - test: rv32im-srai-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srai-01.S
- 
+
 - test: rv32im-srl-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srl-01.S
- 
+
 - test: rv32im-srli-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srli-01.S
- 
+
 - test: rv32im-sub-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sub-01.S
- 
+
 - test: rv32im-sw-align-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sw-align-01.S
- 
+
 - test: rv32im-xor-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xor-01.S
- 
+
 - test: rv32im-xori-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xori-01.S
- 
+
   # M
 - test: rv32im-div-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/div-01.S
- 
+
 - test: rv32im-divu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/divu-01.S
- 
+
 - test: rv32im-mul-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mul-01.S
- 
+
 - test: rv32im-mulh-01
   iterations: 1
   path_var: TESTS_PATH
@@ -451,22 +451,213 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhsu-01.S
- 
+
 - test: rv32im-mulhu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhu-01.S
-  
+
 - test: rv32im-rem-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/rem-01.S
-   
+
 - test: rv32im-remu-01
   iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/remu-01.S
 
+- test: rv32im-andn-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/andn-01.S
+
+- test: rv32im-bclr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bclr-01.S
+
+- test: rv32im-bclri-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bclri-01.S
+
+- test: rv32im-bext-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bext-01.S
+
+- test: rv32im-bexti-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bexti-01.S
+
+- test: rv32im-binv-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/binv-01.S
+
+- test: rv32im-binvi-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/binvi-01.S
+
+- test: rv32im-bset-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bset-01.S
+
+- test: rv32im-bseti-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/bseti-01.S
+
+- test: rv32im-clmul-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clmul-01.S
+
+- test: rv32im-clmulh-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clmulh-01.S
+
+- test: rv32im-clmulr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clmulr-01.S
+
+- test: rv32im-clz-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/clz-01.S
+
+- test: rv32im-cpop-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/cpop-01.S
+
+- test: rv32im-ctz-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/ctz-01.S
+
+- test: rv32im-max-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/max-01.S
+
+- test: rv32im-maxu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/maxu-01.S
+
+- test: rv32im-min-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/min-01.S
+
+- test: rv32im-minu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/minu-01.S
+
+- test: rv32im-orcb_32-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/orcb_32-01.S
+
+- test: rv32im-orn-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/orn-01.S
+
+- test: rv32im-rev8_32-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/rev8_32-01.S
+
+- test: rv32im-rol-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/rol-01.S
+
+- test: rv32im-ror-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/ror-01.S
+
+- test: rv32im-rori-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/rori-01.S
+
+- test: rv32im-sext.b-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sext.b-01.S
+
+- test: rv32im-sext.h-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sext.h-01.S
+
+- test: rv32im-sh1add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh1add-01.S
+
+- test: rv32im-sh2add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh2add-01.S
+
+- test: rv32im-sh3add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh3add-01.S
+
+- test: rv32im-xnor-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/xnor-01.S
+
+- test: rv32im-zext.h_32-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/zext.h_32-01.S

--- a/verif/tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml
+++ b/verif/tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml
@@ -611,6 +611,264 @@
   gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cxor-01.S
 
+- test: rv64i_m-add.uw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/add.uw-01.S
+
+- test: rv64i_m-andn-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/andn-01.S
+
+- test: rv64i_m-bclr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/bclr-01.S
+
+- test: rv64i_m-bclri-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/bclri-01.S
+
+- test: rv64i_m-bext-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/bext-01.S
+
+- test: rv64i_m-bexti-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/bexti-01.S
+
+- test: rv64i_m-binv-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/binv-01.S
+
+- test: rv64i_m-binvi-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/binvi-01.S
+
+- test: rv64i_m-bset-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/bset-01.S
+
+- test: rv64i_m-bseti-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/bseti-01.S
+
+- test: rv64i_m-clmul-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/clmul-01.S
+
+- test: rv64i_m-clmulh-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/clmulh-01.S
+
+- test: rv64i_m-clmulr-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/clmulr-01.S
+
+- test: rv64i_m-clz-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/clz-01.S
+
+- test: rv64i_m-clzw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/clzw-01.S
+
+- test: rv64i_m-cpop-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/cpop-01.S
+
+- test: rv64i_m-cpopw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/cpopw-01.S
+
+- test: rv64i_m-ctz-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/ctz-01.S
+
+- test: rv64i_m-ctzw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/ctzw-01.S
+
+- test: rv64i_m-max-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/max-01.S
+
+- test: rv64i_m-maxu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/maxu-01.S
+
+- test: rv64i_m-min-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/min-01.S
+
+- test: rv64i_m-minu-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/minu-01.S
+
+- test: rv64i_m-orcb_64-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/orcb_64-01.S
+
+- test: rv64i_m-orn-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/orn-01.S
+
+- test: rv64i_m-rev8-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/rev8-01.S
+
+- test: rv64i_m-rol-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/rol-01.S
+
+- test: rv64i_m-rolw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/rolw-01.S
+
+- test: rv64i_m-ror-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/ror-01.S
+
+- test: rv64i_m-rori-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/rori-01.S
+
+- test: rv64i_m-roriw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/roriw-01.S
+
+- test: rv64i_m-rorw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/rorw-01.S
+
+- test: rv64i_m-sext.b-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sext.b-01.S
+
+- test: rv64i_m-sext.h-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sext.h-01.S
+
+- test: rv64i_m-sh1add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sh1add-01.S
+
+- test: rv64i_m-sh1add.uw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sh1add.uw-01.S
+
+- test: rv64i_m-sh2add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sh2add-01.S
+
+- test: rv64i_m-sh2add.uw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sh2add.uw-01.S
+
+- test: rv64i_m-sh3add-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sh3add-01.S
+
+- test: rv64i_m-sh3add.uw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/sh3add.uw-01.S
+
+- test: rv64i_m-slli.uw-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/slli.uw-01.S
+
+- test: rv64i_m-xnor-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/xnor-01.S
+
+- test: rv64i_m-zext.h_64-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/B/src/zext.h_64-01.S
+
 #D
 - test: rv64i_m-fcvt.d.l_b25-01
   iterations: 0
@@ -671,7 +929,7 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b28-01.S
-  
+
 - test: rv64i_m-fcvt.l.d_b29-01
   iterations: 0
   path_var: TESTS_PATH
@@ -701,7 +959,7 @@
   path_var: TESTS_PATH
   gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b24-01.S
-  
+
 - test: rv64i_m-fcvt.lu.d_b27-01
   iterations: 0
   path_var: TESTS_PATH
@@ -774,3 +1032,112 @@
   gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b29-01.S
 
+##A
+
+- test: rv64i_m-amoadd.d-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoadd.d-01.S
+
+- test: rv64i_m-amoadd.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoadd.w-01.S
+
+- test: rv64i_m-amoand.d-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoand.d-01.S
+
+- test: rv64i_m-amoand.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoand.w-01.S
+
+- test: rv64i_m-amomax.d-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amomax.d-01.S
+
+- test: rv64i_m-amomax.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amomax.w-01.S
+
+- test: rv64i_m-amomaxu.d-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amomaxu.d-01.S
+
+- test: rv64i_m-amomaxu.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amomaxu.w-01.S
+
+- test: rv64i_m-amomin.d-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amomin.d-01.S
+
+- test: rv64i_m-amomin.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amomin.w-01.S
+
+- test: rv64i_m-amominu.d-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amominu.d-01.S
+
+- test: rv64i_m-amominu.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amominu.w-01.S
+
+- test: rv64i_m-amoor.d-01.S
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoor.d-01.S
+
+- test: rv64i_m-amoor.w-01.S
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoor.w-01.S
+
+- test: rv64i_m-amoswap.d-01.S
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoswap.d-01.S
+
+- test: rv64i_m-amoswap.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoswap.w-01.S
+
+- test: rv64i_m-amoxor.d-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoxor.d-01.S
+
+- test: rv64i_m-amoxor.w-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/A/src/amoxor.w-01.S


### PR DESCRIPTION
This PR updates the Verilator version to v5.008 in the CI #1558.