### PR TITLE
fix: exception on misaligned branch if no RVC

### DIFF
--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -99,6 +99,8 @@ module branch_unit #(
     branch_exception_o.tval = {{riscv::XLEN - riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
     // Only throw instruction address misaligned exception if this is indeed a `taken` conditional branch or
     // an unconditional jump
-    if (branch_valid_i && target_address[0] != 1'b0 && jump_taken) branch_exception_o.valid = 1'b1;
+    if (branch_valid_i && (target_address[0] || (!CVA6Cfg.RVC && target_address[1])) && jump_taken) begin
+      branch_exception_o.valid = 1'b1;
+    end
   end
 endmodule


### PR DESCRIPTION
The bit at index 1 must be 0 if the RVC extension is disabled.

Fix #1300

Replace PR #1690