### PR TITLE
Bump verif/core-v-verif from `a687a60` to `6779193`

### DIFF
--- a/verif/sim/cva6_spike_log_to_trace_csv.py
+++ b/verif/sim/cva6_spike_log_to_trace_csv.py
@@ -97,7 +97,7 @@ def read_spike_trace(path, full_trace):
     If full_trace is true, extract operands from the disassembled instructions.
 
     Since Spike has a strange trampoline that always runs at the start, we skip
-    instructions up to and including the one at PC 0x1010 (the end of the
+    instructions up to and including the one at PC 0x10010 (the end of the
     trampoline). At the end of a DV program, there's an ECALL instruction, which
     we take as a signal to stop checking, so we ditch everything that follows
     that instruction.
@@ -121,7 +121,7 @@ def read_spike_trace(path, full_trace):
     # true. Otherwise, we are in state EFFECT if instr is not None, otherwise we
     # are in state INSTR.
 
-    end_trampoline_re = re.compile(r'core.*: 0x0*1010 ')
+    end_trampoline_re = re.compile(r'core.*: 0x0*10010 ')
 
     in_trampoline = True
     instr = None


### PR DESCRIPTION
Bumps verif/core-v-verif from `a687a60` to `6779193`.

Changing trampoline PC to the new riscv-isa-sim implementation

