### PR TITLE
docs: fix example of OoO write-back to scoreboard

### DIFF
--- a/docs/03_cva6_design/issue_stage.md
+++ b/docs/03_cva6_design/issue_stage.md
@@ -42,10 +42,10 @@ out-of-order issue ().
 The issuing of instructions happen in-order, that means order of program
 flow is naturally maintained. What can happen out-of-order is the
 write-back of each functional unit. Think for example, that the issue
-stage issues a multiplication which takes $n$ clock cycles to produce a
+stage issues a load which takes $n$ clock cycles to produce a
 valid result. In the next cycle the issue stage issues an ALU
 instruction like an addition. The addition will just take one clock
-cycle to return and therefore return before the multiplication's result
+cycle to return and therefore return before the load's result
 is ready. Because of this we need to assign IDs to the various issue
 stages. The ID resembles the (unique) position in which the scoreboard
 will store the result of this instruction. The ID (called transaction


### PR DESCRIPTION
Multiplication takes two cycles (1 cycle latency) and ALU takes one
cycle (no latency). They share the same writeback port so it is not
possible to issue an ALU instruction just after a MUL.  So the example
is wrong, but it is okay if we replace MUL by LOAD as it uses another
write-back port.

Fix #1106