### PR TITLE
Add embedded target to smoke-tests

### DIFF
--- a/verif/regress/smoke-tests.sh
+++ b/verif/regress/smoke-tests.sh
@@ -43,5 +43,12 @@ python3 cva6.py --target cv32a60x --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_
   --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common"
 make -C ../.. clean
 make clean_all
+python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv32a60x.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv32a6_embedded --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a6_embedded-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target cv32a6_embedded --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv32a60x.yaml --test rv32im-cadd-01 --iss_yaml cva6.yaml --target cv32a6_embedded --iss=$DV_SIMULATORS $DV_OPTS  --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
+python3 cva6.py --target cv32a6_embedded --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c --linker=../tests/custom/common/test.ld\
+  --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common"
+make -C ../.. clean
+make clean_all
 
 cd -


### PR DESCRIPTION
Up to now, only cv64a6_imafdc_sv39 and cv32a60x was run in smoke-test, this PR adds embedded target