### PR TITLE
Update embedded config to improve trade-off performance gate count

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,2 +1,2 @@
 cv32a6_embedded:
-  gates: 119494
+  gates: 120776

--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -18,7 +18,7 @@ iterations = None
 # Will fail if the number of cycles is different from this one
 valid_cycles = {
     'dhrystone': 217900,
-    'coremark': 696571,
+    'coremark': 665193,
 }
 
 for arg in sys.argv[1:]:

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -52,14 +52,14 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigNrLoadPipeRegs = 0;
   localparam CVA6ConfigNrStorePipeRegs = 0;
-  localparam CVA6ConfigNrLoadBufEntries = 2;
+  localparam CVA6ConfigNrLoadBufEntries = 1;
 
   localparam CVA6ConfigInstrTlbEntries = 2;
   localparam CVA6ConfigDataTlbEntries = 2;
 
-  localparam CVA6ConfigRASDepth = 0;
+  localparam CVA6ConfigRASDepth = 2;
   localparam CVA6ConfigBTBEntries = 0;
-  localparam CVA6ConfigBHTEntries = 16;
+  localparam CVA6ConfigBHTEntries = 32;
 
   localparam CVA6ConfigNrPMPEntries = 8;
 


### PR DESCRIPTION
Based on Coremark study, three parameters are fine tuned: BHT, RAS, and load buffer.