### PR TITLE
UM: Part number + reshuffled Zb* RV32/RV64 instructions

### DIFF
--- a/docs/01_cva6_user/AXI_Interface.rst
+++ b/docs/01_cva6_user/AXI_Interface.rst
@@ -24,8 +24,8 @@ In order to understand how the AXI memory interface behaves in CVA6, it is neces
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "AXI included"
    "CV32A60X", "AXI included"
-   "CV32A60MX", "AXI included"
 
 About the AXI4 protocol
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/01_cva6_user/CSR_Performance_Counters.rst
+++ b/docs/01_cva6_user/CSR_Performance_Counters.rst
@@ -25,8 +25,8 @@
    :align: left
    :header: "Configuration", "Implementation"
 
-   "CV32A60X", "Performance counters included"
-   "CV32A60MX", "No performance counters"
+   "CV32A60AX", "Performance counters included"
+   "CV32A60X", "No performance counters"
 
 CSR performance counters control
 ================================

--- a/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
+++ b/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
@@ -31,8 +31,8 @@ with external coprocessors.
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "CV-X-IF included"
    "CV32A60X", "CV-X-IF included"
-   "CV32A60MX", "CV-X-IF included"
 
 
 CV-X-IF interface specification

--- a/docs/01_cva6_user/Interfaces.rst
+++ b/docs/01_cva6_user/Interfaces.rst
@@ -32,8 +32,8 @@ The AXI interface is described in a separate chapter.
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "AXI implemented"
    "CV32A60X", "AXI implemented"
-   "CV32A60MX", "AXI implemented"
 
 Debug Interface
 ---------------
@@ -50,8 +50,8 @@ Debug Interface
    :align: left
    :header: "Configuration", "Implementation"
 
-   "CV32A60X", "Debug interface implemented"
-   "CV32A60MX", "No debug interface"
+   "CV32A60AX", "Debug interface implemented"
+   "CV32A60X", "No debug interface"
 
 Interrupt Interface
 -------------------
@@ -75,5 +75,5 @@ For more information, refer to OpenPiton documents.
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "No TRI interface"
    "CV32A60X", "No TRI interface"
-   "CV32A60MX", "No TRI interface"

--- a/docs/01_cva6_user/Introduction.rst
+++ b/docs/01_cva6_user/Introduction.rst
@@ -100,11 +100,11 @@ As of today, two configurations are being verified and addressed in this documen
    :align: left
    :header: "Configuration", "Short description", "Target", "Privilege levels", "Supported RISC-V ISA", "CV-X-IF"
 
-   "**CV32A60X**", "32-bit **application** core", "ASIC", "Machine, Supervisor, User", "RV32IMACZicsr_Zifencei_Zicount_Zba_Zbb_Zbc_Zbs_Zcb_Zicond", "Included"
-   "**CV32A60MX**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb", "Included"
+   "**CV32A60AX**", "32-bit **application** core", "ASIC", "Machine, Supervisor, User", "RV32IMACZicsr_Zifencei_Zicount_Zba_Zbb_Zbc_Zbs_Zcb_Zicond", "Included"
+   "**CV32A60X**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb", "Included"
 
-CV32A60MX is an interim part number until the team can decide if this configuration is single- or dual-issue.
-If the dual-issue architecture is selected, the part number will become CV32A65MX to denote the extra performance.
+CV32A60X is an interim part number until the team can decide if this configuration is single- or dual-issue.
+If the dual-issue architecture is selected, the part number will become CV32A65X to denote the extra performance.
 
 In the future, dedicated user manuals for each configuration could be generated. The team is looking for a contributor to implement this through *templating*.
 

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -189,7 +189,7 @@ CV32A60AX integrates an MMU and supports both the **Bare** and **Sv32** addressi
 CV32A60X virtual memory
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-CV32A60AX integrates no MMU and only supports the **Bare** addressing mode.
+CV32A60X integrates no MMU and only supports the **Bare** addressing mode.
 
 
 Memory Alignment

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -32,23 +32,25 @@ CVA6 family
 The following extensions are available for the CVA6 family.
 Some of them are optional and are enabled through parameters in the SystemVerilog design.
 
+**RV32** denotes RISC-V 32-bit extensions. **RV64** denotes RISC-V 64-bit extensions.
+
 .. csv-table::
    :widths: auto
    :align: left
    :header: "Extension", "Optional", "RV32 (in CV32A6)", "RV64 (in CV64A6)", "Note"
 
