### PR TITLE
csr_regfile.sv: add RVB field for MISA (fix #1734)

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -75,7 +75,7 @@ module alu
   always_comb begin
     operand_a_bitmanip = fu_data_i.operand_a;
 
-    if (ariane_pkg::BITMANIP) begin
+    if (CVA6Cfg.RVB) begin
       if (riscv::IS_XLEN64) begin
         unique case (fu_data_i.operation)
           SH1ADDUW:           operand_a_bitmanip = fu_data_i.operand_a[31:0] << 1;
@@ -194,7 +194,7 @@ module alu
             $signed({sgn & fu_data_i.operand_b[riscv::XLEN-1], fu_data_i.operand_b}));
   end
 
-  if (ariane_pkg::BITMANIP) begin : gen_bitmanip
+  if (CVA6Cfg.RVB) begin : gen_bitmanip
     // Count Population + Count population Word
 
     popcount #(
@@ -227,7 +227,7 @@ module alu
     end
   end
 
-  if (ariane_pkg::BITMANIP) begin : gen_orcbw_rev8w_results
+  if (CVA6Cfg.RVB) begin : gen_orcbw_rev8w_results
     assign orcbw = {
       {8{|fu_data_i.operand_a[31:24]}},
       {8{|fu_data_i.operand_a[23:16]}},
@@ -290,7 +290,7 @@ module alu
       default: ;  // default case to suppress unique warning
     endcase
 
-    if (ariane_pkg::BITMANIP) begin
+    if (CVA6Cfg.RVB) begin
       // Index for Bitwise Rotation
       bit_indx = 1 << (fu_data_i.operand_b & (riscv::XLEN - 1));
       // rolw, roriw, rorw

--- a/core/compressed_decoder.sv
+++ b/core/compressed_decoder.sv
@@ -588,7 +588,7 @@ module compressed_decoder #(
                         end
 
                         3'b001: begin
-                          if (ariane_pkg::BITMANIP) begin
+                          if (CVA6Cfg.RVB) begin
                             // c.sext.b -> sext.b rd', rd'
                             instr_o = {
                               7'h30,
@@ -604,7 +604,7 @@ module compressed_decoder #(
                         end
 
                         3'b010: begin
-                          if (ariane_pkg::BITMANIP) begin
+                          if (CVA6Cfg.RVB) begin
                             // c.zext.h -> zext.h rd', rd'
                             if (riscv::IS_XLEN64) begin
                               instr_o = {
@@ -633,7 +633,7 @@ module compressed_decoder #(
                         end
 
                         3'b011: begin
-                          if (ariane_pkg::BITMANIP) begin
+                          if (CVA6Cfg.RVB) begin
                             // c.sext.h -> sext.h rd', rd'
                             instr_o = {
                               7'h30,
@@ -649,7 +649,7 @@ module compressed_decoder #(
                         end
 
                         3'b100: begin
-                          if (ariane_pkg::BITMANIP) begin
+                          if (CVA6Cfg.RVB) begin
                             // c.zext.w -> add.uw
                             if (riscv::IS_XLEN64) begin
                               instr_o = {

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -157,9 +157,10 @@ module csr_regfile
   logic [3:0] index;
 
   localparam riscv::xlen_t IsaCode = (riscv::XLEN'(CVA6Cfg.RVA) <<  0)                // A - Atomic Instructions extension
+  | (riscv::XLEN'(CVA6Cfg.RVB) << 1)  // C - Bitmanip extension
   | (riscv::XLEN'(CVA6Cfg.RVC) << 2)  // C - Compressed extension
-  | (riscv::XLEN'(CVA6Cfg.RVD) << 3)  // D - Double precsision floating-point extension
-  | (riscv::XLEN'(CVA6Cfg.RVF) << 5)  // F - Single precsision floating-point extension
+  | (riscv::XLEN'(CVA6Cfg.RVD) << 3)  // D - Double precision floating-point extension
+  | (riscv::XLEN'(CVA6Cfg.RVF) << 5)  // F - Single precision floating-point extension
   | (riscv::XLEN'(1) << 8)  // I - RV32I/64I/128I base ISA
   | (riscv::XLEN'(1) << 12)  // M - Integer Multiply/Divide extension
   | (riscv::XLEN'(0) << 13)  // N - User level interrupts supported

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -177,6 +177,7 @@ module cva6
     CVA6Cfg.XF16ALT,
     CVA6Cfg.XF8,
     CVA6Cfg.RVA,
+    CVA6Cfg.RVB,
     CVA6Cfg.RVV,
     CVA6Cfg.RVC,
     CVA6Cfg.RVZCB,

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -530,7 +530,7 @@ module decoder
             // Integer Reg-Reg Operations
             // ---------------------------
           end else begin
-            if (ariane_pkg::BITMANIP) begin
+            if (CVA6Cfg.RVB) begin
               instruction_o.fu  = (instr.rtype.funct7 == 7'b000_0001 || ((instr.rtype.funct7 == 7'b000_0101) && !(instr.rtype.funct3[14]))) ? MULT : ALU;
             end else begin
               instruction_o.fu = (instr.rtype.funct7 == 7'b000_0001) ? MULT : ALU;
@@ -568,7 +568,7 @@ module decoder
                 illegal_instr_non_bm = 1'b1;
               end
             endcase
-            if (ariane_pkg::BITMANIP) begin
+            if (CVA6Cfg.RVB) begin
               unique case ({
                 instr.rtype.funct7, instr.rtype.funct3
               })
@@ -618,7 +618,7 @@ module decoder
             end
             //VCS coverage on
             unique case ({
-              ariane_pkg::BITMANIP, CVA6Cfg.ZiCondExtEn
+              CVA6Cfg.RVB, CVA6Cfg.ZiCondExtEn
             })
               2'b00: illegal_instr = illegal_instr_non_bm;
               2'b01: illegal_instr = illegal_instr_non_bm & illegal_instr_zic;
@@ -653,7 +653,7 @@ module decoder
               {7'b000_0001, 3'b111} : instruction_o.op = ariane_pkg::REMUW;
               default: illegal_instr_non_bm = 1'b1;
             endcase
-            if (ariane_pkg::BITMANIP) begin
+            if (CVA6Cfg.RVB) begin
               unique case ({
                 instr.rtype.funct7, instr.rtype.funct3
               })
@@ -706,7 +706,7 @@ module decoder
               if (instr.instr[25] != 1'b0 && riscv::XLEN == 32) illegal_instr_non_bm = 1'b1;
             end
           endcase
-          if (ariane_pkg::BITMANIP) begin
+          if (CVA6Cfg.RVB) begin
             unique case (instr.itype.funct3)
               3'b001: begin
                 if (instr.instr[31:25] == 7'b0110000) begin
@@ -760,7 +760,7 @@ module decoder
               end
               default: illegal_instr_non_bm = 1'b1;
             endcase
-            if (ariane_pkg::BITMANIP) begin
+            if (CVA6Cfg.RVB) begin
               unique case (instr.itype.funct3)
                 3'b001: begin
                   if (instr.instr[31:25] == 7'b0110000) begin

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -167,11 +167,6 @@ package ariane_pkg;
   localparam int unsigned INSTR_PER_FETCH = RVC == 1'b1 ? (FETCH_WIDTH / 16) : 1;
   localparam int unsigned LOG2_INSTR_PER_FETCH = RVC == 1'b1 ? $clog2(INSTR_PER_FETCH) : 1;
 
-  // ---------------
-  // Enable BITMANIP
-  // ---------------
-  localparam bit BITMANIP = cva6_config_pkg::CVA6ConfigBExtEn;
-
   // Only use struct when signals have same direction
   // exception
   typedef struct packed {

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -52,6 +52,7 @@ package config_pkg;
     bit                          XF16ALT;
     bit                          XF8;
     bit                          RVA;
+    bit                          RVB;
     bit                          RVV;
     bit                          RVC;
     bit                          RVZCB;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -83,6 +83,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -83,6 +83,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -91,6 +91,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -84,6 +84,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -83,6 +83,7 @@ package cva6_config_pkg;
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),
       RVA: bit'(CVA6ConfigAExtEn),
+      RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
       RVZCB: bit'(CVA6ConfigZcbExtEn),

--- a/core/multiplier.sv
+++ b/core/multiplier.sv
@@ -37,7 +37,7 @@ module multiplier
       clmul_q, clmul_d, clmulr_q, clmulr_d, operand_a, operand_b, operand_a_rev, operand_b_rev;
   logic clmul_rmode, clmul_hmode;
 
-  if (ariane_pkg::BITMANIP) begin : gen_bitmanip
+  if (CVA6Cfg.RVB) begin : gen_bitmanip
     // checking for clmul_rmode and clmul_hmode
     assign clmul_rmode = (operation_i == CLMULR);
     assign clmul_hmode = (operation_i == CLMULH);
@@ -126,7 +126,7 @@ module multiplier
       end
     endcase
   end
-  if (ariane_pkg::BITMANIP) begin
+  if (CVA6Cfg.RVB) begin
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (~rst_ni) begin
         clmul_q  <= '0;

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -172,6 +172,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   XF16ALT:               bit'(cva6_config_pkg::CVA6ConfigF16AltEn),
   XF8:                   bit'(cva6_config_pkg::CVA6ConfigF8En),
   RVA:                   bit'(cva6_config_pkg::CVA6ConfigAExtEn),
+  RVB:                   bit'(cva6_config_pkg::CVA6ConfigAExtEn),
   RVV:                   bit'(cva6_config_pkg::CVA6ConfigVExtEn),
   RVC:                   bit'(cva6_config_pkg::CVA6ConfigCExtEn),
   RVZCB:                 bit'(cva6_config_pkg::CVA6ConfigZcbExtEn),


### PR DESCRIPTION
To have similar for RVB as for other extensions in csr_regfile.sv, replace ariane_pkg::BITMANIP by CVA6Cfg.RVB