### PR TITLE
Parameterize TVAL to reduce size in embedded

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,3 +1,3 @@
 cv32a6_embedded:
-  gates: 114319
+  gates: 110519
 

--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -98,8 +98,7 @@ module branch_unit #(
     branch_exception_o.valid = 1'b0;
     if (CVA6Cfg.TvalEn)
       branch_exception_o.tval = {{riscv::XLEN - riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
-    else
-      branch_exception_o.tval = '0;
+    else branch_exception_o.tval = '0;
     // Only throw instruction address misaligned exception if this is indeed a `taken` conditional branch or
     // an unconditional jump
     if (branch_valid_i && (target_address[0] || (!CVA6Cfg.RVC && target_address[1])) && jump_taken) begin

--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -96,7 +96,10 @@ module branch_unit #(
         ((ariane_pkg::op_is_branch(fu_data_i.operation)) && branch_comp_res_i);
     branch_exception_o.cause = riscv::INSTR_ADDR_MISALIGNED;
     branch_exception_o.valid = 1'b0;
-    branch_exception_o.tval = {{riscv::XLEN - riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
+    if (CVA6Cfg.TvalEn)
+      branch_exception_o.tval = {{riscv::XLEN - riscv::VLEN{pc_i[riscv::VLEN-1]}}, pc_i};
+    else
+      branch_exception_o.tval = '0;
     // Only throw instruction address misaligned exception if this is indeed a `taken` conditional branch or
     // an unconditional jump
     if (branch_valid_i && (target_address[0] || (!CVA6Cfg.RVC && target_address[1])) && jump_taken) begin

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -847,10 +847,8 @@ module csr_regfile
         riscv::CSR_MEPC: mepc_d = {csr_wdata[riscv::XLEN-1:1], 1'b0};
         riscv::CSR_MCAUSE: mcause_d = csr_wdata;
         riscv::CSR_MTVAL: begin
-          if (CVA6Cfg.TvalEn)
-            mtval_d = csr_wdata;
-          else
-            update_access_exception = 1'b1;
+          if (CVA6Cfg.TvalEn) mtval_d = csr_wdata;
+          else update_access_exception = 1'b1;
         end
         riscv::CSR_MIP: begin
           mask  = riscv::MIP_SSIP | riscv::MIP_STIP | riscv::MIP_SEIP;
@@ -1143,7 +1141,7 @@ module csr_regfile
                                       riscv::ENV_CALL_MMODE
                                     } || ex_i.cause[riscv::XLEN-1])) ? '0 : ex_i.tval;
         end else begin
-          mtval_d  = '0;
+          mtval_d = '0;
         end
       end
 
@@ -1594,13 +1592,12 @@ module csr_regfile
       mcause_q         <= mcause_d;
       mcounteren_q     <= mcounteren_d;
       mscratch_q       <= mscratch_d;
-      if (CVA6Cfg.TvalEn)
-        mtval_q          <= mtval_d;
-      fiom_q           <= fiom_d;
-      dcache_q         <= dcache_d;
-      icache_q         <= icache_d;
-      mcountinhibit_q  <= mcountinhibit_d;
-      acc_cons_q       <= acc_cons_d;
+      if (CVA6Cfg.TvalEn) mtval_q <= mtval_d;
+      fiom_q          <= fiom_d;
+      dcache_q        <= dcache_d;
+      icache_q        <= icache_d;
+      mcountinhibit_q <= mcountinhibit_d;
+      acc_cons_q      <= acc_cons_d;
       // supervisor mode registers
       if (CVA6Cfg.RVS) begin
         medeleg_q    <= medeleg_d;
@@ -1610,9 +1607,8 @@ module csr_regfile
         stvec_q      <= stvec_d;
         scounteren_q <= scounteren_d;
         sscratch_q   <= sscratch_d;
-        if (CVA6Cfg.TvalEn)
-          stval_q      <= stval_d;
-        satp_q       <= satp_d;
+        if (CVA6Cfg.TvalEn) stval_q <= stval_d;
+        satp_q <= satp_d;
       end
       // timer and counters
       cycle_q                <= cycle_d;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -204,6 +204,7 @@ module cva6
     CVA6Cfg.BTBEntries,
     CVA6Cfg.BHTEntries,
     CVA6Cfg.DmBaseAddress,
+    CVA6Cfg.TvalEn,
     CVA6Cfg.NrPMPEntries,
     CVA6Cfg.PMPCfgRstVal,
     CVA6Cfg.PMPAddrRstVal,
@@ -256,6 +257,7 @@ module cva6
   // ID <-> ISSUE
   // --------------
   scoreboard_entry_t issue_entry_id_issue;
+  logic [31:0] orig_instr_id_issue;
   logic issue_entry_valid_id_issue;
   logic is_ctrl_fow_id_issue;
   logic issue_instr_issue_id;
@@ -504,6 +506,7 @@ module cva6
       .fetch_entry_ready_o(fetch_ready_id_if),
 
       .issue_entry_o      (issue_entry_id_issue),
+      .orig_instr_o       (orig_instr_id_issue),
       .issue_entry_valid_o(issue_entry_valid_id_issue),
       .is_ctrl_flow_o     (is_ctrl_fow_id_issue),
       .issue_instr_ack_i  (issue_instr_issue_id),
@@ -600,6 +603,7 @@ module cva6
       .stall_i               (stall_acc_id),
       // ID Stage
       .decoded_instr_i       (issue_entry_id_issue),
+      .orig_instr_i          (orig_instr_id_issue),
       .decoded_instr_valid_i (issue_entry_valid_id_issue),
       .is_ctrl_flow_i        (is_ctrl_fow_id_issue),
       .decoded_instr_ack_o   (issue_instr_issue_id),

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -93,6 +93,7 @@ module cva6_rvfi
     CVA6Cfg.BTBEntries,
     CVA6Cfg.BHTEntries,
     CVA6Cfg.DmBaseAddress,
+    CVA6Cfg.TvalEn,
     CVA6Cfg.NrPMPEntries,
     CVA6Cfg.PMPCfgRstVal,
     CVA6Cfg.PMPAddrRstVal,

--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -90,7 +90,8 @@ module cvxif_fu
         x_valid_o = 1'b1;
         x_exception_o.cause = riscv::ILLEGAL_INSTR;
         x_exception_o.valid = 1'b1;
-        x_exception_o.tval = illegal_instr_n;
+        if (CVA6Cfg.TvalEn)
+          x_exception_o.tval = illegal_instr_n;
         x_we_o = '0;
         illegal_n             = '0; // Reset flag for illegal instr. illegal_id and illegal instr values are a don't care, no need to reset it.
       end

--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -90,8 +90,7 @@ module cvxif_fu
         x_valid_o = 1'b1;
         x_exception_o.cause = riscv::ILLEGAL_INSTR;
         x_exception_o.valid = 1'b1;
-        if (CVA6Cfg.TvalEn)
-          x_exception_o.tval = illegal_instr_n;
+        if (CVA6Cfg.TvalEn) x_exception_o.tval = illegal_instr_n;
         x_we_o = '0;
         illegal_n             = '0; // Reset flag for illegal instr. illegal_id and illegal instr values are a don't care, no need to reset it.
       end

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -44,7 +44,7 @@ module decoder
     input logic tw_i,  // timeout wait
     input logic tsr_i,  // trap sret
     output scoreboard_entry_t instruction_o,  // scoreboard entry to scoreboard
-    output logic [31:0] orig_instr_o, // instruction opcode to issue read operand for CVXIF
+    output logic [31:0] orig_instr_o,  // instruction opcode to issue read operand for CVXIF
     output logic is_control_flow_instr_o  // this instruction will change the control flow
 );
   logic illegal_instr;
@@ -1305,7 +1305,7 @@ module decoder
   assign instruction_o.valid = instruction_o.ex.valid;
 
   always_comb begin : exception_handling
-    interrupt_cause  = '0;
+    interrupt_cause = '0;
     instruction_o.ex = ex_i;
     orig_instr_o = '0;
     // look if we didn't already get an exception in any previous
@@ -1313,12 +1313,11 @@ module decoder
     if (~ex_i.valid) begin
       // if we didn't already get an exception save the instruction here as we may need it
       // in the commit stage if we got a access exception to one of the CSR registers
-      if (CVA6Cfg.CvxifEn)
+      if (CVA6Cfg.CvxifEn || CVA6Cfg.FpuEn)
         orig_instr_o = (is_compressed_i) ? {{riscv::XLEN-16{1'b0}}, compressed_instr_i} : {{riscv::XLEN-32{1'b0}}, instruction_i};
       if (CVA6Cfg.TvalEn)
         instruction_o.ex.tval  = (is_compressed_i) ? {{riscv::XLEN-16{1'b0}}, compressed_instr_i} : {{riscv::XLEN-32{1'b0}}, instruction_i};
-      else
-        instruction_o.ex.tval = '0;
+      else instruction_o.ex.tval = '0;
       // instructions which will throw an exception are marked as valid
       // e.g.: they can be committed anytime and do not need to wait for any functional unit
       // check here if we decoded an invalid instruction or if the compressed decoder already decoded

--- a/core/fpu_wrap.sv
+++ b/core/fpu_wrap.sv
@@ -557,7 +557,7 @@ module fpu_wrap
     // Pack status flag into exception cause, tval ignored in wb, exception is always invalid
     assign fpu_exception_o.cause = {59'h0, fpu_status};
     assign fpu_exception_o.valid = 1'b0;
-    assign fpu_exception_o.tval  = '0;
+    assign fpu_exception_o.tval = '0;
 
     // Donwstream write port is dedicated to FPU and always ready
     assign fpu_out_ready = 1'b1;

--- a/core/fpu_wrap.sv
+++ b/core/fpu_wrap.sv
@@ -557,6 +557,7 @@ module fpu_wrap
     // Pack status flag into exception cause, tval ignored in wb, exception is always invalid
     assign fpu_exception_o.cause = {59'h0, fpu_status};
     assign fpu_exception_o.valid = 1'b0;
+    assign fpu_exception_o.tval  = '0;
 
     // Donwstream write port is dedicated to FPU and always ready
     assign fpu_out_ready = 1'b1;

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -282,9 +282,10 @@ ariane_pkg::FETCH_FIFO_DEPTH
           end
           fetch_entry_o.instruction = instr_data_out[i].instr;
           fetch_entry_o.ex.valid = instr_data_out[i].ex != ariane_pkg::FE_NONE;
-          fetch_entry_o.ex.tval = {
-            {(riscv::XLEN - riscv::VLEN) {1'b0}}, instr_data_out[i].ex_vaddr
-          };
+          if (CVA6Cfg.TvalEn)
+            fetch_entry_o.ex.tval = {
+              {(riscv::XLEN - riscv::VLEN) {1'b0}}, instr_data_out[i].ex_vaddr
+            };
           fetch_entry_o.branch_predict.cf = instr_data_out[i].cf;
           pop_instr[i] = fetch_entry_valid_o & fetch_entry_ready_i;
         end
@@ -309,8 +310,10 @@ ariane_pkg::FETCH_FIFO_DEPTH
       end else begin
         fetch_entry_o.ex.cause = riscv::INSTR_PAGE_FAULT;
       end
-      fetch_entry_o.ex.tval = {{64 - riscv::VLEN{1'b0}}, instr_data_out[0].ex_vaddr};
-
+      if (CVA6Cfg.TvalEn)
+        fetch_entry_o.ex.tval = {{64 - riscv::VLEN{1'b0}}, instr_data_out[0].ex_vaddr};
+      else
+        fetch_entry_o.ex.tval = '0;
       fetch_entry_o.branch_predict.predict_address = address_out;
       fetch_entry_o.branch_predict.cf = instr_data_out[0].cf;
 

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -312,8 +312,7 @@ ariane_pkg::FETCH_FIFO_DEPTH
       end
       if (CVA6Cfg.TvalEn)
         fetch_entry_o.ex.tval = {{64 - riscv::VLEN{1'b0}}, instr_data_out[0].ex_vaddr};
-      else
-        fetch_entry_o.ex.tval = '0;
+      else fetch_entry_o.ex.tval = '0;
       fetch_entry_o.branch_predict.predict_address = address_out;
       fetch_entry_o.branch_predict.cf = instr_data_out[0].cf;
 

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -55,7 +55,7 @@ module id_stage #(
 
   logic                                 is_control_flow_instr;
   ariane_pkg::scoreboard_entry_t        decoded_instruction;
-  logic [31:0]                          orig_instr;
+  logic                          [31:0] orig_instr;
 
   logic                                 is_illegal;
   logic                          [31:0] instruction;

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -27,6 +27,7 @@ module id_stage #(
     output logic fetch_entry_ready_o,  // acknowledge the instruction (fetch entry)
     // to ID
     output ariane_pkg::scoreboard_entry_t issue_entry_o,  // a decoded instruction
+    output logic [31:0] orig_instr_o,
     output logic issue_entry_valid_o,  // issue entry is valid
     output logic is_ctrl_flow_o,  // the instruction we issue is a ctrl flow instructions
     input logic issue_instr_ack_i,  // issue stage acknowledged sampling of instructions
@@ -47,12 +48,14 @@ module id_stage #(
   typedef struct packed {
     logic                          valid;
     ariane_pkg::scoreboard_entry_t sbe;
+    logic [31:0]                   orig_instr;
     logic                          is_ctrl_flow;
   } issue_struct_t;
   issue_struct_t issue_n, issue_q;
 
   logic                                 is_control_flow_instr;
   ariane_pkg::scoreboard_entry_t        decoded_instruction;
+  logic [31:0]                          orig_instr;
 
   logic                                 is_illegal;
   logic                          [31:0] instruction;
@@ -102,6 +105,7 @@ module id_stage #(
       .tw_i,
       .tsr_i,
       .instruction_o          (decoded_instruction),
+      .orig_instr_o           (orig_instr),
       .is_control_flow_instr_o(is_control_flow_instr)
   );
 
@@ -111,6 +115,7 @@ module id_stage #(
   assign issue_entry_o = issue_q.sbe;
   assign issue_entry_valid_o = issue_q.valid;
   assign is_ctrl_flow_o = issue_q.is_ctrl_flow;
+  assign orig_instr_o = issue_q.orig_instr;
 
   always_comb begin
     issue_n             = issue_q;
@@ -124,7 +129,7 @@ module id_stage #(
     // for a new instruction
     if ((!issue_q.valid || issue_instr_ack_i) && fetch_entry_valid_i) begin
       fetch_entry_ready_o = 1'b1;
-      issue_n = '{1'b1, decoded_instruction, is_control_flow_instr};
+      issue_n = '{1'b1, decoded_instruction, orig_instr, is_control_flow_instr};
     end
 
     // invalidate the pipeline register on a flush

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -87,6 +87,8 @@ package config_pkg;
     int unsigned                 BHTEntries;
     /// Offset of the debug module.
     logic [63:0]                 DmBaseAddress;
+    /// Tval Support Enable
+    bit                          TvalEn;
     /// Number of PMP entries.
     int unsigned                 NrPMPEntries;
     /// Physical Memory Protection (PMP) CSR reset values and read-only bits

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 0;
   localparam CVA6ConfigBHTEntries = 0;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 0;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -61,6 +61,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 0;
   localparam CVA6ConfigBHTEntries = 32;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 0;
@@ -114,6 +116,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -61,7 +61,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 0;
   localparam CVA6ConfigBHTEntries = 32;
 
-  localparam CVA6ConfigTvalEn = 1;
+  localparam CVA6ConfigTvalEn = 0;
 
   localparam CVA6ConfigNrPMPEntries = 8;
 

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 0;
 
   localparam CVA6ConfigPerfCounterEn = 0;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: unsigned'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: unsigned'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -61,6 +61,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -114,6 +116,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -69,6 +69,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -122,6 +124,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -62,6 +62,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -115,6 +117,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -61,6 +61,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
 
+  localparam CVA6ConfigTvalEn = 1;
+
   localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 1;
@@ -114,6 +116,7 @@ package cva6_config_pkg;
       BTBEntries: unsigned'(CVA6ConfigBTBEntries),
       BHTEntries: unsigned'(CVA6ConfigBHTEntries),
       DmBaseAddress: 64'h0,
+      TvalEn: bit'(CVA6ConfigTvalEn),
       NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -28,6 +28,7 @@ module issue_read_operands
     input logic stall_i,
     // coming from decoder
     input scoreboard_entry_t issue_instr_i,
+    input logic [31:0] orig_instr_i,
     input logic issue_instr_valid_i,
     output logic issue_ack_o,
     // lookup rd in scoreboard
@@ -111,9 +112,9 @@ module issue_read_operands
   // forwarding signals
   logic forward_rs1, forward_rs2, forward_rs3;
 
-  // original instruction stored in tval
+  // original instruction
   riscv::instruction_t orig_instr;
-  assign orig_instr          = riscv::instruction_t'(issue_instr_i.ex.tval[31:0]);
+  assign orig_instr          = riscv::instruction_t'(orig_instr_i);
 
   // ID <-> EX registers
 

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -112,7 +112,7 @@ module issue_stage
   logic                                     rs3_valid_iro_sb;
 
   scoreboard_entry_t                        issue_instr_sb_iro;
-  logic [31:0]                              orig_instr_sb_iro;
+  logic              [                31:0] orig_instr_sb_iro;
   logic                                     issue_instr_valid_sb_iro;
   logic                                     issue_ack_iro_sb;
 

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -28,6 +28,7 @@ module issue_stage
     input logic stall_i,  // Stall issue stage
     // from ISSUE
     input scoreboard_entry_t decoded_instr_i,
+    input logic [31:0] orig_instr_i,
     input logic decoded_instr_valid_i,
     input logic is_ctrl_flow_i,
     output logic decoded_instr_ack_o,
@@ -111,6 +112,7 @@ module issue_stage
   logic                                     rs3_valid_iro_sb;
 
   scoreboard_entry_t                        issue_instr_sb_iro;
+  logic [31:0]                              orig_instr_sb_iro;
   logic                                     issue_instr_valid_sb_iro;
   logic                                     issue_ack_iro_sb;
 
@@ -149,6 +151,7 @@ module issue_stage
       .decoded_instr_valid_i(decoded_instr_valid_i),
       .decoded_instr_ack_o  (decoded_instr_ack_o),
       .issue_instr_o        (issue_instr_sb_iro),
+      .orig_instr_o         (orig_instr_sb_iro),
       .issue_instr_valid_o  (issue_instr_valid_sb_iro),
       .issue_ack_i          (issue_ack_iro_sb),
 
@@ -168,6 +171,7 @@ module issue_stage
   ) i_issue_read_operands (
       .flush_i            (flush_unissued_instr_i),
       .issue_instr_i      (issue_instr_sb_iro),
+      .orig_instr_i       (orig_instr_sb_iro),
       .issue_instr_valid_i(issue_instr_valid_sb_iro),
       .issue_ack_o        (issue_ack_iro_sb),
       .fu_data_o          (fu_data_o),

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -431,28 +431,32 @@ module load_store_unit
     if (data_misaligned) begin
 
       if (lsu_ctrl.fu == LOAD) begin
-        misaligned_exception = {
-          riscv::LD_ADDR_MISALIGNED, {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr}, 1'b1
-        };
+        misaligned_exception.cause = riscv::LD_ADDR_MISALIGNED;
+        misaligned_exception.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
 
       end else if (lsu_ctrl.fu == STORE) begin
-        misaligned_exception = {
-          riscv::ST_ADDR_MISALIGNED, {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr}, 1'b1
-        };
+        misaligned_exception.cause = riscv::ST_ADDR_MISALIGNED;
+        misaligned_exception.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
       end
     end
 
     if (ariane_pkg::MMU_PRESENT && en_ld_st_translation_i && lsu_ctrl.overflow) begin
 
       if (lsu_ctrl.fu == LOAD) begin
-        misaligned_exception = {
-          riscv::LD_ACCESS_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr}, 1'b1
-        };
+        misaligned_exception.cause = riscv::LD_ACCESS_FAULT;
+        misaligned_exception.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
 
       end else if (lsu_ctrl.fu == STORE) begin
-        misaligned_exception = {
-          riscv::ST_ACCESS_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr}, 1'b1
-        };
+        misaligned_exception.cause = riscv::ST_ACCESS_FAULT;
+        misaligned_exception.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
       end
     end
   end

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -296,11 +296,10 @@ module cva6_mmu_sv32
     if (enable_translation_i) begin
       // we work with SV32, so if VM is enabled, check that all bits [riscv::VLEN-1:riscv::SV-1] are equal
       if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b1 || (|icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b0)) begin
-        icache_areq_o.fetch_exception = {
-          riscv::INSTR_ACCESS_FAULT,
-          {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-          1'b1
-        };
+        icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+        icache_areq_o.fetch_exception.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
       end
 
       icache_areq_o.fetch_valid = 1'b0;
@@ -322,15 +321,17 @@ module cva6_mmu_sv32
         // we got an access error
         if (iaccess_err) begin
           // throw a page fault
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_PAGE_FAULT,
-            {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-            1'b1
-          };  //to check on wave --> not connected
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
+          //to check on wave --> not connected
         end else if (!pmp_instr_allow) begin
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_ACCESS_FAULT, icache_areq_i.fetch_vaddr, 1'b1
-          };  //to check on wave --> not connected
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval = icache_areq_i.fetch_vaddr;
+          //to check on wave --> not connected
         end
       end else
       // ---------
@@ -339,23 +340,29 @@ module cva6_mmu_sv32
       // watch out for exceptions happening during walking the page table
       if (ptw_active && walking_instr) begin
         icache_areq_o.fetch_valid = ptw_error | ptw_access_exception;
-        if (ptw_error)
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_PAGE_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr}, 1'b1
-          };  //to check on wave
+        if (ptw_error) begin
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
+        end  //to check on wave
         // TODO(moschn,zarubaf): What should the value of tval be in this case?
-        else
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_ACCESS_FAULT, ptw_bad_paddr[riscv::PLEN-1:2], 1'b1
-          };  //to check on wave --> not connected
+        else begin
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval  = ptw_bad_paddr[riscv::PLEN-1:2];
+        end
       end
     end
     // if it didn't match any execute region throw an `Instruction Access Fault`
     // or: if we are not translating, check PMPs immediately on the paddr
     if (!match_any_execute_region || (!enable_translation_i && !pmp_instr_allow)) begin
-      icache_areq_o.fetch_exception = {
-        riscv::INSTR_ACCESS_FAULT, icache_areq_o.fetch_paddr[riscv::PLEN-1:2], 1'b1
-      };  //to check on wave --> not connected
+      icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+      icache_areq_o.fetch_exception.valid = 1'b1;
+      if (CVA6Cfg.TvalEn)
+        icache_areq_o.fetch_exception.tval  = icache_areq_o.fetch_paddr[riscv::PLEN-1:2]; 
+    //to check on wave --> not connected
     end
   end
 
@@ -453,32 +460,34 @@ module cva6_mmu_sv32
           // check if the page is write-able and we are not violating privileges
           // also check if the dirty flag is set
           if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
-            lsu_exception_o = {
-              riscv::STORE_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };  //to check on wave
+            lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
+            // to check on wave
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
-            lsu_exception_o = {
-              riscv::ST_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1
-            };  //only 32 bits on 34b of lsu_paddr_o are returned.
+            lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
+            //only 32 bits on 34b of lsu_paddr_o are returned.
           end
 
           // this is a load
         end else begin
           // check for sufficient access privileges - throw a page fault if necessary
           if (daccess_err) begin
-            lsu_exception_o = {
-              riscv::LOAD_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
-            lsu_exception_o = {
-              riscv::LD_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1
-            };  //only 32 bits on 34b of lsu_paddr_o are returned.
+            lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
           end
         end
       end else
@@ -494,17 +503,15 @@ module cva6_mmu_sv32
           lsu_valid_o = 1'b1;
           // the page table walker can only throw page faults
           if (lsu_is_store_q) begin
-            lsu_exception_o = {
-              riscv::STORE_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
           end else begin
-            lsu_exception_o = {
-              riscv::LOAD_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
           end
         end
 
@@ -512,15 +519,24 @@ module cva6_mmu_sv32
           // an error makes the translation valid
           lsu_valid_o = 1'b1;
           // the page table walker can only throw page faults
-          lsu_exception_o = {riscv::LD_ACCESS_FAULT, ptw_bad_paddr[riscv::PLEN-1:2], 1'b1};
+          lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
+          lsu_exception_o.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            lsu_exception_o.tval  = ptw_bad_paddr[riscv::PLEN-1:2];
         end
       end
     end  // If translation is not enabled, check the paddr immediately against PMPs
     else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow) begin
       if (lsu_is_store_q) begin
-        lsu_exception_o = {riscv::ST_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1};
+        lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
+        lsu_exception_o.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
       end else begin
-        lsu_exception_o = {riscv::LD_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1};
+        lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
+        lsu_exception_o.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
       end
     end
   end

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -299,7 +299,9 @@ module cva6_mmu_sv32
         icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
         icache_areq_o.fetch_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
+          icache_areq_o.fetch_exception.tval = {
+            {riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+          };
       end
 
       icache_areq_o.fetch_valid = 1'b0;
@@ -324,13 +326,14 @@ module cva6_mmu_sv32
           icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
+            icache_areq_o.fetch_exception.tval = {
+              {riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+            };
           //to check on wave --> not connected
         end else if (!pmp_instr_allow) begin
           icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
-          if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval = icache_areq_i.fetch_vaddr;
+          if (CVA6Cfg.TvalEn) icache_areq_o.fetch_exception.tval = icache_areq_i.fetch_vaddr;
           //to check on wave --> not connected
         end
       end else
@@ -344,14 +347,13 @@ module cva6_mmu_sv32
           icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
+            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
         end  //to check on wave
         // TODO(moschn,zarubaf): What should the value of tval be in this case?
         else begin
           icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
-          if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval  = ptw_bad_paddr[riscv::PLEN-1:2];
+          if (CVA6Cfg.TvalEn) icache_areq_o.fetch_exception.tval = ptw_bad_paddr[riscv::PLEN-1:2];
         end
       end
     end
@@ -361,8 +363,8 @@ module cva6_mmu_sv32
       icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
       icache_areq_o.fetch_exception.valid = 1'b1;
       if (CVA6Cfg.TvalEn)
-        icache_areq_o.fetch_exception.tval  = icache_areq_o.fetch_paddr[riscv::PLEN-1:2]; 
-    //to check on wave --> not connected
+        icache_areq_o.fetch_exception.tval = icache_areq_o.fetch_paddr[riscv::PLEN-1:2];
+      //to check on wave --> not connected
     end
   end
 
@@ -463,14 +465,15 @@ module cva6_mmu_sv32
             lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q
+              };
             // to check on wave
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
             lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
             lsu_exception_o.valid = 1'b1;
-            if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
+            if (CVA6Cfg.TvalEn) lsu_exception_o.tval = lsu_paddr_o[riscv::PLEN-1:2];
             //only 32 bits on 34b of lsu_paddr_o are returned.
           end
 
@@ -481,13 +484,14 @@ module cva6_mmu_sv32
             lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q
+              };
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
             lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
             lsu_exception_o.valid = 1'b1;
-            if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
+            if (CVA6Cfg.TvalEn) lsu_exception_o.tval = lsu_paddr_o[riscv::PLEN-1:2];
           end
         end
       end else
@@ -506,12 +510,16 @@ module cva6_mmu_sv32
             lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr
+              };
           end else begin
             lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr
+              };
           end
         end
 
@@ -521,8 +529,7 @@ module cva6_mmu_sv32
           // the page table walker can only throw page faults
           lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
           lsu_exception_o.valid = 1'b1;
-          if (CVA6Cfg.TvalEn)
-            lsu_exception_o.tval  = ptw_bad_paddr[riscv::PLEN-1:2];
+          if (CVA6Cfg.TvalEn) lsu_exception_o.tval = ptw_bad_paddr[riscv::PLEN-1:2];
         end
       end
     end  // If translation is not enabled, check the paddr immediately against PMPs
@@ -530,13 +537,11 @@ module cva6_mmu_sv32
       if (lsu_is_store_q) begin
         lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
         lsu_exception_o.valid = 1'b1;
-        if (CVA6Cfg.TvalEn)
-          lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
+        if (CVA6Cfg.TvalEn) lsu_exception_o.tval = lsu_paddr_o[riscv::PLEN-1:2];
       end else begin
         lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
         lsu_exception_o.valid = 1'b1;
-        if (CVA6Cfg.TvalEn)
-          lsu_exception_o.tval  = lsu_paddr_o[riscv::PLEN-1:2];
+        if (CVA6Cfg.TvalEn) lsu_exception_o.tval = lsu_paddr_o[riscv::PLEN-1:2];
       end
     end
   end

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -225,7 +225,9 @@ module mmu
         icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
         icache_areq_o.fetch_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
+          icache_areq_o.fetch_exception.tval = {
+            {riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+          };
       end
 
       icache_areq_o.fetch_valid = 1'b0;
@@ -253,12 +255,16 @@ module mmu
           icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
+            icache_areq_o.fetch_exception.tval = {
+              {riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+            };
         end else if (!pmp_instr_allow) begin
           icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
+            icache_areq_o.fetch_exception.tval = {
+              {riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+            };
         end
       end else
       // ---------
@@ -271,13 +277,12 @@ module mmu
           icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
-        end
-        else begin
+            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
+        end else begin
           icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
+            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
         end
       end
     end
@@ -287,7 +292,9 @@ module mmu
       icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
       icache_areq_o.fetch_exception.valid = 1'b1;
       if (CVA6Cfg.TvalEn)
-        icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr};
+        icache_areq_o.fetch_exception.tval = {
+          {riscv::XLEN - riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr
+        };
     end
   end
 
@@ -391,13 +398,17 @@ module mmu
             lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q
+              };
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
             lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q
+              };
           end
 
           // this is a load
@@ -407,13 +418,17 @@ module mmu
             lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q
+              };
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
             lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q
+              };
           end
         end
       end else
@@ -432,12 +447,16 @@ module mmu
             lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr
+              };
           end else begin
             lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
+              lsu_exception_o.tval = {
+                {riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr
+              };
           end
         end
 
@@ -449,12 +468,12 @@ module mmu
             lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n};
+              lsu_exception_o.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n};
           end else begin
             lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
             lsu_exception_o.valid = 1'b1;
             if (CVA6Cfg.TvalEn)
-              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n};
+              lsu_exception_o.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n};
           end
         end
       end
@@ -463,13 +482,11 @@ module mmu
       if (lsu_is_store_q) begin
         lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
         lsu_exception_o.valid = 1'b1;
-        if (CVA6Cfg.TvalEn)
-          lsu_exception_o.tval  = {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o};
+        if (CVA6Cfg.TvalEn) lsu_exception_o.tval = {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o};
       end else begin
         lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
         lsu_exception_o.valid = 1'b1;
-        if (CVA6Cfg.TvalEn)
-          lsu_exception_o.tval  = {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o};
+        if (CVA6Cfg.TvalEn) lsu_exception_o.tval = {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o};
       end
     end
   end

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -222,11 +222,10 @@ module mmu
     if (enable_translation_i) begin
       // we work with SV39 or SV32, so if VM is enabled, check that all bits [riscv::VLEN-1:riscv::SV-1] are equal
       if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b1 || (|icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b0)) begin
-        icache_areq_o.fetch_exception = {
-          riscv::INSTR_ACCESS_FAULT,
-          {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-          1'b1
-        };
+        icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+        icache_areq_o.fetch_exception.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
       end
 
       icache_areq_o.fetch_valid = 1'b0;
@@ -251,17 +250,15 @@ module mmu
         // we got an access error
         if (iaccess_err) begin
           // throw a page fault
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_PAGE_FAULT,
-            {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-            1'b1
-          };
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
         end else if (!pmp_instr_allow) begin
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_ACCESS_FAULT,
-            {{riscv::XLEN - riscv::PLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-            1'b1
-          };
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};
         end
       end else
       // ---------
@@ -270,24 +267,27 @@ module mmu
       // watch out for exceptions happening during walking the page table
       if (ptw_active && walking_instr) begin
         icache_areq_o.fetch_valid = ptw_error | ptw_access_exception;
-        if (ptw_error)
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_PAGE_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr}, 1'b1
-          };
-        else
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr}, 1'b1
-          };
+        if (ptw_error) begin
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
+        end
+        else begin
+          icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+          icache_areq_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn)
+            icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr};
+        end
       end
     end
     // if it didn't match any execute region throw an `Instruction Access Fault`
     // or: if we are not translating, check PMPs immediately on the paddr
     if ((!match_any_execute_region && !ptw_error) || (!enable_translation_i && !pmp_instr_allow)) begin
