### PR TITLE
ISA DVPLAN for embedded config

### DIFF
--- a/verif/docs/VerifPlans/ISA_RV32/RISCV_Instructions.rst
+++ b/verif/docs/VerifPlans/ISA_RV32/RISCV_Instructions.rst
@@ -1,4 +1,4 @@
-..
+﻿..
    Copyright (c) 2023 OpenHW Group
    Copyright (c) 2023 Thales DIS design services SAS
 
@@ -31,6 +31,7 @@ In this document, we present ISA (Instruction Set Architecture) for C32VA6_v5.0.
 * RV32C        – Standard Extension for Compressed Instructions
 * RV32Zicsr    – Standard Extension for CSR Instructions
 * RV32Zifencei – Standard Extension for Instruction-Fetch Fence
+* RV32Zicond   – Standard Extension for Integer Conditional Operations
 
 The base RISC-V ISA has fixed-length 32-bit instructions or 16-bit instructions (the C32VA6_v5.0.0 support C extension), so that must be naturally aligned on 4-byte boundary or 2-byte boundary.
 The C32VA6_v5.0.0 supports:
@@ -451,7 +452,7 @@ Control Transfer Instructions
     **Format**: beq rs1, rs2, imm[12:1]
 
     **Description**: takes the branch (pc is calculated using signed arithmetic) if registers rs1 and rs2 are equal.
-    
+
     **Pseudocode**: if (x[rs1] == x[rs2]) pc += sext({imm[12:1], 1’b0}) else pc += 4
 
     **Invalid values**: NONE
@@ -465,7 +466,7 @@ Control Transfer Instructions
     **Description**: takes the branch (pc is calculated using signed arithmetic) if registers rs1 and rs2 are not equal.
 
     **Pseudocode**: if (x[rs1] != x[rs2]) pc += sext({imm[12:1], 1’b0}) else pc += 4
-       
+
     **Invalid values**: NONE
 
     **Exception raised**: no instruction fetch misaligned exception is generated for a conditional branch that is not taken. An Instruction address misaligned exception is raised if the target address is not aligned on 4-byte or 2-byte boundary, because the core supports compressed instructions.
@@ -479,7 +480,7 @@ Control Transfer Instructions
     **Pseudocode**: if (x[rs1] < x[rs2]) pc += sext({imm[12:1], 1’b0}) else pc += 4
 
     **Invalid values**: NONE
-    
+
     **Exception raised**: no instruction fetch misaligned exception is generated for a conditional branch that is not taken. An Instruction address misaligned exception is raised if the target address is not aligned on 4-byte or 2-byte boundary, because the core supports compressed instructions.
 
 - **BLTU**: Branch Less Than Unsigned
@@ -513,7 +514,7 @@ Control Transfer Instructions
     **Description**: takes the branch (pc is calculated using signed arithmetic) if registers rs1 is greater than or equal rs2 (using unsigned comparison).
 
     **Pseudocode**: if (x[rs1] >=u x[rs2]) pc += sext({imm[12:1], 1’b0}) else pc += 4
-    
+
     **Invalid values**: NONE
 
     **Exception raised**: no instruction fetch misaligned exception is generated for a conditional branch that is not taken. An Instruction address misaligned exception is raised if the target address is not aligned on 4-byte or 2-byte boundary, because the core supports compressed instructions.
@@ -1338,6 +1339,35 @@ RV32Zifencei Instruction-Fetch Fence
     **Description**: The FENCE.I instruction is used to synchronize the instruction and data streams. RISC-V does not guarantee that stores to instruction memory will be made visible to instruction fetches on the same RISC-V hart until a FENCE.I instruction is executed. A FENCE.I instruction only ensures that a subsequent instruction fetch on a RISC-V hart will see any previous data stores already visible to the same RISC-V hart.
 
     **Pseudocode**: Fence(Store, Fetch)
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
+
+RV32Zicond Integer Conditional operations
+-------------------------------------------
+
+The instructions follow the format for R-type instructions with 3 operands (i.e., 2 source operands and 1 destination operand). Using these instructions, branchless sequences can be implemented (typically in two-instruction sequences) without the need for instruction fusion, special provisions during the decoding of architectural instructions, or other microarchitectural provisions.
+
+- **CZERO.EQZ**: Conditional zero, if condition is equal to zero
+
+    **Format**: czero.eqz rd, rs1, rs2
+
+    **Description**: This instruction behaves as if there is a conditional branch dependent on rs2 being equal to zero, wherein it branches to code that writes a 0 into rd when the equivalence is true, and otherwise falls through to code that moves rs1 into rd.
+
+    **Pseudocode**: if (x[rs2] == 0) x[rd] = 0 else x[rs1]
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
+
+- **CZERO.NEZ**: Conditional zero, if condition is nonzero
+
+    **Format**: czero.nez rd, rs1, rs2
+
+    **Description**: This instruction behaves as if there is a conditional branch dependent on rs2 being not equal to zero, wherein it branches to code that writes a 0 into rd when the equivalence is true, and otherwise falls through to code that moves rs1 into rd
+
+    **Pseudocode**: if (x[rs2] != 0) x[rd] = 0 else x[rs1]
 
     **Invalid values**: NONE
 

