### PR TITLE
Updated user manual to address several configuration (first pass)

### DIFF
--- a/docs/01_cva6_user/AXI_Interface.rst
+++ b/docs/01_cva6_user/AXI_Interface.rst
@@ -13,68 +13,75 @@ AXI
 
 Introduction
 ------------
-   In this chapter, we describe in detail the restriction that apply to the supported features.
+In this chapter, we describe in detail the restriction that apply to the supported features.
 
-   In order to understand how the AXI memory interface behaves in CVA6, it is necessary to read the AMBA AXI and ACE Protocol Specification (https://developer.arm.com/documentation/ihi0022/hc) and this chapter.
+In order to understand how the AXI memory interface behaves in CVA6, it is necessary to read the AMBA AXI and ACE Protocol Specification (https://developer.arm.com/documentation/ihi0022/hc) and this chapter.
 
+*Applicability of this chapter to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60X", "AXI included"
+   "CV32E6?X", "AXI included"
 
 About the AXI4 protocol
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-   The AMBA AXI protocol supports high-performance, high-frequency system designs for communication between Manager and Subordinate components.
+The AMBA AXI protocol supports high-performance, high-frequency system designs for communication between Manager and Subordinate components.
 
-   The AXI protocol features are:
+The AXI protocol features are:
 
-     * It is suitable for high-bandwidth and low-latency designs.
-     * High-frequency operation is provided, without using complex bridges.
-     * The protocol meets the interface requirements of a wide range of components.
-     * It is suitable for memory controllers with high initial access latency.
-     * Flexibility in the implementation of interconnect architectures is provided.
-     * It is backward-compatible with AHB and APB interfaces.
+* It is suitable for high-bandwidth and low-latency designs.
+* High-frequency operation is provided, without using complex bridges.
+* The protocol meets the interface requirements of a wide range of components.
+* It is suitable for memory controllers with high initial access latency.
+* Flexibility in the implementation of interconnect architectures is provided.
+* It is backward-compatible with AHB and APB interfaces.
 
-   The key features of the AXI protocol are:
+The key features of the AXI protocol are:
 
-     * Separate address/control and data phases.
-     * Support for unaligned data transfers, using byte strobes.
-     * Uses burst-based transactions with only the start address issued.
-     * Separate read and write data channels, that can provide low-cost Direct Memory Access (DMA).
-     * Support for issuing multiple outstanding addresses.
-     * Support for out-of-order transaction completion.
-     * Permits easy addition of register stages to provide timing closure.
+* Separate address/control and data phases.
+* Support for unaligned data transfers, using byte strobes.
+* Uses burst-based transactions with only the start address issued.
+* Separate read and write data channels, that can provide low-cost Direct Memory Access (DMA).
+* Support for issuing multiple outstanding addresses.
+* Support for out-of-order transaction completion.
+* Permits easy addition of register stages to provide timing closure.
 
-   The present specification is based on :
-
-      https://developer.arm.com/documentation/ihi0022/hc
+The present specification is based on: https://developer.arm.com/documentation/ihi0022/hc
 
 
 AXI4 and CVA6
 ~~~~~~~~~~~~~
 
-   The AXI bus protocol is used with the CVA6 processor as a memory interface. Since the processor is the one that initiates the connection with the memory, it will have a manager interface to send requests to the subordinate, which will be the memory.
+The AXI bus protocol is used with the CVA6 processor as a memory interface. Since the processor is the one that initiates the connection with the memory, it will have a manager interface to send requests to the subordinate, which will be the memory.
 
-   Features supported by CVA6 are the ones in the AMBA AXI4 specification and the Atomic Operation feature from AXI5. With restriction that apply to some features.
+Features supported by CVA6 are the ones in the AMBA AXI4 specification and the Atomic Operation feature from AXI5. With restriction that apply to some features.
 
-   This doesn’t mean that all the full set of signals available on an AXI interface are supported by the CVA6. Nevertheless, all required AXI signals are implemented.
+This doesn’t mean that all the full set of signals available on an AXI interface are supported by the CVA6. Nevertheless, all required AXI signals are implemented.
 
-   Supported AXI4 features are defined in AXI Protocol Specification sections: A3, A4, A5, A6 and A7.
+Supported AXI4 features are defined in AXI Protocol Specification sections: A3, A4, A5, A6 and A7.
 
-   Supported AXI5 feature are defined in AXI Protocol Specification section: E1.1.
+Supported AXI5 feature are defined in AXI Protocol Specification section: E1.1.
 
 
 Signal Description (Section A2)
 -------------------------------
 
-   This section introduces the AXI memory interface signals of CVA6. Most of the signals are supported by CVA6, the tables summarizing the signals identify the exceptions.
+This section introduces the AXI memory interface signals of CVA6. Most of the signals are supported by CVA6, the tables summarizing the signals identify the exceptions.
 
-   In the following tables, the *Src* column tells whether the signal is driven by Manager ou Subordinate.
+In the following tables, the *Src* column tells whether the signal is driven by Manager ou Subordinate.
 
-   The AXI required and optional signals, and the default signals values that apply when an optional signal is not implemented are defined in AXI Protocol Specification section A9.3.
+The AXI required and optional signals, and the default signals values that apply when an optional signal is not implemented are defined in AXI Protocol Specification section A9.3.
 
 
 Global signals (Section A2.1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Table 2.1 shows the global AXI memory interface signals.
+Table 2.1 shows the global AXI memory interface signals.
 
 
 .. list-table::
@@ -96,7 +103,7 @@ Global signals (Section A2.1)
 Write address channel signals (Section A2.2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Table 2.2 shows the AXI memory interface write address channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
+Table 2.2 shows the AXI memory interface write address channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
 
 
 .. list-table::
@@ -201,7 +208,7 @@ Write address channel signals (Section A2.2)
 Write data channel signals (Section A2.3)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Table 2.3 shows the AXI write data channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
+Table 2.3 shows the AXI write data channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
 
 .. list-table::
    :widths: 15 15 15 40
@@ -254,7 +261,7 @@ Write data channel signals (Section A2.3)
 Write Response Channel signals (Section A2.4)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Table 2.4 shows the AXI write response channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
+Table 2.4 shows the AXI write response channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
 
 
 .. list-table::
@@ -299,7 +306,7 @@ Write Response Channel signals (Section A2.4)
 Read address channel signals (Section A2.5)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Table 2.5 shows the AXI read address channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
+Table 2.5 shows the AXI read address channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
 
 
 .. list-table::
@@ -399,7 +406,7 @@ Read address channel signals (Section A2.5)
 Read data channel signals (Section A2.6)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Table 2.6 shows the AXI read data channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
+Table 2.6 shows the AXI read data channel signals. Unless the description indicates otherwise, a signal can take any parameter if is supported.
 
 
 .. list-table::
@@ -446,12 +453,9 @@ Read data channel signals (Section A2.6)
 
 Single Interface Requirements: Transaction structure (Section A3.4)
 -------------------------------------------------------------------
-|
 
 This section describes the structure of transactions. The following sections define the address, data, and response
 structures
-
-|
 
 .. _address_structure_label:
 
@@ -462,44 +466,41 @@ The AXI protocol is burst-based. The Manager begins each burst by driving contro
 
 **Burst length**
 
-   The burst length is specified by:
+The burst length is specified by:
 
-   • **ARLEN[7:0]**, for read transfers
-   • **AWLEN[7:0]**, for write transfers
+* ``ARLEN[7:0]``, for read transfers
+* ``AWLEN[7:0]``, for write transfers
 
-   The burst length for AXI4 is defined as:
+The burst length for AXI4 is defined as: ``Burst_Length = AxLEN[3:0] + 1``.
 
-      ``Burst_Length = AxLEN[3:0] + 1``
+CVA6 has some limitation governing the use of bursts:
 
-   CVA6 has some limitation governing the use of bursts:
-
-   * *All read transactions performed by CVA6 are of burst length equal to 0, ICACHE_LINE_WIDTH/64 or DCACHE_LINE_WIDTH/64.*
-   * *All write transactions performed by CVA6 are of burst length equal to 1.*
+* *All read transactions performed by CVA6 are of burst length equal to 0, ICACHE_LINE_WIDTH/64 or DCACHE_LINE_WIDTH/64.*
+* *All write transactions performed by CVA6 are of burst length equal to 1.*
 
 **Burst size**
 
-   The maximum number of bytes to transfer in each data transfer, or beat, in a burst, is specified by:
+The maximum number of bytes to transfer in each data transfer, or beat, in a burst, is specified by:
 
-   * **ARSIZE[2:0]**, for read transfers
-   * **AWSIZE[2:0]**, for write transfers
+* ``ARSIZE[2:0]``, for read transfers
+* ``AWSIZE[2:0]``, for write transfers
 
-   *The maximum value can be taking by AXSIZE is log2(AXI DATA WIDTH/8) (8 bytes by transfer).*
-
+*The maximum value can be taking by AXSIZE is log2(AXI DATA WIDTH/8) (8 bytes by transfer).*
 
 **Burst type**
 
-   The AXI protocol defines three burst types:
+The AXI protocol defines three burst types:
 
-   * **FIXED**
-   * **INCR**
-   * **WRAP**
+* **FIXED**
+* **INCR**
+* **WRAP**
 
-   The burst type is specified by:
+The burst type is specified by:
 
-   * **ARBURST[1:0]**, for read transfers
-   * **AWBURST[1:0]**, for write transfers
+* ``ARBURST[1:0]``, for read transfers
+* ``AWBURST[1:0]``, for write transfers
 
-   *All transactions performed by CVA6 are of burst type INCR. (AXBURST = 0b01)*
+*All transactions performed by CVA6 are of burst type INCR. (AXBURST = 0b01)*
 
 
 .. _data_read_and_write_structure_label:
@@ -508,22 +509,22 @@ Data read and write structure: (Section A3.4.4)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Write strobes**
 
-   The WSTRB[n:0] signals when HIGH, specify the byte lanes of the data bus that contain valid information. There is one write strobe
-   for each 8 bits of the write data bus, therefore WSTRB[n] corresponds to WDATA[(8n)+7: (8n)].
+The ``WSTRB[n:0]`` signals when HIGH, specify the byte lanes of the data bus that contain valid information. There is one write strobe
+for each 8 bits of the write data bus, therefore ``WSTRB[n]`` corresponds to ``WDATA[(8n)+7: (8n)]``.
 
-   *Write Strobe width is equal to (AXI_DATA_WIDTH/8)  (n = (AXI_DATA_WIDTH/8)-1).*
+*Write Strobe width is equal to (AXI_DATA_WIDTH/8)  (n = (AXI_DATA_WIDTH/8)-1).*
 
-   *The size of all transactions performed by cva6 is equal to the number of byte lanes of the data bus containing valid information.*
-   *This means 1, 2, 4, ... or (AXI_DATA_WIDTH/8) byte lanes containing valid information.*
+*The size of all transactions performed by cva6 is equal to the number of byte lanes of the data bus containing valid information.*
+*This means 1, 2, 4, ... or (AXI_DATA_WIDTH/8) byte lanes containing valid information.*
 
 
 **Unaligned transfers**
 
-   For any burst that is made up of data transfers wider than 1 byte, the first bytes accessed might be unaligned with the natural
-   address boundary. For example, a 32-bit data packet that starts at a byte address of 0x1002 is not aligned to the natural 32-bit
-   transfer size.
+For any burst that is made up of data transfers wider than 1 byte, the first bytes accessed might be unaligned with the natural
+address boundary. For example, a 32-bit data packet that starts at a byte address of 0x1002 is not aligned to the natural 32-bit
+transfer size.
 
-   *CVA6 does not perform Unaligned transfers.*
+*CVA6 does not perform Unaligned transfers.*
 
 
 .. _read_and_write_response_structure_label:
@@ -531,26 +532,26 @@ Data read and write structure: (Section A3.4.4)
 Read and write response structure (Section A3.4.5)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   The AXI protocol provides response signaling for both read and write transactions:
+The AXI protocol provides response signaling for both read and write transactions:
 
-   * For read transactions, the response information from the Subordinate is signaled on the read data channel.
-   * For write transactions, the response information is signaled on the write response channel.
+* For read transactions, the response information from the Subordinate is signaled on the read data channel.
+* For write transactions, the response information is signaled on the write response channel.
 
-   *CVA6 does not consider the responses sent by the memory except in the exclusive Access ( XRESP[1:0] = 0b01 ).*
+CVA6 does not consider the responses sent by the memory except in the exclusive Access ( ``XRESP[1:0]`` = 0b01 ).
 
 Transaction Attributes: Memory types (Section A4)
 --------------------------------------------------
 
-   This section describes the attributes that determine how a transaction should be treated by the AXI subordinate that is connected to the CVA6.
+This section describes the attributes that determine how a transaction should be treated by the AXI subordinate that is connected to the CVA6.
 
-   *AXCACHE always take 0b0010. The subordinate should be a Normal Non-cacheable Non-bufferable.*
+``AXCACHE`` always takeq 0b0010. The subordinate should be a Normal Non-cacheable Non-bufferable.
 
-   The required behavior for Normal Non-cacheable Non-bufferable memory is:
+The required behavior for Normal Non-cacheable Non-bufferable memory is:
 
-   * The write response must be obtained from the final destination.
-   * Read data must be obtained from the final destination.
-   * Transactions are modifiable.
-   * Writes can be merged.
+* The write response must be obtained from the final destination.
+* Read data must be obtained from the final destination.
+* Transactions are modifiable.
+* Writes can be merged.
 
 
 .. _transaction_identifiers_label:
@@ -558,15 +559,13 @@ Transaction Attributes: Memory types (Section A4)
 Transaction Identifiers (Section A5)
 -------------------------------------
 
-   The AXI protocol includes AXI ID transaction identifiers. A Manager can use these to identify separate transactions that must be returned in order.
+The AXI protocol includes AXI ID transaction identifiers. A Manager can use these to identify separate transactions that must be returned in order.
 
-   The CVA6 identify each type of transaction with a specific ID
+The CVA6 identify each type of transaction with a specific ID:
 
-      *For read transaction id can be 0 or 1.*
-
-      *For write transaction id = 1.*
-
-      *For Atomic operation id = 3. This ID must be sent in the write channels and also in the read channel if the transaction performed requires response data.*
+* For read transaction id can be 0 or 1.
+* For write transaction id = 1.
+* For Atomic operation id = 3. This ID must be sent in the write channels and also in the read channel if the transaction performed requires response data.
 
 AXI Ordering Model (Section A6)
 -------------------------------
@@ -575,68 +574,68 @@ AXI ordering model overview (Section A6.1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-   The AXI ordering model is based on the use of the transaction identifier, which is signaled on ARID or AWID.
+The AXI ordering model is based on the use of the transaction identifier, which is signaled on ``ARID`` or ``AWID``.
 
-   Transaction requests on the same channel, with the same ID and destination are guaranteed to remain in order.
+Transaction requests on the same channel, with the same ID and destination are guaranteed to remain in order.
 
-   Transaction responses with the same ID are returned in the same order as the requests were issued.
+Transaction responses with the same ID are returned in the same order as the requests were issued.
 
-   Write transaction requests, with the same destination are guaranteed to remain in order. Because all write transaction performed by CVA6 have the same ID.
+Write transaction requests, with the same destination are guaranteed to remain in order. Because all write transaction performed by CVA6 have the same ID.
 
-   CVA6 can perform multiple outstanding write address transactions.
+CVA6 can perform multiple outstanding write address transactions.
 
-   CVA6 cannot perform a Read transaction and a Write one at the same time. Therefore there no ordering problems between Read and write transactions.
+CVA6 cannot perform a Read transaction and a Write one at the same time. Therefore there no ordering problems between Read and write transactions.
 
 
-   The ordering model does not give any ordering guarantees between:
+The ordering model does not give any ordering guarantees between:
 
-   * Transactions from different Managers
-   * Read Transactions with different IDs
-   * Transactions to different Memory locations
+* Transactions from different Managers
+* Read Transactions with different IDs
+* Transactions to different Memory locations
 
-   If the CVA6 requires ordering between transactions that have no ordering guarantee, the Manager must wait to receive a response to the first transaction before issuing the second transaction.
+If the CVA6 requires ordering between transactions that have no ordering guarantee, the Manager must wait to receive a response to the first transaction before issuing the second transaction.
 
 
 Memory locations and Peripheral regions (Section A6.2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   The address map in AMBA is made up of Memory locations and Peripheral regions. But the AXI is associated to the memory interface of CVA6.
+The address map in AMBA is made up of Memory locations and Peripheral regions. But the AXI is associated to the memory interface of CVA6.
 
-   A Memory location has all of the following properties:
+A Memory location has all of the following properties:
 
-   * A read of a byte from a Memory location returns the last value that was written to that byte location.
-   * A write to a byte of a Memory location updates the value at that location to a new value that is obtained by a subsequent read of that location.
-   * Reading or writing to a Memory location has no side-effects on any other Memory location.
-   * Observation guarantees for Memory are given for each location.
-   * The size of a Memory location is equal to the single-copy atomicity size for that component.
+* A read of a byte from a Memory location returns the last value that was written to that byte location.
+* A write to a byte of a Memory location updates the value at that location to a new value that is obtained by a subsequent read of that location.
+* Reading or writing to a Memory location has no side-effects on any other Memory location.
+* Observation guarantees for Memory are given for each location.
+* The size of a Memory location is equal to the single-copy atomicity size for that component.
 
 
 Transactions and ordering (Section A6.3)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   A transaction is a read or a write to one or more address locations. The locations are determined by AxADDR and any relevant qualifiers such as the Non-secure bit in AxPROT.
+A transaction is a read or a write to one or more address locations. The locations are determined by AxADDR and any relevant qualifiers such as the Non-secure bit in ``AxPROT``.
 
-   * Ordering guarantees are given only between accesses to the same Memory location or Peripheral region.
-   * A transaction to a Peripheral region must be entirely contained within that region.
-   * A transaction that spans multiple Memory locations has multiple ordering guarantees.
+* Ordering guarantees are given only between accesses to the same Memory location or Peripheral region.
+* A transaction to a Peripheral region must be entirely contained within that region.
+* A transaction that spans multiple Memory locations has multiple ordering guarantees.
 
-   *Transaction performed by CVA6 is of type Normal. Because AxCACHE[1] is asserted.*
+Transaction performed by CVA6 is of type Normal, because ``AxCACHE[1]`` is asserted.
 
-   Normal transactions are used to access Memory locations and are not expected to be used to access Peripheral regions.
+Normal transactions are used to access Memory locations and are not expected to be used to access Peripheral regions.
 
-   A Normal access to a Peripheral region must complete in a protocol-compliant manner, but the result is IMPLEMENTATION DEFINED.
+A Normal access to a Peripheral region must complete in a protocol-compliant manner, but the result is IMPLEMENTATION DEFINED.
 
-   *A write transaction performed by CVA6 is Non-bufferable (It is not possible to send an early response before the transaction reach the final destination). Because AxCACHE[0] deasserted.*
+A write transaction performed by CVA6 is Non-bufferable (It is not possible to send an early response before the transaction reach the final destination), because ``AxCACHE[0]`` is deasserted.
 
 Ordered write observation (Section A6.8)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   To improve compatibility with interface protocols that support a different ordering model, a Subordinate interface can give stronger ordering guarantees for write transactions. A stronger ordering guarantee is known as Ordered Write Observation.
+To improve compatibility with interface protocols that support a different ordering model, a Subordinate interface can give stronger ordering guarantees for write transactions. A stronger ordering guarantee is known as Ordered Write Observation.
 
-   *The CVA6 AXI interface exhibits Ordered Write Observation, so the Ordered_Write_Observation property is True.*
+*The CVA6 AXI interface exhibits Ordered Write Observation, so the Ordered_Write_Observation property is True.*
 
-   An interface that exhibits Ordered Write Observation gives guarantees for write transactions that are not dependent on the destination or address:
+An interface that exhibits Ordered Write Observation gives guarantees for write transactions that are not dependent on the destination or address:
 
-   * A write W1 is guaranteed to be observed by a write W2, where W2 is issued after W1, from the same Manager, with the same ID.
+* A write W1 is guaranteed to be observed by a write W2, where W2 is issued after W1, from the same Manager, with the same ID.
 
 
 .. _atomic_transactions_label:
@@ -644,10 +643,10 @@ Ordered write observation (Section A6.8)
 Atomic transactions (Section E1.1)
 -----------------------------------
 
-   AMBA 5 introduces Atomic transactions, which perform more than just a single access and have an operation that is associated with the transaction. Atomic transactions enable sending the operation to the data, permitting the operation to be performed closer to where the data is located. Atomic transactions are suited to situations where the data is located a significant distance from the agent that must perform the operation.
+AMBA 5 introduces Atomic transactions, which perform more than just a single access and have an operation that is associated with the transaction. Atomic transactions enable sending the operation to the data, permitting the operation to be performed closer to where the data is located. Atomic transactions are suited to situations where the data is located a significant distance from the agent that must perform the operation.
 
-   *CVA6 support just the AtomicLoad and AtomicSwap transaction. So AWATOP[5:4] can be 00, 10 or 11*
+CVA6 supports just the AtomicLoad and AtomicSwap transaction. So ``AWATOP[5:4]`` can be 00, 10 or 11.
 
-   *CVA6 perform only little-endian operation. So AWATOP[3] = 0*
+CVA6 performs only little-endian operation. So ``AWATOP[3]`` = 0.
 
-   *For AtomicLoad, CVA6 support all arithmetic operations encoded on the lower-order AWATOP[2:0] signals*
+For AtomicLoad, CVA6 supports all arithmetic operations encoded on the lower-order ``AWATOP[2:0]`` signals.

--- a/docs/01_cva6_user/CSR_Cache_Control.rst
+++ b/docs/01_cva6_user/CSR_Cache_Control.rst
@@ -18,6 +18,8 @@
 
 .. _cva6_csr_cache_control:
 
+The team is looking for contributors for this chapter.
+
 CSR cache control
 =================
 Which cache controls are available to the user, what they do, how to use them.

--- a/docs/01_cva6_user/CVA6_user_guide.rst
+++ b/docs/01_cva6_user/CVA6_user_guide.rst
@@ -20,9 +20,9 @@
 
 OpenHW Group CVA6 User Manual
 =============================
-This is a template for the CVA6 user guide.
+This is the user guide of the CVA6 family and its verified configurations.
 
 Changelog
 ---------
-We start filling in the Changelog after the first “official” release of the user manual, at the end of step 2.
+We will start filling in the Changelog after the first “official” release of a CVA6 configuration. In the meantime, GitHub history will prevail.
 

--- a/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
+++ b/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
@@ -24,6 +24,17 @@ CV-X-IF Interface and Coprocessor
 The CV-X-IF interface of CVA6 allows to extend its supported instruction set
 with external coprocessors.
 
+*Applicability of this chapter to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60X", "CV-X-IF included"
+   "CV32E6?X", "CV-X-IF included"
+
+
 CV-X-IF interface specification
 -------------------------------
 

--- a/docs/01_cva6_user/Compiler_Command_Lines.rst
+++ b/docs/01_cva6_user/Compiler_Command_Lines.rst
@@ -18,8 +18,11 @@
 
 .. _cva6_compiler_command_lines:
 
+*The team is looking for contributors for this chapter.*
+
 Compiler command lines
 ======================
 Add GCC and LLVM command lines, compiler versions, options that work well with CVA6.
+
 Going further to fine tune the compiler options for performance, benchmarking, code density is not the scope here and would call for a white paper.
 

--- a/docs/01_cva6_user/Core_Integration.rst
+++ b/docs/01_cva6_user/Core_Integration.rst
@@ -18,16 +18,19 @@
 
 .. _cva6_core_integration:
 
+*The team is looking for contributors for this chapter.*
+
 Core Integration
 ================
 
 RTL Integration
 ---------------
+Suggested content:
+
 How to integrate CVA6 into a core complex/SoC
-Instantiation template
-As in https://docs.openhwgroup.org/projects/cv32e40p-user-manual/integration.html#instantiation-template
-Specific constructs
+Instantiation template as in https://docs.openhwgroup.org/projects/cv32e40p-user-manual/integration.html#instantiation-template
 Do we have specific constructs that we should mention for the implementation team:
+
 * Non-reset signals, if any
 * Internally controlled asynchronous reset (“SW reset”), if any
 * Multi-cycle paths
@@ -35,19 +38,17 @@ Do we have specific constructs that we should mention for the implementation tea
 
 ASIC Specific Guidelines
 ------------------------
-
 Suggested content:
-~~~~~~~~~~~~~~~~~~
+
 * How to handle the RAM cells for DFT.
 * Typical critical paths in ASIC and suggestions for optimizations (e.g. suggestions for places where to apply regioning/partitioning…)
 * We can also have typical command lines / settings for various ASIC tools
 
 FPGA specific guidelines
 ------------------------
-Desired for step1 (we expect prototyping at this stage).
+Also needed for prototyping of ASICs
 
 Suggested content:
-~~~~~~~~~~~~~~~~~~
+
 * Typical critical paths in FPGA and suggestions for optimizations
 * We can also have typical command lines / settings for various FPGA tools
-

--- a/docs/01_cva6_user/Custom_Instructions.rst
+++ b/docs/01_cva6_user/Custom_Instructions.rst
@@ -18,6 +18,8 @@
 
 .. _cva6_custom_instructions:
 
+*This chapter is applicable to all configurations.*
+
 Custom RISC-V instructions
 ==========================
 As of now, CVA6 does not implement custom RISC-V instructions.

--- a/docs/01_cva6_user/Interfaces.rst
+++ b/docs/01_cva6_user/Interfaces.rst
@@ -23,27 +23,57 @@ Interfaces
 
 AXI Interface
 -------------
-Need for step1 verification. Already written by MU Electronics.
-Focus on the features used by the CVA6 and refer to ARM documentation for the AXI specification (e.g. do not draw the standard chronogram).
-Features:
-* See requirement specification
-* Atomic transactions
-* “USER” bus width extension
-* Transaction ordering
+The AXI interface is described in a separate chapter.
+
+*Applicability to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60X", "AXI implemented"
+   "CV32E6?X", "AXI implemented"
 
 Debug Interface
 ---------------
-Desired for step1 verification, but we can likely reuse an E4 DVplan.
-Remember: the debug module (DTM) is not in the scope, so we focus on the debug interrupt.
-How to use the interface (HW/SW). We can refer to RISC-V specifications.
-If the section is too heavy, promote it to a separate chapter.
+  The team is looking for a contributor for this section.
+  We can likely reuse an E4 DVplan.
+  Remember: the debug module (DTM) is not in the scope, so we focus on the debug interrupt.
+  How to use the interface (HW/SW). We can refer to RISC-V specifications.
+  If the section is too heavy, promote it to a separate chapter.
+
+*Applicability to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60X", "Debug interface implemented"
+   "CV32E6?X", "No debug interface"
 
 Interrupt Interface
 -------------------
-Desired for step1 verification, but we can likely reuse an E4 DVplan.
-How to use the interface (HW/SW). We can refer to RISC-V specifications.
-If the section is too heavy, promote it to a separate chapter.
+  The team is looking for a contributor for this section.
+  We can likely reuse an E4 DVplan.
+  How to use the interface (HW/SW). We can refer to RISC-V specifications.
+  If the section is too heavy, promote it to a separate chapter.
+
+*The interrupt interface is applicable to all configurations.*
 
 TRI Interface
 -------------
-Refer to OpenPiton documents.
+The TRI interface is exclusive of the AXI interface.
+
+For more information, refer to OpenPiton documents.
+
+*Applicability to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60X", "No TRI interface"
+   "CV32E6?X", "No TRI interface"

--- a/docs/01_cva6_user/Introduction.rst
+++ b/docs/01_cva6_user/Introduction.rst
@@ -100,8 +100,8 @@ As of today, two configurations are being verified and addressed in this documen
    :align: left
    :header: "Configuration", "Short description", "Target", "Privilege levels", "Supported RISC-V ISA", "CV-X-IF"
 
-   "**CV32A60X**", "32-bit **application** core", "ASIC", "Machine, Supervisor, User", "RV32IMACZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb_Zicond", "Included"
-   "**CV32E6?X**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs", "Included"
+   "**CV32A60X**", "32-bit **application** core", "ASIC", "Machine, Supervisor, User", "RV32IMACZicsr_Zifencei_Zicount_Zba_Zbb_Zbc_Zbs_Zcb_Zicond", "Included"
+   "**CV32E6?X**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb", "Included"
 
 The "?" digit in CV32E6?X is to be defined, as the team has not yet decided if this core will be extended with dual-issue.
 

--- a/docs/01_cva6_user/Introduction.rst
+++ b/docs/01_cva6_user/Introduction.rst
@@ -34,11 +34,11 @@ See the License for the specific language governing permissions and limitations 
 
 Work In Progress
 ----------------
-This document is a work in progress and the team currently drafting it focuses on its use for the “step 1” verification of the project.
+This document is a work in progress and the team currently drafting it focuses on its use to verify several configurations of CVA6.
 
 The current limitation of documentation on CVA6 is well understood.
-Rather than regretting this; the reader is encouraged to contribute to it to make CVA6 an even better core.
-To contribute to the project, refer to the Contributing_ guidelines.
+Rather than regretting this, the reader is encouraged to contribute to it to make CVA6 an even better core.
+To contribute to the project, refer to the Contributing_ guidelines and get in touch with the team.
 
 .. _Contributing: https://github.com/jquevremont/cva6/blob/master/CONTRIBUTING.md
 
@@ -53,7 +53,7 @@ The CVA6 user manual targets:
 * Verification engineers involved in the OpenHW Group’s CVA6 project who use this manual as a reference.
 
 The user guide does not target people who dig into CVA6 design. No internal mechanisms are described here,
-except if the user has some sort of control on it; there is a separate design specification for this purpose.
+except if the user has some sort of control on it. A separate design document digs into the core microarchitecture.
 
 CVA6 Overview
 --------------
@@ -81,10 +81,34 @@ CV64A6 is an industrial evolution of ARIANE created by ETH Zürich and the
 University of Bologna. CV32A6 is a later addition by Thales. CVA6 is now
 curated at the OpenHW Group by its members.
 
-This guide targets all versions of the cores, except if a specific configuration or parameter setting is mentioned.
+Configurations
+--------------
+
+CVA6 is actually a family of cores, as CVA6 can be configured to the users' needs with more than 50 parameters.
+A configuration is defined as a given set of parameters.
+
+A few configurations undergo a complete verification process to bring them to **TRL-5**,
+the maturity level where they can be integrated in production ASICs.
+
+This manual includes generic descriptions of CVA6 capabilities, as well as their applicability to
+the verified configurations.
+
+As of today, two configurations are being verified and addressed in this document:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Short description", "Target", "Privilege levels", "Supported RISC-V ISA", "CV-X-IF"
+
+   "**CV32A60X**", "32-bit **application** core", "ASIC", "Machine, Supervisor, User", "RV32IMACZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb_Zicond", "Included"
+   "**CV32E6?X**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs", "Included"
+
+The "?" digit in CV32E6?X is to be defined, as the team has not yet decided if this core will be extended with dual-issue.
+
+In the future, dedicated user manuals for each configuration could be generated. The team is looking for a contributor to implement this through *templating*.
 
 Scope of the IP
-~~~~~~~~~~~~~~~
+---------------
 
 The **scope of the IP** refers the subsystem that is documented here.
 

--- a/docs/01_cva6_user/PMA.rst
+++ b/docs/01_cva6_user/PMA.rst
@@ -18,6 +18,8 @@
 
 .. _cva6_pma:
 
+*This chapter is applicable to all configurations.*
+
 PMA
 ===
 

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -27,25 +27,28 @@ RISC-V Extensions
 .. csv-table::
    :widths: auto
    :align: left
-   :header: "Extension", "Optional", "RV32","RV64"
+   :header: "Extension", "Optional", "RV32","RV64", "*Applicable to CV32A60X*", "*Applicable to CV32E6?X*"
 
-   "I- RV32i Base Integer Instruction Set",                             "No","✓","✓"
-   "A - Atomic Instructions",                                           "Yes","✓","✓"
-   "Zb* - Bit-Manipulation",                                            "Yes","✓","✓"
-   "C - Compressed Instructions ",                                      "Yes","✓","✓"
-   "Zcb - Code Size Reduction",                                         "Yes","✓","✓"
-   "D - Double precsision floating-point",                              "Yes","✗ ","✓"
-   "F - Single precsision floating-point",                              "Yes","✓","✓"
-   "M - Integer Multiply/Divide",                                       "No","✓","✓"
-   "Zicount - Performance Counters",                                    "Yes","✓","✓"
-   "Zicsr - Control and Status Register Instructions",                  "No","✓","✓"
-   "Zifencei - Instruction-Fetch Fence",                                "No","✓","✓"
-   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes","✓","✓"
+   "I- RV32i Base Integer Instruction Set",                             "No","✓","✓","✓","✓"
+   "A - Atomic Instructions",                                           "Yes","✓","✓","✓","✗"
+   "Zb* - Bit-Manipulation",                                            "Yes","✓","✓","✓","✓"
+   "C - Compressed Instructions ",                                      "Yes","✓","✓","✓","✓"
+   "Zcb - Code Size Reduction",                                         "Yes","✓","✓","✓","✓"
+   "D - Double precsision floating-point",                              "Yes","✗","✓","✗","✗"
+   "F - Single precsision floating-point",                              "Yes","✓","✓","✗","✗"
+   "M - Integer Multiply/Divide",                                       "No","✓","✓","✓","✓"
+   "Zicount - Performance Counters",                                    "Yes","✓","✓","✓","✗"
+   "Zicsr - Control and Status Register Instructions",                  "No","✓","✓","✓","✓"
+   "Zifencei - Instruction-Fetch Fence",                                "No","✓","✓","✓","✓"
+   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes","✓","✓","✓","✗"
 
 
 
 RISC-V Privileges
 -----------------
+
+CVA6 supports these privilege modes:
+
 .. csv-table::
    :widths: auto
    :align: left
@@ -55,8 +58,17 @@ RISC-V Privileges
    "S - Supervior"
    "U - User"
 
-
 Note: The addition of the H Extension is in the process. After that, HS, VS, and VU modes will also be available.
+
+*Applicability to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60X", "M, S, U implemented"
+   "CV32E6?X", "Only M implemented"
 
 
 RISC-V Virtual Memory
@@ -77,13 +89,28 @@ Notes for the integrator:
 
 * The addition of the hypervisor support will come with **Sv39x4** virtual memory that is not yet documented here.
 
+*Applicability to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60X", "Sv32"
+   "CV32E6?X", "Only Bare mode"
+
+
 Memory Alignment
 ----------------
 CVA6 **does not support non-aligned** memory accesses.
+
+*This is applicable to all configurations.*
 
 Harts
 -----
 CVA6 features a **single hart**, i.e. a single hardware thread.
 
 Therefore the words *hart* and *core* have the same meaning in this guide.
+
+*This is applicable to all configurations.*
 

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -33,7 +33,7 @@ RISC-V Extensions
    :header: "Extension", "Optional", "CV32A60X", "CV32E??X"
 
    "I- RV32i Base Integer Instruction Set",                             "No","✓","✓"
-   "A - Atomic Instructions",                                           "Yes","✓","✗"
+   "A - Atomic Instructions",                                           "Yes","✓",""
    "Zb* - Bit-Manipulation",                                            "Yes","✓","✓"
    "C - Compressed Instructions ",                                      "Yes","✓","✓"
    "Zcb - Code Size Reduction",                                         "Yes","✓","✓"

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -21,34 +21,94 @@
 Programmer’s View
 =================
 RISC-V specifications allow many variations. This chapter provides more details about RISC-V variants available for the programmer.
+A global view of the CVA6 family is provided, as well as details for each verified configuration.
 
 RISC-V Extensions
 -----------------
 
-*These are the RISC-V extensions supported by CVA6 and their applicability to configurations:*
+CVA6 family
+~~~~~~~~~~~
+
+The following extensions are available for the CVA6 family.
+Some of them are optional and are enabled through parameters in the SystemVerilog design.
 
 .. csv-table::
    :widths: auto
    :align: left
-   :header: "Extension", "Optional", "CV32A60X", "CV32E??X"
+   :header: "Extension", "Optional", "RV32 (in CV32A6)", "RV64 (in CV64A6)", "Note"
 
-   "I- RV32i Base Integer Instruction Set",                             "No","✓","✓"
-   "A - Atomic Instructions",                                           "Yes","✓",""
-   "Zb* - Bit-Manipulation",                                            "Yes","✓","✓"
-   "C - Compressed Instructions ",                                      "Yes","✓","✓"
-   "Zcb - Code Size Reduction",                                         "Yes","✓","✓"
-   "D - Double precsision floating-point",                              "Yes","",""
-   "F - Single precsision floating-point",                              "Yes","",""
-   "M - Integer Multiply/Divide",                                       "No","✓","✓"
-   "Zicount - Performance Counters",                                    "Yes","✓",""
-   "Zicsr - Control and Status Register Instructions",                  "No","✓","✓"
-   "Zifencei - Instruction-Fetch Fence",                                "No","✓","✓"
-   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes","✓",""
+   "I- Base Integer Instruction Set",                                   "No",  "✓", "✓", "Note 1"
+   "A - Atomic Instructions",                                           "Yes", "✓", "✓", "Note 1"
+   "Zb* - Bit-Manipulation",                                            "Yes", "✓", "✓", "Note 1"
+   "C - Compressed Instructions ",                                      "Yes", "✓", "✓", "Note 1"
+   "Zcb - Code Size Reduction",                                         "Yes", "✓", "✓", "Note 1"
+   "D - Double precision floating-point",                               "Yes", "",  "✓", "Note 1"
+   "F - Single precision floating-point",                               "Yes", "✓", "✓", "Note 1"
+   "M - Integer Multiply/Divide",                                       "No",  "✓", "✓", "Note 1"
+   "Zicount - Performance Counters",                                    "Yes", "✓", "✓", "Note 2"
+   "Zicsr - Control and Status Register Instructions",                  "No",  "✓", "✓", "Note 2"
+   "Zifencei - Instruction-Fetch Fence",                                "No",  "✓", "✓", "Note 2"
+   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes", "✓", "✓", "Note 2"
 
-The D extension is not available with CV32A6.
+Notes:
+
+* Note 1: These extensions have a slightly  different definition between RV32 and RV64. They are therefore denoted with digits (e.g. RV\ **32**\ M).
+* Note 2: These extensions do not differ between RV32 and RV64. They are therefore denoted without digits below (e.g. RVZifencei).
+
+*The following tables detail the availability of extensions for the various CVA6 configurations:*
+
+CV32A60X extensions
+~~~~~~~~~~~~~~~~~~~
+
+These extensions are available in CV32A60X:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Extension", "Available in CV32A60X"
+
+   "RV32I - Base Integer Instruction Set",                                  "✓"
+   "RV32A - Atomic Instructions",                                           "✓"
+   "RV32Zb* - Bit-Manipulation (Zba, Zbb, Zbc, Zbs)",                       "✓"
+   "RV32C - Compressed Instructions ",                                      "✓"
+   "RV32Zcb - Code Size Reduction",                                         "✓"
+   "RV32D - Double precision floating-point",                               ""
+   "RV32F - Single precision floating-point",                               ""
+   "RV32M - Integer Multiply/Divide",                                       "✓"
+   "RVZicount - Performance Counters",                                      "✓"
+   "RVZicsr - Control and Status Register Instructions",                    "✓"
+   "RVZifencei - Instruction-Fetch Fence",                                  "✓"
+   "RVZicond - Integer Conditional Operations(Ratification pending)",       "✓"
+
+CV32E6?X extensions
+~~~~~~~~~~~~~~~~~~~
+
+These extensions are available in CV32E6?X:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Extension", "Available in CV32A60X"
+
+   "RV32I - Base Integer Instruction Set",                                  "✓"
+   "RV32A - Atomic Instructions",                                           ""
+   "RV32Zb* - Bit-Manipulation (Zba, Zbb, Zbc, Zbs)",                       "✓"
+   "RV32C - Compressed Instructions ",                                      "✓"
+   "RV32Zcb - Code Size Reduction",                                         "✓"
+   "RV32D - Double precision floating-point",                               ""
+   "RV32F - Single precision floating-point",                               ""
+   "RV32M - Integer Multiply/Divide",                                       "✓"
+   "RVZicount - Performance Counters",                                      ""
+   "RVZicsr - Control and Status Register Instructions",                    "✓"
+   "RVZifencei - Instruction-Fetch Fence",                                  "✓"
+   "RVZicond - Integer Conditional Operations(Ratification pending)",       ""
+
 
 RISC-V Privileges
 -----------------
+
+CVA6 family
+~~~~~~~~~~~
 
 CVA6 supports these privilege modes:
 
@@ -61,20 +121,45 @@ CVA6 supports these privilege modes:
    "S - Supervior"
    "U - User"
 
-*Applicability to configurations:*
+Note: The addition of the H Extension is in the process. After that, HS, VS, and VU modes will also be available.
+
+*The following tables detail the availability of privileges modes for the various CVA6 configurations:*
+
+CV32A60X privilege modes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+These privilege modes are available in CV32A60X:
 
 .. csv-table::
    :widths: auto
    :align: left
-   :header: "Configuration", "Implementation"
+   :header: "Privileges", "Available in CV32A60X"
 
-   "CV32A60X", "M, S, U implemented"
-   "CV32E6?X", "Only M implemented"
+   "M - Machine",                   "✓"
+   "S - Supervior",                 "✓"
+   "U - User",                      "✓"
 
-Note: The addition of the H Extension is in the process. After that, HS, VS, and VU modes will also be available.
+CV32E6?X privilege modes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+These privilege modes are available in CV32E6?X:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Privileges", "Available in CV32E6?X"
+
+   "M - Machine",                   "✓"
+   "S - Supervior",                 ""
+   "U - User",                      ""
+
 
 RISC-V Virtual Memory
 ---------------------
+
+CVA6 family
+~~~~~~~~~~~
+
 CV32A6 supports the RISC-V **Sv32** virtual memory when the ``MMUEn`` parameter is set to 1 (and ``Xlen`` is set to 32).
 
 CV64A6 supports the RISC-V **Sv39** virtual memory when the ``MMUEn`` parameter is set to 1 (and ``Xlen`` is set to 64).
@@ -87,19 +172,22 @@ Notes for the integrator:
 
 * The virtual memory is implemented by a memory management unit (MMU) that accelerates the translation from virtual memory addresses (as handled by the core) to physical memory addresses. The MMU integrates translation lookaside buffers (TLB) and a hardware page table walker (PTW). The number of instruction and data TLB entries are configured with ``InstrTlbEntries`` and ``DataTlbEntries``.
 
-* The CV32A6 MMU will evolve with a microarchitectural optimization featuring two levels of TLB: level 1 TBL (sized by ``InstrTlbEntries`` and ``DataTlbEntries``) and a shared level 2 TLB. This optimization remains to be implemented in CV64A6. The optimization has no consequences on the programmer's view.
+* The MMU will integrate a microarchitectural optimization featuring two levels of TLB: level 1 TBL (sized by ``InstrTlbEntries`` and ``DataTlbEntries``) and a shared level 2 TLB. The optimization has no consequences on the programmer's view.
 
 * The addition of the hypervisor support will come with **Sv39x4** virtual memory that is not yet documented here.
 
-*Applicability to configurations:*
+*These are the addressing modes supported by the various CVA6 configurations:*
 
-.. csv-table::
-   :widths: auto
-   :align: left
-   :header: "Configuration", "Implementation"
+CV32A60X virtual memory
+~~~~~~~~~~~~~~~~~~~~~~~
 
-   "CV32A60X", "Bare mode, Sv32"
-   "CV32E6?X", "Bare mode"
+CV32A60X integrates an MMU and supports both the **Bare** and **Sv32** addressing modes.
+
+
+CV32E6?X virtual memory
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+CV32A60X integrates no MMU and only supports the **Bare** addressing mode.
 
 
 Memory Alignment

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -96,8 +96,8 @@ Notes for the integrator:
    :align: left
    :header: "Configuration", "Implementation"
 
-   "CV32A60X", "Sv32"
-   "CV32E6?X", "Only Bare mode"
+   "CV32A60X", "Bare mode, Sv32"
+   "CV32E6?X", "Bare mode"
 
 
 Memory Alignment

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -24,25 +24,28 @@ RISC-V specifications allow many variations. This chapter provides more details 
 
 RISC-V Extensions
 -----------------
+
+*These are the RISC-V extensions supported by CVA6 and their applicability to configurations:*
+
 .. csv-table::
    :widths: auto
    :align: left
-   :header: "Extension", "Optional", "RV32","RV64", "*Applicable to CV32A60X*", "*Applicable to CV32E6?X*"
+   :header: "Extension", "Optional", "CV32A60X", "CV32E??X"
 
-   "I- RV32i Base Integer Instruction Set",                             "No","✓","✓","✓","✓"
-   "A - Atomic Instructions",                                           "Yes","✓","✓","✓","✗"
-   "Zb* - Bit-Manipulation",                                            "Yes","✓","✓","✓","✓"
-   "C - Compressed Instructions ",                                      "Yes","✓","✓","✓","✓"
-   "Zcb - Code Size Reduction",                                         "Yes","✓","✓","✓","✓"
-   "D - Double precsision floating-point",                              "Yes","✗","✓","✗","✗"
-   "F - Single precsision floating-point",                              "Yes","✓","✓","✗","✗"
-   "M - Integer Multiply/Divide",                                       "No","✓","✓","✓","✓"
-   "Zicount - Performance Counters",                                    "Yes","✓","✓","✓","✗"
-   "Zicsr - Control and Status Register Instructions",                  "No","✓","✓","✓","✓"
-   "Zifencei - Instruction-Fetch Fence",                                "No","✓","✓","✓","✓"
-   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes","✓","✓","✓","✗"
+   "I- RV32i Base Integer Instruction Set",                             "No","✓","✓"
+   "A - Atomic Instructions",                                           "Yes","✓","✗"
+   "Zb* - Bit-Manipulation",                                            "Yes","✓","✓"
+   "C - Compressed Instructions ",                                      "Yes","✓","✓"
+   "Zcb - Code Size Reduction",                                         "Yes","✓","✓"
+   "D - Double precsision floating-point",                              "Yes","",""
+   "F - Single precsision floating-point",                              "Yes","",""
+   "M - Integer Multiply/Divide",                                       "No","✓","✓"
+   "Zicount - Performance Counters",                                    "Yes","✓",""
+   "Zicsr - Control and Status Register Instructions",                  "No","✓","✓"
+   "Zifencei - Instruction-Fetch Fence",                                "No","✓","✓"
+   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes","✓",""
 
-
+The D extension is not available with CV32A6.
 
 RISC-V Privileges
 -----------------
@@ -58,8 +61,6 @@ CVA6 supports these privilege modes:
    "S - Supervior"
    "U - User"
 
-Note: The addition of the H Extension is in the process. After that, HS, VS, and VU modes will also be available.
-
 *Applicability to configurations:*
 
 .. csv-table::
@@ -70,6 +71,7 @@ Note: The addition of the H Extension is in the process. After that, HS, VS, and
    "CV32A60X", "M, S, U implemented"
    "CV32E6?X", "Only M implemented"
 
+Note: The addition of the H Extension is in the process. After that, HS, VS, and VU modes will also be available.
 
 RISC-V Virtual Memory
 ---------------------


### PR DESCRIPTION
This is a first pass to update the CVA6 user manual addressing configurations.

@fatimasaleem, can you especially review the ISA extensions supported by CV32A60X in Introduction.rst?

@JeanRochCoulon, can you especially review the ISA extensions supported by CV32E6?X in Introduction.rst?

@AEzzejjari, I took the liberty of updating AXI_Interface.rst to align its style with other chapters (fewer indents). Tell me if it is acceptable or if I have to revert the changes.

Complete reviews are of course welcome.

What will need updates in next passes:
- CSR_Performance_Counters.rst (when Zicount in CV32A60X is confirmed)
- PMP.rst (when their presence/absence in CV32E6?X is confirmed)
- RISCV_Instructions (when the ISA extensions supported by CV32A60X and CV32E6?X are confirmed)
- Traps_Interrupts_Exceptions.rst: expected significant impact of machine-only CV32E6?X

