### PR TITLE
Add the Zc* ISA to "Applicable Specifications"

### DIFF
--- a/docs/02_cva6_requirements/cva6_requirements_specification.rst
+++ b/docs/02_cva6_requirements/cva6_requirements_specification.rst
@@ -138,11 +138,13 @@ The CVA6 is highly configurable via SystemVerilog parameters.
 It is not practical to fully document and verify all possible combinations of parameters, so a set of "viable IP configurations" has been defined.
 The full list of parameters for this configuration will be detailed in the users’ guide.
 
-Below is the configuration of the first release of the CVA6.
+Below are the configuration of the first releases of the CVA6.
 
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 | Release ID         | Target  | ISA     | XLEN | FPU   | CV-X-IF | MMU     | L1 D$   | L1 I$   |
 +====================+=========+=========+======+=======+=========+=========+=========+=========+
+| CV32A60B           | ASIC    | IMC     |  32  | No    | Yes     | None    | None    | None    |
++--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 | CV32A60X           | ASIC    | IMC     |  32  | No    | Yes     | Sv32    | None    | 16 kB   |
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 
@@ -190,6 +192,10 @@ Asanović and John Hauser, RISC-V Foundation, December 4, 2021.
 
 [RVdbg] “RISC-V External Debug Support, Document Version 0.13.2”,
 Editors Tim Newsome and Megan Wachs, RISC-V Foundation, March 22, 2019.
+
+[RVZc] “RISC-V Zc* Code Size Reduction v1.0",
+Editor Tariq Kurd, Codasip, April, 2023.
+https://wiki.riscv.org/display/HOME/Recently+Ratified+Extensions
 
 [RVcompat] “RISC-V Architectural Compatibility Test Framework”,
 https://github.com/riscv-non-isa/riscv-arch-test.

--- a/docs/02_cva6_requirements/cva6_requirements_specification.rst
+++ b/docs/02_cva6_requirements/cva6_requirements_specification.rst
@@ -143,9 +143,9 @@ Below are the configuration of the first releases of the CVA6.
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 | Release ID         | Target  | ISA     | XLEN | FPU   | CV-X-IF | MMU     | L1 D$   | L1 I$   |
 +====================+=========+=========+======+=======+=========+=========+=========+=========+
-| CV32E6?X           | ASIC    | IMC     |  32  | No    | Yes     | None    | None    | None    |
+| CV32E6?X           | ASIC    | IMC     |  32  | No    | Yes     | None    | 2 kB    | 2 kB    |
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
-| CV32A60X           | ASIC    | IMC     |  32  | No    | Yes     | Sv32    | None    | 16 kB   |
+| CV32A60X           | ASIC    | IMC     |  32  | No    | Yes     | Sv32    | 16kB    | 16 kB   |
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 
 The value of the "?" digit above is yet to be defined when all details of this configuration are known.

--- a/docs/02_cva6_requirements/cva6_requirements_specification.rst
+++ b/docs/02_cva6_requirements/cva6_requirements_specification.rst
@@ -143,11 +143,12 @@ Below are the configuration of the first releases of the CVA6.
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 | Release ID         | Target  | ISA     | XLEN | FPU   | CV-X-IF | MMU     | L1 D$   | L1 I$   |
 +====================+=========+=========+======+=======+=========+=========+=========+=========+
-| CV32A60B           | ASIC    | IMC     |  32  | No    | Yes     | None    | None    | None    |
+| CV32E6?X           | ASIC    | IMC     |  32  | No    | Yes     | None    | None    | None    |
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 | CV32A60X           | ASIC    | IMC     |  32  | No    | Yes     | Sv32    | None    | 16 kB   |
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 
+The value of the "?" digit above is yet to be defined when all details of this configuration are known.
 
 Possible Future Releases
 ------------------------


### PR DESCRIPTION
During the CVA6 Verification meeting today (2023-11-09) it was pointed out that we have not defined the version of the Zc* ISA extension we support.  This is a recently ratified spec. and it is not easy to find, so this PR (attempts to) resolve that.

Since I was already editing the `cva6_requirements_specification.rst` doc, I took the liberty of adding the CV32A60B, although I am not sure if the configuration information I added is correct.