### PR TITLE
Code coverage: Add SMODE parameter to the sfence_vma instruction

### DIFF
--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -172,7 +172,7 @@ module commit_stage
       // sfence.vma is idempotent so we can safely re-execute it after returning
       // from interrupt service routine
       // check if this instruction was a SFENCE_VMA
-      if (commit_instr_i[0].op == SFENCE_VMA) begin
+      if (CVA6Cfg.RVS && commit_instr_i[0].op == SFENCE_VMA) begin
         // no store pending so we can flush the TLBs and pipeline
         sfence_vma_o = no_st_pending_i;
         // wait for the store buffer to drain until flushing the pipeline

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -125,7 +125,7 @@ module controller
     // ---------------------------------
     // SFENCE.VMA
     // ---------------------------------
-    if (sfence_vma_i) begin
+    if (CVA6Cfg.RVS && sfence_vma_i) begin
       set_pc_commit_o        = 1'b1;
       flush_if_o             = 1'b1;
       flush_unissued_instr_o = 1'b1;

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -184,7 +184,7 @@ module issue_read_operands
       if (rs1_valid_i && (CVA6Cfg.FpPresent && is_rs1_fpr(
               issue_instr_i.op
           ) ? 1'b1 : ((rd_clobber_gpr_i[issue_instr_i.rs1] != CSR) ||
-                      (issue_instr_i.op == SFENCE_VMA)))) begin
+                      (CVA6Cfg.RVS && issue_instr_i.op == SFENCE_VMA)))) begin
         forward_rs1 = 1'b1;
       end else begin  // the operand is not available -> stall
         stall = 1'b1;
@@ -199,7 +199,7 @@ module issue_read_operands
       if (rs2_valid_i && (CVA6Cfg.FpPresent && is_rs2_fpr(
               issue_instr_i.op
           ) ? 1'b1 : ((rd_clobber_gpr_i[issue_instr_i.rs2] != CSR) ||
-                      (issue_instr_i.op == SFENCE_VMA)))) begin
+                      (CVA6Cfg.RVS && issue_instr_i.op == SFENCE_VMA)))) begin
         forward_rs2 = 1'b1;
       end else begin  // the operand is not available -> stall
         stall = 1'b1;


### PR DESCRIPTION
Condition the sfence_vma instruction with User Mode parameter to identify the dead code and remove the dead gates from netlist.