### PR TITLE
csr_regfile.sv: force mstatus.UBE to 0 (see #1417)

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -789,6 +789,7 @@ module csr_regfile
           mstatus_d.wpri1 = 1'b0;
           mstatus_d.wpri2 = 1'b0;
           mstatus_d.wpri0 = 1'b0;
+          mstatus_d.ube   = 1'b0;  // CVA6 is little-endian
           // this register has side-effects on other registers, flush the pipeline
           flush_o         = 1'b1;
         end


### PR DESCRIPTION
as CVA6 is little endian

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>