### PR TITLE
Adding configuration-specific CSR doc

### DIFF
--- a/docs/01_cva6_user/CSR_CV32A60AX.rst
+++ b/docs/01_cva6_user/CSR_CV32A60AX.rst
@@ -1,0 +1,1 @@
+.. include:: ../csr-from-ip-xact/cv32a60ax/csr.rst

--- a/docs/01_cva6_user/CSR_CV32A60AX.rst
+++ b/docs/01_cva6_user/CSR_CV32A60AX.rst
@@ -1,1 +1,25 @@
-.. include:: ../csr-from-ip-xact/cv32a60ax/csr.rst
+﻿..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 Thales DIS design services SAS
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _CSR_CV32A60AX:
+
+
+CV32A60AX Control Status Registers
+==================================
+
+*This chapter is not yet available.*

--- a/docs/01_cva6_user/CSR_CV32A60AX_list.rst
+++ b/docs/01_cva6_user/CSR_CV32A60AX_list.rst
@@ -1,0 +1,25 @@
+﻿..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 Thales DIS design services SAS
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _CSR_CV32A60AX_list:
+
+
+CV32A60AX Control Status Registers List
+=======================================
+
+*This chapter is not yet available.*

--- a/docs/01_cva6_user/CSR_CV32A60X.rst
+++ b/docs/01_cva6_user/CSR_CV32A60X.rst
@@ -1,0 +1,1 @@
+.. include:: ../csr-from-ip-xact/cv32a60x/csr.rst

--- a/docs/01_cva6_user/CSR_CV32A60X_list.rst
+++ b/docs/01_cva6_user/CSR_CV32A60X_list.rst
@@ -1,0 +1,1 @@
+.. include:: ../csr-from-ip-xact/cv32a60x/csr_list.rst

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -60,7 +60,7 @@ Notes:
 *The following tables detail the availability of extensions for the various CVA6 configurations:*
 
 CV32A60AX extensions
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 These extensions are available in CV32A60AX:
 
@@ -128,7 +128,7 @@ Note: The addition of the H Extension is in the process. After that, HS, VS, and
 *The following tables detail the availability of privileges modes for the various CVA6 configurations:*
 
 CV32A60AX privilege modes
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These privilege modes are available in CV32A60AX:
 
@@ -181,7 +181,7 @@ Notes for the integrator:
 *These are the addressing modes supported by the various CVA6 configurations:*
 
 CV32A60AX virtual memory
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 CV32A60AX integrates an MMU and supports both the **Bare** and **Sv32** addressing modes.
 

--- a/docs/01_cva6_user/RISCV_Instructions.rst
+++ b/docs/01_cva6_user/RISCV_Instructions.rst
@@ -162,7 +162,7 @@ The notations below are used in the description of instructions.
 
 - **>>u**: Right shift of 2 unsigned values.
 
-- **M[address]**: Value existe in the address of the memory.
+- **M[address]**: Value exists in the address of the memory.
 
 - **/s**: Division of 2 signed values.
 

--- a/docs/01_cva6_user/RISCV_Instructions_RVZbs.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZbs.rst
@@ -29,9 +29,9 @@
    "CV32A60X", "Implemented extension"
 
    
-============================
+==============================
 RVZbs: Single-bit instructions
-============================
+==============================
 The single-bit instructions provide a mechanism to set, clear, invert, or extract a single bit in a register. The bit is specified by its index.
 
 The following instructions (and pseudoinstructions) comprise the Zbs extension:

--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -1,3 +1,20 @@
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 Thales DIS design services SAS
+   Licensed under the Solderpad Hardware Licence, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   https://solderpad.org/licenses/
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+CVA6 User Manual
+================
+Editor: **Jerome Quevremont**
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -1,16 +1,21 @@
 ..
    Copyright (c) 2023 OpenHW Group
    Copyright (c) 2023 Thales DIS design services SAS
+   
    Licensed under the Solderpad Hardware Licence, Version 2.1 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
+   
    https://solderpad.org/licenses/
+   
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+   
    SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   
 CVA6 User Manual
 ================
 Editor: **Jerome Quevremont**
@@ -50,3 +55,4 @@ Editor: **Jerome Quevremont**
    Core_Integration
    CVX_Interface_Coprocessor
    AXI_Interface
+   

