### PR TITLE
Remove all logic and sequential related to RVFI in CORE cva6

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,3 +1,3 @@
 cv32a6_embedded:
-  gates: 120760
+  gates: 114319
 

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ fpga_src :=  $(wildcard corev_apu/fpga/src/*.sv) $(wildcard corev_apu/fpga/src/b
 fpga_src := $(addprefix $(root-dir), $(fpga_src))
 
 # look for testbenches
-tbs := core/include/$(target)_config_pkg.sv corev_apu/tb/ariane_tb.sv corev_apu/tb/ariane_testharness.sv
+tbs := core/include/$(target)_config_pkg.sv corev_apu/tb/ariane_tb.sv corev_apu/tb/ariane_testharness.sv core/cva6_rvfi.sv
 
 tbs := $(addprefix $(root-dir), $(tbs))
 
@@ -543,6 +543,7 @@ xrun-ci: xrun-asm-tests xrun-amo-tests xrun-mul-tests xrun-fp-tests xrun-benchma
 # verilator-specific
 verilate_command := $(verilator) --no-timing verilator_config.vlt                                                \
                     -f core/Flist.cva6                                                                           \
+                    core/cva6_rvfi.sv                                                                            \
                     $(filter-out %.vhd, $(ariane_pkg))                                                           \
                     $(filter-out core/fpu_wrap.sv, $(filter-out %.vhd, $(filter-out %_config_pkg.sv, $(src))))   \
                     +define+$(defines)$(if $(TRACE_FAST),+VM_TRACE)$(if $(TRACE_COMPACT),+VM_TRACE+VM_TRACE_FST) \

--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -98,6 +98,7 @@ ${CVA6_REPO_DIR}/vendor/pulp-platform/common_cells/src/delta_counter.sv
 
 // Top-level source files (not necessarily instantiated at the top of the cva6).
 ${CVA6_REPO_DIR}/core/cva6.sv
+${CVA6_REPO_DIR}/core/cva6_rvfi_probes.sv
 ${CVA6_REPO_DIR}/core/alu.sv
 // Note: depends on fpnew_pkg, above
 ${CVA6_REPO_DIR}/core/fpu_wrap.sv

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -25,7 +25,12 @@ module cva6
       logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0]                    commit_pointer;
       logic                                                                   flush_unissued_instr;
       logic                                                                   decoded_instr_valid;
+      logic                                                                   flush;
       logic                                                                   decoded_instr_ack;
+      logic                                                                   issue_instr_ack;
+      logic                                                                   fetch_entry_valid;
+      logic [31:0]                                                            instruction;
+      logic                                                                   is_compressed;
       riscv::xlen_t                                                           rs1_forwarding;
       riscv::xlen_t                                                           rs2_forwarding;
       scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0]                          commit_instr;
@@ -444,6 +449,7 @@ module cva6
   //RVFI
   lsu_ctrl_t                                             rvfi_lsu_ctrl;
   logic          [riscv::PLEN-1:0]                       rvfi_mem_paddr;
+  logic                                                  rvfi_is_compressed;
   rvfi_probes_t                                          rvfi_probes;
 
 
@@ -498,6 +504,8 @@ module cva6
       .issue_entry_valid_o(issue_entry_valid_id_issue),
       .is_ctrl_flow_o     (is_ctrl_fow_id_issue),
       .issue_instr_ack_i  (issue_instr_issue_id),
+
+      .rvfi_is_compressed_o(rvfi_is_compressed),
 
       .priv_lvl_i  (priv_lvl),
       .fs_i        (fs),
@@ -1349,6 +1357,12 @@ module cva6
         .CVA6Cfg   (CVA6ExtendCfg),
         .rvfi_probes_t(rvfi_probes_t)
     ) i_cva6_rvfi_combi (
+
+        .flush_i            (flush_ctrl_if),
+        .issue_instr_ack_i  (issue_instr_issue_id),
+        .fetch_entry_valid_i(fetch_valid_if_id),
+        .instruction_i      (fetch_entry_if_id.instruction),
+        .is_compressed_i    (rvfi_is_compressed),
 
         .issue_pointer_i (rvfi_issue_pointer),
         .commit_pointer_i(rvfi_commit_pointer),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -20,31 +20,25 @@ module cva6
     parameter config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg,
     parameter bit IsRVFI = bit'(cva6_config_pkg::CVA6ConfigRvfiTrace),
     // RVFI
-    parameter type rvfi_instr_t = struct packed {
-      logic [config_pkg::NRET-1:0]                  valid;
-      logic [config_pkg::NRET*64-1:0]               order;
-      logic [config_pkg::NRET*config_pkg::ILEN-1:0] insn;
-      logic [config_pkg::NRET-1:0]                  trap;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      cause;
-      logic [config_pkg::NRET-1:0]                  halt;
-      logic [config_pkg::NRET-1:0]                  intr;
-      logic [config_pkg::NRET*2-1:0]                mode;
-      logic [config_pkg::NRET*2-1:0]                ixl;
-      logic [config_pkg::NRET*5-1:0]                rs1_addr;
-      logic [config_pkg::NRET*5-1:0]                rs2_addr;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      rs1_rdata;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      rs2_rdata;
-      logic [config_pkg::NRET*5-1:0]                rd_addr;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      rd_wdata;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_rdata;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_wdata;
-      logic [config_pkg::NRET*riscv::VLEN-1:0]      mem_addr;
-      logic [config_pkg::NRET*riscv::PLEN-1:0]      mem_paddr;
-      logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_rmask;
-      logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_wmask;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_rdata;
-      logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_wdata;
+    parameter type rvfi_probes_t = struct packed {
+      logic [TRANS_ID_BITS-1:0]                                               issue_pointer;
+      logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0]                    commit_pointer;
+      logic                                                                   flush_unissued_instr;
+      logic                                                                   decoded_instr_valid;
+      logic                                                                   decoded_instr_ack;
+      riscv::xlen_t                                                           rs1_forwarding;
+      riscv::xlen_t                                                           rs2_forwarding;
+      scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0]                          commit_instr;
+      exception_t                                                             ex_commit;
+      riscv::priv_lvl_t                                                       priv_lvl;
+      lsu_ctrl_t                                                              lsu_ctrl;
+      logic [((CVA6Cfg.CvxifEn || CVA6Cfg.RVV) ? 5 : 4)-1:0][riscv::XLEN-1:0] wbdata;
+      logic [CVA6Cfg.NrCommitPorts-1:0]                                       commit_ack;
+      logic [riscv::PLEN-1:0]                                                 mem_paddr;
+      logic                                                                   debug_mode;
+      logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0]                      wdata;
     },
+
     // AXI types
     parameter type axi_ar_chan_t = struct packed {
       logic [CVA6Cfg.AxiIdWidth-1:0]   id;
@@ -129,7 +123,7 @@ module cva6
     input logic debug_req_i,  // debug request (async)
     // RISC-V formal interface port (`rvfi`):
     // Can be left open when formal tracing is not needed.
-    output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o,
+    output rvfi_probes_t rvfi_probes_o,
     output cvxif_req_t cvxif_req_o,
     input cvxif_resp_t cvxif_resp_i,
     // memory side
@@ -348,6 +342,11 @@ module cva6
   // --------------
   scoreboard_entry_t [CVA6ExtendCfg.NrCommitPorts-1:0] commit_instr_id_commit;
   // --------------
+  // RVFI
+  // --------------
+  logic [TRANS_ID_BITS-1:0] rvfi_issue_pointer;
+  logic [CVA6ExtendCfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] rvfi_commit_pointer;
+  // --------------
   // COMMIT <-> ID
   // --------------
   logic [CVA6ExtendCfg.NrCommitPorts-1:0][4:0] waddr_commit_id;
@@ -392,66 +391,66 @@ module cva6
   // ----------------------------
   logic [11:0] addr_csr_perf;
   riscv::xlen_t data_csr_perf, data_perf_csr;
-  logic                                                                we_csr_perf;
+  logic                                                  we_csr_perf;
 
-  logic                                                                icache_flush_ctrl_cache;
-  logic                                                                itlb_miss_ex_perf;
-  logic                                                                dtlb_miss_ex_perf;
-  logic                                                                dcache_miss_cache_perf;
-  logic                                                                icache_miss_cache_perf;
-  logic          [                 NumPorts-1:0][DCACHE_SET_ASSOC-1:0] miss_vld_bits;
-  logic                                                                stall_issue;
+  logic                                                  icache_flush_ctrl_cache;
+  logic                                                  itlb_miss_ex_perf;
+  logic                                                  dtlb_miss_ex_perf;
+  logic                                                  dcache_miss_cache_perf;
+  logic                                                  icache_miss_cache_perf;
+  logic          [   NumPorts-1:0][DCACHE_SET_ASSOC-1:0] miss_vld_bits;
+  logic                                                  stall_issue;
   // --------------
   // CTRL <-> *
   // --------------
-  logic                                                                set_pc_ctrl_pcgen;
-  logic                                                                flush_csr_ctrl;
-  logic                                                                flush_unissued_instr_ctrl_id;
-  logic                                                                flush_ctrl_if;
-  logic                                                                flush_ctrl_id;
-  logic                                                                flush_ctrl_ex;
-  logic                                                                flush_ctrl_bp;
-  logic                                                                flush_tlb_ctrl_ex;
-  logic                                                                fence_i_commit_controller;
-  logic                                                                fence_commit_controller;
-  logic                                                                sfence_vma_commit_controller;
-  logic                                                                halt_ctrl;
-  logic                                                                halt_csr_ctrl;
-  logic                                                                dcache_flush_ctrl_cache;
-  logic                                                                dcache_flush_ack_cache_ctrl;
-  logic                                                                set_debug_pc;
-  logic                                                                flush_commit;
-  logic                                                                flush_acc;
+  logic                                                  set_pc_ctrl_pcgen;
+  logic                                                  flush_csr_ctrl;
+  logic                                                  flush_unissued_instr_ctrl_id;
+  logic                                                  flush_ctrl_if;
+  logic                                                  flush_ctrl_id;
+  logic                                                  flush_ctrl_ex;
+  logic                                                  flush_ctrl_bp;
+  logic                                                  flush_tlb_ctrl_ex;
+  logic                                                  fence_i_commit_controller;
+  logic                                                  fence_commit_controller;
+  logic                                                  sfence_vma_commit_controller;
+  logic                                                  halt_ctrl;
+  logic                                                  halt_csr_ctrl;
+  logic                                                  dcache_flush_ctrl_cache;
+  logic                                                  dcache_flush_ack_cache_ctrl;
+  logic                                                  set_debug_pc;
+  logic                                                  flush_commit;
+  logic                                                  flush_acc;
 
-  icache_areq_t                                                        icache_areq_ex_cache;
-  icache_arsp_t                                                        icache_areq_cache_ex;
-  icache_dreq_t                                                        icache_dreq_if_cache;
-  icache_drsp_t                                                        icache_dreq_cache_if;
+  icache_areq_t                                          icache_areq_ex_cache;
+  icache_arsp_t                                          icache_areq_cache_ex;
+  icache_dreq_t                                          icache_dreq_if_cache;
+  icache_drsp_t                                          icache_dreq_cache_if;
 
-  amo_req_t                                                            amo_req;
-  amo_resp_t                                                           amo_resp;
-  logic                                                                sb_full;
+  amo_req_t                                              amo_req;
+  amo_resp_t                                             amo_resp;
+  logic                                                  sb_full;
 
   // ----------------
   // DCache <-> *
   // ----------------
-  dcache_req_i_t [                          2:0]                       dcache_req_ports_ex_cache;
-  dcache_req_o_t [                          2:0]                       dcache_req_ports_cache_ex;
-  dcache_req_i_t [                          1:0]                       dcache_req_ports_acc_cache;
-  dcache_req_o_t [                          1:0]                       dcache_req_ports_cache_acc;
-  logic                                                                dcache_commit_wbuffer_empty;
-  logic                                                                dcache_commit_wbuffer_not_ni;
+  dcache_req_i_t [            2:0]                       dcache_req_ports_ex_cache;
+  dcache_req_o_t [            2:0]                       dcache_req_ports_cache_ex;
+  dcache_req_i_t [            1:0]                       dcache_req_ports_acc_cache;
+  dcache_req_o_t [            1:0]                       dcache_req_ports_cache_acc;
+  logic                                                  dcache_commit_wbuffer_empty;
+  logic                                                  dcache_commit_wbuffer_not_ni;
 
-  logic          [              riscv::VLEN-1:0]                       lsu_addr;
-  logic          [              riscv::PLEN-1:0]                       mem_paddr;
-  logic          [          (riscv::XLEN/8)-1:0]                       lsu_rmask;
-  logic          [          (riscv::XLEN/8)-1:0]                       lsu_wmask;
-  logic          [ariane_pkg::TRANS_ID_BITS-1:0]                       lsu_addr_trans_id;
+  //RVFI
+  lsu_ctrl_t                                             rvfi_lsu_ctrl;
+  logic          [riscv::PLEN-1:0]                       rvfi_mem_paddr;
+  rvfi_probes_t                                          rvfi_probes;
+
 
   // Accelerator port
-  logic          [                         63:0]                       inval_addr;
-  logic                                                                inval_valid;
-  logic                                                                inval_ready;
+  logic          [           63:0]                       inval_addr;
+  logic                                                  inval_valid;
+  logic                                                  inval_ready;
 
   // --------------
   // Frontend
@@ -580,9 +579,7 @@ module cva6
   // Issue
   // ---------
   issue_stage #(
-      .CVA6Cfg   (CVA6ExtendCfg),
-      .IsRVFI    (IsRVFI),
-      .NR_ENTRIES(NR_SB_ENTRIES)
+      .CVA6Cfg(CVA6ExtendCfg)
   ) issue_stage_i (
       .clk_i,
       .rst_ni,
@@ -636,19 +633,17 @@ module cva6
       .wt_valid_i            (wt_valid_ex_id),
       .x_we_i                (x_we_ex_id),
 
-      .waddr_i            (waddr_commit_id),
-      .wdata_i            (wdata_commit_id),
-      .we_gpr_i           (we_gpr_commit_id),
-      .we_fpr_i           (we_fpr_commit_id),
-      .commit_instr_o     (commit_instr_id_commit),
-      .commit_ack_i       (commit_ack),
+      .waddr_i              (waddr_commit_id),
+      .wdata_i              (wdata_commit_id),
+      .we_gpr_i             (we_gpr_commit_id),
+      .we_fpr_i             (we_fpr_commit_id),
+      .commit_instr_o       (commit_instr_id_commit),
+      .commit_ack_i         (commit_ack),
       // Performance Counters
-      .stall_issue_o      (stall_issue),
+      .stall_issue_o        (stall_issue),
       //RVFI
-      .lsu_addr_i         (lsu_addr),
-      .lsu_rmask_i        (lsu_rmask),
-      .lsu_wmask_i        (lsu_wmask),
-      .lsu_addr_trans_id_i(lsu_addr_trans_id),
+      .rvfi_issue_pointer_o (rvfi_issue_pointer),
+      .rvfi_commit_pointer_o(rvfi_commit_pointer),
       .*
   );
 
@@ -757,11 +752,8 @@ module cva6
       .pmpcfg_i               (pmpcfg),
       .pmpaddr_i              (pmpaddr),
       //RVFI
-      .lsu_addr_o             (lsu_addr),
-      .mem_paddr_o            (mem_paddr),
-      .lsu_rmask_o            (lsu_rmask),
-      .lsu_wmask_o            (lsu_wmask),
-      .lsu_addr_trans_id_o    (lsu_addr_trans_id)
+      .rvfi_lsu_ctrl_o        (rvfi_lsu_ctrl),
+      .rvfi_mem_paddr_o       (rvfi_mem_paddr)
   );
 
   // ---------
@@ -1350,41 +1342,39 @@ module cva6
 `endif  // VERILATOR
   //pragma translate_on
 
+
   if (IsRVFI) begin
-    always_comb begin
-      for (int i = 0; i < CVA6ExtendCfg.NrCommitPorts; i++) begin
-        logic exception;
-        exception = commit_instr_id_commit[i].valid && ex_commit.valid;
-        rvfi_o[i].valid    = (commit_ack[i] && !ex_commit.valid) ||
-          (exception && (ex_commit.cause == riscv::ENV_CALL_MMODE ||
-                    ex_commit.cause == riscv::ENV_CALL_SMODE ||
-                    ex_commit.cause == riscv::ENV_CALL_UMODE));
-        rvfi_o[i].insn = ex_commit.valid ? ex_commit.tval[31:0] : commit_instr_id_commit[i].ex.tval[31:0];
-        // when trap, the instruction is not executed
-        rvfi_o[i].trap = exception;
-        rvfi_o[i].cause = ex_commit.cause;
-        rvfi_o[i].mode = (CVA6Cfg.DebugEn && debug_mode) ? 2'b10 : priv_lvl;
-        rvfi_o[i].ixl = riscv::XLEN == 64 ? 2 : 1;
-        rvfi_o[i].rs1_addr = commit_instr_id_commit[i].rs1[4:0];
-        rvfi_o[i].rs2_addr = commit_instr_id_commit[i].rs2[4:0];
-        rvfi_o[i].rd_addr = commit_instr_id_commit[i].rd[4:0];
-        rvfi_o[i].rd_wdata =
-            (CVA6ExtendCfg.FpPresent && ariane_pkg::is_rd_fpr(commit_instr_id_commit[i].op)) ?
-            commit_instr_id_commit[i].result : wdata_commit_id[i];
-        rvfi_o[i].pc_rdata = commit_instr_id_commit[i].pc;
 
-        rvfi_o[i].mem_addr = commit_instr_id_commit[i].lsu_addr;
-        // So far, only write paddr is reported. TODO: read paddr
-        rvfi_o[i].mem_paddr = mem_paddr;
-        rvfi_o[i].mem_wmask = commit_instr_id_commit[i].lsu_wmask;
-        rvfi_o[i].mem_wdata = commit_instr_id_commit[i].lsu_wdata;
-        rvfi_o[i].mem_rmask = commit_instr_id_commit[i].lsu_rmask;
-        rvfi_o[i].mem_rdata = commit_instr_id_commit[i].result;
-        rvfi_o[i].rs1_rdata = commit_instr_id_commit[i].rs1_rdata;
-        rvfi_o[i].rs2_rdata = commit_instr_id_commit[i].rs2_rdata;
+    cva6_rvfi_probes #(
+        .CVA6Cfg   (CVA6ExtendCfg),
+        .rvfi_probes_t(rvfi_probes_t)
+    ) i_cva6_rvfi_combi (
 
-      end
-    end
-  end
+        .issue_pointer_i (rvfi_issue_pointer),
+        .commit_pointer_i(rvfi_commit_pointer),
+
+        .flush_unissued_instr_i(flush_unissued_instr_ctrl_id),
+        .decoded_instr_valid_i (issue_entry_valid_id_issue),
+        .decoded_instr_ack_i   (issue_instr_issue_id),
+
+        .rs1_forwarding_i(rs1_forwarding_id_ex),
+        .rs2_forwarding_i(rs2_forwarding_id_ex),
+
+        .commit_instr_i(commit_instr_id_commit),
+        .ex_commit_i   (ex_commit),
+        .priv_lvl_i    (priv_lvl),
+
+        .lsu_ctrl_i  (rvfi_lsu_ctrl),
+        .wbdata_i    (wbdata_ex_id),
+        .commit_ack_i(commit_ack),
+        .mem_paddr_i (rvfi_mem_paddr),
+        .debug_mode_i(debug_mode),
+        .wdata_i     (wdata_commit_id),
+
+        .rvfi_probes_o(rvfi_probes_o)
+
+    );
+
+  end  //IsRVFI
 
 endmodule  // ariane

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -1,0 +1,247 @@
+// Copyright 2024 Thales DIS France SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Yannick Casamatta - Thales
+// Date: 09/01/2024
+
+
+module cva6_rvfi
+  import ariane_pkg::*;
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type rvfi_instr_t = logic,
+    parameter type rvfi_probes_t = logic
+) (
+
+    input logic clk_i,
+    input logic rst_ni,
+
+    input rvfi_probes_t rvfi_probes_i,
+    output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o
+
+);
+
+  // ------------------------------------------
+  // CVA6 configuration
+  // ------------------------------------------
+  // Extended config
+  localparam bit RVF = (riscv::IS_XLEN64 | riscv::IS_XLEN32) & CVA6Cfg.FpuEn;
+  localparam bit RVD = (riscv::IS_XLEN64 ? 1 : 0) & CVA6Cfg.FpuEn;
+  localparam bit FpPresent = RVF | RVD | CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8;
+  localparam bit NSX = CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8 | CVA6Cfg.XFVec;  // Are non-standard extensions present?
+  localparam int unsigned FLen = RVD ? 64 :  // D ext.
+  RVF ? 32 :  // F ext.
+  CVA6Cfg.XF16 ? 16 :  // Xf16 ext.
+  CVA6Cfg.XF16ALT ? 16 :  // Xf16alt ext.
+  CVA6Cfg.XF8 ? 8 :  // Xf8 ext.
+  1;  // Unused in case of no FP
+
+  // Transprecision floating-point extensions configuration
+  localparam bit RVFVec     = RVF             & CVA6Cfg.XFVec & FLen>32; // FP32 vectors available if vectors and larger fmt enabled
+  localparam bit XF16Vec    = CVA6Cfg.XF16    & CVA6Cfg.XFVec & FLen>16; // FP16 vectors available if vectors and larger fmt enabled
+  localparam bit XF16ALTVec = CVA6Cfg.XF16ALT & CVA6Cfg.XFVec & FLen>16; // FP16ALT vectors available if vectors and larger fmt enabled
+  localparam bit XF8Vec     = CVA6Cfg.XF8     & CVA6Cfg.XFVec & FLen>8;  // FP8 vectors available if vectors and larger fmt enabled
+
+  localparam bit EnableAccelerator = CVA6Cfg.RVV;  // Currently only used by V extension (Ara)
+  localparam int unsigned NrWbPorts = (CVA6Cfg.CvxifEn || EnableAccelerator) ? 5 : 4;
+
+  localparam NrRgprPorts = 2;
+
+  localparam bit NonIdemPotenceEn = CVA6Cfg.NrNonIdempotentRules && CVA6Cfg.NonIdempotentLength;  // Currently only used by V extension (Ara)
+
+  localparam config_pkg::cva6_cfg_t CVA6ExtendCfg = {
+    CVA6Cfg.NrCommitPorts,
+    CVA6Cfg.AxiAddrWidth,
+    CVA6Cfg.AxiDataWidth,
+    CVA6Cfg.AxiIdWidth,
+    CVA6Cfg.AxiUserWidth,
+    CVA6Cfg.NrLoadBufEntries,
+    CVA6Cfg.FpuEn,
+    CVA6Cfg.XF16,
+    CVA6Cfg.XF16ALT,
+    CVA6Cfg.XF8,
+    CVA6Cfg.RVA,
+    CVA6Cfg.RVV,
+    CVA6Cfg.RVC,
+    CVA6Cfg.RVZCB,
+    CVA6Cfg.XFVec,
+    CVA6Cfg.CvxifEn,
+    CVA6Cfg.ZiCondExtEn,
+    // Extended
+    bit'(RVF),
+    bit'(RVD),
+    bit'(FpPresent),
+    bit'(NSX),
+    unsigned'(FLen),
+    bit'(RVFVec),
+    bit'(XF16Vec),
+    bit'(XF16ALTVec),
+    bit'(XF8Vec),
+    unsigned'(NrRgprPorts),
+    unsigned'(NrWbPorts),
+    bit'(EnableAccelerator),
+    CVA6Cfg.RVS,
+    CVA6Cfg.RVU,
+    CVA6Cfg.HaltAddress,
+    CVA6Cfg.ExceptionAddress,
+    CVA6Cfg.RASDepth,
+    CVA6Cfg.BTBEntries,
+    CVA6Cfg.BHTEntries,
+    CVA6Cfg.DmBaseAddress,
+    CVA6Cfg.NrPMPEntries,
+    CVA6Cfg.NOCType,
+    CVA6Cfg.NrNonIdempotentRules,
+    CVA6Cfg.NonIdempotentAddrBase,
+    CVA6Cfg.NonIdempotentLength,
+    CVA6Cfg.NrExecuteRegionRules,
+    CVA6Cfg.ExecuteRegionAddrBase,
+    CVA6Cfg.ExecuteRegionLength,
+    CVA6Cfg.NrCachedRegionRules,
+    CVA6Cfg.CachedRegionAddrBase,
+    CVA6Cfg.CachedRegionLength,
+    CVA6Cfg.MaxOutstandingStores,
+    CVA6Cfg.DebugEn,
+    NonIdemPotenceEn,
+    CVA6Cfg.AxiBurstWriteEn
+  };
+
+
+
+  logic [TRANS_ID_BITS-1:0] issue_pointer;
+  logic [CVA6ExtendCfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] commit_pointer;
+
+  logic flush_unissued_instr;
+  logic decoded_instr_valid;
+  logic decoded_instr_ack;
+
+  riscv::xlen_t rs1_forwarding;
+  riscv::xlen_t rs2_forwarding;
+
+  scoreboard_entry_t [CVA6ExtendCfg.NrCommitPorts-1:0] commit_instr;
+  exception_t ex_commit;
+  riscv::priv_lvl_t priv_lvl;
+
+  lsu_ctrl_t lsu_ctrl;
+  logic [CVA6ExtendCfg.NrWbPorts-1:0][riscv::XLEN-1:0] wbdata;
+  logic [CVA6ExtendCfg.NrCommitPorts-1:0] commit_ack;
+  logic [riscv::PLEN-1:0] mem_paddr;
+  logic debug_mode;
+  logic [CVA6ExtendCfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata;
+
+  logic [riscv::VLEN-1:0] lsu_addr;
+  logic [(riscv::XLEN/8)-1:0] lsu_rmask;
+  logic [(riscv::XLEN/8)-1:0] lsu_wmask;
+  logic [TRANS_ID_BITS-1:0] lsu_addr_trans_id;
+
+
+  assign issue_pointer = rvfi_probes_i.issue_pointer;
+  assign commit_pointer = rvfi_probes_i.commit_pointer;
+
+  assign flush_unissued_instr = rvfi_probes_i.flush_unissued_instr;
+  assign decoded_instr_valid = rvfi_probes_i.decoded_instr_valid;
+  assign decoded_instr_ack = rvfi_probes_i.decoded_instr_ack;
+
+  assign rs1_forwarding = rvfi_probes_i.rs1_forwarding;
+  assign rs2_forwarding = rvfi_probes_i.rs2_forwarding;
+
+  assign commit_instr = rvfi_probes_i.commit_instr;
+  assign ex_commit = rvfi_probes_i.ex_commit;
+  assign priv_lvl = rvfi_probes_i.priv_lvl;
+
+  assign lsu_ctrl = rvfi_probes_i.lsu_ctrl;
+  assign wbdata = rvfi_probes_i.wbdata;
+  assign commit_ack = rvfi_probes_i.commit_ack;
+  assign mem_paddr = rvfi_probes_i.mem_paddr;
+  assign debug_mode = rvfi_probes_i.debug_mode;
+  assign wdata = rvfi_probes_i.wdata;
+
+  assign lsu_addr = lsu_ctrl.vaddr;
+  assign lsu_rmask = lsu_ctrl.fu == LOAD ? lsu_ctrl.be : '0;
+  assign lsu_wmask = lsu_ctrl.fu == STORE ? lsu_ctrl.be : '0;
+  assign lsu_addr_trans_id = lsu_ctrl.trans_id;
+
+  // this is the FIFO struct of the issue queue
+  typedef struct packed {
+    riscv::xlen_t rs1_rdata;  // information needed by RVFI
+    riscv::xlen_t rs2_rdata;  // information needed by RVFI
+    logic [riscv::VLEN-1:0] lsu_addr;  // information needed by RVFI
+    logic [(riscv::XLEN/8)-1:0] lsu_rmask;  // information needed by RVFI
+    logic [(riscv::XLEN/8)-1:0] lsu_wmask;  // information needed by RVFI
+    riscv::xlen_t lsu_wdata;  // information needed by RVFI
+  } sb_mem_t;
+  sb_mem_t [NR_SB_ENTRIES-1:0] mem_q, mem_n;
+
+  always_comb begin : issue_fifo
+    mem_n = mem_q;
+
+    if (decoded_instr_valid && decoded_instr_ack && !flush_unissued_instr) begin
+      mem_n[issue_pointer] = '{
+          rs1_rdata: rs1_forwarding,
+          rs2_rdata: rs2_forwarding,
+          lsu_addr: '0,
+          lsu_rmask: '0,
+          lsu_wmask: '0,
+          lsu_wdata: '0
+      };
+    end
+
+    if (lsu_rmask != 0) begin
+      mem_n[lsu_addr_trans_id].lsu_addr  = lsu_addr;
+      mem_n[lsu_addr_trans_id].lsu_rmask = lsu_rmask;
+    end else if (lsu_wmask != 0) begin
+      mem_n[lsu_addr_trans_id].lsu_addr  = lsu_addr;
+      mem_n[lsu_addr_trans_id].lsu_wmask = lsu_wmask;
+      mem_n[lsu_addr_trans_id].lsu_wdata = wbdata[1];
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : regs
+    if (!rst_ni) begin
+      mem_q <= '{default: sb_mem_t'(0)};
+    end else begin
+      mem_q <= mem_n;
+    end
+  end
+
+  //----------------------------------------------------------------------------------------------------------
+  // PACK
+  //----------------------------------------------------------------------------------------------------------
+
+  always_comb begin
+    for (int i = 0; i < CVA6ExtendCfg.NrCommitPorts; i++) begin
+      logic exception;
+      exception = commit_instr[i].valid && ex_commit.valid;
+      rvfi_o[i].valid    = (commit_ack[i] && !ex_commit.valid) ||
+        (exception && (ex_commit.cause == riscv::ENV_CALL_MMODE ||
+                  ex_commit.cause == riscv::ENV_CALL_SMODE ||
+                  ex_commit.cause == riscv::ENV_CALL_UMODE));
+      rvfi_o[i].insn = ex_commit.valid ? ex_commit.tval[31:0] : commit_instr[i].ex.tval[31:0];
+      // when trap, the instruction is not executed
+      rvfi_o[i].trap = exception;
+      rvfi_o[i].cause = ex_commit.cause;
+      rvfi_o[i].mode = (CVA6ExtendCfg.DebugEn && debug_mode) ? 2'b10 : priv_lvl;
+      rvfi_o[i].ixl = riscv::XLEN == 64 ? 2 : 1;
+      rvfi_o[i].rs1_addr = commit_instr[i].rs1[4:0];
+      rvfi_o[i].rs2_addr = commit_instr[i].rs2[4:0];
+      rvfi_o[i].rd_addr = commit_instr[i].rd[4:0];
+      rvfi_o[i].rd_wdata = (CVA6ExtendCfg.FpPresent && is_rd_fpr(commit_instr[i].op)) ?
+          commit_instr[i].result : wdata[i];
+      rvfi_o[i].pc_rdata = commit_instr[i].pc;
+      rvfi_o[i].mem_addr = mem_q[commit_pointer[i]].lsu_addr;
+      // So far, only write paddr is reported. TODO: read paddr
+      rvfi_o[i].mem_paddr = mem_paddr;
+      rvfi_o[i].mem_wmask = mem_q[commit_pointer[i]].lsu_wmask;
+      rvfi_o[i].mem_wdata = mem_q[commit_pointer[i]].lsu_wdata;
+      rvfi_o[i].mem_rmask = mem_q[commit_pointer[i]].lsu_rmask;
+      rvfi_o[i].mem_rdata = commit_instr[i].result;
+      rvfi_o[i].rs1_rdata = mem_q[commit_pointer[i]].rs1_rdata;
+      rvfi_o[i].rs2_rdata = mem_q[commit_pointer[i]].rs2_rdata;
+    end
+  end
+
+
+endmodule

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -65,6 +65,7 @@ module cva6_rvfi
     CVA6Cfg.XF16ALT,
     CVA6Cfg.XF8,
     CVA6Cfg.RVA,
+    CVA6Cfg.RVB,
     CVA6Cfg.RVV,
     CVA6Cfg.RVC,
     CVA6Cfg.RVZCB,

--- a/core/cva6_rvfi_probes.sv
+++ b/core/cva6_rvfi_probes.sv
@@ -15,6 +15,13 @@ module cva6_rvfi_probes
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter type rvfi_probes_t = logic
 ) (
+
+    input logic        flush_i,
+    input logic        issue_instr_ack_i,
+    input logic        fetch_entry_valid_i,
+    input logic [31:0] instruction_i,
+    input logic        is_compressed_i,
+
     input logic [TRANS_ID_BITS-1:0] issue_pointer_i,
     input logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] commit_pointer_i,
 
@@ -40,6 +47,12 @@ module cva6_rvfi_probes
 
   always_comb begin
     rvfi_probes_o = '0;
+
+    rvfi_probes_o.flush = flush_i;
+    rvfi_probes_o.issue_instr_ack = issue_instr_ack_i;
+    rvfi_probes_o.fetch_entry_valid = fetch_entry_valid_i;
+    rvfi_probes_o.instruction = instruction_i;
+    rvfi_probes_o.is_compressed = is_compressed_i;
 
     rvfi_probes_o.issue_pointer = issue_pointer_i;
     rvfi_probes_o.commit_pointer = commit_pointer_i;

--- a/core/cva6_rvfi_probes.sv
+++ b/core/cva6_rvfi_probes.sv
@@ -1,0 +1,68 @@
+// Copyright 2024 Thales DIS France SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Yannick Casamatta - Thales
+// Date: 09/01/2024
+
+
+module cva6_rvfi_probes
+  import ariane_pkg::*;
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type rvfi_probes_t = logic
+) (
+    input logic [TRANS_ID_BITS-1:0] issue_pointer_i,
+    input logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] commit_pointer_i,
+
+    input logic flush_unissued_instr_i,
+    input logic decoded_instr_valid_i,
+    input logic decoded_instr_ack_i,
+
+    input riscv::xlen_t rs1_forwarding_i,
+    input riscv::xlen_t rs2_forwarding_i,
+
+    input scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    input exception_t ex_commit_i,
+    input riscv::priv_lvl_t priv_lvl_i,
+
+    input  lsu_ctrl_t                                                 lsu_ctrl_i,
+    input  logic         [    CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0] wbdata_i,
+    input  logic         [CVA6Cfg.NrCommitPorts-1:0]                  commit_ack_i,
+    input  logic         [          riscv::PLEN-1:0]                  mem_paddr_i,
+    input  logic                                                      debug_mode_i,
+    input  logic         [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_i,
+    output rvfi_probes_t                                              rvfi_probes_o
+);
+
+  always_comb begin
+    rvfi_probes_o = '0;
+
+    rvfi_probes_o.issue_pointer = issue_pointer_i;
+    rvfi_probes_o.commit_pointer = commit_pointer_i;
+
+    rvfi_probes_o.flush_unissued_instr = flush_unissued_instr_i;
+    rvfi_probes_o.decoded_instr_valid = decoded_instr_valid_i;
+    rvfi_probes_o.decoded_instr_ack = decoded_instr_ack_i;
+
+    rvfi_probes_o.rs1_forwarding = rs1_forwarding_i;
+    rvfi_probes_o.rs2_forwarding = rs2_forwarding_i;
+
+    rvfi_probes_o.commit_instr = commit_instr_i;
+    rvfi_probes_o.ex_commit = ex_commit_i;
+    rvfi_probes_o.priv_lvl = priv_lvl_i;
+
+    rvfi_probes_o.lsu_ctrl = lsu_ctrl_i;
+    rvfi_probes_o.wbdata = wbdata_i;
+    rvfi_probes_o.commit_ack = commit_ack_i;
+    rvfi_probes_o.mem_paddr = mem_paddr_i;
+    rvfi_probes_o.debug_mode = debug_mode_i;
+    rvfi_probes_o.wdata = wdata_i;
+
+  end
+
+
+endmodule

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -722,8 +722,10 @@ module decoder
               end
               3'b101: begin
                 if (instr.instr[31:20] == 12'b001010000111) instruction_o.op = ariane_pkg::ORCB;
-                else if (riscv::IS_XLEN64 && instr.instr[31:20] == 12'b011010111000) instruction_o.op = ariane_pkg::REV8;
-                else if (instr.instr[31:20] == 12'b011010011000) instruction_o.op = ariane_pkg::REV8;
+                else if (riscv::IS_XLEN64 && instr.instr[31:20] == 12'b011010111000)
+                  instruction_o.op = ariane_pkg::REV8;
+                else if (instr.instr[31:20] == 12'b011010011000)
+                  instruction_o.op = ariane_pkg::REV8;
                 else if (instr.instr[31:26] == 6'b010_010) instruction_o.op = ariane_pkg::BEXTI;
                 else if (instr.instr[31:26] == 6'b011_000) instruction_o.op = ariane_pkg::RORI;
                 else illegal_instr_bm = 1'b1;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -123,11 +123,8 @@ module ex_stage
     input logic [15:0][riscv::PLEN-3:0] pmpaddr_i,
 
     // RVFI
-    output [              riscv::VLEN-1:0] lsu_addr_o,
-    output [              riscv::PLEN-1:0] mem_paddr_o,
-    output [          (riscv::XLEN/8)-1:0] lsu_rmask_o,
-    output [          (riscv::XLEN/8)-1:0] lsu_wmask_o,
-    output [ariane_pkg::TRANS_ID_BITS-1:0] lsu_addr_trans_id_o
+    output lsu_ctrl_t                   rvfi_lsu_ctrl_o,
+    output            [riscv::PLEN-1:0] rvfi_mem_paddr_o
 );
 
   // -------------------------
@@ -350,11 +347,8 @@ module ex_stage
       .amo_resp_i,
       .pmpcfg_i,
       .pmpaddr_i,
-      .lsu_addr_o,
-      .mem_paddr_o,
-      .lsu_rmask_o,
-      .lsu_wmask_o,
-      .lsu_addr_trans_id_o
+      .rvfi_lsu_ctrl_o,
+      .rvfi_mem_paddr_o
   );
 
   if (CVA6Cfg.CvxifEn) begin : gen_cvxif

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -30,6 +30,7 @@ module id_stage #(
     output logic issue_entry_valid_o,  // issue entry is valid
     output logic is_ctrl_flow_o,  // the instruction we issue is a ctrl flow instructions
     input logic issue_instr_ack_i,  // issue stage acknowledged sampling of instructions
+    output logic rvfi_is_compressed_o,
     // from CSR file
     input riscv::priv_lvl_t priv_lvl_i,  // current privilege level
     input riscv::xs_t fs_i,  // floating point extension status
@@ -74,6 +75,8 @@ module id_stage #(
     assign is_illegal = '0;
     assign is_compressed = '0;
   end
+
+  assign rvfi_is_compressed_o = is_compressed;
   // ---------------------------------------------------------
   // 2. Decode and emit instruction to issue stage
   // ---------------------------------------------------------

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -696,12 +696,6 @@ package ariane_pkg;
     branchpredict_sbe_t bp;  // branch predict scoreboard data structure
     logic                     is_compressed; // signals a compressed instructions, we need this information at the commit stage if
                                              // we want jump accordingly e.g.: +4, +2
-    riscv::xlen_t rs1_rdata;  // information needed by RVFI
-    riscv::xlen_t rs2_rdata;  // information needed by RVFI
-    logic [riscv::VLEN-1:0] lsu_addr;  // information needed by RVFI
-    logic [(riscv::XLEN/8)-1:0] lsu_rmask;  // information needed by RVFI
-    logic [(riscv::XLEN/8)-1:0] lsu_wmask;  // information needed by RVFI
-    riscv::xlen_t lsu_wdata;  // information needed by RVFI
     logic vfp;  // is this a vector floating-point instruction?
   } scoreboard_entry_t;
 

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -17,9 +17,7 @@
 module issue_stage
   import ariane_pkg::*;
 #(
-    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter bit IsRVFI = bit'(0),
-    parameter int unsigned NR_ENTRIES = 8
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni, // Asynchronous reset active low
@@ -89,10 +87,8 @@ module issue_stage
     output logic stall_issue_o,  // Used in Performance Counters
 
     //RVFI
-    input [              riscv::VLEN-1:0] lsu_addr_i,
-    input [          (riscv::XLEN/8)-1:0] lsu_rmask_i,
-    input [          (riscv::XLEN/8)-1:0] lsu_wmask_i,
-    input [ariane_pkg::TRANS_ID_BITS-1:0] lsu_addr_trans_id_i
+    output logic [TRANS_ID_BITS-1:0] rvfi_issue_pointer_o,
+    output logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] rvfi_commit_pointer_o
 );
   // ---------------------------------------------------
   // Scoreboard (SB) <-> Issue and Read Operands (IRO)
@@ -132,10 +128,8 @@ module issue_stage
   // 2. Manage instructions in a scoreboard
   // ---------------------------------------------------------
   scoreboard #(
-      .CVA6Cfg   (CVA6Cfg),
-      .IsRVFI    (IsRVFI),
-      .rs3_len_t (rs3_len_t),
-      .NR_ENTRIES(NR_ENTRIES)
+      .CVA6Cfg  (CVA6Cfg),
+      .rs3_len_t(rs3_len_t)
   ) i_scoreboard (
       .sb_full_o          (sb_full_o),
       .unresolved_branch_i(1'b0),
@@ -158,16 +152,10 @@ module issue_stage
       .issue_instr_valid_o  (issue_instr_valid_sb_iro),
       .issue_ack_i          (issue_ack_iro_sb),
 
-      .resolved_branch_i  (resolved_branch_i),
-      .trans_id_i         (trans_id_i),
-      .wbdata_i           (wbdata_i),
-      .ex_i               (ex_ex_i),
-      .lsu_addr_i         (lsu_addr_i),
-      .lsu_rmask_i        (lsu_rmask_i),
-      .lsu_wmask_i        (lsu_wmask_i),
-      .lsu_addr_trans_id_i(lsu_addr_trans_id_i),
-      .rs1_forwarding_i   (rs1_forwarding_xlen),
-      .rs2_forwarding_i   (rs2_forwarding_xlen),
+      .resolved_branch_i(resolved_branch_i),
+      .trans_id_i       (trans_id_i),
+      .wbdata_i         (wbdata_i),
+      .ex_i             (ex_ex_i),
       .*
   );
 

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -77,11 +77,8 @@ module load_store_unit
     input  logic           [15:0][riscv::PLEN-3:0] pmpaddr_i,
 
     //RVFI
-    output [              riscv::VLEN-1:0] lsu_addr_o,
-    output [              riscv::PLEN-1:0] mem_paddr_o,
-    output [          (riscv::XLEN/8)-1:0] lsu_rmask_o,
-    output [          (riscv::XLEN/8)-1:0] lsu_wmask_o,
-    output [ariane_pkg::TRANS_ID_BITS-1:0] lsu_addr_trans_id_o
+    output lsu_ctrl_t                   rvfi_lsu_ctrl_o,
+    output            [riscv::PLEN-1:0] rvfi_mem_paddr_o
 );
   // data is misaligned
   logic                               data_misaligned;
@@ -269,7 +266,7 @@ module load_store_unit
       // MMU port
       .translation_req_o    (st_translation_req),
       .vaddr_o              (st_vaddr),
-      .mem_paddr_o          (mem_paddr_o),
+      .rvfi_mem_paddr_o     (rvfi_mem_paddr_o),
       .paddr_i              (mmu_paddr),
       .ex_i                 (mmu_exception),
       .dtlb_hit_i           (dtlb_hit),
@@ -490,10 +487,7 @@ module load_store_unit
       .*
   );
 
-  assign lsu_addr_o = lsu_ctrl.vaddr;
-  assign lsu_rmask_o = lsu_ctrl.fu == LOAD ? lsu_ctrl.be : '0;
-  assign lsu_wmask_o = lsu_ctrl.fu == STORE ? lsu_ctrl.be : '0;
-  assign lsu_addr_trans_id_o = lsu_ctrl.trans_id;
+  assign rvfi_lsu_ctrl_o = lsu_ctrl;
 
 endmodule
 

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -14,9 +14,7 @@
 
 module scoreboard #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter bit IsRVFI = bit'(0),
-    parameter type rs3_len_t = logic,
-    parameter int unsigned NR_ENTRIES = 8  // must be a power of 2
+    parameter type rs3_len_t = logic
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
@@ -65,14 +63,9 @@ module scoreboard #(
     input logic x_we_i,  // cvxif we for writeback
 
     // RVFI
-    input               [              riscv::VLEN-1:0] lsu_addr_i,
-    input               [          (riscv::XLEN/8)-1:0] lsu_rmask_i,
-    input               [          (riscv::XLEN/8)-1:0] lsu_wmask_i,
-    input               [ariane_pkg::TRANS_ID_BITS-1:0] lsu_addr_trans_id_i,
-    input riscv::xlen_t                                 rs1_forwarding_i,
-    input riscv::xlen_t                                 rs2_forwarding_i
+    output logic [ariane_pkg::TRANS_ID_BITS-1:0] rvfi_issue_pointer_o,
+    output logic [CVA6Cfg.NrCommitPorts-1:0][ariane_pkg::TRANS_ID_BITS-1:0] rvfi_commit_pointer_o
 );
-  localparam int unsigned BITS_ENTRIES = $clog2(NR_ENTRIES);
 
   // this is the FIFO struct of the issue queue
   typedef struct packed {
@@ -80,31 +73,24 @@ module scoreboard #(
     logic is_rd_fpr_flag;  // redundant meta info, added for speed
     ariane_pkg::scoreboard_entry_t sbe;  // this is the score board entry we will send to ex
   } sb_mem_t;
-  sb_mem_t [NR_ENTRIES-1:0] mem_q, mem_n;
+  sb_mem_t [ariane_pkg::NR_SB_ENTRIES-1:0] mem_q, mem_n;
 
   logic issue_full, issue_en;
-  logic [BITS_ENTRIES:0] issue_cnt_n, issue_cnt_q;
-  logic [BITS_ENTRIES-1:0] issue_pointer_n, issue_pointer_q;
-  logic [CVA6Cfg.NrCommitPorts-1:0][BITS_ENTRIES-1:0] commit_pointer_n, commit_pointer_q;
+  logic [ariane_pkg::TRANS_ID_BITS:0] issue_cnt_n, issue_cnt_q;
+  logic [ariane_pkg::TRANS_ID_BITS-1:0] issue_pointer_n, issue_pointer_q;
+  logic [CVA6Cfg.NrCommitPorts-1:0][ariane_pkg::TRANS_ID_BITS-1:0]
+      commit_pointer_n, commit_pointer_q;
   logic [$clog2(CVA6Cfg.NrCommitPorts):0] num_commit;
 
   // the issue queue is full don't issue any new instructions
   // works since aligned to power of 2
-  assign issue_full = (issue_cnt_q[BITS_ENTRIES] == 1'b1);
+  assign issue_full = (issue_cnt_q[ariane_pkg::TRANS_ID_BITS] == 1'b1);
 
   assign sb_full_o  = issue_full;
 
   ariane_pkg::scoreboard_entry_t decoded_instr;
   always_comb begin
     decoded_instr = decoded_instr_i;
-    if (IsRVFI) begin
-      decoded_instr.rs1_rdata = rs1_forwarding_i;
-      decoded_instr.rs2_rdata = rs2_forwarding_i;
-      decoded_instr.lsu_addr  = '0;
-      decoded_instr.lsu_rmask = '0;
-      decoded_instr.lsu_wmask = '0;
-      decoded_instr.lsu_wdata = '0;
-    end
   end
 
   // output commit instruction directly
@@ -150,7 +136,7 @@ module scoreboard #(
     // ------------
     // FU NONE
     // ------------
-    for (int unsigned i = 0; i < NR_ENTRIES; i++) begin
+    for (int unsigned i = 0; i < ariane_pkg::NR_SB_ENTRIES; i++) begin
       // The FU is NONE -> this instruction is valid immediately
       if (mem_q[i].sbe.fu == ariane_pkg::NONE && mem_q[i].issued) mem_n[i].sbe.valid = 1'b1;
     end
@@ -158,17 +144,6 @@ module scoreboard #(
     // ------------
     // Write Back
     // ------------
-    if (IsRVFI) begin
-      if (lsu_rmask_i != 0) begin
-        mem_n[lsu_addr_trans_id_i].sbe.lsu_addr  = lsu_addr_i;
-        mem_n[lsu_addr_trans_id_i].sbe.lsu_rmask = lsu_rmask_i;
-      end else if (lsu_wmask_i != 0) begin
-        mem_n[lsu_addr_trans_id_i].sbe.lsu_addr  = lsu_addr_i;
-        mem_n[lsu_addr_trans_id_i].sbe.lsu_wmask = lsu_wmask_i;
-        mem_n[lsu_addr_trans_id_i].sbe.lsu_wdata = wbdata_i[1];
-      end
-    end
-
     for (int unsigned i = 0; i < CVA6Cfg.NrWbPorts; i++) begin
       // check if this instruction was issued (e.g.: it could happen after a flush that there is still
       // something in the pipeline e.g. an incomplete memory operation)
@@ -207,7 +182,7 @@ module scoreboard #(
     // Flush
     // ------
     if (flush_i) begin
-      for (int unsigned i = 0; i < NR_ENTRIES; i++) begin
+      for (int unsigned i = 0; i < ariane_pkg::NR_SB_ENTRIES; i++) begin
         // set all valid flags for all entries to zero
         mem_n[i].issued       = 1'b0;
         mem_n[i].sbe.valid    = 1'b0;
@@ -223,9 +198,9 @@ module scoreboard #(
     assign num_commit = commit_ack_i[0];
   end
 
-  assign issue_cnt_n = (flush_i) ? '0 : issue_cnt_q - {{BITS_ENTRIES - $clog2(
+  assign issue_cnt_n = (flush_i) ? '0 : issue_cnt_q - {{ariane_pkg::TRANS_ID_BITS - $clog2(
       CVA6Cfg.NrCommitPorts
-  ) {1'b0}}, num_commit} + {{BITS_ENTRIES - 1{1'b0}}, issue_en};
+  ) {1'b0}}, num_commit} + {{ariane_pkg::TRANS_ID_BITS - 1{1'b0}}, issue_en};
   assign commit_pointer_n[0] = (flush_i) ? '0 : commit_pointer_q[0] + num_commit;
   assign issue_pointer_n = (flush_i) ? '0 : issue_pointer_q + issue_en;
 
@@ -238,23 +213,23 @@ module scoreboard #(
   // RD clobber process
   // -------------------
   // rd_clobber output: output currently clobbered destination registers
-  logic            [2**ariane_pkg::REG_ADDR_SIZE-1:0][NR_ENTRIES:0] gpr_clobber_vld;
-  logic            [2**ariane_pkg::REG_ADDR_SIZE-1:0][NR_ENTRIES:0] fpr_clobber_vld;
-  ariane_pkg::fu_t [                    NR_ENTRIES:0]               clobber_fu;
+  logic            [2**ariane_pkg::REG_ADDR_SIZE-1:0][ariane_pkg::NR_SB_ENTRIES:0] gpr_clobber_vld;
+  logic            [2**ariane_pkg::REG_ADDR_SIZE-1:0][ariane_pkg::NR_SB_ENTRIES:0] fpr_clobber_vld;
+  ariane_pkg::fu_t [     ariane_pkg::NR_SB_ENTRIES:0]                              clobber_fu;
 
   always_comb begin : clobber_assign
     gpr_clobber_vld = '0;
     fpr_clobber_vld = '0;
 
     // default (highest entry hast lowest prio in arbiter tree below)
-    clobber_fu[NR_ENTRIES] = ariane_pkg::NONE;
+    clobber_fu[ariane_pkg::NR_SB_ENTRIES] = ariane_pkg::NONE;
     for (int unsigned i = 0; i < 2 ** ariane_pkg::REG_ADDR_SIZE; i++) begin
-      gpr_clobber_vld[i][NR_ENTRIES] = 1'b1;
-      fpr_clobber_vld[i][NR_ENTRIES] = 1'b1;
+      gpr_clobber_vld[i][ariane_pkg::NR_SB_ENTRIES] = 1'b1;
+      fpr_clobber_vld[i][ariane_pkg::NR_SB_ENTRIES] = 1'b1;
     end
 
     // check for all valid entries and set the clobber accordingly
-    for (int unsigned i = 0; i < NR_ENTRIES; i++) begin
+    for (int unsigned i = 0; i < ariane_pkg::NR_SB_ENTRIES; i++) begin
       gpr_clobber_vld[mem_q[i].sbe.rd][i] = mem_q[i].issued & ~mem_q[i].is_rd_fpr_flag;
       fpr_clobber_vld[mem_q[i].sbe.rd][i] = mem_q[i].issued & mem_q[i].is_rd_fpr_flag;
       clobber_fu[i]                       = mem_q[i].sbe.fu;
@@ -267,7 +242,7 @@ module scoreboard #(
   for (genvar k = 0; k < 2 ** ariane_pkg::REG_ADDR_SIZE; k++) begin : gen_sel_clobbers
     // get fu that is going to clobber this register (there should be only one)
     rr_arb_tree #(
-        .NumIn(NR_ENTRIES + 1),
+        .NumIn(ariane_pkg::NR_SB_ENTRIES + 1),
         .DataType(ariane_pkg::fu_t),
         .ExtPrio(1'b1),
         .AxiVldRdy(1'b1)
@@ -286,7 +261,7 @@ module scoreboard #(
     );
     if (CVA6Cfg.FpPresent) begin
       rr_arb_tree #(
-          .NumIn(NR_ENTRIES + 1),
+          .NumIn(ariane_pkg::NR_SB_ENTRIES + 1),
           .DataType(ariane_pkg::fu_t),
           .ExtPrio(1'b1),
           .AxiVldRdy(1'b1)
@@ -310,8 +285,8 @@ module scoreboard #(
   // Read Operands (a.k.a forwarding)
   // ----------------------------------
   // read operand interface: same logic as register file
-  logic [NR_ENTRIES+CVA6Cfg.NrWbPorts-1:0] rs1_fwd_req, rs2_fwd_req, rs3_fwd_req;
-  logic [NR_ENTRIES+CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0] rs_data;
+  logic [ariane_pkg::NR_SB_ENTRIES+CVA6Cfg.NrWbPorts-1:0] rs1_fwd_req, rs2_fwd_req, rs3_fwd_req;
+  logic [ariane_pkg::NR_SB_ENTRIES+CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0] rs_data;
   logic rs1_valid, rs2_valid, rs3_valid;
 
   // WB ports have higher prio than entries
@@ -327,7 +302,7 @@ module scoreboard #(
     )));
     assign rs_data[k] = wbdata_i[k];
   end
-  for (genvar k = 0; unsigned'(k) < NR_ENTRIES; k++) begin : gen_rs_entries
+  for (genvar k = 0; unsigned'(k) < ariane_pkg::NR_SB_ENTRIES; k++) begin : gen_rs_entries
     assign rs1_fwd_req[k+CVA6Cfg.NrWbPorts] = (mem_q[k].sbe.rd == rs1_i) & mem_q[k].issued & mem_q[k].sbe.valid & (mem_q[k].is_rd_fpr_flag == (CVA6Cfg.FpPresent && ariane_pkg::is_rs1_fpr(
         issue_instr_o.op
     )));
@@ -354,7 +329,7 @@ module scoreboard #(
   // use fixed prio here
   // this implicitly gives higher prio to WB ports
   rr_arb_tree #(
-      .NumIn(NR_ENTRIES + CVA6Cfg.NrWbPorts),
+      .NumIn(ariane_pkg::NR_SB_ENTRIES + CVA6Cfg.NrWbPorts),
       .DataWidth(riscv::XLEN),
       .ExtPrio(1'b1),
       .AxiVldRdy(1'b1)
@@ -373,7 +348,7 @@ module scoreboard #(
   );
 
   rr_arb_tree #(
-      .NumIn(NR_ENTRIES + CVA6Cfg.NrWbPorts),
+      .NumIn(ariane_pkg::NR_SB_ENTRIES + CVA6Cfg.NrWbPorts),
       .DataWidth(riscv::XLEN),
       .ExtPrio(1'b1),
       .AxiVldRdy(1'b1)
@@ -394,7 +369,7 @@ module scoreboard #(
   riscv::xlen_t rs3;
 
   rr_arb_tree #(
-      .NumIn(NR_ENTRIES + CVA6Cfg.NrWbPorts),
+      .NumIn(ariane_pkg::NR_SB_ENTRIES + CVA6Cfg.NrWbPorts),
       .DataWidth(riscv::XLEN),
       .ExtPrio(1'b1),
       .AxiVldRdy(1'b1)
@@ -434,9 +409,13 @@ module scoreboard #(
     end
   end
 
+  //RVFI
+  assign rvfi_issue_pointer_o  = issue_pointer_q;
+  assign rvfi_commit_pointer_o = commit_pointer_q;
+
   //pragma translate_off
   initial begin
-    assert (NR_ENTRIES == 2 ** BITS_ENTRIES)
+    assert (ariane_pkg::NR_SB_ENTRIES == 2 ** ariane_pkg::TRANS_ID_BITS)
     else $fatal(1, "Scoreboard size needs to be a power of two.");
   end
 

--- a/core/store_buffer.sv
+++ b/core/store_buffer.sv
@@ -39,7 +39,7 @@ module store_buffer
     input  logic         valid_without_flush_i, // just tell if the address is valid which we are current putting and do not take any further action
 
     input  logic [riscv::PLEN-1:0]  paddr_i,         // physical address of store which needs to be placed in the queue
-    output [riscv::PLEN-1:0] mem_paddr_o,
+    output [riscv::PLEN-1:0] rvfi_mem_paddr_o,
     input riscv::xlen_t data_i,  // data which is placed in the queue
     input logic [(riscv::XLEN/8)-1:0] be_i,  // byte enable in
     input logic [1:0] data_size_i,  // type of request we are making (e.g.: bytes to write)
@@ -148,7 +148,7 @@ module store_buffer
   assign req_port_o.data_be = commit_queue_q[commit_read_pointer_q].be;
   assign req_port_o.data_size = commit_queue_q[commit_read_pointer_q].data_size;
 
-  assign mem_paddr_o = commit_queue_n[commit_read_pointer_n].address;
+  assign rvfi_mem_paddr_o = commit_queue_n[commit_read_pointer_n].address;
 
   always_comb begin : store_if
     automatic logic [$clog2(DEPTH_COMMIT):0] commit_status_cnt;

--- a/core/store_unit.sv
+++ b/core/store_unit.sv
@@ -39,7 +39,7 @@ module store_unit
     // MMU -> Address Translation
     output logic translation_req_o,  // request address translation
     output logic [riscv::VLEN-1:0] vaddr_o,  // virtual address out
-    output [riscv::PLEN-1:0] mem_paddr_o,
+    output [riscv::PLEN-1:0] rvfi_mem_paddr_o,
     input logic [riscv::PLEN-1:0] paddr_i,  // physical address in
     input exception_t ex_i,
     input  logic                     dtlb_hit_i,       // will be one in the same cycle translation_req was asserted if it hits
@@ -245,7 +245,7 @@ module store_unit
       // the whole pipeline anyway
       .valid_without_flush_i(st_valid_without_flush),
       .paddr_i,
-      .mem_paddr_o          (mem_paddr_o),
+      .rvfi_mem_paddr_o     (rvfi_mem_paddr_o),
       .data_i               (st_data_q),
       .be_i                 (st_be_q),
       .data_size_i          (st_data_size_q),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -215,7 +215,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   AxiBurstWriteEn: bit'(0)
 };
 
-localparam type rvfi_instr_t = logic;
+localparam type rvfi_probes_t = logic;
 
 
 // 24 MByte in 8 byte words
@@ -763,7 +763,7 @@ ariane_axi::resp_t   axi_ariane_resp;
 ariane #(
     .CVA6Cfg ( CVA6Cfg ),
     .IsRVFI ( IsRVFI ),
-    .rvfi_instr_t ( rvfi_instr_t )
+    .rvfi_probes_t ( rvfi_probes_t )
 ) i_ariane (
     .clk_i        ( clk                 ),
     .rst_ni       ( ndmreset_n          ),
@@ -772,7 +772,7 @@ ariane #(
     .irq_i        ( irq                 ),
     .ipi_i        ( ipi                 ),
     .time_irq_i   ( timer_irq           ),
-    .rvfi_o       ( /* open */          ),
+    .rvfi_probes_o( /* open */          ),
     .debug_req_i  ( debug_req_irq       ),
     .noc_req_o    ( axi_ariane_req      ),
     .noc_resp_i   ( axi_ariane_resp     )

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -16,7 +16,7 @@
 module ariane import ariane_pkg::*; #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
   parameter bit IsRVFI = bit'(0),
