### PR TITLE
ci(merge rep): prevent interpolation in commit msg

### DIFF
--- a/.gitlab-ci/scripts/merge_job_reports.py
+++ b/.gitlab-ci/scripts/merge_job_reports.py
@@ -119,6 +119,7 @@ with open(f'{sys.argv[1]}/{filename}', 'w+') as f:
     yaml.dump(pipeline, f)
 
 try:
+  quoted_title = "'" + title.replace("'", "'\"'\"'") + "'"
   print(subprocess.check_output(f'''
 rm -r .gitlab-ci/dashboard_tmp || echo "nothing to do"
 git clone {dashboard_url} .gitlab-ci/dashboard_tmp
@@ -129,7 +130,7 @@ cd .gitlab-ci/dashboard_tmp
 git config user.email {git_email}
 git config user.name {git_name}
 git add pipelines_{workflow_repo}/{filename}
-git commit -m  "{workflow_repo}: {title.replace('"',"'")}" || echo "commit fail"
+git commit -m  '{workflow_repo}: '{quoted_title} || echo "commit fail"
 git push
 cd -
 ''', shell=True))


### PR DESCRIPTION
Double quotes behaviour in shell is that it avoids spaces; however the
shell still performs $() and `` interpolations.  To avoid that, we must
use single quotes instead.

To prevent a double quote in the message from ending the string, it was
replaced by a single quote.  Instead, here we chase the single quotes
by:

1. Ending the first string using a single quote.
2. Starting a second string using a double quote.
3. Placing the single quote we want to display in the message.
4. Ending the second string using another double quote.
5. Starting a third string using another single quote.

As there are no spaces, the shell merges the three strings.

For instance the message a'b is enquoted as 'a'"'"'b' which are three
merged strings 'a', "'" and 'b'.