### PR TITLE
ci: add Verible to GitHub Actions

### DIFF
--- a/.github/workflows/verible.yml
+++ b/.github/workflows/verible.yml
@@ -1,0 +1,23 @@
+# Copyright 2023 Thales DIS
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Verible
+on:
+  pull_request_target:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: chipsalliance/verible-formatter-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'core/**/*.{v,sv}'


### PR DESCRIPTION
This workflow will add suggestions as comments to the PRs when the modified lines have formatting issues.

Source: https://github.com/chipsalliance/verible-formatter-action/tree/main#automatic-review-on-prs-from-external-repositories

Note: the `fail_on_formatting_suggestions` option seems interesting; however it is not evaluated in PR workflows so we did not enable it in this configuration.