### PR TITLE
CVA6-DV : Add ecall instruction into generate tests

### DIFF
--- a/verif/env/corev-dv/cva6_ecall_instr_stream.sv
+++ b/verif/env/corev-dv/cva6_ecall_instr_stream.sv
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 OpenHW Group
+ * Copyright 2020 Silicon Labs, Inc.
+ * Copyright 2023 Thales DIS France SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * cva6_ecall_isntr_stream: Directed test stream to inject ECALL in tests 
+ */
+
+ class cva6_ecall_instr_stream_c extends cva6_load_store_rand_instr_stream_c;
+  
+  // Number of ecall instructions to generate (note: will be back-to-back)
+  rand int unsigned ecall_cnt;
+
+  constraint ecall_c {
+    ecall_cnt inside {[1:4]};
+  }
+
+  `uvm_object_utils(cva6_ecall_instr_stream_c)
+  `uvm_object_new
+
+  virtual function void add_mixed_instr(int instr_cnt);
+    super.add_mixed_instr(instr_cnt);
+    add_ecall(ecall_cnt);
+  endfunction : add_mixed_instr
+
+  virtual function void add_ecall(int unsigned cnt);
+    riscv_instr ecall_instr;
+
+    for (int i = 0; i < cnt; i++) begin
+      ecall_instr = riscv_instr::get_rand_instr(.include_instr({ECALL}));
+      `DV_CHECK_RANDOMIZE_FATAL(ecall_instr)
+      ecall_instr.comment = "cva6-dv: cva6_ecall_instr_stream";
+      insert_instr(ecall_instr);
+    end
+  endfunction : add_ecall
+
+ endclass

--- a/verif/env/corev-dv/cva6_instr_test_pkg.sv
+++ b/verif/env/corev-dv/cva6_instr_test_pkg.sv
@@ -25,6 +25,7 @@ package cva6_instr_test_pkg;
    `include "cva6_instr_base_test.sv"
    `include "cva6_instr_hazard_test.sv"
    `include "cva6_load_store_instr_lib.sv"
+   `include "cva6_ecall_instr_stream.sv"
    `include "cvxif_custom_instr.sv"
    `include "riscv_zicond_instr.sv"
    `include "riscv_zcb_instr.sv"

--- a/verif/sim/cva6_base_testlist.yaml
+++ b/verif/sim/cva6_base_testlist.yaml
@@ -514,7 +514,8 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
-    +no_data_page=1
+    +directed_instr_0=cva6_ecall_instr_stream_c,1
+    +no_data_page=0
     +no_branch_jump=1
     +boot_mode=m
     +no_csr_instr=1


### PR DESCRIPTION
This related to adding tests for improving CC, this about the ecall instruction that never been executed in the generated tests, so I create a class to inject ecall instruction.