### PR TITLE
compressed_decoder.sv: remove useless condition

### DIFF
--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -928,7 +928,7 @@ module compressed_decoder #(
     endcase
 
     // Check if the instruction was illegal, if it was then output the offending instruction (zero-extended)
-    if (illegal_instr_o && is_compressed_o) begin
+    if (illegal_instr_o) begin
       instr_o = instr_i;
     end
   end


### PR DESCRIPTION
Only compressed illegal instructions are identified in this module.
Therefore is_compressed_o is always equal to 1.

This modification improves condition coverage.

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>