-  parameter type rvfi_instr_t = logic,
+  parameter type rvfi_probes_t = logic,
   parameter int unsigned AxiAddrWidth = ariane_axi::AddrWidth,
   parameter int unsigned AxiDataWidth = ariane_axi::DataWidth,
   parameter int unsigned AxiIdWidth   = ariane_axi::IdWidth,
@@ -40,7 +40,7 @@ module ariane import ariane_pkg::*; #(
   input  logic                         debug_req_i,  // debug request (async)
   // RISC-V formal interface port (`rvfi`):
   // Can be left open when formal tracing is not needed.
-  output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o,
+  output rvfi_probes_t rvfi_probes_o,
   // memory side
   output noc_req_t                     noc_req_o,
   input  noc_resp_t                    noc_resp_i
@@ -52,7 +52,7 @@ module ariane import ariane_pkg::*; #(
   cva6 #(
     .CVA6Cfg ( CVA6Cfg ),
     .IsRVFI ( IsRVFI ),
-    .rvfi_instr_t ( rvfi_instr_t ),
+    .rvfi_probes_t ( rvfi_probes_t ),
     .axi_ar_chan_t (axi_ar_chan_t),
     .axi_aw_chan_t (axi_aw_chan_t),
     .axi_w_chan_t (axi_w_chan_t),
