### PR TITLE
Set default NUM_JOBS value to be the same accross all scripts

### DIFF
--- a/ci/install-verilator.sh
+++ b/ci/install-verilator.sh
@@ -3,8 +3,8 @@
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd $ROOT/tmp
 
-if [ -z ${NUM_JOBS} ]; then
-    NUM_JOBS=4
+if [ -z "$NUM_JOBS" ]; then
+    NUM_JOBS=1
 fi
 
 VERILATOR_REPO="https://github.com/verilator/verilator.git"

--- a/verif/regress/install-cva6.sh
+++ b/verif/regress/install-cva6.sh
@@ -63,9 +63,6 @@ else
   echo "Skipping Verilator setup on user's request (\$VERILATOR_INSTALL_DIR = \"NO\")."
 fi
 
-# number of parallel jobs to use for make commands and simulation
-export NUM_JOBS=24
-
 # install the required tools for cva6
 if [ -z "$CVA6_REPO" ]; then
   CVA6_REPO="https://github.com/openhwgroup/cva6.git"

--- a/verif/regress/install-verilator.sh
+++ b/verif/regress/install-verilator.sh
@@ -8,7 +8,7 @@
 # Original Author: Jean-Roch COULON - Thales
 
 if [ -z "$NUM_JOBS" ]; then
-    NUM_JOBS=4
+    NUM_JOBS=1
 fi
 
 # Ensure the location of tools is known (usually, .../core-v-verif/tools).


### PR DESCRIPTION
- Removed an hardcoded `NUM_JOBS` value in `verif/regress/install-cva6.py` which defeated the purpose of setting `NUM_JOBS` and could have potentially resulted in issues on some system configurations, since it was set quite high.
- Set the default `NUM_JOBS` value to 1 in all scripts.

An unset `NUM_JOBS` environment variable should now results in a sequential execution of make jobs in all scripts, as described in the `README`'s Quickstart