--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -1,21 +1,21 @@
 ..
    Copyright (c) 2023 OpenHW Group
    Copyright (c) 2023 Thales DIS design services SAS
-   
+
    Licensed under the Solderpad Hardware Licence, Version 2.1 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-   
+
    https://solderpad.org/licenses/
-   
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
    SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-   
+
 CVA6 User Manual
 ================
 Editor: **Jerome Quevremont**

--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -1,25 +1,3 @@
-..
-   Copyright (c) 2023 OpenHW Group
-   Copyright (c) 2023 Thales DIS design services SAS
-
-   Licensed under the Solderpad Hardware Licence, Version 2.1 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-   https://solderpad.org/licenses/
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-
-CVA6 User Manual
-================
-Editor: **Jerome Quevremont**
-
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
@@ -45,7 +23,8 @@ Editor: **Jerome Quevremont**
    RISCV_Instructions_RVZicsr
    RISCV_Instructions_RVZifencei
    RISCV_Instructions_RVZicond
-   CV32A6_Control_Status_Registers
+   CSR_CV32A60X_list
+   CSR_CV32A60X
    CV64A6_Control_Status_Registers
    CSR_Cache_Control
    CSR_Performance_Counters

--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -47,6 +47,7 @@ Editor: **Jerome Quevremont**
    RISCV_Instructions_RVZicond
    CSR_CV32A60X_list
    CSR_CV32A60X
+   CSR_CV32A60AX
    CV64A6_Control_Status_Registers
    CSR_Cache_Control
    CSR_Performance_Counters

--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -18,7 +18,6 @@
 
 CVA6 User Manual
 ================
-Editor: **Jerome Quevremont**
 
 .. toctree::
    :maxdepth: 2
@@ -33,27 +32,30 @@ Editor: **Jerome Quevremont**
    Traps_Interrupts_Exceptions
    Compiler_Command_Lines
    RISCV_Instructions
-   RISCV_Instructions_RV32I
-   RISCV_Instructions_RV32M
-   RISCV_Instructions_RV32A
-   RISCV_Instructions_RV32C
-   RISCV_Instructions_RVZba
-   RISCV_Instructions_RVZbb
-   RISCV_Instructions_RVZbc
-   RISCV_Instructions_RVZbs
-   RISCV_Instructions_RV32ZCb
-   RISCV_Instructions_RVZicsr
-   RISCV_Instructions_RVZifencei
-   RISCV_Instructions_RVZicond
-   CSR_CV32A60X_list
-   CSR_CV32A60X
-   CSR_CV32A60AX
-   CV64A6_Control_Status_Registers
+   RV32I <RISCV_Instructions_RV32I>
+   RV32M <RISCV_Instructions_RV32M>
+   RV32A <RISCV_Instructions_RV32A>
+   RV32C <RISCV_Instructions_RV32C>
+   RV32Zcb <RISCV_Instructions_RV32ZCb>
+   RVZba <RISCV_Instructions_RVZba>
+   RVZbb <RISCV_Instructions_RVZbb>
+   RVZbc <RISCV_Instructions_RVZbc>
+   RVZbs <RISCV_Instructions_RVZbs>
+   RVZicsr <RISCV_Instructions_RVZicsr>
+   RVZifencei <RISCV_Instructions_RVZifencei>
+   RVZicond <RISCV_Instructions_RVZicond>
+   CV32A60X CSR List <CSR_CV32A60X_list>
+   CV32A60X CSR Details <CSR_CV32A60X>
+   CV32A60AX CSR List <CSR_CV32A60AX_list>
+   CV32A60AX CSR Details <CSR_CV32A60AX>
+   CV64A6 CSR <CV64A6_Control_Status_Registers>
    CSR_Cache_Control
-   CSR_Performance_Counters
+   CSR Performance Counters <CSR_Performance_Counters>
    Parameters_Configuration
    Interfaces
+   AXI Bus Interface <AXI_Interface>
+   CV-X-IF Interface <CVX_Interface_Coprocessor>
    Core_Integration
-   CVX_Interface_Coprocessor
-   AXI_Interface
+
+   
    


### PR DESCRIPTION
First attempt to add configuration-specific CSR lists and descriptions in the user manual.
First attempt to point to a file in another subdirectory (common between user manual and design document). I think we need to PR to test if it creates the expected result in ReadTheDocs.