-   "I- Base Integer Instruction Set",                                   "No",  "✓", "✓", "Note 1"
-   "A - Atomic Instructions",                                           "Yes", "✓", "✓", "Note 1"
-   "Zb* - Bit-Manipulation",                                            "Yes", "✓", "✓", "Note 1"
-   "C - Compressed Instructions ",                                      "Yes", "✓", "✓", "Note 1"
-   "Zcb - Code Size Reduction",                                         "Yes", "✓", "✓", "Note 1"
-   "D - Double precision floating-point",                               "Yes", "",  "✓", "Note 1"
-   "F - Single precision floating-point",                               "Yes", "✓", "✓", "Note 1"
-   "M - Integer Multiply/Divide",                                       "No",  "✓", "✓", "Note 1"
-   "Zicount - Performance Counters",                                    "Yes", "✓", "✓", "Note 2"
-   "Zicsr - Control and Status Register Instructions",                  "No",  "✓", "✓", "Note 2"
-   "Zifencei - Instruction-Fetch Fence",                                "No",  "✓", "✓", "Note 2"
-   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes", "✓", "✓", "Note 2"
+   "I- Base Integer Instruction Set",                                   "No",  "✔", "✔", "Note 1"
+   "A - Atomic Instructions",                                           "Yes", "✔", "✔", "Note 1"
+   "Zb* - Bit-Manipulation",                                            "Yes", "✔", "✔", "Note 1"
+   "C - Compressed Instructions ",                                      "Yes", "✔", "✔", "Note 1"
+   "Zcb - Code Size Reduction",                                         "Yes", "✔", "✔", "Note 1"
+   "D - Double precision floating-point",                               "Yes", "",  "✔", "Note 1"
+   "F - Single precision floating-point",                               "Yes", "✔", "✔", "Note 1"
+   "M - Integer Multiply/Divide",                                       "No",  "✔", "✔", "Note 1"
+   "Zicount - Performance Counters",                                    "Yes", "✔", "✔", "Note 2"
+   "Zicsr - Control and Status Register Instructions",                  "No",  "✔", "✔", "Note 2"
+   "Zifencei - Instruction-Fetch Fence",                                "No",  "✔", "✔", "Note 2"
+   "Zicond - Integer Conditional Operations(Ratification pending)",     "Yes", "✔", "✔", "Note 2"
 
 Notes:
 
@@ -56,6 +58,29 @@ Notes:
 * Note 2: These extensions do not differ between RV32 and RV64. They are therefore denoted without digits below (e.g. RVZifencei).
 
 *The following tables detail the availability of extensions for the various CVA6 configurations:*
+
+CV32A60AX extensions
+~~~~~~~~~~~~~~~~~~~
+
+These extensions are available in CV32A60AX:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Extension", "Available in CV32A60AX"
+
+   "RV32I - Base Integer Instruction Set",                                  "✔"
+   "RV32A - Atomic Instructions",                                           "✔"
+   "RV32Zb* - Bit-Manipulation (Zba, Zbb, Zbc, Zbs)",                       "✔"
+   "RV32C - Compressed Instructions ",                                      "✔"
+   "RV32Zcb - Code Size Reduction",                                         "✔"
+   "RV32D - Double precision floating-point",                               ""
+   "RV32F - Single precision floating-point",                               ""
+   "RV32M - Integer Multiply/Divide",                                       "✔"
+   "RVZicount - Performance Counters",                                      "✔"
+   "RVZicsr - Control and Status Register Instructions",                    "✔"
+   "RVZifencei - Instruction-Fetch Fence",                                  "✔"
+   "RVZicond - Integer Conditional Operations(Ratification pending)",       "✔"
 
 CV32A60X extensions
 ~~~~~~~~~~~~~~~~~~~
@@ -65,42 +90,19 @@ These extensions are available in CV32A60X:
 .. csv-table::
    :widths: auto
    :align: left
-   :header: "Extension", "Available in CV32A60X"
+   :header: "Extension", "Available in CV32A60AX"
 