--- a/verif/docs/VerifPlans/ISA_RV32/VP_IP016.yml
+++ b/verif/docs/VerifPlans/ISA_RV32/VP_IP016.yml
@@ -1,0 +1,142 @@
+!Feature
+next_elt_id: 2
+name: RV32Zicond Integer Conditional Instructions
+id: 16
+display_order: 16
+subfeatures: !!omap
+- 000_CZERO.EQZ: !Subfeature
+    name: 000_CZERO.EQZ
+    tag: VP_ISA_RV32_F016_S000
+    next_elt_id: 3
+    display_order: 0
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32_F016_S000_I000
+        description: "czero.eqz rd, rs1, rs2\nif (x[rs2] == 0) x[rd] = 0 else x[rs1]\n
+          Set rd's value to zero if rs2 is equal to zero, otherwise moves rs1 into
+          rd"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd registers are used\nAll
+          possible rs1 registers are used\nAll possible rs2 registers are used\nAll
+          possible register combinations where rs1 == rd are used\nAll possible register
+          combinations where rs2 == rd are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32_F016_S000_I001
+        description: "czero.eqz rd, rs1, rs2\nif (x[rs2] == 0) x[rd] = 0 else x[rs1]\n
+          Set rd's value to zero if rs2 is equal to zero, otherwise moves rs1 into
+          rd"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nrs1 value is +ve, -ve and zero\nrs2 value
+          is +ve, -ve and zero\nAll combinations of rs1 and rs2 +ve, -ve, and zero
+          values are used\nAll bits of rs1 are toggled\nAll bits of rs2 are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '002': !VerifItem
+        name: '002'
+        tag: VP_ISA_RV32_F016_S000_I002
+        description: "czero.eqz rd, rs1, rs2\nif (x[rs2] == 0) x[rd] = 0 else x[rs1]\n
+          Set rd's value to zero if rs2 is equal to zero, otherwise moves rs1 into
+          rd"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nrd value is +ve, -ve and zero\nAll bits of
+          rd are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 001_CZERO.NEZ: !Subfeature
+    name: 001_CZERO.NEZ
+    tag: VP_ISA_RV32_F016_S001
+    next_elt_id: 3
+    display_order: 1
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32_F016_S001_I000
+        description: "czero.nez rd, rs1, rs2\nif (x[rs2] != 0) x[rd] = 0 else x[rs1]\n
+          Set rd's value to zero if rs2 isn't equal to zero, otherwise moves rs1 into
+          rd"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd registers are used\nAll
+          possible rs1 registers are used\nAll possible rs2 registers are used\nAll
+          possible register combinations where rs1 == rd are used\nAll possible register
+          combinations where rs2 == rd are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32_F016_S001_I001
+        description: "czero.nez rd, rs1, rs2\nif (x[rs2] != 0) x[rd] = 0 else x[rs1]\n
+          Set rd's value to zero if rs2 isn't equal to zero, otherwise moves rs1 into
+          rd"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nrs1 value is +ve, -ve and zero\nrs2 value
+          is +ve, -ve and zero\nAll combinations of rs1 and rs2 +ve, -ve, and zero
+          values are used\nAll bits of rs1 are toggled\nAll bits of rs2 are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '002': !VerifItem
+        name: '002'
+        tag: VP_ISA_RV32_F016_S001_I002
+        description: "czero.nez rd, rs1, rs2\nif (x[rs2] != 0) x[rd] = 0 else x[rs1]\n
+          Set rd's value to zero if rs2 isn't equal to zero, otherwise moves rs1 into
+          rd"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nrd value is +ve, -ve and zero\nAll bits of
+          rd are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+vptool_gitrev: '$Id: b0efb3ae3f9057b71a577d43c2b77f1cfb2ef82f $'
+io_fmt_gitrev: '$Id: 7ee5d68801f5498a957bcbe23fcad87817a364c5 $'
+config_gitrev: '$Id: 0422e19126dae20ffc4d5a84e4ce3de0b6eb4eb5 $'
+ymlcfg_gitrev: '$Id: 286c689bd48b7a58f9a37754267895cffef1270c $'

