### PR TITLE
Set StallRandom I/O to 0 to gain performance on vcs-testharness bench

### DIFF
--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -82,8 +82,8 @@ module ariane_tb;
         //
         .NUM_WORDS         ( NUM_WORDS ),
         .InclSimDTM        ( 1'b1      ),
-        .StallRandomOutput ( 1'b1      ),
-        .StallRandomInput  ( 1'b1      )
+        .StallRandomOutput ( 1'b0      ),
+        .StallRandomInput  ( 1'b0      )
     ) dut (
         .clk_i,
         .rst_ni,


### PR DESCRIPTION
Fix for issue #1564. 

It sets the value of `StallRandomInput `and `StallRandomOutput `of the `axi_delayer_intf `to 0.

@JeanRochCoulon can you review it ?