### PR TITLE
Update version of the HPDcache submodule

### DIFF
--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -157,6 +157,11 @@ ${CVA6_REPO_DIR}/core/cache_subsystem/std_cache_subsystem.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/std_nbdcache.sv
 ${HPDCACHE_TARGET_CFG}
 -F ${HPDCACHE_DIR}/rtl/hpdcache.Flist
+${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_req_read_arbiter.sv
+${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_req_write_arbiter.sv
+${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_resp_demux.sv
+${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_to_axi_read.sv
+${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_to_axi_write.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_subsystem.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_if_adapter.sv

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -144,6 +144,7 @@ package cva6_config_pkg;
       ),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
+      MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
       NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -61,7 +61,7 @@ package hpdcache_params_pkg;
 
   //  Definition of constants and types for HPDcache data memory
   //  {{{
-  localparam int unsigned PARAM_DATA_WAYS_PER_RAM_WORD = 128/PARAM_WORD_WIDTH;
+  localparam int unsigned PARAM_DATA_WAYS_PER_RAM_WORD = 128 / PARAM_WORD_WIDTH;
   localparam int unsigned PARAM_DATA_SETS_PER_RAM = PARAM_SETS;
 
   //  HPDcache DATA RAM macros whether implements:

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -27,9 +27,11 @@ package hpdcache_params_pkg;
 
   //  Definition of constants used only in this file
   //  {{{
-  localparam int unsigned __BYTES_PER_WAY = CVA6ConfigDcacheByteSize / CVA6ConfigDcacheSetAssoc;
+  localparam int unsigned __BYTES_PER_WAY =
+      CVA6ConfigDcacheByteSize/CVA6ConfigDcacheSetAssoc;
 
-  localparam int unsigned __BYTES_PER_CACHELINE = CVA6ConfigDcacheLineWidth / 8;
+  localparam int unsigned __BYTES_PER_CACHELINE =
+      CVA6ConfigDcacheLineWidth/8;
   //  }}}
 
   //  Definition of global constants for the HPDcache data and directory
@@ -38,7 +40,7 @@ package hpdcache_params_pkg;
   localparam int unsigned PARAM_PA_WIDTH = riscv::PLEN;
 
   //  HPDcache number of sets
-  localparam int unsigned PARAM_SETS = __BYTES_PER_WAY / __BYTES_PER_CACHELINE;
+  localparam int unsigned PARAM_SETS = __BYTES_PER_WAY/__BYTES_PER_CACHELINE;
 
   //  HPDcache number of ways
   localparam int unsigned PARAM_WAYS = CVA6ConfigDcacheSetAssoc;
@@ -47,7 +49,7 @@ package hpdcache_params_pkg;
   localparam int unsigned PARAM_WORD_WIDTH = CVA6ConfigXlen;
 
   //  HPDcache cache-line width (bits)
-  localparam int unsigned PARAM_CL_WORDS = CVA6ConfigDcacheLineWidth / PARAM_WORD_WIDTH;
+  localparam int unsigned PARAM_CL_WORDS = CVA6ConfigDcacheLineWidth/PARAM_WORD_WIDTH;
 
   //  HPDcache number of words in the request data channels (request and response)
   localparam int unsigned PARAM_REQ_WORDS = 1;
@@ -61,7 +63,7 @@ package hpdcache_params_pkg;
 
   //  Definition of constants and types for HPDcache data memory
   //  {{{
-  localparam int unsigned PARAM_DATA_WAYS_PER_RAM_WORD = 128 / PARAM_WORD_WIDTH;
+  localparam int unsigned PARAM_DATA_WAYS_PER_RAM_WORD = 128/PARAM_WORD_WIDTH;
   localparam int unsigned PARAM_DATA_SETS_PER_RAM = PARAM_SETS;
 
   //  HPDcache DATA RAM macros whether implements:
@@ -73,7 +75,7 @@ package hpdcache_params_pkg;
   //  simultaneously from the cache.
   //  -  This limits the maximum width for the data channel from requesters
   //  -  This impacts the refill latency (more ACCESS_WORDS -> less REFILL LATENCY)
-  localparam int unsigned PARAM_ACCESS_WORDS = PARAM_CL_WORDS / 2;
+  localparam int unsigned PARAM_ACCESS_WORDS = PARAM_CL_WORDS/2;
   //  }}}
 
   //  Definition of constants and types for the Miss Status Holding Register (MSHR)
@@ -96,7 +98,8 @@ package hpdcache_params_pkg;
   localparam bit PARAM_MSHR_RAM_WBYTEENABLE = 1'b1;
 
   //  HPDcache MSHR whether uses FFs or SRAM
-  localparam bit PARAM_MSHR_USE_REGBANK = (PARAM_MSHR_SETS * PARAM_MSHR_WAYS) <= 16;
+  localparam bit PARAM_MSHR_USE_REGBANK = (PARAM_MSHR_SETS*PARAM_MSHR_WAYS) <= 16;
+  localparam bit PARAM_REFILL_CORE_RSP_FEEDTHROUGH = 1'b1;
   //  }}}
 
   //  Definition of constants and types for the Write Buffer (WBUF)
@@ -112,6 +115,7 @@ package hpdcache_params_pkg;
 
   //  HPDcache Write-Buffer threshold counter width (in bits)
   localparam int unsigned PARAM_WBUF_TIMECNT_WIDTH = 3;
+  localparam bit PARAM_WBUF_SEND_FEEDTHROUGH = 1'b0;
   //  }}}
 
   //  Definition of constants and types for the Replay Table (RTAB)

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -39,7 +39,7 @@ package hpdcache_params_pkg;
   localparam int unsigned PARAM_PA_WIDTH = riscv::PLEN;
 
   //  HPDcache number of sets
-  localparam int unsigned PARAM_SETS = __BYTES_PER_WAY/__BYTES_PER_CACHELINE;
+  localparam int unsigned PARAM_SETS = __BYTES_PER_WAY / __BYTES_PER_CACHELINE;
 
   //  HPDcache number of ways
   localparam int unsigned PARAM_WAYS = CVA6ConfigDcacheSetAssoc;

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -96,7 +96,7 @@ package hpdcache_params_pkg;
   localparam bit PARAM_MSHR_RAM_WBYTEENABLE = 1'b1;
 
   //  HPDcache MSHR whether uses FFs or SRAM
-  localparam bit PARAM_MSHR_USE_REGBANK = (PARAM_MSHR_SETS*PARAM_MSHR_WAYS) <= 16;
+  localparam bit PARAM_MSHR_USE_REGBANK = (PARAM_MSHR_SETS * PARAM_MSHR_WAYS) <= 16;
   localparam bit PARAM_REFILL_CORE_RSP_FEEDTHROUGH = 1'b1;
   //  }}}
 

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -47,7 +47,7 @@ package hpdcache_params_pkg;
   localparam int unsigned PARAM_WORD_WIDTH = CVA6ConfigXlen;
 
   //  HPDcache cache-line width (bits)
-  localparam int unsigned PARAM_CL_WORDS = CVA6ConfigDcacheLineWidth/PARAM_WORD_WIDTH;
+  localparam int unsigned PARAM_CL_WORDS = CVA6ConfigDcacheLineWidth / PARAM_WORD_WIDTH;
 
   //  HPDcache number of words in the request data channels (request and response)
   localparam int unsigned PARAM_REQ_WORDS = 1;

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -73,7 +73,7 @@ package hpdcache_params_pkg;
   //  simultaneously from the cache.
   //  -  This limits the maximum width for the data channel from requesters
   //  -  This impacts the refill latency (more ACCESS_WORDS -> less REFILL LATENCY)
-  localparam int unsigned PARAM_ACCESS_WORDS = PARAM_CL_WORDS/2;
+  localparam int unsigned PARAM_ACCESS_WORDS = PARAM_CL_WORDS / 2;
   //  }}}
 
   //  Definition of constants and types for the Miss Status Holding Register (MSHR)

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -27,8 +27,7 @@ package hpdcache_params_pkg;
 
   //  Definition of constants used only in this file
   //  {{{
-  localparam int unsigned __BYTES_PER_WAY =
-      CVA6ConfigDcacheByteSize/CVA6ConfigDcacheSetAssoc;
+  localparam int unsigned __BYTES_PER_WAY = CVA6ConfigDcacheByteSize / CVA6ConfigDcacheSetAssoc;
 
   localparam int unsigned __BYTES_PER_CACHELINE =
       CVA6ConfigDcacheLineWidth/8;

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -29,8 +29,7 @@ package hpdcache_params_pkg;
   //  {{{
   localparam int unsigned __BYTES_PER_WAY = CVA6ConfigDcacheByteSize / CVA6ConfigDcacheSetAssoc;
 
-  localparam int unsigned __BYTES_PER_CACHELINE =
-      CVA6ConfigDcacheLineWidth/8;
+  localparam int unsigned __BYTES_PER_CACHELINE = CVA6ConfigDcacheLineWidth / 8;
   //  }}}
 
   //  Definition of global constants for the HPDcache data and directory


### PR DESCRIPTION
- Update the reference of the HPDcache's submodule.
- Update CVA6 and HPDcache configuration packages to add recently introduced parameters.