### PR TITLE
No hard coded gcc param

### DIFF
--- a/verif/regress/benchmark.sh
+++ b/verif/regress/benchmark.sh
@@ -37,6 +37,9 @@ GCC_COMMON_SRC=(
 
 GCC_CFLAGS=(
         -fno-tree-loop-distribute-patterns
+        -static
+        -mcmodel=medany
+        -fvisibility=hidden
         -nostdlib
         -nostartfiles
         -lgcc

--- a/verif/regress/coremark.sh
+++ b/verif/regress/coremark.sh
@@ -48,6 +48,9 @@ srcA=(
 cflags_opt=(
         -O3 -g
         -fno-tree-loop-distribute-patterns
+        -static
+        -mcmodel=medany
+        -fvisibility=hidden
         -nostdlib
         -nostartfiles
         -lgcc

--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -36,6 +36,9 @@ srcA=(
 )
 cflags=(
         -fno-tree-loop-distribute-patterns
+        -static
+        -mcmodel=medany
+        -fvisibility=hidden
         -nostdlib
         -nostartfiles
         -lgcc

--- a/verif/regress/smoke-tests.sh
+++ b/verif/regress/smoke-tests.sh
@@ -32,14 +32,14 @@ python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv64a6_imafdc_sv39
 python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml --test rv64i_m-add-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS  --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
 python3 cva6.py --testlist=../tests/testlist_custom.yaml --test custom_test_template --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
 python3 cva6.py --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c\
-  --gcc_opts "-g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld"
+  --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld"
 make -C ../.. clean
 make clean_all
 python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv32a60x.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv32a60x --iss=$DV_SIMULATORS $DV_OPTS
 python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target cv32a60x --iss=$DV_SIMULATORS $DV_OPTS
 python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv32a60x.yaml --test rv32im-cadd-01 --iss_yaml cva6.yaml --target cv32a60x --iss=$DV_SIMULATORS $DV_OPTS  --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
 python3 cva6.py --target cv32a60x --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c --linker=../tests/custom/common/test.ld\
-  --gcc_opts "-g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common"
+  --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common"
 make -C ../.. clean
 make clean_all
 

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -382,9 +382,7 @@ def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd, linker):
         logging.error("Cannot find assembly test: %s\n", asm)
         sys.exit(RET_FAIL)
       # gcc comilation
-      cmd = ("%s -static -mcmodel=medany \
-             -fvisibility=hidden -nostdlib \
-             -nostartfiles %s \
+      cmd = ("%s %s \
              -I%s/../env/corev-dv/user_extension \
              -T%s %s -o %s " % \
              (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), asm, cwd, linker, opts, elf))
@@ -444,9 +442,7 @@ def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, outp
   logging.info("Compiling assembly test : %s" % asm_test)
 
   # gcc compilation
-  cmd = ("%s -static -mcmodel=medany \
-         -fvisibility=hidden -nostdlib \
-         -nostartfiles %s \
+  cmd = ("%s %s \
          -I%s/../env/corev-dv/user_extension \
          -T%s %s -o %s " % \
          (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), asm_test, cwd, linker,
@@ -583,8 +579,7 @@ def run_c(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
   logging.info("Compiling c test : %s" % c_test)
 
   # gcc compilation
-  cmd = ("%s -mcmodel=medany -nostdlib \
-         -nostartfiles %s \
+  cmd = ("%s %s \
          -I%s/dv/user_extension \
           -T%s %s -o %s " % \
          (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), c_test, cwd,

--- a/verif/sim/cva6_base_testlist.yaml
+++ b/verif/sim/cva6_base_testlist.yaml
@@ -32,6 +32,12 @@
   description: >
     Test with different patterns of load/store instructions, stress test MMU
     operations.
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=5
@@ -52,6 +58,12 @@
   description: >
     Test with different patterns of load/store instructions, stress test MMU
     operations.
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=5
@@ -72,6 +84,12 @@
 - test: riscv_rand_jump_illegal_test
   description: >
     Jump among large number of sub-programs, stress testing iTLB operations.
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=300
     +num_of_sub_program=0
@@ -92,6 +110,12 @@
 - test: riscv_rand_jump_hint_comp_test
   description: >
     Jump among large number of sub-programs, stress testing iTLB operations.
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -109,6 +133,12 @@
 - test: riscv_rand_jump_no_cmp_test
   description: >
     Jump among large number of sub-programs, stress testing iTLB operations.
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -126,6 +156,12 @@
 - test: riscv_load_store_test
   description: >
     Unaligned load/store test
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -145,6 +181,12 @@
 - test: riscv_load_store_cmp_test
   description: >
     Unaligned load/store test
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -165,6 +207,12 @@
 - test: riscv_load_store_hazard_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -186,6 +234,12 @@
 - test: riscv_arithmetic_basic_xif_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -209,6 +263,12 @@
 - test: riscv_arithmetic_basic_xif_illegal_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -232,6 +292,12 @@
 - test: riscv_load_store_xif_test
   description: >
     Unaligned load/store test
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -253,6 +319,12 @@
 - test: riscv_rand_jump_xif_test
   description: >
     Jump among large number of sub-programs, stress testing iTLB operations.
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -271,6 +343,12 @@
 - test: riscv_arithmetic_basic_test_no_comp
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -292,6 +370,12 @@
 - test: riscv_arithmetic_basic_test_comp
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -312,6 +396,12 @@
 - test: riscv_arithmetic_basic_test_bcomp
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -332,6 +422,12 @@
 - test: riscv_arithmetic_basic_sub_prog_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=20
@@ -352,6 +448,12 @@
 - test: riscv_arithmetic_basic_illegal
   description: >
     Arithmetic instruction test, no load/store/branch instructions
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -376,6 +478,12 @@
     Unaligned load/store test
   gcc_opts: >
     -mno-strict-align
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=100
     +num_of_sub_program=0
@@ -397,6 +505,12 @@
 - test: riscv_arithmetic_basic_illegal_csr
   description: >
     Arithmetic instruction test, no load/store/branch instructions
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=5
@@ -419,6 +533,12 @@
 - test: riscv_arithmetic_basic_hint_illegal_csr
   description: >
     Arithmetic instruction test, no load/store/branch instructions
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -442,6 +562,12 @@
 - test: riscv_arithmetic_basic_illegal_hint_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -467,6 +593,12 @@
 - test: riscv_arithmetic_basic_loop_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=10
@@ -488,6 +620,12 @@
 - test: riscv_arithmetic_basic_ebreak_dret_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=500
     +num_of_sub_program=0
@@ -512,6 +650,12 @@
 - test: riscv_arithmetic_basic_same_reg_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=1000
     +num_of_sub_program=0
@@ -534,6 +678,12 @@
 - test: riscv_arithmetic_basic_hazard_rdrs1_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=1000
     +num_of_sub_program=0
@@ -556,6 +706,12 @@
 - test: riscv_arithmetic_basic_hazard_rdrs2_test
   description: >
     Arithmetic instruction test, no load/store/branch instructions no compressed
+  gcc_opts: >
+    -static
+    -mcmodel=medany
+    -fvisibility=hidden
+    -nostdlib
+    -nostartfiles
   gen_opts: >
     +instr_cnt=1000
     +num_of_sub_program=0


### PR DESCRIPTION
Currently, some GCC compilation parameters are hard-coded in CVA6.py whereas the same parameters are given in the yaml files of most tests, meaning they are given twice.

This also allows removing them easily in cases where they are not required.