### PR TITLE
[Verif] Clear MIP CSR to avoid trapping in CSR tests (resume #1660)

### DIFF
--- a/verif/tests/custom/csr_embedded/csrrw_ro_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_ro_test.S
@@ -984,6 +984,11 @@ main:
     #MIP read value
     csrr x14, 0x344
 
+    #Clear MIP to avoid traping
+    csrw 0x344, x0
+
+    #MIP read value
+    csrr x14, 0x344
     ##########################
     #PMPADDR3 testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'hf479076} 
     ##########################


### PR DESCRIPTION
I forgot to clean the MIP, in csrrw_ro_test.S