### PR TITLE
Add more unmapped instructions tests with more combinations

### DIFF
--- a/verif/env/corev-dv/cva6_illegal_instr.sv
+++ b/verif/env/corev-dv/cva6_illegal_instr.sv
@@ -61,4 +61,15 @@ class cva6_illegal_instr_c extends riscv_illegal_instr;
     }
   }
 
+  // Invalid SYSTEM instructions
+  constraint system_instr_c {
+    if (exception == kIllegalSystemInstr) {
+      opcode == 7'b1110011;
+      func3 == 3'b000;
+      // ECALL/EBREAK/xRET/WFI
+      // Constrain the upper 12 bits to avoid ecall instruction
+      instr_bin[31:20] != 0;
+    }
+  }
+
 endclass

--- a/verif/env/corev-dv/cva6_instr_sequence.sv
+++ b/verif/env/corev-dv/cva6_instr_sequence.sv
@@ -45,7 +45,7 @@ class cva6_instr_sequence_c extends riscv_instr_sequence;
                       bin_instr_cnt, cfg_cva6.unsupported_instr_ratio), UVM_LOW)
       repeat (bin_instr_cnt) begin
         `DV_CHECK_RANDOMIZE_WITH_FATAL(unsupported_instr, 
-                                       unsupported_instr inside {rv64i_instr,rv64c_instr,rv64m_instr,rvfdq_instr,illegal_sll_sra,sys_instr};)
+                                       unsupported_instr inside {rv64i_instr,rv64c_instr,rv64m_instr,rvfdq_instr,illegal_slli_srai,sys_instr};)
         str = {indent, $sformatf(".4byte 0x%s # %0s",
                        unsupported_instr.get_bin_str(), unsupported_instr.comment)};
                idx = $urandom_range(0, instr_string_list.size());

--- a/verif/env/corev-dv/cva6_instr_sequence.sv
+++ b/verif/env/corev-dv/cva6_instr_sequence.sv
@@ -45,7 +45,7 @@ class cva6_instr_sequence_c extends riscv_instr_sequence;
                       bin_instr_cnt, cfg_cva6.unsupported_instr_ratio), UVM_LOW)
       repeat (bin_instr_cnt) begin
         `DV_CHECK_RANDOMIZE_WITH_FATAL(unsupported_instr, 
-                                       unsupported_instr inside {rv64i_instr,rv64c_instr,rv64m_instr,rvfdq_instr};)
+                                       unsupported_instr inside {rv64i_instr,rv64c_instr,rv64m_instr,rvfdq_instr,illegal_sll_sra,sys_instr};)
         str = {indent, $sformatf(".4byte 0x%s # %0s",
                        unsupported_instr.get_bin_str(), unsupported_instr.comment)};
                idx = $urandom_range(0, instr_string_list.size());

--- a/verif/env/corev-dv/cva6_unsupported_instr.sv
+++ b/verif/env/corev-dv/cva6_unsupported_instr.sv
@@ -32,7 +32,7 @@ class cva6_unsupported_instr_c extends uvm_object;
     rv64m_instr,
     rvfdq_instr,
     sys_instr,
-    illegal_sll_sra
+    illegal_slli_srai
   } illegal_ext_instr_type_e;
 
   // Default legal opcode for RV32I instructions
@@ -119,7 +119,7 @@ class cva6_unsupported_instr_c extends uvm_object;
       rv64m_instr := 3,
       rvfdq_instr := 3,
       sys_instr   := 1,
-      illegal_sll_sra := 1
+      illegal_slli_srai := 1
     };
   }
 
@@ -148,6 +148,7 @@ class cva6_unsupported_instr_c extends uvm_object;
   }
 
   // unsupported system instructions
+  // sfence.vma instruction
   constraint sys_instr_c {
     if (unsupported_instr == sys_instr) {
          compressed == 0;
@@ -159,9 +160,9 @@ class cva6_unsupported_instr_c extends uvm_object;
     }
   }
 