-   "RV32I - Base Integer Instruction Set",                                  "✓"
-   "RV32A - Atomic Instructions",                                           "✓"
-   "RV32Zb* - Bit-Manipulation (Zba, Zbb, Zbc, Zbs)",                       "✓"
-   "RV32C - Compressed Instructions ",                                      "✓"
-   "RV32Zcb - Code Size Reduction",                                         "✓"
-   "RV32D - Double precision floating-point",                               ""
-   "RV32F - Single precision floating-point",                               ""
-   "RV32M - Integer Multiply/Divide",                                       "✓"
-   "RVZicount - Performance Counters",                                      "✓"
-   "RVZicsr - Control and Status Register Instructions",                    "✓"
-   "RVZifencei - Instruction-Fetch Fence",                                  "✓"
-   "RVZicond - Integer Conditional Operations(Ratification pending)",       "✓"
-
-CV32A60MX extensions
-~~~~~~~~~~~~~~~~~~~
-
-These extensions are available in CV32A60MX:
-
-.. csv-table::
-   :widths: auto
-   :align: left
-   :header: "Extension", "Available in CV32A60X"
-
-   "RV32I - Base Integer Instruction Set",                                  "✓"
+   "RV32I - Base Integer Instruction Set",                                  "✔"
    "RV32A - Atomic Instructions",                                           ""
-   "RV32Zb* - Bit-Manipulation (Zba, Zbb, Zbc, Zbs)",                       "✓"
-   "RV32C - Compressed Instructions ",                                      "✓"
-   "RV32Zcb - Code Size Reduction",                                         "✓"
+   "RV32Zb* - Bit-Manipulation (Zba, Zbb, Zbc, Zbs)",                       "✔"
+   "RV32C - Compressed Instructions ",                                      "✔"
+   "RV32Zcb - Code Size Reduction",                                         "✔"
    "RV32D - Double precision floating-point",                               ""
    "RV32F - Single precision floating-point",                               ""
-   "RV32M - Integer Multiply/Divide",                                       "✓"
+   "RV32M - Integer Multiply/Divide",                                       "✔"
    "RVZicount - Performance Counters",                                      ""
-   "RVZicsr - Control and Status Register Instructions",                    "✓"
-   "RVZifencei - Instruction-Fetch Fence",                                  "✓"
+   "RVZicsr - Control and Status Register Instructions",                    "✔"
+   "RVZifencei - Instruction-Fetch Fence",                                  "✔"
    "RVZicond - Integer Conditional Operations(Ratification pending)",       ""
 
 
@@ -125,6 +127,20 @@ Note: The addition of the H Extension is in the process. After that, HS, VS, and
 
 *The following tables detail the availability of privileges modes for the various CVA6 configurations:*
 
+CV32A60AX privilege modes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+These privilege modes are available in CV32A60AX:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Privileges", "Available in CV32A60AX"
+
+   "M - Machine",                   "✔"
+   "S - Supervior",                 "✔"
+   "U - User",                      "✔"
+
 CV32A60X privilege modes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -135,21 +151,7 @@ These privilege modes are available in CV32A60X:
    :align: left
    :header: "Privileges", "Available in CV32A60X"
 
-   "M - Machine",                   "✓"
-   "S - Supervior",                 "✓"
-   "U - User",                      "✓"
-
-CV32A60MX privilege modes
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-These privilege modes are available in CV32A60MX:
-
-.. csv-table::
-   :widths: auto
-   :align: left
-   :header: "Privileges", "Available in CV32A60MX"
-
-   "M - Machine",                   "✓"
+   "M - Machine",                   "✔"
    "S - Supervior",                 ""
    "U - User",                      ""
 
@@ -178,16 +180,16 @@ Notes for the integrator:
 
 *These are the addressing modes supported by the various CVA6 configurations:*
 
-CV32A60X virtual memory
+CV32A60AX virtual memory
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-CV32A60X integrates an MMU and supports both the **Bare** and **Sv32** addressing modes.
+CV32A60AX integrates an MMU and supports both the **Bare** and **Sv32** addressing modes.
 
 
-CV32A60MX virtual memory
+CV32A60X virtual memory
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-CV32A60X integrates no MMU and only supports the **Bare** addressing mode.
+CV32A60AX integrates no MMU and only supports the **Bare** addressing mode.
 
 
 Memory Alignment

