### PR TITLE
Code_coverage: condition RTL with the U-MODE parameter

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -163,7 +163,7 @@ module csr_regfile
   | (riscv::XLEN'(1) << 12)  // M - Integer Multiply/Divide extension
   | (riscv::XLEN'(0) << 13)  // N - User level interrupts supported
   | (riscv::XLEN'(CVA6Cfg.RVS) << 18)  // S - Supervisor mode implemented
-  | (riscv::XLEN'(1) << 20)  // U - User mode implemented
+  | (riscv::XLEN'(CVA6Cfg.RVU) << 20)  // U - User mode implemented
   | (riscv::XLEN'(CVA6Cfg.RVV) << 21)  // V - Vector extension
   | (riscv::XLEN'(CVA6Cfg.NSX) << 23)  // X - Non-standard extensions present
   | ((riscv::XLEN == 64 ? 2 : 1) << riscv::XLEN - 2);  // MXL
@@ -1139,8 +1139,10 @@ module csr_regfile
             end
           end
           riscv::PRIV_LVL_U: begin
-            debug_mode_d   = dcsr_q.ebreaku;
-            set_debug_pc_o = dcsr_q.ebreaku;
+            if (CVA6Cfg.RVU) begin
+              debug_mode_d   = dcsr_q.ebreaku;
+              set_debug_pc_o = dcsr_q.ebreaku;
+            end
           end
           default: ;
         endcase
@@ -1330,7 +1332,8 @@ module csr_regfile
           riscv::PRIV_LVL_M: privilege_violation = 1'b0;
           riscv::PRIV_LVL_S: if (CVA6Cfg.RVS) privilege_violation = ~mcounteren_q[csr_addr_i[4:0]];
           riscv::PRIV_LVL_U:
-          privilege_violation = ~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]];
+          if (CVA6Cfg.RVU)
+            privilege_violation = ~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]];
         endcase
       end
     end

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -195,6 +195,7 @@ module cva6
     unsigned'(NrWbPorts),
     bit'(EnableAccelerator),
     CVA6Cfg.RVS,
+    CVA6Cfg.RVU,
     CVA6Cfg.HaltAddress,
     CVA6Cfg.ExceptionAddress,
     CVA6Cfg.RASDepth,

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -72,6 +72,7 @@ package config_pkg;
     int unsigned                 NrWbPorts;
     bit                          EnableAccelerator;
     bit                          RVS;    //Supervisor mode
+    bit                          RVU;    //User mode
     // Debug Module
     // address to which a hart should jump when it was requested to halt
     logic [63:0]                 HaltAddress;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(0),
+      RVU: bit'(0),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -114,6 +114,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       NrWbPorts: unsigned'(0),
       EnableAccelerator: bit'(0),
       RVS: bit'(1),
+      RVU: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -191,6 +191,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   NrWbPorts:             unsigned'(0),
   EnableAccelerator:     bit'(0),
   RVS:                   bit'(1),
+  RVU:                   bit'(1),
   HaltAddress:           dm::HaltAddress,
   ExceptionAddress:      dm::ExceptionAddress,
   DmBaseAddress:         ariane_soc::DebugBase,


### PR DESCRIPTION
Add User Mode parameter to the CVA6 configuration and set it to 0 in the embedded config.

Condition RTL with User Mode parameter to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to reach 100% code coverage.