-      icache_areq_o.fetch_exception = {
-        riscv::INSTR_ACCESS_FAULT,
-        {{riscv::XLEN - riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr},
-        1'b1
-      };
+      icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+      icache_areq_o.fetch_exception.valid = 1'b1;
+      if (CVA6Cfg.TvalEn)
+        icache_areq_o.fetch_exception.tval  = {{riscv::XLEN - riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr};
     end
   end
 
@@ -388,36 +388,32 @@ module mmu
           // check if the page is write-able and we are not violating privileges
           // also check if the dirty flag is set
           if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
-            lsu_exception_o = {
-              riscv::STORE_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
-            lsu_exception_o = {
-              riscv::ST_ACCESS_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
           end
 
           // this is a load
         end else begin
           // check for sufficient access privileges - throw a page fault if necessary
           if (daccess_err) begin
-            lsu_exception_o = {
-              riscv::LOAD_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
             // Check if any PMPs are violated
           end else if (!pmp_data_allow) begin
-            lsu_exception_o = {
-              riscv::LD_ACCESS_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q};
           end
         end
       end else
@@ -433,17 +429,15 @@ module mmu
           lsu_valid_o = 1'b1;
           // the page table walker can only throw page faults
           if (lsu_is_store_q) begin
-            lsu_exception_o = {
-              riscv::STORE_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::STORE_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
           end else begin
-            lsu_exception_o = {
-              riscv::LOAD_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr},
-              1'b1
-            };
+            lsu_exception_o.cause = riscv::LOAD_PAGE_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr};
           end
         end
 
@@ -452,26 +446,30 @@ module mmu
           lsu_valid_o = 1'b1;
           // Any fault of the page table walk should be based of the original access type
           if (lsu_is_store_q) begin
-            lsu_exception_o = {
-              riscv::ST_ACCESS_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n}, 1'b1
-            };
+            lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n};
           end else begin
-            lsu_exception_o = {
-              riscv::LD_ACCESS_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n}, 1'b1
-            };
+            lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
+            lsu_exception_o.valid = 1'b1;
+            if (CVA6Cfg.TvalEn)
+              lsu_exception_o.tval  = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n};
           end
         end
       end
     end  // If translation is not enabled, check the paddr immediately against PMPs
     else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow) begin
       if (lsu_is_store_q) begin
