### PR TITLE
fix: extra space in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ python3 cva6.py --target cv32a60x --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml \
 --c_tests ../tests/custom/hello_world/hello_world.c \
 --linker=../tests/custom/common/test.ld \
 --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib \
--nostartfiles -g ../tests/custom/ common/syscalls.c \
+-nostartfiles -g ../tests/custom/common/syscalls.c \
 ../tests/custom/common/crt.S -lgcc \
 -I../tests/custom/env -I../tests/custom/common"
 ```


### PR DESCRIPTION
This will lead to an error, because the space separates one file path into 2 paths.