--- a/docs/01_cva6_user/RISCV_Instructions.rst
+++ b/docs/01_cva6_user/RISCV_Instructions.rst
@@ -31,6 +31,10 @@ In the next pages, the ISA (Instruction Set Architecture) for various CVA6 confi
 * RV32M        – Standard Extension for Integer Multiplication and Division Instructions
 * RV32A        – Standard Extension for Atomic Instructions
 * RV32C        – Standard Extension for Compressed Instructions
+* RVZba        - Standard Extension for Bit Manipulation: Address generation instructions (RV32 and RV64)
+* RVZbb        - Standard Extension for Bit Manipulation: Basic bit manipulation (RV32 and RV64)
+* RVZbc        - Standard Extension for Bit Manipulation: Carry-less multiplication (RV32 and RV64)
+* RVZbs        - Standard Extension for Bit Manipulation: Single-bit instructions (RV32 and RV64)
 * RV32Zcb      – Standard Extension for Code Size Reduction
 * RVZicsr      – Standard Extension for CSR Instructions
 * RVZifencei   – Standard Extension for Instruction-Fetch Fence

--- a/docs/01_cva6_user/RISCV_Instructions_RV32A.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32A.rst
@@ -25,8 +25,8 @@
    :align: left
    :header: "Configuration", "Implementation"
 
-   "CV32A60X", "Implemented extension"
-   "CV32A60MX", "Not implemented extension"
+   "CV32A60AX", "Implemented extension"
+   "CV32A60X", "Not implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64A, that includes additional instructions.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RV32C.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32C.rst
@@ -25,8 +25,8 @@
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
-   "CV32A60MX", "Implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64C, that includes a different list of instructions.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RV32I.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32I.rst
@@ -27,8 +27,8 @@ This chapter is applicable to all CV32A6 configurations.
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
-   "CV32A60MX", "Implemented extension"
 
 **Note**: CV64A6 implements RV64I that includes additional instructions.
 

--- a/docs/01_cva6_user/RISCV_Instructions_RV32M.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32M.rst
@@ -27,8 +27,8 @@ This chapter is applicable to all CV32A6 configurations.
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
-   "CV32A60MX", "Implemented extension"
 
 **Note**: CV64A6 implements RV64M that includes additional instructions.
 

--- a/docs/01_cva6_user/RISCV_Instructions_RV32ZCb.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32ZCb.rst
@@ -25,8 +25,8 @@
    :align: left
    :header: "Configuration", "Implementation"
 
+   "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
-   "CV32A60MX", "Implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64Zcb, that includes one additional instruction.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RVZba.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZba.rst
@@ -1,5 +1,36 @@
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 10xEngineers
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _cva6_riscv_instructions_RV32Zba:
+
+*Applicability of this chapter to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60AX", "Implemented extension"
+   "CV32A60X", "Implemented extension"
+
+   
 ======================================
-Zba: Address generation instructions
+RVZba: Address generation instructions
 ======================================
 The Zba instructions can be used to accelerate the generation of addresses that index into arrays of basic types (halfword, word, doubleword) using both unsigned word-sized and XLEN-sized indices: a shifted index is added to a base address.
 
@@ -29,17 +60,9 @@ The following instructions (and pseudoinstructions) comprise the Zba extension:
 |           | ✔         | slli.uw rd, rs1, imm  |
 +-----------+-----------+-----------------------+
 
-- **ADD.UW**: Add unsigned word
+RV32 and RV64 Instructions
+--------------------------
 
-    **Format**: add.uw rd, rs1, rs2
-
-    **Description**: This instruction performs an XLEN-wide addition between rs2 and the zero-extended least-significant word of rs1.
-
-    **Pseudocode**: X(rd) = rs2 + EXTZ(X(rs1)[31..0])
-
-    **Invalid values**: NONE
-
-    **Exception raised**: NONE
 
 - **SH1ADD**: Shift left by 1 and add
 
@@ -48,18 +71,6 @@ The following instructions (and pseudoinstructions) comprise the Zba extension:
     **Description**: This instruction shifts rs1 to the left by 1 bit and adds it to rs2.
 
     **Pseudocode**: X(rd) = X(rs2) + (X(rs1) << 1)
