### PR TITLE
report coverage even when a verif job fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -334,6 +334,7 @@ riscv-tests-p:
     - .regress_test
   rules: &on_verif
     - if: $CI_KIND == "verif"
+      allow_failure: true
     - when: manual
       allow_failure: true
   timeout: 4h


### PR DESCRIPTION
Because of directed_isacov-tests failures, coverage report generation is
not run on scheduled pipelines the week-end; it is run only when the job
is manually started from a regress pipeline because in this case, the
job is allowed to fail.

Allowing failures on verif jobs will let report coverage running.