@@ -67,7 +67,7 @@ module ariane import ariane_pkg::*; #(
     .ipi_i                ( ipi_i                     ),
     .time_irq_i           ( time_irq_i                ),
     .debug_req_i          ( debug_req_i               ),
-    .rvfi_o               ( rvfi_o                    ),
+    .rvfi_probes_o        ( rvfi_probes_o             ),
     .cvxif_req_o          ( cvxif_req                 ),
     .cvxif_resp_i         ( cvxif_resp                ),
     .noc_req_o            ( noc_req_o                 ),

--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -31,31 +31,6 @@ module ariane_tb;
     // cva6 configuration
     localparam config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg;
     localparam bit IsRVFI = bit'(cva6_config_pkg::CVA6ConfigRvfiTrace);
-    localparam type rvfi_instr_t = struct packed {
-        logic [config_pkg::NRET-1:0]                  valid;
-        logic [config_pkg::NRET*64-1:0]               order;
-        logic [config_pkg::NRET*config_pkg::ILEN-1:0] insn;
-        logic [config_pkg::NRET-1:0]                  trap;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      cause;
-        logic [config_pkg::NRET-1:0]                  halt;
-        logic [config_pkg::NRET-1:0]                  intr;
-        logic [config_pkg::NRET*2-1:0]                mode;
-        logic [config_pkg::NRET*2-1:0]                ixl;
-        logic [config_pkg::NRET*5-1:0]                rs1_addr;
-        logic [config_pkg::NRET*5-1:0]                rs2_addr;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      rs1_rdata;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      rs2_rdata;
-        logic [config_pkg::NRET*5-1:0]                rd_addr;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      rd_wdata;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_rdata;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_wdata;
-        logic [config_pkg::NRET*riscv::VLEN-1:0]      mem_addr;
-        logic [config_pkg::NRET*riscv::PLEN-1:0]      mem_paddr;
-        logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_rmask;
-        logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_wmask;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_rdata;
-        logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_wdata;
-    };
 
     static uvm_cmdline_processor uvcl = uvm_cmdline_processor::get_inst();
 