-
-    **Invalid values**: NONE
-
-    **Exception raised**: NONE
-
-- **SH1ADD.UW**: Shift unsigned word left by 1 and add
-
-    **Format**: sh1add.uw rd, rs1, rs2
-
-    **Description**: This instruction performs an XLEN-wide addition of two addends. The first addend is rs2. The second addend is the unsigned value formed by extracting the least-significant word of rs1 and shifting it left by 1 place.
-
-    **Pseudocode**: X(rd) = rs2 + (EXTZ(X(rs1)[31..0]) << 1)
 
     **Invalid values**: NONE
 
@@ -77,18 +88,6 @@ The following instructions (and pseudoinstructions) comprise the Zba extension:
 
     **Exception raised**: NONE
 
-- **SH2ADD.UW**: Shift unsigned word left by 2 and add
-
-    **Format**: sh2add.uw rd, rs1, rs2
-
-    **Description**: This instruction performs an XLEN-wide addition of two addends. The first addend is rs2. The second addend is the unsigned value formed by extracting the least-significant word of rs1 and shifting it left by 2 places.
-
-    **Pseudocode**: X(rd) = rs2 + (EXTZ(X(rs1)[31..0]) << 2)
-
-    **Invalid values**: NONE
-
-    **Exception raised**: NONE
-
 - **SH3ADD**: Shift left by 3 and add
 
     **Format**: sh3add rd, rs1, rs2
@@ -100,6 +99,46 @@ The following instructions (and pseudoinstructions) comprise the Zba extension:
     **Invalid values**: NONE
 
     **Exception raised**: NONE    
+
+
+RV64 specific instructions
+--------------------------
+
+- **ADD.UW**: Add unsigned word
+
+    **Format**: add.uw rd, rs1, rs2
+
+    **Description**: This instruction performs an XLEN-wide addition between rs2 and the zero-extended least-significant word of rs1.
+
+    **Pseudocode**: X(rd) = rs2 + EXTZ(X(rs1)[31..0])
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
+
+- **SH1ADD.UW**: Shift unsigned word left by 1 and add
+
+    **Format**: sh1add.uw rd, rs1, rs2
+
+    **Description**: This instruction performs an XLEN-wide addition of two addends. The first addend is rs2. The second addend is the unsigned value formed by extracting the least-significant word of rs1 and shifting it left by 1 place.
+
+    **Pseudocode**: X(rd) = rs2 + (EXTZ(X(rs1)[31..0]) << 1)
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
+
+- **SH2ADD.UW**: Shift unsigned word left by 2 and add
+
+    **Format**: sh2add.uw rd, rs1, rs2
+
+    **Description**: This instruction performs an XLEN-wide addition of two addends. The first addend is rs2. The second addend is the unsigned value formed by extracting the least-significant word of rs1 and shifting it left by 2 places.
+
+    **Pseudocode**: X(rd) = rs2 + (EXTZ(X(rs1)[31..0]) << 2)
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
 
 - **SH3ADD.UW**: Shift unsigned word left by 3 and add
 
@@ -124,5 +163,3 @@ The following instructions (and pseudoinstructions) comprise the Zba extension:
     **Invalid values**: NONE
 
     **Exception raised**: NONE   
-   
-

--- a/docs/01_cva6_user/RISCV_Instructions_RVZbb.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZbb.rst
@@ -1,6 +1,36 @@
-============================
-Zbb: Basic bit-manipulation
-============================
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 10xEngineers
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _cva6_riscv_instructions_RV32Zbb:
+
+*Applicability of this chapter to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60AX", "Implemented extension"
+   "CV32A60X", "Implemented extension"
+
+=============================
+RVZbb: Basic bit-manipulation
+=============================
 
 The following instructions comprise the Zbb extension:
 
@@ -17,6 +47,10 @@ The Logical with Negate instructions can be implemented by inverting the rs2 inp
 +-----------+-----------+-----------------------+
 | ✔         | ✔         | xnor rd, rs1, rs2     |
 +-----------+-----------+-----------------------+
+
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 - **ANDN**: AND with inverted operand
 
@@ -71,23 +105,14 @@ These instructions are used to count the leading/trailing zero bits.
 |           | ✔         | ctzw rd, rs           |
 +-----------+-----------+-----------------------+
 
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 - **CLZ**: Count leading zero bits
 
     **Format**: clz rd, rs 
 
     **Description**: This instruction counts the number of 0’s before the first 1, starting at the most-significant bit (i.e., XLEN-1) and progressing to bit 0. Accordingly, if the input is 0, the output is XLEN, and if the most-significant bit of the input is a 1, the output is 0
