### PR TITLE
[Skip CI] Changing part number in user manual

### DIFF
--- a/docs/01_cva6_user/AXI_Interface.rst
+++ b/docs/01_cva6_user/AXI_Interface.rst
@@ -25,7 +25,7 @@ In order to understand how the AXI memory interface behaves in CVA6, it is neces
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "AXI included"
-   "CV32E6?X", "AXI included"
+   "CV32A60MX", "AXI included"
 
 About the AXI4 protocol
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/01_cva6_user/CSR_Performance_Counters.rst
+++ b/docs/01_cva6_user/CSR_Performance_Counters.rst
@@ -26,7 +26,7 @@
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Performance counters included"
-   "CV32E6?X", "No performance counters"
+   "CV32A60MX", "No performance counters"
 
 CSR performance counters control
 ================================

--- a/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
+++ b/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
@@ -32,7 +32,7 @@ with external coprocessors.
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "CV-X-IF included"
-   "CV32E6?X", "CV-X-IF included"
+   "CV32A60MX", "CV-X-IF included"
 
 
 CV-X-IF interface specification

--- a/docs/01_cva6_user/Interfaces.rst
+++ b/docs/01_cva6_user/Interfaces.rst
@@ -33,7 +33,7 @@ The AXI interface is described in a separate chapter.
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "AXI implemented"
-   "CV32E6?X", "AXI implemented"
+   "CV32A60MX", "AXI implemented"
 
 Debug Interface
 ---------------
@@ -51,7 +51,7 @@ Debug Interface
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Debug interface implemented"
-   "CV32E6?X", "No debug interface"
+   "CV32A60MX", "No debug interface"
 
 Interrupt Interface
 -------------------
@@ -76,4 +76,4 @@ For more information, refer to OpenPiton documents.
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "No TRI interface"
-   "CV32E6?X", "No TRI interface"
+   "CV32A60MX", "No TRI interface"

--- a/docs/01_cva6_user/Introduction.rst
+++ b/docs/01_cva6_user/Introduction.rst
@@ -101,9 +101,10 @@ As of today, two configurations are being verified and addressed in this documen
    :header: "Configuration", "Short description", "Target", "Privilege levels", "Supported RISC-V ISA", "CV-X-IF"
 
    "**CV32A60X**", "32-bit **application** core", "ASIC", "Machine, Supervisor, User", "RV32IMACZicsr_Zifencei_Zicount_Zba_Zbb_Zbc_Zbs_Zcb_Zicond", "Included"
-   "**CV32E6?X**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb", "Included"
+   "**CV32A60MX**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb", "Included"
 
-The "?" digit in CV32E6?X is to be defined, as the team has not yet decided if this core will be extended with dual-issue.
+CV32A60MX is an interim part number until the team can decide if this configuration is single- or dual-issue.
+If the dual-issue architecture is selected, the part number will become CV32A65MX to denote the extra performance.
 
 In the future, dedicated user manuals for each configuration could be generated. The team is looking for a contributor to implement this through *templating*.
 

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -80,10 +80,10 @@ These extensions are available in CV32A60X:
    "RVZifencei - Instruction-Fetch Fence",                                  "✓"
    "RVZicond - Integer Conditional Operations(Ratification pending)",       "✓"
 
-CV32E6?X extensions
+CV32A60MX extensions
 ~~~~~~~~~~~~~~~~~~~
 
-These extensions are available in CV32E6?X:
+These extensions are available in CV32A60MX:
 
 .. csv-table::
    :widths: auto
@@ -139,15 +139,15 @@ These privilege modes are available in CV32A60X:
    "S - Supervior",                 "✓"
    "U - User",                      "✓"
 
-CV32E6?X privilege modes
+CV32A60MX privilege modes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-These privilege modes are available in CV32E6?X:
+These privilege modes are available in CV32A60MX:
 
 .. csv-table::
    :widths: auto
    :align: left
-   :header: "Privileges", "Available in CV32E6?X"
+   :header: "Privileges", "Available in CV32A60MX"
 
    "M - Machine",                   "✓"
    "S - Supervior",                 ""
@@ -184,7 +184,7 @@ CV32A60X virtual memory
 CV32A60X integrates an MMU and supports both the **Bare** and **Sv32** addressing modes.
 
 
-CV32E6?X virtual memory
+CV32A60MX virtual memory
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 CV32A60X integrates no MMU and only supports the **Bare** addressing mode.

--- a/docs/01_cva6_user/RISCV_Instructions_RV32A.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32A.rst
@@ -26,7 +26,7 @@
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Implemented extension"
-   "CV32E6?X", "Not implemented extension"
+   "CV32A60MX", "Not implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64A, that includes additional instructions.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RV32C.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32C.rst
@@ -26,7 +26,7 @@
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Implemented extension"
-   "CV32E6?X", "Implemented extension"
+   "CV32A60MX", "Implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64C, that includes a different list of instructions.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RV32I.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32I.rst
@@ -28,7 +28,7 @@ This chapter is applicable to all CV32A6 configurations.
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Implemented extension"
-   "CV32E6?X", "Implemented extension"
+   "CV32A60MX", "Implemented extension"
 
 **Note**: CV64A6 implements RV64I that includes additional instructions.
 

--- a/docs/01_cva6_user/RISCV_Instructions_RV32M.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32M.rst
@@ -28,7 +28,7 @@ This chapter is applicable to all CV32A6 configurations.
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Implemented extension"
-   "CV32E6?X", "Implemented extension"
+   "CV32A60MX", "Implemented extension"
 
 **Note**: CV64A6 implements RV64M that includes additional instructions.
 

--- a/docs/01_cva6_user/RISCV_Instructions_RV32ZCb.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32ZCb.rst
@@ -26,7 +26,7 @@
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Implemented extension"
-   "CV32E6?X", "Implemented extension"
+   "CV32A60MX", "Implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64Zcb, that includes one additional instruction.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RVZicond.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZicond.rst
@@ -26,7 +26,7 @@
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Implemented extension"
-   "CV32E6?X", "Not implemented extension"
+   "CV32A60MX", "Not implemented extension"
 
 **Note**: RV32Zicond and RV64Zicond are identical.
 


### PR DESCRIPTION
We accelerate this action to stabilize the embedded part number for upcoming commits.

Consensus (not unanimity) on CV32A60MX for the embedded configuration. Indeed, the previous CV32E60X (or CV32E65X) part number does not reflect the CVA6 family name and is a real issue for Thales.

CV32A60MX will change to CV32A65MX is the configuration is upgraded with dual-issue.