### PR TITLE
use cathales version of verible-formatter-action

### DIFF
--- a/.github/workflows/verible.yml
+++ b/.github/workflows/verible.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: chipsalliance/verible-formatter-action@main
+      - uses: cathales/verible-formatter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: 'core/**/*.{v,sv}'


### PR DESCRIPTION
Temporary workaround before [chipsalliance/verible-actions-common#5](https://github.com/chipsalliance/verible-actions-common/pull/5) is merged