### PR TITLE
csr: Implement `mconfigptr`

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -257,6 +257,7 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MARCHID:            csr_rdata = ARIANE_MARCHID;
                 riscv::CSR_MIMPID:             csr_rdata = '0; // not implemented
                 riscv::CSR_MHARTID:            csr_rdata = hart_id_i;
+                riscv::CSR_MCONFIGPTR:         csr_rdata = '0;
                 riscv::CSR_MCOUNTINHIBIT:      csr_rdata = mcountinhibit_q;
                 // Counters and Timers
                 riscv::CSR_MCYCLE:             csr_rdata = cycle_q[riscv::XLEN-1:0];

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -95,7 +95,7 @@ package riscv;
         logic         sie;    // supervisor interrupts enable
         logic         wpri0;  // writes preserved reads ignored
     } sstatus_rv_t;
-    
+
     typedef struct packed {
         logic         sd;     // signal dirty state - read-only
         logic [62:36] wpri4;  // writes preserved reads ignored
@@ -457,6 +457,7 @@ package riscv;
         CSR_MARCHID        = 12'hF12,
         CSR_MIMPID         = 12'hF13,
         CSR_MHARTID        = 12'hF14,
+        CSR_MCONFIGPTR     = 12'hF15,
         CSR_MCYCLE         = 12'hB00,
         CSR_MCYCLEH        = 12'hB80,
         CSR_MINSTRET       = 12'hB02,
@@ -466,8 +467,8 @@ package riscv;
         CSR_MHPM_COUNTER_4 = 12'hB04,
         CSR_MHPM_COUNTER_5 = 12'hB05,
         CSR_MHPM_COUNTER_6 = 12'hB06,
-        CSR_MHPM_COUNTER_7 = 12'hB07, 
-        CSR_MHPM_COUNTER_8 = 12'hB08, 
+        CSR_MHPM_COUNTER_7 = 12'hB07,
+        CSR_MHPM_COUNTER_8 = 12'hB08,
         CSR_MHPM_COUNTER_9 = 12'hB09,   // reserved
         CSR_MHPM_COUNTER_10 = 12'hB0A,  // reserved
         CSR_MHPM_COUNTER_11 = 12'hB0B,  // reserved
@@ -490,11 +491,11 @@ package riscv;
         CSR_MHPM_COUNTER_28 = 12'hB1C,  // reserved
         CSR_MHPM_COUNTER_29 = 12'hB1D,  // reserved
         CSR_MHPM_COUNTER_30 = 12'hB1E,  // reserved
-        CSR_MHPM_COUNTER_31 = 12'hB1F,  // reserved        
-        CSR_MHPM_COUNTER_3H = 12'hB83,  
-        CSR_MHPM_COUNTER_4H = 12'hB84,  
-        CSR_MHPM_COUNTER_5H = 12'hB85,  
-        CSR_MHPM_COUNTER_6H = 12'hB86, 
+        CSR_MHPM_COUNTER_31 = 12'hB1F,  // reserved
+        CSR_MHPM_COUNTER_3H = 12'hB83,
+        CSR_MHPM_COUNTER_4H = 12'hB84,
+        CSR_MHPM_COUNTER_5H = 12'hB85,
+        CSR_MHPM_COUNTER_6H = 12'hB86,
         CSR_MHPM_COUNTER_7H = 12'hB87,
         CSR_MHPM_COUNTER_8H = 12'hB88,
         CSR_MHPM_COUNTER_9H = 12'hB89,   // reserved
@@ -544,20 +545,20 @@ package riscv;
         CSR_INSTRET        = 12'hC02,
         CSR_INSTRETH       = 12'hC82,
         // Performance counters (User Mode - R/O Shadows)
-        CSR_HPM_COUNTER_3   = 12'hC03,  
-        CSR_HPM_COUNTER_4   = 12'hC04,  
-        CSR_HPM_COUNTER_5   = 12'hC05,  
-        CSR_HPM_COUNTER_6   = 12'hC06,  
-        CSR_HPM_COUNTER_7   = 12'hC07,  
-        CSR_HPM_COUNTER_8   = 12'hC08,  
-        CSR_HPM_COUNTER_9   = 12'hC09,  // reserved  
-        CSR_HPM_COUNTER_10  = 12'hC0A,  // reserved  
-        CSR_HPM_COUNTER_11  = 12'hC0B,  // reserved  
-        CSR_HPM_COUNTER_12  = 12'hC0C,  // reserved  
-        CSR_HPM_COUNTER_13  = 12'hC0D,  // reserved  
-        CSR_HPM_COUNTER_14  = 12'hC0E,  // reserved  
-        CSR_HPM_COUNTER_15  = 12'hC0F,  // reserved  
-        CSR_HPM_COUNTER_16  = 12'hC10,  // reserved  
+        CSR_HPM_COUNTER_3   = 12'hC03,
+        CSR_HPM_COUNTER_4   = 12'hC04,
+        CSR_HPM_COUNTER_5   = 12'hC05,
+        CSR_HPM_COUNTER_6   = 12'hC06,
+        CSR_HPM_COUNTER_7   = 12'hC07,
+        CSR_HPM_COUNTER_8   = 12'hC08,
+        CSR_HPM_COUNTER_9   = 12'hC09,  // reserved
+        CSR_HPM_COUNTER_10  = 12'hC0A,  // reserved
+        CSR_HPM_COUNTER_11  = 12'hC0B,  // reserved
+        CSR_HPM_COUNTER_12  = 12'hC0C,  // reserved
+        CSR_HPM_COUNTER_13  = 12'hC0D,  // reserved
+        CSR_HPM_COUNTER_14  = 12'hC0E,  // reserved
+        CSR_HPM_COUNTER_15  = 12'hC0F,  // reserved
+        CSR_HPM_COUNTER_16  = 12'hC10,  // reserved
         CSR_HPM_COUNTER_17  = 12'hC11,  // reserved
         CSR_HPM_COUNTER_18  = 12'hC12,  // reserved
         CSR_HPM_COUNTER_19  = 12'hC13,  // reserved
@@ -573,20 +574,20 @@ package riscv;
         CSR_HPM_COUNTER_29  = 12'hC1D,  // reserved
         CSR_HPM_COUNTER_30  = 12'hC1E,  // reserved
         CSR_HPM_COUNTER_31  = 12'hC1F,  // reserved
-        CSR_HPM_COUNTER_3H   = 12'hC83,  
-        CSR_HPM_COUNTER_4H   = 12'hC84,  
-        CSR_HPM_COUNTER_5H   = 12'hC85,  
-        CSR_HPM_COUNTER_6H   = 12'hC86,  
-        CSR_HPM_COUNTER_7H   = 12'hC87,  
-        CSR_HPM_COUNTER_8H   = 12'hC88,  
-        CSR_HPM_COUNTER_9H   = 12'hC89,  // reserved  
-        CSR_HPM_COUNTER_10H  = 12'hC8A,  // reserved  
-        CSR_HPM_COUNTER_11H  = 12'hC8B,  // reserved  
-        CSR_HPM_COUNTER_12H  = 12'hC8C,  // reserved  
-        CSR_HPM_COUNTER_13H  = 12'hC8D,  // reserved  
-        CSR_HPM_COUNTER_14H  = 12'hC8E,  // reserved  
-        CSR_HPM_COUNTER_15H  = 12'hC8F,  // reserved  
-        CSR_HPM_COUNTER_16H  = 12'hC90,  // reserved  
+        CSR_HPM_COUNTER_3H   = 12'hC83,
+        CSR_HPM_COUNTER_4H   = 12'hC84,
+        CSR_HPM_COUNTER_5H   = 12'hC85,
+        CSR_HPM_COUNTER_6H   = 12'hC86,
+        CSR_HPM_COUNTER_7H   = 12'hC87,
+        CSR_HPM_COUNTER_8H   = 12'hC88,
+        CSR_HPM_COUNTER_9H   = 12'hC89,  // reserved
+        CSR_HPM_COUNTER_10H  = 12'hC8A,  // reserved
+        CSR_HPM_COUNTER_11H  = 12'hC8B,  // reserved
+        CSR_HPM_COUNTER_12H  = 12'hC8C,  // reserved
+        CSR_HPM_COUNTER_13H  = 12'hC8D,  // reserved
+        CSR_HPM_COUNTER_14H  = 12'hC8E,  // reserved
+        CSR_HPM_COUNTER_15H  = 12'hC8F,  // reserved
+        CSR_HPM_COUNTER_16H  = 12'hC90,  // reserved
         CSR_HPM_COUNTER_17H  = 12'hC91,  // reserved
         CSR_HPM_COUNTER_18H  = 12'hC92,  // reserved
         CSR_HPM_COUNTER_19H  = 12'hC93,  // reserved


### PR DESCRIPTION
`mconfigptr` became mandatory with privileged spec 1.12. It seemed easy enough to implement the bare minimum (tieing it to `0`). If this is not on the roadmap @JeanRochCoulon let me know. Also happy to add it to the CSR description file if you can point me towards it.