### PR TITLE
Add more constraints to cover corner cases in CC

### DIFF
--- a/verif/env/corev-dv/cva6_illegal_instr.sv
+++ b/verif/env/corev-dv/cva6_illegal_instr.sv
@@ -63,12 +63,13 @@ class cva6_illegal_instr_c extends riscv_illegal_instr;
 
   // Invalid SYSTEM instructions
   constraint system_instr_c {
-    if (exception == kIllegalSystemInstr) {
-      opcode == 7'b1110011;
-      func3 == 3'b000;
-      // ECALL/EBREAK/xRET/WFI
-      // Constrain the upper 12 bits to avoid ecall instruction
-      instr_bin[31:20] != 0;
+    if (!(SUPERVISOR_MODE inside supported_privileged_mode)) {
+       if (exception == kIllegalSystemInstr) {
+         opcode == 7'b1110011;
+         func3 == 3'b000;
+         // Constrain the upper 12 bits to generate SRET instruction
+         instr_bin[31:20] == 12'b100000010;
+       }
     }
   }
 

--- a/verif/env/corev-dv/cva6_instr_sequence.sv
+++ b/verif/env/corev-dv/cva6_instr_sequence.sv
@@ -45,7 +45,8 @@ class cva6_instr_sequence_c extends riscv_instr_sequence;
                       bin_instr_cnt, cfg_cva6.unsupported_instr_ratio), UVM_LOW)
       repeat (bin_instr_cnt) begin
         `DV_CHECK_RANDOMIZE_WITH_FATAL(unsupported_instr, 
-                                       unsupported_instr inside {rv64i_instr,rv64c_instr,rv64m_instr,rvfdq_instr,illegal_slli_srai,sys_instr};)
+                                       unsupported_instr inside {rv64i_instr, rv64c_instr, rv64m_instr, rvfdq_instr, illegal_slli_srai, sys_instr,
+                                                                 illegal_rv32zcb_instr, rv64zcb_instr, rv32vf_instr};)
         str = {indent, $sformatf(".4byte 0x%s # %0s",
                        unsupported_instr.get_bin_str(), unsupported_instr.comment)};
                idx = $urandom_range(0, instr_string_list.size());


### PR DESCRIPTION
Adding constraint to generate illegal RV32Zcb instruction (illegal func3 & func2), also generate RV64zcb instruction, to improve CC