-  // illegal SLL & SRA instruction
-  constraint illegal_sll_sra_instr_c {
-    if (unsupported_instr == illegal_sll_sra) {
+  // illegal RV32 SLLI & SRAI instruction with 25th bit is high
+  constraint illegal_slli_srai_32_instr_c {
+    if (unsupported_instr == illegal_slli_srai) {
          compressed == 0;
          opcode == 7'b0010011;
          instr_bin[25] != 1'b0;

--- a/verif/regress/dv-generated-tests.sh
+++ b/verif/regress/dv-generated-tests.sh
@@ -62,7 +62,7 @@ elif [[ "$list_num" = 3 ]];then
            "riscv_arithmetic_basic_illegal_hint_test"
            "riscv_arithmetic_basic_ebreak_dret_test"
            );
-   I=(50 50 50);
+   I=(100 100 20);
 elif [[ "$list_num" = 4 ]];then
 	TEST_NAME=(
            "riscv_mmu_stress_hint_test"

--- a/verif/regress/dv-generated-tests.sh
+++ b/verif/regress/dv-generated-tests.sh
@@ -67,9 +67,8 @@ elif [[ "$list_num" = 4 ]];then
 	TEST_NAME=(
            "riscv_mmu_stress_hint_test"
            "riscv_mmu_stress_test"
-           "riscv_unaligned_mmu_stress_illegal_test"
            );
-	I=(100 100 100);
+	I=(100 100);
 elif [[ "$list_num" = 5 ]];then
   TEST_NAME=(
            "riscv_load_store_test"

--- a/verif/regress/dv-generated-tests.sh
+++ b/verif/regress/dv-generated-tests.sh
@@ -67,8 +67,9 @@ elif [[ "$list_num" = 4 ]];then
 	TEST_NAME=(
            "riscv_mmu_stress_hint_test"
            "riscv_mmu_stress_test"
+           "riscv_unaligned_mmu_stress_illegal_test"
            );
-	I=(100 100);
+	I=(100 100 100);
 elif [[ "$list_num" = 5 ]];then
   TEST_NAME=(
            "riscv_load_store_test"

--- a/verif/sim/cva6_base_testlist.yaml
+++ b/verif/sim/cva6_base_testlist.yaml
@@ -67,29 +67,6 @@
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
 
-- test: riscv_unaligned_mmu_stress_illegal_test
-  description: >
-    Test with different patterns of load/store instructions, stress test MMU
-    operations.
-  gen_opts: >
-    +instr_cnt=500
-    +num_of_sub_program=5
-    +directed_instr_0=cva6_load_store_rand_instr_stream_c,30
-    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,30
-    +directed_instr_2=cva6_multi_page_load_store_instr_stream_c,30
-    +directed_instr_3=cva6_mem_region_stress_test_c,30
-    +enable_unaligned_load_store=1
-    +illegal_instr_ratio=100
-    +unsupported_instr_ratio=100
-    +enable_zba_extension=1
-    +enable_zbb_extension=1
-    +enable_zbc_extension=1
-    +enable_zbs_extension=1
-    +enable_zcb_extension=1
-  iterations: 2
-  gen_test: cva6_instr_base_test_c
-  rtl_test: core_base_test
-
 - test: riscv_rand_jump_illegal_test
   description: >
     Jump among large number of sub-programs, stress testing iTLB operations.

--- a/verif/sim/cva6_base_testlist.yaml
+++ b/verif/sim/cva6_base_testlist.yaml
@@ -67,6 +67,29 @@
   gen_test: cva6_instr_base_test_c
   rtl_test: core_base_test
 
+- test: riscv_unaligned_mmu_stress_illegal_test
+  description: >
+    Test with different patterns of load/store instructions, stress test MMU
+    operations.
+  gen_opts: >
+    +instr_cnt=500
+    +num_of_sub_program=5
+    +directed_instr_0=cva6_load_store_rand_instr_stream_c,30
+    +directed_instr_1=cva6_load_store_hazard_instr_stream_c,30
+    +directed_instr_2=cva6_multi_page_load_store_instr_stream_c,30
+    +directed_instr_3=cva6_mem_region_stress_test_c,30
+    +enable_unaligned_load_store=1
+    +illegal_instr_ratio=100
+    +unsupported_instr_ratio=100
+    +enable_zba_extension=1
+    +enable_zbb_extension=1
+    +enable_zbc_extension=1
+    +enable_zbs_extension=1
+    +enable_zcb_extension=1
+  iterations: 2
+  gen_test: cva6_instr_base_test_c
+  rtl_test: core_base_test
+
 - test: riscv_rand_jump_illegal_test
   description: >
     Jump among large number of sub-programs, stress testing iTLB operations.


### PR DESCRIPTION
This related to improving CC, by adding more constraints for the unmapped instructions tests, to generate tests covering some corner cases.