@@ -78,7 +53,6 @@ module ariane_tb;
     ariane_testharness #(
         .CVA6Cfg ( CVA6Cfg ),
         .IsRVFI ( IsRVFI ),
-        .rvfi_instr_t ( rvfi_instr_t ),
         //
         .NUM_WORDS         ( NUM_WORDS ),
         .InclSimDTM        ( 1'b1      ),

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -68,6 +68,11 @@ module ariane_testharness #(
     logic                            flush_unissued_instr;
     logic                            decoded_instr_valid;
     logic                            decoded_instr_ack;
+    logic                            flush;
+    logic                            issue_instr_ack;
+    logic                            fetch_entry_valid;
+    logic [31:0]                     instruction;
+    logic                            is_compressed;
     riscv::xlen_t                    rs1_forwarding;
     riscv::xlen_t                    rs2_forwarding;
     ariane_pkg::scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr;

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -18,31 +18,6 @@
 module ariane_testharness #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg,
   parameter bit IsRVFI = bit'(cva6_config_pkg::CVA6ConfigRvfiTrace),
-  parameter type rvfi_instr_t = struct packed {
-    logic [config_pkg::NRET-1:0]                  valid;
-    logic [config_pkg::NRET*64-1:0]               order;
-    logic [config_pkg::NRET*config_pkg::ILEN-1:0] insn;
-    logic [config_pkg::NRET-1:0]                  trap;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      cause;
-    logic [config_pkg::NRET-1:0]                  halt;
-    logic [config_pkg::NRET-1:0]                  intr;
-    logic [config_pkg::NRET*2-1:0]                mode;
-    logic [config_pkg::NRET*2-1:0]                ixl;
-    logic [config_pkg::NRET*5-1:0]                rs1_addr;
-    logic [config_pkg::NRET*5-1:0]                rs2_addr;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      rs1_rdata;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      rs2_rdata;
-    logic [config_pkg::NRET*5-1:0]                rd_addr;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      rd_wdata;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_rdata;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_wdata;
-    logic [config_pkg::NRET*riscv::VLEN-1:0]      mem_addr;
-    logic [config_pkg::NRET*riscv::PLEN-1:0]      mem_paddr;
-    logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_rmask;
-    logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_wmask;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_rdata;
-    logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_wdata;
-  },
   //
   parameter int unsigned AXI_USER_WIDTH    = ariane_pkg::AXI_USER_WIDTH,
   parameter int unsigned AXI_USER_EN       = ariane_pkg::AXI_USER_EN,
@@ -60,6 +35,51 @@ module ariane_testharness #(
 );
 
   localparam [7:0] hart_id = '0;
