### PR TITLE
dependabot: update hpdcache

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       time: "19:30"
       timezone: "Europe/Paris"
     allow:
+      - dependency-name: "core/cache_subsystem/hpdcache"
       - dependency-name: "verif/core-v-verif"
       - dependency-name: "verif/sim/dv"
     labels: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,4 @@ updates:
     allow:
       - dependency-name: "verif/core-v-verif"
       - dependency-name: "verif/sim/dv"
-    labels:
-      - "Component:Verif"
+    labels: []


### PR DESCRIPTION
Adds hpdcache to the list of submodules kept up-to-date by dependabot.

Also removes the `Component:Verif` label from Dependabot PRs because:

- hpdcache submodule is an RTL feature and not a verification tool
- CVA6 PRs are usually unlabelled