### PR TITLE
Replacing KDT with Chips JU logo

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -3,10 +3,10 @@
 Thanks to Gian Marti, Thomas Kramer and Thomas E. Benz for implementing the PLIC.
 
 Some contributions to CVA6 are supported by the FRACTAL, TRISTAN and ISOLDE projects,
-which have received funding from the Key Digital Technologies Joint Undertaking (KDT JU),
+which have received funding from the Chips Joint Undertaking (Chips JU),
 Austria, Belgium, Czechia, Finland, France, Germany, Italy, the Netherlands, Poland, Romania, Sweden, Switzerland, Spain and Turkey
 under grant agreements 877056, 101095947 and 101112274.
 The JU receives support from the European Union’s Horizon Europe research and innovation program.
 
-![EU Logo](https://github.com/openhwgroup/tristan-unified-access-page/blob/main/images/logo_EU.png)
-![KDT Logo](https://github.com/openhwgroup/tristan-unified-access-page/blob/main/images/logo_KDT_JU.png)   
+![EU Logo](https://github.com/openhwgroup/tristan-unified-access-page/blob/main/images/logo_EU.png)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+![ChipsJU Logo](https://github.com/openhwgroup/tristan-unified-access-page/blob/main/images/logo_chipsJU.png)   


### PR DESCRIPTION
We've just received the "official" notification that KDT JU has become Chips JU. Hence, acknowledgements need an update.