--- a/verif/docs/VerifPlans/ISA_RV32/VP_IP017.yml
+++ b/verif/docs/VerifPlans/ISA_RV32/VP_IP017.yml
@@ -1,0 +1,266 @@
+!Feature
+next_elt_id: 7
+name: RV32Zcb Integer Computational Instructions
+id: 17
+display_order: 17
+subfeatures: !!omap
+- 000_C.ZEXT.B: !Subfeature
+    name: 000_C.ZEXT.B
+    tag: VP_ISA_RV32 EMBEDDED_F016_S000
+    next_elt_id: 2
+    display_order: 0
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S000_I000
+        description: "c.zext.b rd'\nx[8 + rd'] = zext(x[8 + rd'][7:0])\nIt zero-extends
+          the least-significant byte of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd` registers are used."
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S000_I001
+        description: "c.zext.b rd'\nx[8 + rd'] = zext(x[8 + rd'][7:0])\nIt zero-extends
+          the least-significant byte of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nAll bits of rd'[7:0] are toggled"
+        pfc: 3
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 001_C.SEXT.B: !Subfeature
+    name: 001_C.SEXT.B
+    tag: VP_ISA_RV32 EMBEDDED_F016_S001
+    next_elt_id: 2
+    display_order: 1
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S001_I000
+        description: "c.sext.b rd'\nx[8 + rd'] = sext(x[8 + rd'][7:0])\nIt sign-extends
+          the least-significant byte of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S001_I001
+        description: "c.sext.b rd'\nx[8 + rd'] = sext(x[8 + rd'][7:0])\nIt sign-extends
+          the least-significant byte of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output operands:\n\nAll bits of rd' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 002_C.ZEXT.H: !Subfeature
+    name: 002_C.ZEXT.H
+    tag: VP_ISA_RV32 EMBEDDED_F016_S002
+    next_elt_id: 2
+    display_order: 2
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S002_I000
+        description: "c.zext.h rd'\nx[8 + rd'] = zext(x[8 + rd'][15:0])\nIt zero-extends
+          the least-significant half-word of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' registers are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S002_I001
+        description: "c.zext.h rd'\nx[8 + rd'] = zext(x[8 + rd'][15:0])\nIt zero-extends
+          the least-significant half-word of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nAll bits of rd'[15:0] are toggled"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 003_C.SEXT.H: !Subfeature
+    name: 003_C.SEXT.H
+    tag: VP_ISA_RV32 EMBEDDED_F016_S003
+    next_elt_id: 2
+    display_order: 3
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S003_I000
+        description: "c.sext.h rd'\nx[8 + rd'] = sext(x[8 + rd'][15:0])\nIt sign-extends
+          the least-significant half-word of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' registers are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S003_I001
+        description: "c.sext.h rd'\nx[8 + rd'] = sext(x[8 + rd'][15:0])\nIt sign-extends
+          the least-significant half-word of the operand"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nAll bits of rd' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 005_C.NOT: !Subfeature
+    name: 005_C.NOT
+    tag: VP_ISA_RV32 EMBEDDED_F016_S005
+    next_elt_id: 2
+    display_order: 5
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S005_I000
+        description: "c.not rd'\nx[8 + rd'] = x[8 + rd']^ -1"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' registers are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S005_I001
+        description: "c.not rd'\nx[8 + rd'] = x[8 + rd']^ -1"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nAll bits of rd' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 006_C.MUL: !Subfeature
+    name: 006_C.MUL
+    tag: VP_ISA_RV32 EMBEDDED_F016_S006
+    next_elt_id: 3
+    display_order: 6
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S006_I000
+        description: "c.mul rd',rs2'\nx[8 + rd'] = x[8 + rd'] * x[8 + rs2']\nArithmetic
+          overflow is ignored."
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' registers are used\n
+          All possible register combinations where rs2' == rd' are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S006_I001
+        description: "c.mul rd',rs2'\nx[8 + rd'] = x[8 + rd'] * x[8 + rs2']\nArithmetic
+          overflow is ignored."
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nAll bits of rs2' are toggled"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '002': !VerifItem
+        name: '002'
+        tag: VP_ISA_RV32 EMBEDDED_F016_S006_I002
+        description: "c.mul rd',rs2'\nx[8 + rd'] = x[8 + rd'] * x[8 + rs2']\nArithmetic
+          overflow is ignored."
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nAll bits of rd' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+vptool_gitrev: '$Id: b0efb3ae3f9057b71a577d43c2b77f1cfb2ef82f $'
+io_fmt_gitrev: '$Id: 7ee5d68801f5498a957bcbe23fcad87817a364c5 $'
+config_gitrev: '$Id: 0422e19126dae20ffc4d5a84e4ce3de0b6eb4eb5 $'
+ymlcfg_gitrev: '$Id: 286c689bd48b7a58f9a37754267895cffef1270c $'

--- a/verif/docs/VerifPlans/ISA_RV32/VP_IP018.yml
+++ b/verif/docs/VerifPlans/ISA_RV32/VP_IP018.yml
@@ -1,0 +1,272 @@
+!Feature
+next_elt_id: 5
+name: RV32Zcb Load and Store Instructions
+id: 18
+display_order: 18
+subfeatures: !!omap
+- 000_C.LBU: !Subfeature
+    name: 000_C.LBU
+    tag: VP_ISA_RV32 EMBEDDED_F017_S000
+    next_elt_id: 3
+    display_order: 0
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S000_I000
+        description: "c.lbu rd', uimm(rs1')\nx[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1:0])][7:0])"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' register are used\nAll
+          possible rs1' register are used\nALl possible combinations where rd' ==
+          rs1' are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S000_I001
+        description: "c.lbu rd', uimm(rs1')\nx[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1:0])][7:0])"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nuimm value is non-zero and zero\nAll bits
+          of uimm are toggled\nAll bits of rs1' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '002': !VerifItem
+        name: '002'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S000_I002
+        description: "c.lbu rd', uimm(rs1')\nx[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1:0])][7:0])"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nrd' value is non-zero and zero\nAll bits of
+          rd' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 001_C.SB: !Subfeature
+    name: 001_C.SB
+    tag: VP_ISA_RV32 EMBEDDED_F017_S001
+    next_elt_id: 3
+    display_order: 1
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S001_I000
+        description: "c.sb rs1', uimm(rs2')\nM[x[8 + rs1'] + zext(uimm[1:0])][7:0]
+          = x[8 + rs2']"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rs1' register are used\n
+          All possible rs2' register are used\nAll possible combinations where rs1'
+          = rs2' register are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S001_I001
+        description: "c.sb rs1', uimm(rs2')\nM[x[8 + rs1'] + zext(uimm[1:0])][7:0]
+          = x[8 + rs2']"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nuimm value is non-zero and zero\nAll bits
+          of uimm are toggled\nAll bits of rs1' are toggled\nAll bits of rs2' are
+          toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 002_C.LHU: !Subfeature
+    name: 002_C.LHU
+    tag: VP_ISA_RV32 EMBEDDED_F017_S002
+    next_elt_id: 3
+    display_order: 2
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S002_I000
+        description: "c.lhu rd', uimm(rs1')\nx[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1])][15:0])"
+        reqt_doc: ./RISCV_Instructions
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' register are used\nAll
+          possible rs1' register are used\nALl possible combinations where rd' ==
+          rs1' are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S002_I001
+        description: "c.lhu rd', uimm(rs1')\nx[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1])][15:0])"
+        reqt_doc: ./RISCV_Instructions
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nuimm value is non-zero and zero\nAll bits
+          of uimm are toggled\nAll bits of rs1' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '002': !VerifItem
+        name: '002'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S002_I002
+        description: "c.lhu rd', uimm(rs1')\nx[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1])][15:0])"
+        reqt_doc: ./RISCV_Instructions
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nrd' value is non-zero and zero\nAll bits of
+          rd' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 003_C.LH: !Subfeature
+    name: 003_C.LH
+    tag: VP_ISA_RV32 EMBEDDED_F017_S003
+    next_elt_id: 3
+    display_order: 3
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S003_I000
+        description: "c.lh rd', uimm(rs1')\nx[8 + rd'] = sext(M[x[8 + rd'] + zext(uimm[1])][15:0])"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rd' register are used\nAll
+          possible rs1' register are used\nALl possible combinations where rd' ==
+          rs1' are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S003_I001
+        description: "c.lh rd', uimm(rs1')\nx[8 + rd'] = sext(M[x[8 + rd'] + zext(uimm[1])][15:0])"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nuimm value is non-zero and zero\nAll bits
+          of uimm are toggled\nAll bits of rs1' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '002': !VerifItem
+        name: '002'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S003_I002
+        description: "c.lh rd', uimm(rs1')\nx[8 + rd'] = sext(M[x[8 + rd'] + zext(uimm[1])][15:0])"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Output result:\n\nrd' value is non-zero and zero\nAll bits of
+          rd' are toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+- 004_C.SH: !Subfeature
+    name: 004_C.SH
+    tag: VP_ISA_RV32 EMBEDDED_F017_S004
+    next_elt_id: 2
+    display_order: 4
+    items: !!omap
+    - '000': !VerifItem
+        name: '000'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S004_I000
+        description: "c.sh rs1', uimm(rs2')\nM[x[8 + rs1'] + zext(uimm[1])][15:0]
+          = x[8 + rs2']"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Register operands:\n\nAll possible rs1' register are used\n
+          All possible rs2' register are used\nAll possible combinations where rs1'
+          = rs2' are used"
+        pfc: 3
+        test_type: 3
+        cov_method: 1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+    - '001': !VerifItem
+        name: '001'
+        tag: VP_ISA_RV32 EMBEDDED_F017_S004_I001
+        description: "c.sh rs1', uimm(rs2')\nM[x[8 + rs1'] + zext(uimm[1])][15:0]
+          = x[8 + rs2']"
+        reqt_doc: ./RISCV_Instructions.rst
+        ref_mode: page
+        ref_page: ''
+        ref_section: ''
+        ref_viewer: firefox
+        verif_goals: "Input operands:\n\nuimm value is non-zero and zero\nAll bits
+          of uimm are toggled\nAll bits of rs1' are toggled\nAll bits of rs2' are
+          toggled"
+        pfc: -1
+        test_type: -1
+        cov_method: -1
+        cores: 56
+        coverage_loc: ''
+        comments: ''
+vptool_gitrev: '$Id: b0efb3ae3f9057b71a577d43c2b77f1cfb2ef82f $'
+io_fmt_gitrev: '$Id: 7ee5d68801f5498a957bcbe23fcad87817a364c5 $'
+config_gitrev: '$Id: 0422e19126dae20ffc4d5a84e4ce3de0b6eb4eb5 $'
+ymlcfg_gitrev: '$Id: 286c689bd48b7a58f9a37754267895cffef1270c $'

--- a/verif/docs/VerifPlans/ISA_RV32/runme.sh
+++ b/verif/docs/VerifPlans/ISA_RV32/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*
+sh $ROOTDIR/../../../../verif/core-v-verif/tools/vptool/vptool.sh $*

--- a/verif/docs/VerifPlans/source/dvplan_ISA_RV32.md
+++ b/verif/docs/VerifPlans/source/dvplan_ISA_RV32.md
@@ -17,7 +17,7 @@
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -102,7 +102,7 @@ isacov.rv32i_addi_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -187,7 +187,7 @@ isacov.rv32i_xori_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -272,7 +272,7 @@ isacov.rv32i_ori_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -351,13 +351,13 @@ isacov.rv32i_andi_cg.cp_rd_toggle
   
   slti rd, rs1, imm[11:0]  
   rd = (rs1 < Sext(imm[11:0]) ? 1 : 0  
-  Both imm and rs1 treated as signed numbers
+   Both imm and rs1 treated as signed numbers
 * **Verification Goals**
   
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -378,7 +378,7 @@ isacov.rv32i_slti_cg.cp_rd_rs1_hazard
   
   slti rd, rs1, imm[11:0]  
   rd = (rs1 < Sext(imm[11:0]) ? 1 : 0  
-  Both imm and rs1 treated as signed numbers
+   Both imm and rs1 treated as signed numbers
 * **Verification Goals**
   
   Input operands:  
@@ -409,7 +409,7 @@ isacov.rv32i_slti_cg.cp_immi_toggle
   
   slti rd, rs1, imm[11:0]  
   rd = (rs1 < Sext(imm[11:0]) ? 1 : 0  
-  Both imm and rs1 treated as signed numbers
+   Both imm and rs1 treated as signed numbers
 * **Verification Goals**
   
   Output result:  
@@ -440,7 +440,7 @@ isacov.rv32i_slti_cg.cp_immi_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -523,7 +523,7 @@ isacov.rv32i_sltiu_cg.cp_immi_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -606,7 +606,7 @@ isacov.rv32i_slli_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -689,7 +689,7 @@ isacov.rv32i_srli_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -932,9 +932,9 @@ isacov.rv32i_auipc_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1021,9 +1021,9 @@ isacov.rv32i_add_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1110,9 +1110,9 @@ isacov.rv32i_sub_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1204,9 +1204,9 @@ isacov.rv32i_and_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1293,9 +1293,9 @@ isacov.rv32i_or_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1382,9 +1382,9 @@ isacov.rv32i_xor_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1469,9 +1469,9 @@ isacov.rv32i_slt_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1556,9 +1556,9 @@ isacov.rv32i_sltu_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1645,9 +1645,9 @@ isacov.rv32i_sll_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1732,9 +1732,9 @@ isacov.rv32i_srl_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1815,7 +1815,7 @@ isacov.rv32i_sra_cg.cp_rd_toggle
   
   jal rd, imm[20:1]  
   rd = pc+4; pc += Sext({imm[20:1], 1’b0})  
-  pc is calculated using signed arithmetic  
+   pc is calculated using signed arithmetic  
     
   jal x0, imm[20:1] (special case: unconditional jump)  
   pc += Sext({imm[20:1], 1’b0})
@@ -1841,7 +1841,7 @@ isacov.rv32i_sra_cg.cp_rd_toggle
   
   jal rd, imm[20:1]  
   rd = pc+4; pc += Sext({imm[20:1], 1’b0})  
-  pc is calculated using signed arithmetic  
+   pc is calculated using signed arithmetic  
     
   jal x0, imm[20:1] (special case: unconditional jump)  
   pc += Sext({imm[20:1], 1’b0})
@@ -1869,7 +1869,7 @@ isacov.rv32i_jal_cg.cp_immj_toggle
   
   jal rd, imm[20:1]  
   rd = pc+4; pc += Sext({imm[20:1], 1’b0})  
-  pc is calculated using signed arithmetic  
+   pc is calculated using signed arithmetic  
     
   jal x0, imm[20:1] (special case: unconditional jump)  
   pc += Sext({imm[20:1], 1’b0})
@@ -1897,13 +1897,13 @@ isacov.rv32i_jal_cg.cp_immj_toggle
   
   jalr rd, rs1, imm[11:0]  
   rd = pc+4; pc = rs1 + Sext(imm[11:0])  
-  pc is calculated using signed arithmetic
+   pc is calculated using signed arithmetic
 * **Verification Goals**
   
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -1924,7 +1924,7 @@ isacov.rv32i_jalr_cg.cp_rd_rs1_hazard
   
   jalr rd, rs1, imm[11:0]  
   rd = pc+4; pc = rs1 + Sext(imm[11:0])  
-  pc is calculated using signed arithmetic
+   pc is calculated using signed arithmetic
 * **Verification Goals**
   
   Input operands:  
@@ -1951,7 +1951,7 @@ isacov.rv32i_jalr_cg.cp_rs1_toggle
   
   jalr rd, rs1, imm[11:0]  
   rd = pc+4; pc = rs1 + Sext(imm[11:0])  
-  pc is calculated using signed arithmetic
+   pc is calculated using signed arithmetic
 * **Verification Goals**
   
   Output result:  
@@ -1982,7 +1982,7 @@ isacov.rv32i_jalr_cg.cp_rs1_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2060,7 +2060,7 @@ isacov.rv32i_beq_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2138,7 +2138,7 @@ isacov.rv32i_bne_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2216,7 +2216,7 @@ isacov.rv32i_blt_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2294,7 +2294,7 @@ isacov.rv32i_bge_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2372,7 +2372,7 @@ isacov.rv32i_bltu_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2452,7 +2452,7 @@ isacov.rv32i_bgeu_cg.cp_rs2_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -2534,7 +2534,7 @@ isacov.rv32i_lb_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -2618,7 +2618,7 @@ isacov.rv32i_lh_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -2702,7 +2702,7 @@ isacov.rv32i_lw_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -2784,7 +2784,7 @@ isacov.rv32i_lbu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -2867,7 +2867,7 @@ isacov.rv32i_lhu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2921,7 +2921,7 @@ isacov.rv32i_sb_cg.cp_imms_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2948,7 +2948,7 @@ isacov.rv32i_sh_cg.cp_rs2
   All bits of rs1 are toggled  
   All bits of rs2 are toggled  
   All bits of imms are toggled  
-  Unaligned and aligned accesses to memory
+   Unaligned and aligned accesses to memory
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -2977,7 +2977,7 @@ isacov.rv32i_sh_cg.cp_aligned
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.
+   All possible rs2 registers are used.
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -3004,7 +3004,7 @@ isacov.rv32i_sw_cg.cp_rs2
   All bits of rs1 are toggled  
   All bits of rs2 are toggled  
   All bits of imms are toggled  
-  Unaligned and aligned accesses to memory
+   Unaligned and aligned accesses to memory
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -3123,9 +3123,9 @@ isacov.rv32i_sw_cg.cp_aligned
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3165,7 +3165,7 @@ isacov.rv32m_mul_cg.cp_rd_rs2_hazard
 * **Unique verification tag:** VP_ISA_RV32_F006_S000_I001
 * **Link to Coverage:** isacov.rv32m_mul_cg.cp_rs1_value
 isacov.rv32m_mul_cg.cp_rs2_value
-isacov.rv32m_mul_cg.cross_rs1_rs2_value
+ isacov.rv32m_mul_cg.cross_rs1_rs2_value
 isacov.rv32m_mul_cg.cp_rs1_toggle 
 isacov.rv32m_mul_cg.cp_rs2_toggle
 * **Comments**
@@ -3239,9 +3239,9 @@ isacov.rv32m_mulh_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3281,7 +3281,7 @@ isacov.rv32m_mulhu_cg.cp_rd_rs2_hazard
 * **Unique verification tag:** VP_ISA_RV32_F006_S002_I001
 * **Link to Coverage:** isacov.rv32m_mulhu_cg.cp_rs1_value
 isacov.rv32m_mulhu_cg.cp_rs2_value
-isacov.rv32m_mulhu_cg.cross_rs1_rs2_value
+ isacov.rv32m_mulhu_cg.cross_rs1_rs2_value
 isacov.rv32m_mulhu_cg.cp_rs1_toggle 
 isacov.rv32m_mulhu_cg.cp_rs2_toggle
 * **Comments**
@@ -3328,9 +3328,9 @@ isacov.rv32m_mulhu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3370,7 +3370,7 @@ isacov.rv32m_mulhsu_cg.cp_rd_rs2_hazard
 * **Unique verification tag:** VP_ISA_RV32_F006_S003_I001
 * **Link to Coverage:** isacov.rv32m_mulhsu_cg.cp_rs1_value
 isacov.rv32m_mulhsu_cg.cp_rs2_value
-isacov.rv32m_mulhsu_cg.cross_rs1_rs2_value
+ isacov.rv32m_mulhsu_cg.cross_rs1_rs2_value
 isacov.rv32m_mulhsu_cg.cp_rs1_toggle 
 isacov.rv32m_mulhsu_cg.cp_rs2_toggle
 * **Comments**
@@ -3420,9 +3420,9 @@ Chapter 7.2
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3463,7 +3463,7 @@ Chapter 7.2
 * **Unique verification tag:** VP_ISA_RV32_F007_S000_I001
 * **Link to Coverage:** isacov.rv32m_div_cg.cp_rs1_value
 isacov.rv32m_div_cg.cp_rs2_value
-isacov.rv32m_div_cg.cross_rs1_rs2_value
+ isacov.rv32m_div_cg.cross_rs1_rs2_value
 isacov.rv32m_div_cg.cp_rs1_toggle 
 isacov.rv32m_div_cg.cp_rs2_toggle
 * **Comments**
@@ -3492,7 +3492,7 @@ Chapter 7.2
 * **Unique verification tag:** VP_ISA_RV32_F007_S000_I002
 * **Link to Coverage:** isacov.rv32m_div_cg.cp_rs1_value
 isacov.rv32m_div_cg.cp_rs2_value
-isacov.rv32m_div_cg.cross_rs1_rs2_value
+ isacov.rv32m_div_cg.cross_rs1_rs2_value
 isacov.rv32m_div_cg.cp_rs1_toggle 
 isacov.rv32m_div_cg.cp_rs2_toggle
 * **Comments**
@@ -3538,9 +3538,9 @@ isacov.rv32m_div_results_cg.cp_div_arithmetic_overflow
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3580,7 +3580,7 @@ isacov.rv32m_rem_cg.cp_rd_rs2_hazard
 * **Unique verification tag:** VP_ISA_RV32_F007_S001_I001
 * **Link to Coverage:** isacov.rv32m_rem_cg.cp_rs1_value
 isacov.rv32m_rem_cg.cp_rs2_value
-isacov.rv32m_rem_cg.cross_rs1_rs2_value
+ isacov.rv32m_rem_cg.cross_rs1_rs2_value
 isacov.rv32m_rem_cg.cp_rs1_toggle 
 isacov.rv32m_rem_cg.cp_rs2_toggle
 * **Comments**
@@ -3650,9 +3650,9 @@ isacov.rv32m_rem_results_cg.cp_div_arithmetic_overflow
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3692,7 +3692,7 @@ isacov.rv32m_divu_cg.cp_rd_rs2_hazard
 * **Unique verification tag:** VP_ISA_RV32_F007_S002_I001
 * **Link to Coverage:** isacov.rv32m_divu_cg.cp_rs1_value
 isacov.rv32m_divu_cg.cp_rs2_value
-isacov.rv32m_divu_cg.cross_rs1_rs2_value
+ isacov.rv32m_divu_cg.cross_rs1_rs2_value
 isacov.rv32m_divu_cg.cp_rs1_toggle 
 isacov.rv32m_divu_cg.cp_rs2_toggle
 * **Comments**
@@ -3760,9 +3760,9 @@ isacov.rv32m_divu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rs2 registers are used.  
+   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3802,7 +3802,7 @@ isacov.rv32m_remu_cg.cp_rd_rs2_hazard
 * **Unique verification tag:** VP_ISA_RV32_F007_S003_I001
 * **Link to Coverage:** isacov.rv32m_remu_cg.cp_rs1_value
 isacov.rv32m_remu_cg.cp_rs2_value
-isacov.rv32m_remu_cg.cross_rs1_rs2_value
+ isacov.rv32m_remu_cg.cross_rs1_rs2_value
 isacov.rv32m_remu_cg.cp_rs1_toggle 
 isacov.rv32m_remu_cg.cp_rs2_toggle
 * **Comments**
@@ -3873,7 +3873,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -3975,7 +3975,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used.  
-  All possible rd registers are used.  
+   All possible rd registers are used.  
   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
@@ -4088,7 +4088,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4196,7 +4196,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4250,7 +4250,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Output result:   
     
   +ve, -ve and zero values of rd are used  
-  All bits of rd are toggled
+   All bits of rd are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -4305,7 +4305,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4413,7 +4413,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4521,7 +4521,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4629,7 +4629,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4683,7 +4683,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Output result:   
     
   +ve, -ve and zero values of rd are used  
-  All bits of rd are toggled
+   All bits of rd are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -4738,7 +4738,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4845,7 +4845,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -4898,7 +4898,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Output result:   
     
   +ve, -ve and zero values of rd are used  
-  All bits of rd are toggled
+   All bits of rd are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -4953,7 +4953,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   All possible rs1 registers are used.  
   All possible rs2 registers are used.  
   All possible rd registers are used.  
-  All possible register combinations where rs1 == rd are used  
+   All possible register combinations where rs1 == rd are used  
   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -5282,7 +5282,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.addi4spn rd', nzuimm[9:2]  
   x[8+rd'] = x[2] + nzuimm[9:2]  
-  Expands to addi rd', x2, nzuimm[9:2]. Invalid when nzuimm = 0.  
+   Expands to addi rd', x2, nzuimm[9:2]. Invalid when nzuimm = 0.  
   rd is calculated using signed arithmetic.
 * **Verification Goals**
   
@@ -5306,7 +5306,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.addi4spn rd', nzuimm[9:2]  
   x[8+rd'] = x[2] + nzuimm[9:2]  
-  Expands to addi rd', x2, nzuimm[9:2]. Invalid when nzuimm = 0.  
+   Expands to addi rd', x2, nzuimm[9:2]. Invalid when nzuimm = 0.  
   rd is calculated using signed arithmetic.
 * **Verification Goals**
   
@@ -5331,7 +5331,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.addi4spn rd', nzuimm[9:2]  
   x[8+rd'] = x[2] + nzuimm[9:2]  
-  Expands to addi rd', x2, nzuimm[9:2]. Invalid when nzuimm = 0.  
+   Expands to addi rd', x2, nzuimm[9:2]. Invalid when nzuimm = 0.  
   rd is calculated using signed arithmetic.
 * **Verification Goals**
   
@@ -5386,7 +5386,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   All shift amounts from [0:31] are used  
-  All bits of rd before instruction execution are toggled
+   All bits of rd before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -5458,7 +5458,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   All shift amounts from [0:31] are used  
-  All bits of rd before instruction execution are toggled
+   All bits of rd before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -5530,7 +5530,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   All shift amounts from [0:31] are used  
-  +ve, -ve and zero values of rd` are used  
+   +ve, -ve and zero values of rd` are used  
   All bits of rd` before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -5574,7 +5574,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.andi rd', imm[5:0]  
   x[8+rd'] = x[8+rd'] & sext(imm[5:0])  
