### PR TITLE
Code_coverage: condition RTL with the AxiBurstWriteEn parameter

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -217,7 +217,8 @@ module cva6
     CVA6Cfg.CachedRegionLength,
     CVA6Cfg.MaxOutstandingStores,
     CVA6Cfg.DebugEn,
-    NonIdemPotenceEn
+    NonIdemPotenceEn,
+    CVA6Cfg.AxiBurstWriteEn
   };
 
 

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -113,6 +113,7 @@ package config_pkg;
     int unsigned                 MaxOutstandingStores;
     bit                          DebugEn;
     bit                          NonIdemPotenceEn;
+    bit                          AxiBurstWriteEn;
   } cva6_cfg_t;
 
 

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -139,7 +139,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(0),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -139,7 +139,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -139,6 +139,7 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 endpackage

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -139,7 +139,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -139,7 +139,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -138,7 +138,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -139,7 +139,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -145,7 +145,8 @@ package cva6_config_pkg;
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -139,7 +139,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -139,7 +139,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -138,6 +138,7 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0)
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
   };
 endpackage

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -210,7 +210,8 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   CachedRegionLength:    1024'({ariane_soc::DRAMLength}),
   MaxOutstandingStores:  unsigned'(7),
   DebugEn: bit'(1),
-  NonIdemPotenceEn: bit'(0)
+  NonIdemPotenceEn: bit'(0),
+  AxiBurstWriteEn: bit'(0)
 };
 
 localparam type rvfi_instr_t = logic;


### PR DESCRIPTION
Add AxiBurstWriteEn parameter to the CVA6 configuration and set it to 0 as the CVA6 does not support bursts with a length greater than 0.

Condition RTL with AxiBurstWriteEn parameter to identify the dead code and remove the dead gates from netlist.

Based on if() directives, VCS is able to identify the unused code, this will allow to improve code coverage