### PR TITLE
Quickstart fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,24 @@ cd cva6
 git submodule update --init --recursive
 ```
 
-2. Install the [GCC Toolchain](file:util/gcc-toolchain-builder/README.md#Prerequisites).
+2. Install the GCC Toolchain [build prerequisites](util/gcc-toolchain-builder/README.md#Prerequisites) then [the toolchain itself](util/gcc-toolchain-builder/README.md#Getting-started).
 
-:warning: It is **strongly recommanded** to use the toolchain built with the provided scripts.
+:warning: It is **strongly recommended** to use the toolchain built with the provided scripts.
 
 3. Set the RISCV environment variable.
 ```sh
 export RISCV=/path/to/toolchain/installation/directory
 ```
 
-4. Run these commands to install a custom Spike and Verilator (i.e. these versions must be used to simulate the CVA6) and [these](#running-regression-tests-simulations) tests suites.
+4. Install `help2man` and `device-tree-compiler` packages. 
+
+For Debian-based Linux distributions, run :
+
+```sh
+sudo apt-get install help2man device-tree-compiler
+```
+
+5. Run these commands to install a custom Spike and Verilator (i.e. these versions must be used to simulate the CVA6) and [these](#running-regression-tests-simulations) tests suites.
 ```sh
 # DV_SIMULATORS is detailed in the next section
 export DV_SIMULATORS=veri-testharness,spike

--- a/util/gcc-toolchain-builder/README.md
+++ b/util/gcc-toolchain-builder/README.md
@@ -40,7 +40,7 @@ On macOS, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
 ## Getting started
 
-Once the prerequisites (see [below](#prerequisites)) are satisfied, you can fetch and build the
+Once the prerequisites (see [above](#prerequisites)) are satisfied, you can fetch and build the
 upstream GCC toolchain (default: 13.1.0) for bare-metal 32-bit and 64-bit applications in just three steps.
 
     # 1. Select an installation location for the toolchain (here: the default RISC-V tooling directory $RISCV).


### PR DESCRIPTION
Fixed a broken link to `util/gcc-toolchain-builder/README.md` leading to https://github.com/openhwgroup/cva6/issues/1693.
Added a section regarding Spike and Verilator install preriquisites (see https://github.com/openhwgroup/cva6/issues/1700)