### PR TITLE
Code_coverage: condition RTL with the S-MODE parameter

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,2 +1,2 @@
 cv32a6_embedded:
-  gates: 127005
+  gates: 123953

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -194,6 +194,7 @@ module cva6
     unsigned'(NrRgprPorts),
     unsigned'(NrWbPorts),
     bit'(EnableAccelerator),
+    CVA6Cfg.RVS,
     CVA6Cfg.HaltAddress,
     CVA6Cfg.ExceptionAddress,
     CVA6Cfg.RASDepth,
@@ -1306,7 +1307,7 @@ module cva6
       else begin
         case (priv_lvl)
           riscv::PRIV_LVL_M: mode = "M";
-          riscv::PRIV_LVL_S: mode = "S";
+          riscv::PRIV_LVL_S: if(CVA6Cfg.RVS) mode = "S";
           riscv::PRIV_LVL_U: mode = "U";
           default: ;  // Do nothing
         endcase

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -143,19 +143,21 @@ module decoder
                 12'b1: ebreak = 1'b1;
                 // SRET
                 12'b1_0000_0010: begin
-                  instruction_o.op = ariane_pkg::SRET;
-                  // check privilege level, SRET can only be executed in S and M mode
-                  // we'll just decode an illegal instruction if we are in the wrong privilege level
-                  if (priv_lvl_i == riscv::PRIV_LVL_U) begin
-                    illegal_instr = 1'b1;
-                    //  do not change privilege level if this is an illegal instruction
-                    instruction_o.op = ariane_pkg::ADD;
-                  end
-                  // if we are in S-Mode and Trap SRET (tsr) is set -> trap on illegal instruction
-                  if (priv_lvl_i == riscv::PRIV_LVL_S && tsr_i) begin
-                    illegal_instr = 1'b1;
-                    //  do not change privilege level if this is an illegal instruction
-                    instruction_o.op = ariane_pkg::ADD;
+                  if (CVA6Cfg.RVS) begin
+                    instruction_o.op = ariane_pkg::SRET;
+                    // check privilege level, SRET can only be executed in S and M mode
+                    // we'll just decode an illegal instruction if we are in the wrong privilege level
+                    if (priv_lvl_i == riscv::PRIV_LVL_U) begin
+                      illegal_instr = 1'b1;
+                      //  do not change privilege level if this is an illegal instruction
+                      instruction_o.op = ariane_pkg::ADD;
+                    end
+                    // if we are in S-Mode and Trap SRET (tsr) is set -> trap on illegal instruction
+                    if (priv_lvl_i == riscv::PRIV_LVL_S && tsr_i) begin
+                      illegal_instr = 1'b1;
+                      //  do not change privilege level if this is an illegal instruction
+                      instruction_o.op = ariane_pkg::ADD;
+                    end
                   end
                 end
                 // MRET
@@ -163,7 +165,7 @@ module decoder
                   instruction_o.op = ariane_pkg::MRET;
                   // check privilege level, MRET can only be executed in M mode
                   // otherwise we decode an illegal instruction
-                  if (priv_lvl_i inside {riscv::PRIV_LVL_U, riscv::PRIV_LVL_S})
+                  if ((CVA6Cfg.RVS && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_U)
                     illegal_instr = 1'b1;
                 end
                 // DRET
@@ -177,7 +179,7 @@ module decoder
                   if (ENABLE_WFI) instruction_o.op = ariane_pkg::WFI;
                   // if timeout wait is set, trap on an illegal instruction in S Mode
                   // (after 0 cycles timeout)
-                  if (priv_lvl_i == riscv::PRIV_LVL_S && tw_i) begin
+                  if (CVA6Cfg.RVS && priv_lvl_i == riscv::PRIV_LVL_S && tw_i) begin
                     illegal_instr = 1'b1;
                     instruction_o.op = ariane_pkg::ADD;
                   end
@@ -192,10 +194,11 @@ module decoder
                   if (instr.instr[31:25] == 7'b1001) begin
                     // check privilege level, SFENCE.VMA can only be executed in M/S mode
                     // otherwise decode an illegal instruction
-                    illegal_instr    = ((priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) && instr.itype.rd == '0) ? 1'b0 : 1'b1;
+                    illegal_instr    = (((CVA6Cfg.RVS && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_M) && instr.itype.rd == '0) ? 1'b0 : 1'b1;
                     instruction_o.op = ariane_pkg::SFENCE_VMA;
                     // check TVM flag and intercept SFENCE.VMA call if necessary
-                    if (priv_lvl_i == riscv::PRIV_LVL_S && tvm_i) illegal_instr = 1'b1;
+                    if (CVA6Cfg.RVS && priv_lvl_i == riscv::PRIV_LVL_S && tvm_i)
+                      illegal_instr = 1'b1;
                   end else begin
                     illegal_instr = 1'b1;
                   end
@@ -1317,7 +1320,7 @@ module decoder
         // depending on the privilege mode, set the appropriate cause
         case (priv_lvl_i)
           riscv::PRIV_LVL_M: instruction_o.ex.cause = riscv::ENV_CALL_MMODE;
-          riscv::PRIV_LVL_S: instruction_o.ex.cause = riscv::ENV_CALL_SMODE;
+          riscv::PRIV_LVL_S: if (CVA6Cfg.RVS) instruction_o.ex.cause = riscv::ENV_CALL_SMODE;
           riscv::PRIV_LVL_U: instruction_o.ex.cause = riscv::ENV_CALL_UMODE;
           default: ;  // this should not happen
         endcase
@@ -1390,7 +1393,7 @@ module decoder
         // mode equals the delegated privilege mode (S or U) and that mode’s interrupt enable bit
         // (SIE or UIE in mstatus) is set, or if the current privilege mode is less than the delegated privilege mode.
         if (irq_ctrl_i.mideleg[interrupt_cause[$clog2(riscv::XLEN)-1:0]]) begin
-          if ((irq_ctrl_i.sie && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_U) begin
+          if ((CVA6Cfg.RVS && irq_ctrl_i.sie && priv_lvl_i == riscv::PRIV_LVL_S) || priv_lvl_i == riscv::PRIV_LVL_U) begin
             instruction_o.ex.valid = 1'b1;
             instruction_o.ex.cause = interrupt_cause;
           end

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -71,6 +71,7 @@ package config_pkg;
     int unsigned                 NrRgprPorts;
     int unsigned                 NrWbPorts;
     bit                          EnableAccelerator;
+    bit                          RVS;    //Supervisor mode
     // Debug Module
     // address to which a hart should jump when it was requested to halt
     logic [63:0]                 HaltAddress;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(0),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -113,6 +113,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       NrRgprPorts: unsigned'(0),
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
+      RVS: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -190,6 +190,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   NrRgprPorts:           unsigned'(0),
   NrWbPorts:             unsigned'(0),
   EnableAccelerator:     bit'(0),
+  RVS:                   bit'(1),
   HaltAddress:           dm::HaltAddress,
   ExceptionAddress:      dm::ExceptionAddress,
   DmBaseAddress:         ariane_soc::DebugBase,


### PR DESCRIPTION
Add Supervisor Mode parameter to the CVA6 configuration and set it to 0 in the embedded config.

Condition RTL with Supervisor Mode parameter to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to reach 100% code coverage.