-
-    **Pseudocode**: if [x[i]] == 1 then return(i) else return -1
-
-    **Invalid values**: NONE
-
-    **Exception raised**: NONE
-
-- **CLZW**: Count leading zero bits in word
-
-    **Format**: clzw rd, rs
-
-    **Description**: This instruction counts the number of 0’s before the first 1 starting at bit 31 and progressing to bit 0. Accordingly, if the least-significant word is 0, the output is 32, and if the most-significant bit of the word (i.e., bit 31) is a 1, the output is 0.
 
     **Pseudocode**: if [x[i]] == 1 then return(i) else return -1
 
@@ -107,6 +132,21 @@ These instructions are used to count the leading/trailing zero bits.
 
     **Exception raised**: NONE
 
+RV64 specific instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~	
+
+- **CLZW**: Count leading zero bits in word
+
+    **Format**: clzw rd, rs
+
+    **Description**: This instruction counts the number of 0’s before the first 1 starting at bit 31 and progressing to bit 0. Accordingly, if the least-significant word is 0, the output is 32, and if the most-significant bit of the word (i.e., bit 31) is a 1, the output is 0.
+
+    **Pseudocode**: if [x[i]] == 1 then return(i) else return -1
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
+
 - **CTZW**: Count trailing zero bits in word
 
     **Format**: ctzw rd, rs 
@@ -119,7 +159,7 @@ These instructions are used to count the leading/trailing zero bits.
 
     **Exception raised**: NONE
 
-
+	
 Count population
 -------------------
 These instructions count the number of set bits (1-bits). This is also commonly referred to as population count.
@@ -131,6 +171,9 @@ These instructions count the number of set bits (1-bits). This is also commonly 
 +-----------+-----------+-----------------------+
 |           | ✔         | cpopw rd, rs          |
 +-----------+-----------+-----------------------+
+
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **CPOP**: Count set bits
 
@@ -144,6 +187,9 @@ These instructions count the number of set bits (1-bits). This is also commonly 
 
     **Exception raised**: NONE
 
+RV64 specific instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~	
+	
 - **CPOPW**: Count set bits in word
 
     **Format**: cpopw rd, rs 
@@ -173,6 +219,9 @@ The integer minimum/maximum instructions are arithmetic R-type instructions that
 +-----------+-----------+-----------------------+
 | ✔         | ✔         | minu rd, rs1, rs2     |
 +-----------+-----------+-----------------------+
+
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **MAX**: Maximum
 
@@ -239,6 +288,9 @@ These instructions replace the generalized idioms slli rD,rS,(XLEN-<size>) + srl
 | ✔         | ✔         | zext.h rd, rs         |
 +-----------+-----------+-----------------------+
 
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 - **SEXT.B**: Sign-extend byte
 
     **Format**: sext.b rd, rs 
@@ -295,6 +347,9 @@ Bitwise rotation instructions are similar to the shift-logical operations from t
 |           | ✔         | rorw rd, rs1, rs2     |
 +-----------+-----------+-----------------------+
 
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 - **ROL**: Rotate Left (Register)
 
     **Format**: rol rd, rs1, rs2
@@ -302,18 +357,6 @@ Bitwise rotation instructions are similar to the shift-logical operations from t
     **Description**: This instruction performs a rotate left of rs1 by the amount in least-significant log2(XLEN) bits of rs2.
 
     **Pseudocode**: (X(rs1) << log2(XLEN)) | (X(rs1) >> (xlen - log2(XLEN)))
-
-    **Invalid values**: NONE
-
-    **Exception raised**: NONE
-
-- **ROLW**: Rotate Left Word (Register)
-
-    **Format**: rolw rd, rs1, rs2
-
-    **Description**: This instruction performs a rotate left on the least-significant word of rs1 by the amount in least-significant 5 bits of rs2. The resulting word value is sign-extended by copying bit 31 to all of the more-significant bits.
-
-    **Pseudocode**: EXTS((rs1 << X(rs2)[4..0];) | (rs1 >> (32 - X(rs2)[4..0];)))
 
     **Invalid values**: NONE
 
@@ -343,6 +386,21 @@ Bitwise rotation instructions are similar to the shift-logical operations from t
 
     **Exception raised**: NONE
 
