### PR TITLE
[Verif] Clear MIP CSR to avoid trapping in CSR tests

### DIFF
--- a/verif/tests/custom/csr_embedded/csrcs_test.S
+++ b/verif/tests/custom/csr_embedded/csrcs_test.S
@@ -3042,6 +3042,12 @@ csrcs:
     #MIP read value
     csrr x14, 0x344
 
+    #Clear MIP to avoid traping
+    csrw 0x344, x0
+
+    #MIP read value
+    csrr x14, 0x344
+
     ##########################
     #MHPMCOUNTERH9 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'ha} 
     ##########################

--- a/verif/tests/custom/csr_embedded/csrcsi_test.S
+++ b/verif/tests/custom/csr_embedded/csrcsi_test.S
@@ -3560,6 +3560,12 @@ csrcsi:
     #MIP read value
     csrr x14, 0x344
 
+    #Clear MIP to avoid traping
+    csrw 0x344, x0
+
+    #MIP read value
+    csrr x14, 0x344
+
     ##########################
     #MHPMCOUNTERH11 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h11} 
     ##########################

--- a/verif/tests/custom/csr_embedded/csrrw_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_test.S
@@ -1350,6 +1350,12 @@ csrrw:
     #MIP read value
     csrr x14, 0x344
 
+    #Clear MIP to avoid traping
+    csrw 0x344, x0
+
+    #MIP read value
+    csrr x14, 0x344
+
     ##########################
     #MHPMCOUNTERH27 testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'h22c2d883} 
     ##########################

--- a/verif/tests/custom/csr_embedded/csrrwi_test.S
+++ b/verif/tests/custom/csr_embedded/csrrwi_test.S
@@ -3320,6 +3320,12 @@ csrrwi:
     #MIP read value
     csrr x14, 0x344
 
+    #Clear MIP to avoid traping
+    csrw 0x344, x0
+
+    #MIP read value
+    csrr x14, 0x344
+
     ##########################
     #MHPMEVENT9 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'ha} 
     ##########################


### PR DESCRIPTION
This fix the falling csr tests, after the last commit.
we should always clear MIP after write into it, to avoid raising an interrupt.
We can't add exception handler to resolve this because we write into mtvec also.