-  Expands to andi rd', rd', imm[5:0].  
+   Expands to andi rd', rd', imm[5:0].  
   imm treated as signed number
 * **Verification Goals**
   
@@ -5598,14 +5598,14 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.andi rd', imm[5:0]  
   x[8+rd'] = x[8+rd'] & sext(imm[5:0])  
-  Expands to andi rd', rd', imm[5:0].  
+   Expands to andi rd', rd', imm[5:0].  
   imm treated as signed number
 * **Verification Goals**
   
   Input operands:  
     
   All shift amounts from [0:31] are used  
-  +ve, -ve and zero values of imm are used  
+   +ve, -ve and zero values of imm are used  
   All bits of rd` before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -5624,7 +5624,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.andi rd', imm[5:0]  
   x[8+rd'] = x[8+rd'] & sext(imm[5:0])  
-  Expands to andi rd', rd', imm[5:0].  
+   Expands to andi rd', rd', imm[5:0].  
   imm treated as signed number
 * **Verification Goals**
   
@@ -5657,7 +5657,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rd registers are used.  
-  All possible register combinations where rs2 == rd are used
+   All possible register combinations where rs2 == rd are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -5756,9 +5756,9 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   +ve,-ve and zero values of rs2 are used  
-  +ve,-ve, and zero values of rdrs1 are used  
+   +ve,-ve, and zero values of rdrs1 are used  
   All bits of rs2 are toggled  
-  All bits of rd before instruction execution are toggled
+   All bits of rd before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -5832,9 +5832,9 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   Non-zero and zero values of rs2` are used  
-  Non-zero and zero values of rd` are used  
+   Non-zero and zero values of rd` are used  
   All bits of rs2` are toggled  
-  All bits of rd` before instruction execution are toggled
+   All bits of rd` before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -5906,9 +5906,9 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   Non-zero and zero values of rs2` are used  
-  Non-zero and zero values of rd` are used  
+   Non-zero and zero values of rd` are used  
   All bits of rs2` are toggled  
-  All bits of rd` before instruction execution are toggled
+   All bits of rd` before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -5980,9 +5980,9 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   Non-zero and zero values of rs2` are used  
-  Non-zero and zero values of rd` are used  
+   Non-zero and zero values of rd` are used  
   All bits of rs2` are toggled  
-  All bits of rd` before instruction execution are toggled
+   All bits of rd` before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -6054,9 +6054,9 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operands:  
     
   +ve,-ve and zero values of rs2` are used  