+RV64 specific instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~	
+	
+- **ROLW**: Rotate Left Word (Register)
+
+    **Format**: rolw rd, rs1, rs2
+
+    **Description**: This instruction performs a rotate left on the least-significant word of rs1 by the amount in least-significant 5 bits of rs2. The resulting word value is sign-extended by copying bit 31 to all of the more-significant bits.
+
+    **Pseudocode**: EXTS((rs1 << X(rs2)[4..0];) | (rs1 >> (32 - X(rs2)[4..0];)))
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
+
 - **RORIW**: Rotate Right Word by Immediate
 
     **Format**: roriw rd, rs1, shamt
@@ -366,7 +424,7 @@ Bitwise rotation instructions are similar to the shift-logical operations from t
     **Invalid values**: NONE
 
     **Exception raised**: NONE
-
+	
 OR Combine
 ------------
 orc.b sets the bits of each byte in the result rd to all zeros if no bit within the respective byte of rs is set, or to all ones if any bit within the respective byte of rs is set.
@@ -378,6 +436,9 @@ One use-case is string-processing functions, such as strlen and strcpy, which ca
 +===========+===========+=======================+
 | ✔         | ✔         | orc.b rd, rs          |
 +-----------+-----------+-----------------------+
+
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **ORC.B**: Bitwise OR-Combine, byte granule
 
@@ -400,6 +461,9 @@ rev8 reverses the byte-ordering of rs.
 +===========+===========+=======================+
 | ✔         | ✔         | rev8 rd, rs           |
 +-----------+-----------+-----------------------+
+
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **REV8**: Byte-reverse register
 

--- a/docs/01_cva6_user/RISCV_Instructions_RVZbc.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZbc.rst
@@ -1,5 +1,36 @@
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 10xEngineers
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _cva6_riscv_instructions_RV32Zbc:
+
+*Applicability of this chapter to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60AX", "Implemented extension"
+   "CV32A60X", "Implemented extension"
+
+   
 =================================
-Zbc: Carry-less multiplication
+RVZbc: Carry-less multiplication
 =================================
 Carry-less multiplication is the multiplication in the polynomial ring over GF(2).
 
@@ -18,6 +49,9 @@ The following instructions (and pseudoinstructions) comprise the Zbc extension:
 +-----------+-----------+-----------------------+
 | ✔         | ✔         | clmulr rd, rs1, rs2   |
 +-----------+-----------+-----------------------+
+
+RV32 and RV64 Instructions
+--------------------------
 
 - **CLMUL**: Carry-less multiply (low-part)
 

--- a/docs/01_cva6_user/RISCV_Instructions_RVZbs.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZbs.rst
@@ -1,5 +1,36 @@
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 10xEngineers
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _cva6_riscv_instructions_RV32Zbs:
+
+*Applicability of this chapter to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60AX", "Implemented extension"
+   "CV32A60X", "Implemented extension"
+
+   
 ============================
-Zbs: Single-bit instructions
+RVZbs: Single-bit instructions
 ============================
 The single-bit instructions provide a mechanism to set, clear, invert, or extract a single bit in a register. The bit is specified by its index.
 
@@ -24,6 +55,9 @@ The following instructions (and pseudoinstructions) comprise the Zbs extension:
 +-----------+-----------+-----------------------+
 | ✔         | ✔         | bseti rd, rs1, imm    |
 +-----------+-----------+-----------------------+
+
+RV32 and RV64 Instructions
+--------------------------
 
 - **BCLR**: Single-Bit Clear (Register)
 

--- a/docs/01_cva6_user/RISCV_Instructions_RVZicond.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZicond.rst
@@ -25,8 +25,8 @@
    :align: left
    :header: "Configuration", "Implementation"
 
-   "CV32A60X", "Implemented extension"
-   "CV32A60MX", "Not implemented extension"
+   "CV32A60AX", "Implemented extension"
+   "CV32A60X", "Not implemented extension"
 
 **Note**: RV32Zicond and RV64Zicond are identical.
 

--- a/docs/02_cva6_requirements/cva6_requirements_specification.rst
+++ b/docs/02_cva6_requirements/cva6_requirements_specification.rst
@@ -143,30 +143,30 @@ Below are the configuration of the first releases of the CVA6.
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 | Release ID         | Target  | ISA     | XLEN | FPU   | CV-X-IF | MMU     | L1 D$   | L1 I$   |
 +====================+=========+=========+======+=======+=========+=========+=========+=========+