+  
+  localparam type rvfi_instr_t = struct packed {
+      logic [config_pkg::NRET-1:0]                  valid;
+      logic [config_pkg::NRET*64-1:0]               order;
+      logic [config_pkg::NRET*config_pkg::ILEN-1:0] insn;
+      logic [config_pkg::NRET-1:0]                  trap;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      cause;
+      logic [config_pkg::NRET-1:0]                  halt;
+      logic [config_pkg::NRET-1:0]                  intr;
+      logic [config_pkg::NRET*2-1:0]                mode;
+      logic [config_pkg::NRET*2-1:0]                ixl;
+      logic [config_pkg::NRET*5-1:0]                rs1_addr;
+      logic [config_pkg::NRET*5-1:0]                rs2_addr;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      rs1_rdata;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      rs2_rdata;
+      logic [config_pkg::NRET*5-1:0]                rd_addr;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      rd_wdata;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_rdata;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      pc_wdata;
+      logic [config_pkg::NRET*riscv::VLEN-1:0]      mem_addr;
+      logic [config_pkg::NRET*riscv::PLEN-1:0]      mem_paddr;
+      logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_rmask;
+      logic [config_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_wmask;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_rdata;
+      logic [config_pkg::NRET*riscv::XLEN-1:0]      mem_wdata;
+  };
+    
+  localparam type rvfi_probes_t = struct packed { 
+    logic [ariane_pkg::TRANS_ID_BITS-1:0] issue_pointer; 
+    logic [CVA6Cfg.NrCommitPorts-1:0][ariane_pkg::TRANS_ID_BITS-1:0] commit_pointer; 
+    logic                            flush_unissued_instr;
+    logic                            decoded_instr_valid;
+    logic                            decoded_instr_ack;
+    riscv::xlen_t                    rs1_forwarding;
+    riscv::xlen_t                    rs2_forwarding;
+    ariane_pkg::scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr;
+    ariane_pkg::exception_t ex_commit; 
+    riscv::priv_lvl_t priv_lvl;
+    ariane_pkg::lsu_ctrl_t                       lsu_ctrl;
+    logic [((CVA6Cfg.CvxifEn || CVA6Cfg.RVV) ? 5 : 4)-1:0][riscv::XLEN-1:0] wbdata;
+    logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack;
+    logic [riscv::PLEN-1:0] mem_paddr;
+    logic debug_mode;
+    logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata;
+  };
 
   // disable test-enable
   logic        test_en;
@@ -625,12 +645,13 @@ module ariane_testharness #(
   // ---------------
   ariane_axi::req_t    axi_ariane_req;
   ariane_axi::resp_t   axi_ariane_resp;
-  rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi;
-
+  rvfi_probes_t rvfi_probes;
+  rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0]  rvfi_instr;
+  
   ariane #(
     .CVA6Cfg              ( CVA6Cfg             ),
     .IsRVFI               ( IsRVFI              ),
