### PR TITLE
Do not support DRET when DebugEn = 0

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -171,8 +171,12 @@ module decoder
                 // DRET
                 12'b111_1011_0010: begin
                   instruction_o.op = ariane_pkg::DRET;
-                  // check that we are in debug mode when executing this instruction
-                  illegal_instr = (!debug_mode_i) ? 1'b1 : illegal_instr;
+                  if (CVACfg.DebugEn) begin
+                    // check that we are in debug mode when executing this instruction
+                    illegal_instr = (!debug_mode_i) ? 1'b1 : illegal_instr;
+                  else begin
+                    illegal_instr = 1'b1;
+                  end
                 end
                 // WFI
                 12'b1_0000_0101: begin

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -174,7 +174,7 @@ module decoder
                   if (CVACfg.DebugEn) begin
                     // check that we are in debug mode when executing this instruction
                     illegal_instr = (!debug_mode_i) ? 1'b1 : illegal_instr;
-                  else begin
+                  end else begin
                     illegal_instr = 1'b1;
                   end
                 end

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -171,7 +171,7 @@ module decoder
                 // DRET
                 12'b111_1011_0010: begin
                   instruction_o.op = ariane_pkg::DRET;
-                  if (CVACfg.DebugEn) begin
+                  if (CVA6Cfg.DebugEn) begin
                     // check that we are in debug mode when executing this instruction
                     illegal_instr = (!debug_mode_i) ? 1'b1 : illegal_instr;
                   end else begin


### PR DESCRIPTION
When debug mode is disable, DRET instruction is not supported.