-        lsu_exception_o = {
-          riscv::ST_ACCESS_FAULT, {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1
-        };
+        lsu_exception_o.cause = riscv::ST_ACCESS_FAULT;
+        lsu_exception_o.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          lsu_exception_o.tval  = {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o};
       end else begin
-        lsu_exception_o = {
-          riscv::LD_ACCESS_FAULT, {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o}, 1'b1
-        };
+        lsu_exception_o.cause = riscv::LD_ACCESS_FAULT;
+        lsu_exception_o.valid = 1'b1;
+        if (CVA6Cfg.TvalEn)
+          lsu_exception_o.tval  = {{riscv::XLEN - riscv::PLEN{1'b0}}, lsu_paddr_o};
       end
     end
   end

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -46,11 +46,13 @@ module scoreboard #(
     // instruction to put on top of scoreboard e.g.: top pointer
     // we can always put this instruction to the top unless we signal with asserted full_o
     input  ariane_pkg::scoreboard_entry_t decoded_instr_i,
+    input  logic [31:0]                   orig_instr_i,
     input  logic                          decoded_instr_valid_i,
     output logic                          decoded_instr_ack_o,
 
     // instruction to issue logic, if issue_instr_valid and issue_ready is asserted, advance the issue pointer
     output ariane_pkg::scoreboard_entry_t issue_instr_o,
+    output logic [31:0]                   orig_instr_o,
     output logic                          issue_instr_valid_o,
     input  logic                          issue_ack_i,
 
@@ -104,6 +106,7 @@ module scoreboard #(
   // an instruction is ready for issue if we have place in the issue FIFO and it the decoder says it is valid
   always_comb begin
     issue_instr_o          = decoded_instr_i;
+    orig_instr_o           = orig_instr_i;
     // make sure we assign the correct trans ID
     issue_instr_o.trans_id = issue_pointer_q;
     // we are ready if we are not full and don't have any unresolved branches, but it can be

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -45,16 +45,16 @@ module scoreboard #(
 
     // instruction to put on top of scoreboard e.g.: top pointer
     // we can always put this instruction to the top unless we signal with asserted full_o
-    input  ariane_pkg::scoreboard_entry_t decoded_instr_i,
-    input  logic [31:0]                   orig_instr_i,
-    input  logic                          decoded_instr_valid_i,
-    output logic                          decoded_instr_ack_o,
+    input  ariane_pkg::scoreboard_entry_t        decoded_instr_i,
+    input  logic                          [31:0] orig_instr_i,
+    input  logic                                 decoded_instr_valid_i,
+    output logic                                 decoded_instr_ack_o,
 
     // instruction to issue logic, if issue_instr_valid and issue_ready is asserted, advance the issue pointer
-    output ariane_pkg::scoreboard_entry_t issue_instr_o,
-    output logic [31:0]                   orig_instr_o,
-    output logic                          issue_instr_valid_o,
-    input  logic                          issue_ack_i,
+    output ariane_pkg::scoreboard_entry_t        issue_instr_o,
+    output logic                          [31:0] orig_instr_o,
+    output logic                                 issue_instr_valid_o,
+    input  logic                                 issue_ack_i,
 
     // write-back port
     input ariane_pkg::bp_resolve_t resolved_branch_i,

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -196,6 +196,7 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   HaltAddress:           dm::HaltAddress,
   ExceptionAddress:      dm::ExceptionAddress,
   DmBaseAddress:         ariane_soc::DebugBase,
+  TvalEn:                bit'(cva6_config_pkg::CVA6ConfigTvalEn),
   NrPMPEntries:          unsigned'(cva6_config_pkg::CVA6ConfigNrPMPEntries),
   PMPCfgRstVal:          {16{64'h0}},
   PMPAddrRstVal:         {16{64'h0}},


### PR DESCRIPTION
Add a parameter TvalEn to remove tval gates in embedded configuration.

Behaviour when software is trying to write to MTVAL or STVAL should be determined. 
In this PR, it is forbidden and access to MTVAL or STVAL when TvalEn is disabled will raise an illegal instruction exception.