-| CV32E6?X           | ASIC    | IMC     |  32  | No    | Yes     | None    | 2 kB    | 2 kB    |
+| ``CV32A60X``       | ASIC    | IMC     |  32  | No    | Yes     | None    | 2 kB    | 2 kB    |
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
-| CV32A60X           | ASIC    | IMC     |  32  | No    | Yes     | Sv32    | 16kB    | 16 kB   |
+| ``CV32A60AX``      | ASIC    | IMC     |  32  | No    | Yes     | Sv32    | 16kB    | 16 kB   |
 +--------------------+---------+---------+------+-------+---------+---------+---------+---------+
 
-The value of the "?" digit above is yet to be defined when all details of this configuration are known.
+CV32A60X could evolve to CV32A65X if the team decides to integrate the dual-issue optional architectural feature.
 
-Possible Future Releases
-------------------------
-
-Below is a proposed list of configurations that could undergo verification and their main parameters.
-The full list of parameters for these configurations will be detailed in the users’ guide if and when these configurations are fully verified.
-
-+--------------------+---------+--------+------+-------+---------+---------+---------+---------+
-| Configuation ID    | Target  | ISA    | XLEN | FPU   | CV-X-IF | MMU     | L1 D$   | L1 I$   |
-+====================+=========+========+======+=======+=========+=========+=========+=========+
-| cv32a6_imacf_sv32  | FPGA    | IMACF  |  32  | Yes   | TBD     | Sv32    | 32 kB   | 16 kB   |
-+--------------------+---------+--------+------+-------+---------+---------+---------+---------+
-| cv32a6_imac_sv32   | FPGA    | IMAC   |  32  | No    | TBD     | Sv32    | 32 kB   | 16 kB   |
-+--------------------+---------+--------+------+-------+---------+---------+---------+---------+
-| cv64a6_imacfd_sv39 | ASIC    | IMACFD |  64  | Yes   | Yes     | Sv39    | 16 kB   | 16 kB   |
-+--------------------+---------+--------+------+-------+---------+---------+---------+---------+
-| cv32a6_imac_sv0    | ASIC    | IMAC   |  32  | No    | Yes     | None    | None    | 4 kB    |
-+--------------------+---------+--------+------+-------+---------+---------+---------+---------+
+.. Possible Future Releases
+.. ------------------------
+..
+.. Below is a proposed list of configurations that could undergo verification and their main parameters.
+.. The full list of parameters for these configurations will be detailed in the users’ guide if and when these configurations are fully verified.
+..
+.. +--------------------+---------+--------+------+-------+---------+---------+---------+---------+
+.. | Configuation ID    | Target  | ISA    | XLEN | FPU   | CV-X-IF | MMU     | L1 D$   | L1 I$   |
+.. +====================+=========+========+======+=======+=========+=========+=========+=========+
+.. | cv32a6_imacf_sv32  | FPGA    | IMACF  |  32  | Yes   | TBD     | Sv32    | 32 kB   | 16 kB   |
+.. +--------------------+---------+--------+------+-------+---------+---------+---------+---------+
+.. | cv32a6_imac_sv32   | FPGA    | IMAC   |  32  | No    | TBD     | Sv32    | 32 kB   | 16 kB   |
+.. +--------------------+---------+--------+------+-------+---------+---------+---------+---------+
+.. | cv64a6_imacfd_sv39 | ASIC    | IMACFD |  64  | Yes   | Yes     | Sv39    | 16 kB   | 16 kB   |
+.. +--------------------+---------+--------+------+-------+---------+---------+---------+---------+
+.. | cv32a6_imac_sv0    | ASIC    | IMAC   |  32  | No    | Yes     | None    | None    | 4 kB    |
+.. +--------------------+---------+--------+------+-------+---------+---------+---------+---------+
 
 .. _references:
 


### PR DESCRIPTION
In the user manual:
- Updated part numbers: CV32A60X (embedded configuration), CV32A60AX (application configuration)
- In the Zb* extensions, grouped RV32+RV64 instructions on one side and RV64-specific instructions on the other side, to ease the upcoming templating.

The upcoming templating will allow to generate documentation that are specific to a given configuration.