### PR TITLE
Code coverage: Add NonIdemPotence parameter

### DIFF
--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -255,7 +255,7 @@ module cva6_icache
         // readout speculatively
         cache_rden  = cache_en_q;
 
-        if (areq_i.fetch_valid && (!dreq_i.spec || !addr_ni)) begin
+        if (areq_i.fetch_valid && (!dreq_i.spec || ((CVA6Cfg.NonIdemPotenceEn && !addr_ni) || (!CVA6Cfg.NonIdemPotenceEn)))) begin
           // check if we have to flush
           if (flush_d) begin
             state_d = IDLE;

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -437,7 +437,7 @@ module wt_dcache_wbuffer
 
   logic ni_inside, ni_conflict;
   assign ni_inside = |ni_pending_q;
-  assign ni_conflict = is_ni && ni_inside;
+  assign ni_conflict = CVA6Cfg.NonIdemPotenceEn && is_ni && ni_inside;
   assign not_ni_o = !ni_inside;
   assign empty_o    = !(|valid);
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -163,6 +163,8 @@ module cva6
 
   localparam NrRgprPorts = 2;
 
+  localparam bit NonIdemPotenceEn = CVA6Cfg.NrNonIdempotentRules && CVA6Cfg.NonIdempotentLength;  // Currently only used by V extension (Ara)
+
   localparam config_pkg::cva6_cfg_t CVA6ExtendCfg = {
     CVA6Cfg.NrCommitPorts,
     CVA6Cfg.AxiAddrWidth,
@@ -214,7 +216,8 @@ module cva6
     CVA6Cfg.CachedRegionAddrBase,
     CVA6Cfg.CachedRegionLength,
     CVA6Cfg.MaxOutstandingStores,
-    CVA6Cfg.DebugEn
+    CVA6Cfg.DebugEn,
+    NonIdemPotenceEn
   };
 
 

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -112,6 +112,7 @@ package config_pkg;
     /// Maximum number of outstanding stores.
     int unsigned                 MaxOutstandingStores;
     bit                          DebugEn;
+    bit                          NonIdemPotenceEn;
   } cva6_cfg_t;
 
 

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -137,7 +137,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(0)
+      DebugEn: bit'(0),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -138,6 +138,7 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 endpackage

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -137,7 +137,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -144,7 +144,8 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -137,6 +137,7 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(1)
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0)
   };
 endpackage

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -419,7 +419,7 @@ module load_unit
     // exceptions can retire out-of-order -> but we need to give priority to non-excepting load and stores
     // so we simply check if we got an rvalid if so we prioritize it by not retiring the exception - we simply go for another
     // round in the load FSM
-    if (ariane_pkg::MMU_PRESENT && CVA6Cfg.NonIdemPotenceEn && (state_q == WAIT_TRANSLATION) && !req_port_i.data_rvalid && ex_i.valid && valid_i) begin
+    if ((ariane_pkg::MMU_PRESENT || CVA6Cfg.NonIdemPotenceEn) && (state_q == WAIT_TRANSLATION) && !req_port_i.data_rvalid && ex_i.valid && valid_i) begin
       trans_id_o = lsu_ctrl_i.trans_id;
       valid_o = 1'b1;
       ex_o.valid = 1'b1;

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -210,6 +210,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   CachedRegionLength:    1024'({ariane_soc::DRAMLength}),
   MaxOutstandingStores:  unsigned'(7),
   DebugEn: bit'(1)
+  NonIdemPotenceEn: bit'(0)
 };
 
 localparam type rvfi_instr_t = logic;

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -209,7 +209,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   CachedRegionAddrBase:  1024'({ariane_soc::DRAMBase}),
   CachedRegionLength:    1024'({ariane_soc::DRAMLength}),
   MaxOutstandingStores:  unsigned'(7),
-  DebugEn: bit'(1)
+  DebugEn: bit'(1),
   NonIdemPotenceEn: bit'(0)
 };
 


### PR DESCRIPTION
Condition RTL with NonIdemPotence parameters to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to reach 100% code coverage.