### PR TITLE
Fix verilator bin path

### DIFF
--- a/verif/sim/setup-env.sh
+++ b/verif/sim/setup-env.sh
@@ -44,4 +44,4 @@ fi
 export SPIKE_PATH=$SPIKE_INSTALL_DIR/bin
 
 # Update the PATH to add all the tools
-export PATH="$VERILATOR_INSTALL_DIR/bin:$RISCV/bin:$PATH"
+export PATH="$VERILATOR_INSTALL_DIR/verilator/bin:$RISCV/bin:$PATH"


### PR DESCRIPTION
The verilator installed by given script `verif/regress/smoke-tests.sh` has a new `bin` path, which looks like `cva6/tools/verilator-v5.018/verilator/bin`. So the original `setup-env.sh` fails to put verilator into $PATH.