-    .rvfi_instr_t         ( rvfi_instr_t        ),
+    .rvfi_probes_t        ( rvfi_probes_t       ),
     .noc_req_t            ( ariane_axi::req_t   ),
     .noc_resp_t           ( ariane_axi::resp_t  )
   ) i_ariane (
@@ -641,7 +662,7 @@ module ariane_testharness #(
     .irq_i                ( irqs                ),
     .ipi_i                ( ipi                 ),
     .time_irq_i           ( timer_irq           ),
-    .rvfi_o               ( rvfi                ),
+    .rvfi_probes_o        ( rvfi_probes         ),
 // Disable Debug when simulating with Spike
 `ifdef SPIKE_TANDEM
     .debug_req_i          ( 1'b0                ),
@@ -672,6 +693,17 @@ module ariane_testharness #(
     end
   end
 
+  cva6_rvfi #(
+      .CVA6Cfg   (CVA6Cfg),
+      .rvfi_instr_t(rvfi_instr_t),
+      .rvfi_probes_t(rvfi_probes_t)
+  ) i_cva6_rvfi (
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .rvfi_probes_i(rvfi_probes),
+      .rvfi_o(rvfi_instr)
+  );
+
   rvfi_tracer  #(
     .CVA6Cfg(CVA6Cfg),
     .rvfi_instr_t(rvfi_instr_t),
@@ -679,10 +711,10 @@ module ariane_testharness #(
     .HART_ID(hart_id),
     .DEBUG_START(0),
     .DEBUG_STOP(0)
-  ) rvfi_tracer_i (
+  ) i_rvfi_tracer (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .rvfi_i(rvfi),
+    .rvfi_i(rvfi_instr),
     .end_of_test_o(rvfi_exit)
   );
 
@@ -694,7 +726,7 @@ module ariane_testharness #(
         .clk_i,
         .rst_ni,
         .clint_tick_i   ( rtc_i    ),
-        .rvfi_i         ( rvfi )
+        .rvfi_i         ( rvfi_instr )
     );
     initial begin
         $display("Running binary in tandem mode");

--- a/verif/tb/core/Flist.cva6_tb
+++ b/verif/tb/core/Flist.cva6_tb
@@ -34,6 +34,7 @@ ${CVA6_REPO_DIR}/corev_apu/tb/ariane_axi_pkg.sv
 ${CVA6_REPO_DIR}/corev_apu/tb/ariane_axi_soc_pkg.sv
 
 // RVFI tracer
+${CVA6_REPO_DIR}/core/cva6_rvfi.sv
 ${CVA6_REPO_DIR}/corev_apu/tb/rvfi_tracer.sv
 
 // AXI master connect

--- a/verif/tb/uvmt/cva6_tb_wrapper.sv
+++ b/verif/tb/uvmt/cva6_tb_wrapper.sv
@@ -61,6 +61,11 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
     logic                            flush_unissued_instr;
     logic                            decoded_instr_valid;
     logic                            decoded_instr_ack;
+    logic                            flush;
+    logic                            issue_instr_ack;
+    logic                            fetch_entry_valid;
+    logic [31:0]                     instruction;
+    logic                            is_compressed;
     riscv::xlen_t                    rs1_forwarding;
     riscv::xlen_t                    rs2_forwarding;
     ariane_pkg::scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr;


### PR DESCRIPTION
Support for post-synthesis RVFI tracer without impacting the number of gates
- remove logic in the scoreboard, in the lsu and at the top
- creation of a module to build rvfi_probes structure with all the internal signals used to build the rvfi_instr structure, This module is instantiated at top cva6
- creation of a module which builds rvfi_instr. This module is instantiated in all supported testbenches

Breaking change: rvfi_o port removed, rvfi_probes_o added. Can be left open as before if you don't need tracer_rvfi