### PR TITLE
Generate Zcb extension instructions

### DIFF
--- a/verif/env/corev-dv/custom/riscv_zcb_instr.sv
+++ b/verif/env/corev-dv/custom/riscv_zcb_instr.sv
@@ -18,7 +18,14 @@
 class riscv_zcb_instr_c extends riscv_custom_instr;
 
    `uvm_object_utils(riscv_zcb_instr_c)
-   `uvm_object_new
+
+  function new(string name = "");
+    super.new(name);
+    rs1 = S0;
+    rs2 = S0;
+    rd  = S0;
+    is_compressed = 1'b1;
+  endfunction : new
 
   constraint rvc_rx_c {
     //  Registers specified by the three-bit rs1’, rs2’, and rd’

--- a/verif/regress/dv-generated-tests.sh
+++ b/verif/regress/dv-generated-tests.sh
@@ -7,6 +7,11 @@
 #
 # Original Author: Ayoub JALALI (ayoub.jalali@external.thalesgroup.com)
 
+if [ -n "$RISCV_ZCB" ]; then
+  echo "Using RISCV_ZCB to support Zcb extension"
+  RISCV=$RISCV_ZCB
+fi
+
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
   return
@@ -108,7 +113,7 @@ printf "+=======================================================================
 j=0
 while [[ $j -lt ${#TEST_NAME[@]} ]];do
   cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
-  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike -i ${I[j]} -bz 1 --iss_timeout 300
+  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike -i ${I[j]} -bz 1 --iss_timeout 300
   n=0
   echo "Generate the test: ${TEST_NAME[j]}"
 #this while loop detects the failed tests from the log file and remove them

--- a/verif/regress/dv-generated-xif-tests.sh
+++ b/verif/regress/dv-generated-xif-tests.sh
@@ -7,6 +7,11 @@
 #
 # Original Author: Ayoub JALALI (ayoub.jalali@external.thalesgroup.com)
 
+if [ -n "$RISCV_ZCB" ]; then
+  echo "Using RISCV_ZCB to support Zcb extension"
+  RISCV=$RISCV_ZCB
+fi
+
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
   return
@@ -74,7 +79,7 @@ printf "+=======================================================================
 j=0
 while [[ $j -lt ${#TEST_NAME[@]} ]];do
   cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
-  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike -i ${I[j]} -bz 1 --iss_timeout 300
+  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike -i ${I[j]} -bz 1 --iss_timeout 300
   n=0
   echo "Generate the test: ${TEST_NAME[j]}"
 #this while loop detects the failed tests from the log file and remove them

--- a/verif/regress/smoke-gen_tests.sh
+++ b/verif/regress/smoke-gen_tests.sh
@@ -7,7 +7,11 @@
 #
 # Original Author: Ayoub JALALI - Thales
 
-# where are the tools
+if [ -n "$RISCV_ZCB" ]; then
+  echo "Using RISCV_ZCB to support Zcb extension"
+  RISCV=$RISCV_ZCB
+fi
+
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
   return
@@ -27,9 +31,9 @@ fi
 
 cd verif/sim/
 cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
-python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_arithmetic_basic_test_comp --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS -i 1 --iss_timeout 300
-python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS -i 1 --iss_timeout 300
-python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_unaligned_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS -i 1 --iss_timeout 300
+python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_arithmetic_basic_test_comp --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS -i 1 --iss_timeout 300
+python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS -i 1 --iss_timeout 300
+python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_unaligned_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS -i 1 --iss_timeout 300
 make clean_all
 
 cd -

--- a/verif/sim/cva6_base_testlist.yaml
+++ b/verif/sim/cva6_base_testlist.yaml
@@ -35,14 +35,15 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=5
-    +directed_instr_0=riscv_load_store_rand_instr_stream,10
-    +directed_instr_1=riscv_load_store_hazard_instr_stream,10
-    +directed_instr_2=riscv_multi_page_load_store_instr_stream,10
-    +directed_instr_3=riscv_mem_region_stress_test,10
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,30
+    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,30
+    +directed_instr_2=cva6_multi_page_load_store_instr_stream_c,30
+    +directed_instr_3=cva6_mem_region_stress_test_c,30
     +enable_zba_extension=1
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -54,15 +55,16 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=5
-    +directed_instr_0=riscv_load_store_rand_instr_stream,10
-    +directed_instr_1=riscv_load_store_hazard_instr_stream,10
-    +directed_instr_2=riscv_multi_page_load_store_instr_stream,10
-    +directed_instr_3=riscv_mem_region_stress_test,10
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,30
+    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,30
+    +directed_instr_2=cva6_multi_page_load_store_instr_stream_c,30
+    +directed_instr_3=cva6_mem_region_stress_test_c,30
     +hint_instr_ratio=500
     +enable_zba_extension=1
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -73,7 +75,7 @@
   gen_opts: >
     +instr_cnt=300
     +num_of_sub_program=0
-    +directed_instr_0=riscv_load_store_rand_instr_stream,10
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,10
     +directed_instr_1=riscv_jal_instr,20
     +illegal_instr_ratio=100
     +unsupported_instr_ratio=100
@@ -82,6 +84,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -98,6 +101,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -114,6 +118,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -126,12 +131,13 @@
     +num_of_sub_program=0
     +no_load_store=0
     +no_branch_jump=0
-    +directed_instr_0=riscv_load_store_rand_instr_stream,70
-    +directed_instr_1=riscv_load_store_hazard_instr_stream,50
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,70
+    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,50
     +enable_zba_extension=1
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -144,13 +150,14 @@
     +num_of_sub_program=0
     +no_load_store=0
     +no_branch_jump=0
-    +directed_instr_0=riscv_load_store_rand_instr_stream,20
-    +directed_instr_1=riscv_load_store_hazard_instr_stream,50
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,20
+    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,50
     +disable_compressed_instr=1
     +enable_zba_extension=1
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -162,7 +169,7 @@
     +instr_cnt=500
     +num_of_sub_program=0
     +no_fence=1
-    +directed_instr_1=riscv_multi_page_load_store_instr_stream,20
+    +directed_instr_1=cva6_multi_page_load_store_instr_stream_c,50
     +no_data_page=0
     +no_branch_jump=1
     +boot_mode=m
@@ -171,6 +178,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -193,6 +201,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -215,6 +224,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -227,14 +237,15 @@
     +num_of_sub_program=0
     +no_load_store=0
     +no_branch_jump=1
-    +directed_instr_0=riscv_load_store_rand_instr_stream,20
-    +directed_instr_1=riscv_load_store_hazard_instr_stream,50
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,20
+    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,50
     +tvec_alignment=8
     +enable_x_extension=1
     +enable_zba_extension=1
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -252,6 +263,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -262,7 +274,6 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
-    +directed_instr_0=riscv_int_numeric_corner_stream,4
     +no_fence=1
     +no_data_page=1
     +no_branch_jump=1
@@ -273,6 +284,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -283,7 +295,6 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
-    +directed_instr_0=riscv_int_numeric_corner_stream,4
     +no_fence=1
     +no_data_page=1
     +no_branch_jump=1
@@ -293,6 +304,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -303,7 +315,6 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
-    +directed_instr_0=riscv_int_numeric_corner_stream,4
     +no_fence=1
     +no_data_page=1
     +no_branch_jump=0
@@ -313,6 +324,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -332,6 +344,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -353,6 +366,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -367,57 +381,37 @@
     +num_of_sub_program=0
     +no_branch_jump=1
     +no_data_page=0
-    +directed_instr_0=riscv_load_store_rand_instr_stream,20
-    +directed_instr_1=riscv_load_store_hazard_instr_stream,20
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,30
+    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,30
     +enable_unaligned_load_store=1
     +tvec_alignment=8
     +enable_zba_extension=1
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
 
-- test: riscv_arithmetic_basic_csr_dummy
+- test: riscv_arithmetic_basic_illegal_csr
   description: >
     Arithmetic instruction test, no load/store/branch instructions
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=5
-    +directed_instr_0=riscv_int_numeric_corner_stream,4
-    +no_data_page=1
-    +no_branch_jump=1
-    +boot_mode=m
-    +enable_dummy_csr_write=1
-    +no_csr_instr=0
-    +enable_zba_extension=1
-    +enable_zbb_extension=1
-    +enable_zbc_extension=1
-    +enable_zbs_extension=1
-  iterations: 2
-  gen_test: cva6_instr_base_test_c
-  rtl_test: core_base_test
-  
-- test: riscv_arithmetic_basic_Randcsr_test
-  description: >
-    Arithmetic instruction test, no load/store/branch instructions
-  gen_opts: >
-    +instr_cnt=500
-    +num_of_sub_program=0
-    +directed_instr_0=riscv_int_numeric_corner_stream,10
-    +no_fence=0
     +no_data_page=1
     +no_branch_jump=1
     +boot_mode=m
     +no_csr_instr=0
-    +randomize_csr=1
-    +enable_acess_invalid_csr_level=1
+    +enable_access_invalid_csr_level=1
+    +disable_compressed_instr=1
     +tvec_alignment=8
     +enable_zba_extension=1
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -428,7 +422,6 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
-    +directed_instr_0=riscv_int_numeric_corner_stream,5
     +no_fence=0
     +no_data_page=1
     +no_branch_jump=1
@@ -441,6 +434,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test 
@@ -451,7 +445,6 @@
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
-    +directed_instr_0=riscv_int_numeric_corner_stream,4
     +no_fence=1
     +no_data_page=1
     +no_branch_jump=1
@@ -466,6 +459,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -486,6 +480,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -509,6 +504,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
@@ -530,6 +526,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_hazard_test_c
   rtl_test: core_base_test
@@ -551,6 +548,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_hazard_test_c
   rtl_test: core_base_test
@@ -572,6 +570,7 @@
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +enable_zcb_extension=1
   iterations: 2
   gen_test: cva6_instr_hazard_test_c
   rtl_test: core_base_test


### PR DESCRIPTION
Hello, this MR related to generate Zcb instruction in the CI tests, so to workaroud the problem of the gcc-13 that doesn't support zcb extension, I change in every Job generate zcb instruction the RISCV variable to point to the right gcc.