### PR TITLE
verible-verilog-format: update to bypass verible limitations

### DIFF
--- a/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
@@ -97,9 +97,9 @@ module cva6_hpdcache_if_adapter
           cva6_req_o.data_gnt = hpdcache_req_ready_i;
     end  //  }}}
 
-         //  STORE/AMO request
          //  {{{
     else begin : store_amo_gen
+      //  STORE/AMO request
       hpdcache_req_addr_t   amo_addr;
       hpdcache_req_offset_t amo_addr_offset;
       hpdcache_tag_t        amo_tag;

--- a/core/include/std_cache_pkg.sv
+++ b/core/include/std_cache_pkg.sv
@@ -21,6 +21,7 @@ package std_cache_pkg;
   localparam DCACHE_BYTE_OFFSET = $clog2(ariane_pkg::DCACHE_LINE_WIDTH / 8);
   localparam DCACHE_NUM_WORDS = 2 ** (ariane_pkg::DCACHE_INDEX_WIDTH - DCACHE_BYTE_OFFSET);
   localparam DCACHE_DIRTY_WIDTH = ariane_pkg::DCACHE_SET_ASSOC * 2;
+  localparam DCACHE_SET_ASSOC_WIDTH = $clog2(ariane_pkg::DCACHE_SET_ASSOC);
   // localparam DECISION_BIT = 30; // bit on which to decide whether the request is cache-able or not
 
   typedef struct packed {
@@ -75,7 +76,7 @@ package std_cache_pkg;
   } cl_be_t;
 
   // convert one hot to bin for -> needed for cache replacement
-  function automatic logic [$clog2(ariane_pkg::DCACHE_SET_ASSOC)-1:0] one_hot_to_bin(
+  function automatic logic [DCACHE_SET_ASSOC_WIDTH-1:0] one_hot_to_bin(
       input logic [ariane_pkg::DCACHE_SET_ASSOC-1:0] in);
     for (int unsigned i = 0; i < ariane_pkg::DCACHE_SET_ASSOC; i++) begin
       if (in[i]) return i;


### PR DESCRIPTION
using verible-v0.0-3422-g520ca4b9/bin/verible-verilog-format
with default configuration