### PR TITLE
Code_coverage: condition RTL with the debug parameter

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,2 +1,2 @@
 cv32a6_embedded:
-  gates: 123953
+  gates: 121071

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -341,7 +341,9 @@ module wt_dcache_wbuffer
 
   for (genvar k = 0; k < DCACHE_WBUF_DEPTH; k++) begin : gen_flags
     // only for debug, will be pruned
-    assign debug_paddr[k] = {{riscv::XLEN_ALIGN_BYTES{1'b0}}, wbuffer_q[k].wtag << riscv::XLEN_ALIGN_BYTES};
+    if(CVA6Cfg.DebugEn) begin
+      assign debug_paddr[k] = {{riscv::XLEN_ALIGN_BYTES{1'b0}}, wbuffer_q[k].wtag << riscv::XLEN_ALIGN_BYTES};
+    end
 
     // dirty bytes that are ready for transmission.
     // note that we cannot retransmit a word that is already in-flight

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -154,7 +154,7 @@ module controller
     // 1. Exception
     // 2. Return from exception
     // ---------------------------------
-    if (ex_valid_i || eret_i || set_debug_pc_i) begin
+    if (ex_valid_i || eret_i || (CVA6Cfg.DebugEn && set_debug_pc_i)) begin
       // don't flush pcgen as we want to take the exception: Flush PCGen is not a flush signal
       // for the PC Gen stage but instead tells it to take the PC we gave it
       set_pc_commit_o        = 1'b0;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -212,7 +212,8 @@ module cva6
     CVA6Cfg.NrCachedRegionRules,
     CVA6Cfg.CachedRegionAddrBase,
     CVA6Cfg.CachedRegionLength,
-    CVA6Cfg.MaxOutstandingStores
+    CVA6Cfg.MaxOutstandingStores,
+    CVA6Cfg.DebugEn
   };
 
 
@@ -1303,7 +1304,7 @@ module cva6
       cycles <= 0;
     end else begin
       byte mode = "";
-      if (debug_mode) mode = "D";
+      if (CVA6Cfg.DebugEn && debug_mode) mode = "D";
       else begin
         case (priv_lvl)
           riscv::PRIV_LVL_M: mode = "M";
@@ -1321,7 +1322,7 @@ module cva6
             $fwrite(f, "Exception Cause: Illegal Instructions, DASM(%h) PC=%h\n",
                     commit_instr_id_commit[i].ex.tval[31:0], commit_instr_id_commit[i].pc);
           end else begin
-            if (debug_mode) begin
+            if (CVA6Cfg.DebugEn && debug_mode) begin
               $fwrite(f, "%d 0x%0h %s (0x%h) DASM(%h)\n", cycles, commit_instr_id_commit[i].pc,
                       mode, commit_instr_id_commit[i].ex.tval[31:0],
                       commit_instr_id_commit[i].ex.tval[31:0]);
@@ -1368,7 +1369,7 @@ module cva6
         // when trap, the instruction is not executed
         rvfi_o[i].trap = mem_exception;
         rvfi_o[i].cause = ex_commit.cause;
-        rvfi_o[i].mode = debug_mode ? 2'b10 : priv_lvl;
+        rvfi_o[i].mode = (CVA6Cfg.DebugEn && debug_mode) ? 2'b10 : priv_lvl;
         rvfi_o[i].ixl = riscv::XLEN == 64 ? 2 : 1;
         rvfi_o[i].rs1_addr = commit_instr_id_commit[i].rs1[4:0];
         rvfi_o[i].rs2_addr = commit_instr_id_commit[i].rs2[4:0];

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -1405,7 +1405,7 @@ module decoder
     end
 
     // a debug request has precendece over everything else
-    if (debug_req_i && !debug_mode_i) begin
+    if (CVA6Cfg.DebugEn && debug_req_i && !debug_mode_i) begin
       instruction_o.ex.valid = 1'b1;
       instruction_o.ex.cause = riscv::DEBUG_REQUEST;
     end

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -361,7 +361,7 @@ module frontend
     end
     // 7. Debug
     // enter debug on a hard-coded base-address
-    if (set_debug_pc_i)
+    if (CVA6Cfg.DebugEn && set_debug_pc_i)
       npc_d = CVA6Cfg.DmBaseAddress[riscv::VLEN-1:0] + CVA6Cfg.HaltAddress[riscv::VLEN-1:0];
     icache_dreq_o.vaddr = fetch_address;
   end

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -110,6 +110,7 @@ package config_pkg;
     logic [NrMaxRules-1:0][63:0] CachedRegionLength;
     /// Maximum number of outstanding stores.
     int unsigned                 MaxOutstandingStores;
+    bit                          DebugEn;
   } cva6_cfg_t;
 
 

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -136,7 +136,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -135,7 +135,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -136,7 +136,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -136,6 +136,7 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 endpackage

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -136,7 +136,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -136,7 +136,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -135,7 +135,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -136,7 +136,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -142,7 +142,8 @@ package cva6_config_pkg;
       1
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
-      CachedRegionLength: 1024'({64'h40000000})
+      CachedRegionLength: 1024'({64'h40000000}),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -136,7 +136,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -136,7 +136,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -135,6 +135,7 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7)
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1)
   };
 endpackage

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -176,7 +176,9 @@ module scoreboard #(
         mem_n[trans_id_i[i]].sbe.valid = 1'b1;
         mem_n[trans_id_i[i]].sbe.result = wbdata_i[i];
         // save the target address of a branch (needed for debug in commit stage)
-        mem_n[trans_id_i[i]].sbe.bp.predict_address = resolved_branch_i.target_address;
+        if(CVA6Cfg.DebugEn) begin
+          mem_n[trans_id_i[i]].sbe.bp.predict_address = resolved_branch_i.target_address;
+        end
         if (mem_n[trans_id_i[i]].sbe.fu == ariane_pkg::CVXIF && ~x_we_i) begin
           mem_n[trans_id_i[i]].sbe.rd = 5'b0;
         end

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -207,7 +207,8 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   NrCachedRegionRules:   unsigned'(1),
   CachedRegionAddrBase:  1024'({ariane_soc::DRAMBase}),
   CachedRegionLength:    1024'({ariane_soc::DRAMLength}),
-  MaxOutstandingStores:  unsigned'(7)
+  MaxOutstandingStores:  unsigned'(7),
+  DebugEn: bit'(1)
 };
 
 localparam type rvfi_instr_t = logic;


### PR DESCRIPTION
Add parameter for debug to the CVA6 configuration and set it to 0 in the embedded config.

Condition RTL with Debug Mode parameter to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to reach 100% code coverage.