### PR TITLE
Code_coverage: condition RTL with the IS_XLEN64 parameter

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -341,7 +341,9 @@ module alu
         ORCB: result_o = orcbw_result;
         REV8: result_o = rev8w_result;
 
-        default: if(fu_data_i.operation == SLLIUW && riscv::IS_XLEN64) result_o = {{riscv::XLEN-32{1'b0}}, fu_data_i.operand_a[31:0]} << fu_data_i.operand_b[5:0];  // Left Shift 32 bit unsigned
+        default:
+        if (fu_data_i.operation == SLLIUW && riscv::IS_XLEN64)
+          result_o = {{riscv::XLEN-32{1'b0}}, fu_data_i.operand_a[31:0]} << fu_data_i.operand_b[5:0];  // Left Shift 32 bit unsigned
       endcase
     end
     if (CVA6Cfg.ZiCondExtEn) begin

--- a/core/alu.sv
+++ b/core/alu.sv
@@ -284,9 +284,6 @@ module alu
         endcase
       end
       unique case (fu_data_i.operation)
-        // Left Shift 32 bit unsigned
-        SLLIUW:
-        result_o = {{riscv::XLEN-32{1'b0}}, fu_data_i.operand_a[31:0]} << fu_data_i.operand_b[5:0];
         // Integer minimum/maximum
         MAX: result_o = less ? fu_data_i.operand_b : fu_data_i.operand_a;
         MAXU: result_o = less ? fu_data_i.operand_b : fu_data_i.operand_a;
@@ -323,8 +320,8 @@ module alu
         result_o = orcbw_result;
         REV8:
         result_o = rev8w_result;
-
-        default: ;  // default case to suppress unique warning
+        // Left Shift 32 bit unsigned
+        default: if(fu_data_i.operation == SLLIUW && riscv::IS_XLEN64) result_o = {{riscv::XLEN-32{1'b0}}, fu_data_i.operand_a[31:0]} << fu_data_i.operand_b[5:0];  // default case to suppress unique warning
       endcase
     end
     if (CVA6Cfg.ZiCondExtEn) begin

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -205,7 +205,10 @@ module wt_axi_adapter
               2'b10:
               axi_wr_be[0][dcache_data.paddr[$clog2(CVA6Cfg.AxiDataWidth/8)-1:0]+:4] = '1;  // word
               default:
-              if (riscv::IS_XLEN64) axi_wr_be[0][dcache_data.paddr[$clog2(CVA6Cfg.AxiDataWidth/8)-1:0]+:8] = '1;  // dword
+              if (riscv::IS_XLEN64)
+                axi_wr_be[0][dcache_data.paddr[$clog2(
+                    CVA6Cfg.AxiDataWidth/8
+                )-1:0]+:8] = '1;  // dword
             endcase
           end
           //////////////////////////////////////

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -205,7 +205,7 @@ module wt_axi_adapter
               2'b10:
               axi_wr_be[0][dcache_data.paddr[$clog2(CVA6Cfg.AxiDataWidth/8)-1:0]+:4] = '1;  // word
               default:
-              axi_wr_be[0][dcache_data.paddr[$clog2(CVA6Cfg.AxiDataWidth/8)-1:0]+:8] = '1;  // dword
+              if (riscv::IS_XLEN64) axi_wr_be[0][dcache_data.paddr[$clog2(CVA6Cfg.AxiDataWidth/8)-1:0]+:8] = '1;  // dword
             endcase
           end
           //////////////////////////////////////

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -722,7 +722,7 @@ module decoder
               end
               3'b101: begin
                 if (instr.instr[31:20] == 12'b001010000111) instruction_o.op = ariane_pkg::ORCB;
-                else if (riscv::IS_XLEN64 && (instr.instr[31:20] == 12'b011010111000 || instr.instr[31:20] == 12'b011010011000))
+                else if (instr.instr[31:20] == 12'b011010111000 || instr.instr[31:20] == 12'b011010011000)
                   instruction_o.op = ariane_pkg::REV8;
                 else if (instr.instr[31:26] == 6'b010_010) instruction_o.op = ariane_pkg::BEXTI;
                 else if (instr.instr[31:26] == 6'b011_000) instruction_o.op = ariane_pkg::RORI;

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -722,7 +722,7 @@ module decoder
               end
               3'b101: begin
                 if (instr.instr[31:20] == 12'b001010000111) instruction_o.op = ariane_pkg::ORCB;
-                else if (instr.instr[31:20] == 12'b011010111000 || instr.instr[31:20] == 12'b011010011000)
+                else if (riscv::IS_XLEN64 && (instr.instr[31:20] == 12'b011010111000 || instr.instr[31:20] == 12'b011010011000))
                   instruction_o.op = ariane_pkg::REV8;
                 else if (instr.instr[31:26] == 6'b010_010) instruction_o.op = ariane_pkg::BEXTI;
                 else if (instr.instr[31:26] == 6'b011_000) instruction_o.op = ariane_pkg::RORI;

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -107,7 +107,7 @@ module load_store_unit
   assign vaddr_xlen = $unsigned($signed(fu_data_i.imm) + $signed(fu_data_i.operand_a));
   assign vaddr_i = vaddr_xlen[riscv::VLEN-1:0];
   // we work with SV39 or SV32, so if VM is enabled, check that all bits [XLEN-1:38] or [XLEN-1:31] are equal
-  assign overflow = (riscv::IS_XLEN64 && !((&vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b1 || (|vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b0));
+  assign overflow = (riscv::IS_XLEN64 && (!((&vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b1 || (|vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b0)));
 
   logic                   st_valid_i;
   logic                   ld_valid_i;

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -107,7 +107,7 @@ module load_store_unit
   assign vaddr_xlen = $unsigned($signed(fu_data_i.imm) + $signed(fu_data_i.operand_a));
   assign vaddr_i = vaddr_xlen[riscv::VLEN-1:0];
   // we work with SV39 or SV32, so if VM is enabled, check that all bits [XLEN-1:38] or [XLEN-1:31] are equal
-  assign overflow = !((&vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b1 || (|vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b0);
+  assign overflow = (riscv::IS_XLEN64 && !((&vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b1 || (|vaddr_xlen[riscv::XLEN-1:riscv::SV-1]) == 1'b0));
 
   logic                   st_valid_i;
   logic                   ld_valid_i;
@@ -406,7 +406,7 @@ module load_store_unit
                 AMO_SWAPD, AMO_ADDD, AMO_ANDD, AMO_ORD,
                 AMO_XORD, AMO_MAXD, AMO_MAXDU, AMO_MIND,
                 AMO_MINDU: begin
-          if (lsu_ctrl.vaddr[2:0] != 3'b000) begin
+          if (riscv::IS_XLEN64 && lsu_ctrl.vaddr[2:0] != 3'b000) begin
             data_misaligned = 1'b1;
           end
         end

--- a/core/mult.sv
+++ b/core/mult.sv
@@ -89,7 +89,7 @@ module mult
     // we've go a new division operation
     if (mult_valid_i && fu_data_i.operation inside {DIV, DIVU, DIVW, DIVUW, REM, REMU, REMW, REMUW}) begin
       // is this a word operation?
-      if (fu_data_i.operation inside {DIVW, DIVUW, REMW, REMUW}) begin
+      if (riscv::IS_XLEN64 && (fu_data_i.operation inside {DIVW, DIVUW, REMW, REMUW})) begin
         // yes so check if we should sign extend this is only done for a signed operation
         if (div_signed) begin
           operand_a = sext32(fu_data_i.operand_a[31:0]);
@@ -134,7 +134,7 @@ module mult
 
   // Result multiplexer
   // if it was a signed word operation the bit will be set and the result will be sign extended accordingly
-  assign div_result = (word_op_q) ? sext32(result) : result;
+  assign div_result = (riscv::IS_XLEN64 && word_op_q) ? sext32(result) : result;
 
   // ---------------------
   // Registers

--- a/core/multiplier.sv
+++ b/core/multiplier.sv
@@ -116,12 +116,14 @@ module multiplier
   always_comb begin : p_selmux
     unique case (operator_q)
       MULH, MULHU, MULHSU: result_o = mult_result_q[riscv::XLEN*2-1:riscv::XLEN];
-      MULW:                result_o = sext32(mult_result_q[31:0]);
       CLMUL:               result_o = clmul_q;
       CLMULH:              result_o = clmulr_q >> 1;
       CLMULR:              result_o = clmulr_q;
       // MUL performs an XLEN-bit×XLEN-bit multiplication and places the lower XLEN bits in the destination register
-      default:             result_o = mult_result_q[riscv::XLEN-1:0];  // including MUL
+      default: begin
+        if (operator_q == MULW && riscv::IS_XLEN64) result_o = sext32(mult_result_q[31:0]);
+        else result_o = mult_result_q[riscv::XLEN-1:0];  // including MUL
+      end
     endcase
   end
   if (ariane_pkg::BITMANIP) begin


### PR DESCRIPTION
Condition RTL with IS_XLEN64 parameter to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to improuve code coverage.