### PR TITLE
[Skip CI] Integrated Zb* in user manual (index.rst)

### DIFF
--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -37,6 +37,10 @@ Editor: **Jerome Quevremont**
    RISCV_Instructions_RV32M
    RISCV_Instructions_RV32A
    RISCV_Instructions_RV32C
+   RISCV_Instructions_RVZba
+   RISCV_Instructions_RVZbb
+   RISCV_Instructions_RVZbc
+   RISCV_Instructions_RVZbs
    RISCV_Instructions_RV32ZCb
    RISCV_Instructions_RVZicsr
    RISCV_Instructions_RVZifencei


### PR DESCRIPTION
index.rst needs an update too so that the Zb* extension appear in ReadTheDoc.