-  +ve, -ve, and zero values of rd` are used  
+   +ve, -ve, and zero values of rd` are used  
   All bits of rs2` are toggled  
-  All bits of rd` before instruction execution are toggled
+   All bits of rd` before instruction execution are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -6324,7 +6324,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.beqz rs1', imm[8:1]  
   if (x[8+rs1'] == 0) pc += sext(imm)  
-  Expands to beq rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
+   Expands to beq rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
 * **Verification Goals**
   
   Register operands:  
@@ -6347,7 +6347,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.beqz rs1', imm[8:1]  
   if (x[8+rs1'] == 0) pc += sext(imm)  
-  Expands to beq rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
+   Expands to beq rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
 * **Verification Goals**
   
   Input operands:  
@@ -6370,7 +6370,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.beqz rs1', imm[8:1]  
   if (x[8+rs1'] == 0) pc += sext(imm)  
-  Expands to beq rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
+   Expands to beq rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
 * **Verification Goals**
   
   Output result:  
@@ -6395,7 +6395,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.bnez  rs1', imm[8:1]  
   if (x[8+rs1'] ≠ 0) pc += sext(imm)  
-  Expands to bne rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
+   Expands to bne rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
 * **Verification Goals**
   
   Register operands:  
@@ -6418,7 +6418,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.bnez  rs1', imm[8:1]  
   if (x[8+rs1'] ≠ 0) pc += sext(imm)  
-  Expands to bne rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
+   Expands to bne rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
 * **Verification Goals**
   
   Input operands:  
@@ -6441,7 +6441,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   c.bnez  rs1', imm[8:1]  
   if (x[8+rs1'] ≠ 0) pc += sext(imm)  
-  Expands to bne rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
+   Expands to bne rs1', x0, imm[8:1]. pc is calculated using signed arithmetic.
 * **Verification Goals**
   
   Output result:  
@@ -6604,7 +6604,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1` registers are used.  
-  All possible rd` registers are used.  
+   All possible rd` registers are used.  
   All possible register combinations where rs1` == rd` are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -6680,7 +6680,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1` registers are used.  
-  All possible rd` registers are used.  
+   All possible rd` registers are used.  
   All possible register combinations where rs1` == rd` are used
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
@@ -6734,7 +6734,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used  
-  All possible rd registers are used  
+   All possible rd registers are used  
   All supported CSRs are used  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
@@ -6784,7 +6784,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used  
-  All possible rd registers are used  
+   All possible rd registers are used  
   All supported CSRs are used  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
@@ -6835,7 +6835,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Register operands:  
     
   All possible rs1 registers are used  
-  All possible rd registers are used  
+   All possible rd registers are used  
   All supported CSRs are used  
   All possible register combinations where rs1 == rd are used
 * **Pass/Fail Criteria:** Check RM
@@ -6880,7 +6880,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   csrrwi rd, imm[4:0], csr  
   rd = Zext([csr]); csr = Zext(imm[4:0])  
-  If rd == x0 then CSR is not read.
+   If rd == x0 then CSR is not read.
 * **Verification Goals**
   
   Register operands:  
@@ -6904,13 +6904,13 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   
   csrrwi rd, imm[4:0], csr  
   rd = Zext([csr]); csr = Zext(imm[4:0])  
-  If rd == x0 then CSR is not read.
+   If rd == x0 then CSR is not read.
 * **Verification Goals**
   
   Input operand:  
     
   Non-zero and zero imm[4:0] operands are used  
-  All bits of imm[4:0] are toggled
+   All bits of imm[4:0] are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -6960,7 +6960,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operand:  
     
   Non-zero and zero imm[4:0] operands are used  
-  All bits of imm[4:0] are toggled
+   All bits of imm[4:0] are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -7010,7 +7010,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
   Input operand:  
     
   Non-zero and zero imm[4:0] operands are used  
-  All bits of imm[4:0] are toggled
+   All bits of imm[4:0] are toggled
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -7159,7 +7159,7 @@ isacov.rv32m_remu_cg.cp_rd_toggle
 * **Verification Goals**
   
   CSR write instruction attempts to write to a supported CSR  
-  This does not include csr set or clear instructions where rs1 is x0 (bypassing the write)
+   This does not include csr set or clear instructions where rs1 is x0 (bypassing the write)
 * **Pass/Fail Criteria:** Check RM
 * **Test Type:** Constrained Random
 * **Coverage Method:** Functional Coverage
@@ -7184,6 +7184,803 @@ isacov.rv32m_remu_cg.cp_rd_toggle
 * **Coverage Method:** NDY (Not Defined Yet)
 * **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
 * **Unique verification tag:** VP_ISA_RV32_F015_S003_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+## Feature: RV32Zicond Integer Conditional Instructions
+
+### Sub-feature: 000_CZERO.EQZ
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  czero.eqz rd, rs1, rs2  
+  if (x[rs2] == 0) x[rd] = 0 else x[rs1]  
+   Set rd's value to zero if rs2 is equal to zero, otherwise moves rs1 into rd
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd registers are used  
+  All possible rs1 registers are used  
+  All possible rs2 registers are used  
+  All possible register combinations where rs1 == rd are used  
+  All possible register combinations where rs2 == rd are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32_F016_S000_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  czero.eqz rd, rs1, rs2  
+  if (x[rs2] == 0) x[rd] = 0 else x[rs1]  
+   Set rd's value to zero if rs2 is equal to zero, otherwise moves rs1 into rd
+* **Verification Goals**
+  
+  Input operands:  
+    
+  rs1 value is +ve, -ve and zero  
+  rs2 value is +ve, -ve and zero  
+  All combinations of rs1 and rs2 +ve, -ve, and zero values are used  
+  All bits of rs1 are toggled  
+  All bits of rs2 are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32_F016_S000_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 002
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  czero.eqz rd, rs1, rs2  
+  if (x[rs2] == 0) x[rd] = 0 else x[rs1]  
+   Set rd's value to zero if rs2 is equal to zero, otherwise moves rs1 into rd
+* **Verification Goals**
+  
+  Output result:  
+    
+  rd value is +ve, -ve and zero  
+  All bits of rd are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32_F016_S000_I002
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 001_CZERO.NEZ
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  czero.nez rd, rs1, rs2  
+  if (x[rs2] != 0) x[rd] = 0 else x[rs1]  
+   Set rd's value to zero if rs2 isn't equal to zero, otherwise moves rs1 into rd
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd registers are used  
+  All possible rs1 registers are used  
+  All possible rs2 registers are used  
+  All possible register combinations where rs1 == rd are used  
+  All possible register combinations where rs2 == rd are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32_F016_S001_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  czero.nez rd, rs1, rs2  
+  if (x[rs2] != 0) x[rd] = 0 else x[rs1]  
+   Set rd's value to zero if rs2 isn't equal to zero, otherwise moves rs1 into rd
+* **Verification Goals**
+  
+  Input operands:  
+    
+  rs1 value is +ve, -ve and zero  
+  rs2 value is +ve, -ve and zero  
+  All combinations of rs1 and rs2 +ve, -ve, and zero values are used  
+  All bits of rs1 are toggled  
+  All bits of rs2 are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32_F016_S001_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 002
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  czero.nez rd, rs1, rs2  
+  if (x[rs2] != 0) x[rd] = 0 else x[rs1]  
+   Set rd's value to zero if rs2 isn't equal to zero, otherwise moves rs1 into rd
+* **Verification Goals**
+  
+  Output result:  
+    
+  rd value is +ve, -ve and zero  
+  All bits of rd are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32_F016_S001_I002
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+## Feature: RV32Zcb Integer Computational Instructions
+
+### Sub-feature: 000_C.ZEXT.B
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.zext.b rd'  
+  x[8 + rd'] = zext(x[8 + rd'][7:0])  
+  It zero-extends the least-significant byte of the operand
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd` registers are used.
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S000_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.zext.b rd'  
+  x[8 + rd'] = zext(x[8 + rd'][7:0])  
+  It zero-extends the least-significant byte of the operand
+* **Verification Goals**
+  
+  Output result:  
+    
+  All bits of rd'[7:0] are toggled
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S000_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 001_C.SEXT.B
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sext.b rd'  
+  x[8 + rd'] = sext(x[8 + rd'][7:0])  
+  It sign-extends the least-significant byte of the operand
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S001_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sext.b rd'  
+  x[8 + rd'] = sext(x[8 + rd'][7:0])  
+  It sign-extends the least-significant byte of the operand
+* **Verification Goals**
+  
+  Output operands:  
+    
+  All bits of rd' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S001_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 002_C.ZEXT.H
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.zext.h rd'  
+  x[8 + rd'] = zext(x[8 + rd'][15:0])  
+  It zero-extends the least-significant half-word of the operand
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' registers are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S002_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.zext.h rd'  
+  x[8 + rd'] = zext(x[8 + rd'][15:0])  
+  It zero-extends the least-significant half-word of the operand
+* **Verification Goals**
+  
+  Output result:  
+    
+  All bits of rd'[15:0] are toggled
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S002_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 003_C.SEXT.H
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sext.h rd'  
+  x[8 + rd'] = sext(x[8 + rd'][15:0])  
+  It sign-extends the least-significant half-word of the operand
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' registers are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S003_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sext.h rd'  
+  x[8 + rd'] = sext(x[8 + rd'][15:0])  
+  It sign-extends the least-significant half-word of the operand
+* **Verification Goals**
+  
+  Output result:  
+    
+  All bits of rd' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S003_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 005_C.NOT
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.not rd'  
+  x[8 + rd'] = x[8 + rd']^ -1
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' registers are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S005_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.not rd'  
+  x[8 + rd'] = x[8 + rd']^ -1
+* **Verification Goals**
+  
+  Output result:  
+    
+  All bits of rd' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S005_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 006_C.MUL
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.mul rd',rs2'  
+  x[8 + rd'] = x[8 + rd'] * x[8 + rs2']  
+  Arithmetic overflow is ignored.
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' registers are used  
+   All possible register combinations where rs2' == rd' are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S006_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.mul rd',rs2'  
+  x[8 + rd'] = x[8 + rd'] * x[8 + rs2']  
+  Arithmetic overflow is ignored.
+* **Verification Goals**
+  
+  Input operands:  
+    
+  All bits of rs2' are toggled
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S006_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 002
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.mul rd',rs2'  
+  x[8 + rd'] = x[8 + rd'] * x[8 + rs2']  
+  Arithmetic overflow is ignored.
+* **Verification Goals**
+  
+  Output result:  
+    
+  All bits of rd' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F016_S006_I002
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+## Feature: RV32Zcb Load and Store Instructions
+
+### Sub-feature: 000_C.LBU
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.lbu rd', uimm(rs1')  
+  x[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1:0])][7:0])
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' register are used  
+  All possible rs1' register are used  
+  ALl possible combinations where rd' == rs1' are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S000_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.lbu rd', uimm(rs1')  
+  x[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1:0])][7:0])
+* **Verification Goals**
+  
+  Input operands:  
+    
+  uimm value is non-zero and zero  
+  All bits of uimm are toggled  
+  All bits of rs1' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S000_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 002
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.lbu rd', uimm(rs1')  
+  x[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1:0])][7:0])
+* **Verification Goals**
+  
+  Output result:  
+    
+  rd' value is non-zero and zero  
+  All bits of rd' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S000_I002
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 001_C.SB
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sb rs1', uimm(rs2')  
+  M[x[8 + rs1'] + zext(uimm[1:0])][7:0] = x[8 + rs2']
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rs1' register are used  
+   All possible rs2' register are used  
+  All possible combinations where rs1' = rs2' register are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S001_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sb rs1', uimm(rs2')  
+  M[x[8 + rs1'] + zext(uimm[1:0])][7:0] = x[8 + rs2']
+* **Verification Goals**
+  
+  Input operands:  
+    
+  uimm value is non-zero and zero  
+  All bits of uimm are toggled  
+  All bits of rs1' are toggled  
+  All bits of rs2' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S001_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 002_C.LHU
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions
+* **Feature Description**
+  
+  c.lhu rd', uimm(rs1')  
+  x[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1])][15:0])
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' register are used  
+  All possible rs1' register are used  
+  ALl possible combinations where rd' == rs1' are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S002_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions
+* **Feature Description**
+  
+  c.lhu rd', uimm(rs1')  
+  x[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1])][15:0])
+* **Verification Goals**
+  
+  Input operands:  
+    
+  uimm value is non-zero and zero  
+  All bits of uimm are toggled  
+  All bits of rs1' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S002_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 002
+
+* **Requirement location:** ./RISCV_Instructions
+* **Feature Description**
+  
+  c.lhu rd', uimm(rs1')  
+  x[8 + rd'] = zext(M[x[8 + rd'] + zext(uimm[1])][15:0])
+* **Verification Goals**
+  
+  Output result:  
+    
+  rd' value is non-zero and zero  
+  All bits of rd' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S002_I002
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 003_C.LH
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.lh rd', uimm(rs1')  
+  x[8 + rd'] = sext(M[x[8 + rd'] + zext(uimm[1])][15:0])
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rd' register are used  
+  All possible rs1' register are used  
+  ALl possible combinations where rd' == rs1' are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S003_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.lh rd', uimm(rs1')  
+  x[8 + rd'] = sext(M[x[8 + rd'] + zext(uimm[1])][15:0])
+* **Verification Goals**
+  
+  Input operands:  
+    
+  uimm value is non-zero and zero  
+  All bits of uimm are toggled  
+  All bits of rs1' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S003_I001
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 002
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.lh rd', uimm(rs1')  
+  x[8 + rd'] = sext(M[x[8 + rd'] + zext(uimm[1])][15:0])
+* **Verification Goals**
+  
+  Output result:  
+    
+  rd' value is non-zero and zero  
+  All bits of rd' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S003_I002
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+### Sub-feature: 004_C.SH
+
+#### Item: 000
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sh rs1', uimm(rs2')  
+  M[x[8 + rs1'] + zext(uimm[1])][15:0] = x[8 + rs2']
+* **Verification Goals**
+  
+  Register operands:  
+    
+  All possible rs1' register are used  
+   All possible rs2' register are used  
+  All possible combinations where rs1' = rs2' are used
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** Constrained Random
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S004_I000
+* **Link to Coverage:** 
+* **Comments**
+  
+  *(none)*  
+  
+#### Item: 001
+
+* **Requirement location:** ./RISCV_Instructions.rst
+* **Feature Description**
+  
+  c.sh rs1', uimm(rs2')  
+  M[x[8 + rs1'] + zext(uimm[1])][15:0] = x[8 + rs2']
+* **Verification Goals**
+  
+  Input operands:  
+    
+  uimm value is non-zero and zero  
+  All bits of uimm are toggled  
+  All bits of rs1' are toggled  
+  All bits of rs2' are toggled
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6_v0.1.0, CV32A6-step2, CV64A6-step3
+* **Unique verification tag:** VP_ISA_RV32 EMBEDDED_F017_S004_I001
 * **Link to Coverage:** 
 * **Comments**
   


### PR DESCRIPTION
I add dvplan for embedded version base on STEP1 dvplan :
1. I change the dvplan's STEP1 name to ISA_CV32A60X
2. Add cva6 embedded under name ISA_CV326_EMBEDDED That I add Zcb instructions & remove Atomic instructions