### PR TITLE
Add 16 entry BHT in embedded configuration 

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,2 +1,2 @@
 cv32a6_embedded:
-  gates: 118625
+  gates: 119494

--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,2 +1,2 @@
 cv32a6_embedded:
-  gates: 119508
+  gates: 118625

--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -18,7 +18,7 @@ iterations = None
 # Will fail if the number of cycles is different from this one
 valid_cycles = {
     'dhrystone': 217900,
-    'coremark': 733510,
+    'coremark': 696571,
 }
 
 for arg in sys.argv[1:]:

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -59,7 +59,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRASDepth = 0;
   localparam CVA6ConfigBTBEntries = 0;
-  localparam CVA6ConfigBHTEntries = 0;
+  localparam CVA6ConfigBHTEntries = 16;
 
   localparam CVA6ConfigNrPMPEntries = 8;
 

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -50,7 +50,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigFPGAEn = 0;
 
-  localparam CVA6ConfigNrLoadPipeRegs = 1;
+  localparam CVA6ConfigNrLoadPipeRegs = 0;
   localparam CVA6ConfigNrStorePipeRegs = 0;
   localparam CVA6ConfigNrLoadBufEntries = 2;
 


### PR DESCRIPTION
16 entry BHT is not so costy in term of gate count, and will increase performance