### PR TITLE
remove wrong and now useless variable declaration in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ VCOM ?= vcom$(questa_version)
 VLIB ?= vlib$(questa_version)
 VMAP ?= vmap$(questa_version)
 # verilator version
-VERILATOR_INSTALL_DIR ?= $(PWD)/tmp/verilator-v5.008/verilator/
 verilator             ?= verilator
 # traget option
 target-options ?=


### PR DESCRIPTION
Related to https://github.com/openhwgroup/cva6/issues/1572 and https://github.com/openhwgroup/cva6/issues/1569 .

Setting `VERILATOR_INSTALL_DIR` in the `./Makefile` is not relevant anymore since it now has to be set before running CVA.py to simulate which will then use the Makefile.

On top of that, the path is wrong (should be `./tools` not `./tmp`).