### PR TITLE
[csr/scounteren] fix privilege violation logic

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1351,7 +1351,7 @@ module csr_regfile
         end else if (priv_lvl_o == riscv::PRIV_LVL_S && CVA6Cfg.RVS) begin
           privilege_violation = ~mcounteren_q[csr_addr_i[4:0]];
         end else if (priv_lvl_o == riscv::PRIV_LVL_U && CVA6Cfg.RVU) begin
-          privilege_violation = ~mcounteren_q[csr_addr_i[4:0]] & ~scounteren_q[csr_addr_i[4:0]];
+          privilege_violation = ~mcounteren_q[csr_addr_i[4:0]] | ~scounteren_q[csr_addr_i[4:0]];
         end
       end
     end


### PR DESCRIPTION
This PR fixes a privilege violation check when accessing the counter CSR from U-mode.
According to the spec:

> ...U-mode may only access a counter if the corresponding bits in scounteren and mcounteren are both set.

Before this fix, the violation only happens if both are set.

Tested on Linux 5.19 while using `rdcycle` from U-mode.
