### PR TITLE
Add overflow counter test & fix reset value

### DIFF
--- a/verif/tests/custom/csr_embedded/csr_counters_overflow.S
+++ b/verif/tests/custom/csr_embedded/csr_counters_overflow.S
@@ -1,0 +1,158 @@
+# Copyright 2023 Thales DIS France SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+
+.globl main
+main:
+    call csr_cycle_overflow
+    call csr_instert_overflow
+    #End of csr test
+    j csr_pass
+
+csr_cycle_overflow:
+    #Overflow CYCLE and MCYCLE, MCYCLEH and CYCLEH should increment by 1
+    li x3, 0xfffffff0
+    csrw mcycle, x3
+    
+    #Read backs registers
+    csrr x14, cycle
+    csrr x14, cycleh
+    csrr x14, mcycle
+    csrr x14, mcycleh
+
+    #Wait some cycles to overflow MCYCLE and CYCLE
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+    #Read backs registers. cycle and mcycle should be arround 0, cycleh and mcycleh should increment by 1
+    csrr x14, cycle
+    csrr x14, cycleh
+    csrr x14, mcycle
+    csrr x14, mcycleh
+
+    #Overflow MCYCLEH and CYCLEH.
+    li x3, 0xffffffff
+    csrw mcycleh, x3
+    li x3, 0xfffffff0
+    csrw mcycle, x3
+
+    #Read backs registers
+    csrr x14, cycle
+    csrr x14, cycleh
+    csrr x14, mcycle
+    csrr x14, mcycleh
+    
+    #Wait some cycles to overflow
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+        
+    #Read backs registers, cycle and mcycle should be arround 0, cycleh and mcycleh should be 0
+    csrr x14, cycle
+    csrr x14, cycleh
+    csrr x14, mcycle
+    csrr x14, mcycleh
+
+    ret
+
+csr_instert_overflow:
+    #Overflow INSTRET and MINSTRET, MINSTRETH and INSTRETH should increment by 1
+    li x3, 0xfffffff0
+    csrw minstret, x3
+    
+    #Read backs registers
+    csrr x14, instret
+    csrr x14, instreth
+    csrr x14, minstret
+    csrr x14, minstreth
+
+    #Wait some instrets to overflow MINSTRET and INSTRET
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+    #Read backs registers. instret and minstret should be arround 0, instreth and minstreth should increment by 1
+    csrr x14, instret
+    csrr x14, instreth
+    csrr x14, minstret
+    csrr x14, minstreth
+
+    #Overflow MINSTRETH and INSTRETH.
+    li x3, 0xffffffff
+    csrw minstreth, x3
+    li x3, 0xfffffff0
+    csrw minstret, x3
+
+    #Read backs registers
+    csrr x14, instret
+    csrr x14, instreth
+    csrr x14, minstret
+    csrr x14, minstreth
+    
+    #Wait some instrets to overflow
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+        
+    #Read backs registers, instret and minstret should be arround 0, instreth and minstreth should be 0
+    csrr x14, instret
+    csrr x14, instreth
+    csrr x14, minstret
+    csrr x14, minstreth
+
+    ret
+
+csr_pass:
+    li x1, 0
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, x30
+    self_loop: j self_loop
+
+csr_fail:
+    li x1, 1
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, x30
+    self_loop_2: j self_loop_2

--- a/verif/tests/custom/csr_embedded/csrrw_fields_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_fields_test.S
@@ -2813,6 +2813,13 @@ csrrw_fields:
     #PMPCFG0 fields testing W/R
     ##########################
     #PMPCFG0.PMP0CFG testing W/R values '{'hff, 'h0, 'h55, 'haa, 'h79} 
+    #PMPCFG0 Write value 0x00088808
+    li x3, 0x00088808
+    csrw 0x3a0, x3
+
+    #PMPCFG0 read value
+    csrr x14, 0x3a0
+
     #PMPCFG0 Write value 0xff
     li x3, 0xff
     csrw 0x3a0, x3
@@ -2848,7 +2855,7 @@ csrrw_fields:
     #PMPCFG0 read value
     csrr x14, 0x3a0
 
-    #PMPCFG0.PMP1CFG testing W/R values '{'hff, 'h0, 'h55, 'haa, 'hcd} 
+    #PMPCFG0.PMP1CFG testing W/R values '{'hff, 'h0, 'h55, 'haa, 'hcd}
     #PMPCFG0 Write value 0xff00
     li x3, 0xff00
     csrw 0x3a0, x3

--- a/verif/tests/custom/csr_embedded/csrrw_ro_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_ro_test.S
@@ -903,17 +903,17 @@ main:
     ##########################
     #MVENDORID testing W/R values '{'hffff3fbf, 'hc040, 'h55555555, 'haaaaaaaa, 'h49c2df61} 
     ##########################
-    #MVENDORID Writing data 0xffff3fbf to RO register/fields with mask 0xffffffff will generate exception
-    #MVENDORID Write value 0xffff3fbf
+    #MVENDORID Writing data 0xfffff9fd to RO register/fields with mask 0xffffffff will generate exception
+    #MVENDORID Write value 0xfffff9fd
     li x3, 0xffff3fbf
     csrw 0xf11, x3
 
     #MVENDORID read value
     csrr x14, 0xf11
 
-    #MVENDORID Writing data 0xc040 to RO register/fields with mask 0xffffffff will generate exception
-    #MVENDORID Write value 0xc040
-    li x3, 0xc040
+    #MVENDORID Writing data 0x0602 to RO register/fields with mask 0xffffffff will generate exception
+    #MVENDORID Write value 0x0602
+    li x3, 0x0602
     csrw 0xf11, x3
 
     #MVENDORID read value

--- a/verif/tests/custom/csr_embedded/csrrw_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_test.S
@@ -3225,15 +3225,15 @@ csrrw:
     ##########################
     #MISA testing W/R values '{'hfdbf7bfb, 'h2408404, 'h55555555, 'haaaaaaaa, 'heefe0e69} 
     ##########################
-    #MISA Write value 0xfdbf7bfb
-    li x3, 0xfdbf7bfb
+    #MISA Write value 0xbfffeef9
+    li x3, 0xbfffeef9
     csrw 0x301, x3
 
     #MISA read value
     csrr x14, 0x301
 
-    #MISA Write value 0x2408404
-    li x3, 0x2408404
+    #MISA Write value 0x40001106
+    li x3, 0x40001106
     csrw 0x301, x3
 
     #MISA read value

--- a/verif/tests/testlist_csr_embedded.yaml
+++ b/verif/tests/testlist_csr_embedded.yaml
@@ -49,3 +49,9 @@
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld -lgcc"
   asm_tests: <path_var>/custom/csr_embedded/csrrw_unmapped_test.S
+
+- test: counters_overflow_test
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld -lgcc"
+  asm_tests: <path_var>/custom/csr_embedded/csr_counters_overflow.S


### PR DESCRIPTION
This MR add overflow counters test for, m[cycle]h , m[instret]h, also fixing reset value for misa & mvendorid