### PR TITLE
MTVAL : Remove MTVAL CSR from CVA6 UVM environment

### DIFF
--- a/verif/env/uvme/reg/cva6_csr_reg_file.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_file.sv
@@ -2590,8 +2590,7 @@ class reg_mtval extends csr_reg;
       option.name = "csr_mtval__read_cg";
       option.per_instance = 1;
       mtval: coverpoint data[31:0] {
-         bins ZERO[]  = {0};
-         bins other_values[3]  = {[1:$]};
+         bins reset_value = {0};
       }
   endgroup
 

--- a/verif/env/uvme/uvme_cva6_cfg.sv
+++ b/verif/env/uvme/uvme_cva6_cfg.sv
@@ -253,8 +253,9 @@ function void uvme_cva6_cfg_c::set_unsupported_csr_mask();
 
    super.set_unsupported_csr_mask();
 
-   // Remove unsupported CSRs for STEP1 configuration
+   // Remove unsupported CSRs for Embedded configuration
    unsupported_csr_mask[uvma_core_cntrl_pkg::MCOUNTINHIBIT] = 1;
+   unsupported_csr_mask[uvma_core_cntrl_pkg::MTVAL] = 1;
 
 endfunction : set_unsupported_csr_mask
 

--- a/verif/tests/custom/csr_embedded/csrcs_test.S
+++ b/verif/tests/custom/csr_embedded/csrcs_test.S
@@ -1405,54 +1405,6 @@ csrcs:
     csrr x14, 0xb0d
 
     ##########################
-    #MTVAL testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h0} 
-    ##########################
-    #MTVAL Write clear/set value 0x1f
-    li x3, 0xffffffe0
-    csrrc x14, 0x343, x3
-    li x3, 0x1f
-    csrrs x14, 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0x0
-    li x3, 0xffffffff
-    csrrc x14, 0x343, x3
-    li x3, 0x0
-    csrrs x14, 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0x15
-    li x3, 0xffffffea
-    csrrc x14, 0x343, x3
-    li x3, 0x15
-    csrrs x14, 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0xa
-    li x3, 0xfffffff5
-    csrrc x14, 0x343, x3
-    li x3, 0xa
-    csrrs x14, 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0x0
-    li x3, 0xffffffff
-    csrrc x14, 0x343, x3
-    li x3, 0x0
-    csrrs x14, 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    ##########################
     #MHPMCOUNTER8 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h1} 
     ##########################
     #MHPMCOUNTER8 Write clear/set value 0x1f

--- a/verif/tests/custom/csr_embedded/csrcsi_test.S
+++ b/verif/tests/custom/csr_embedded/csrcsi_test.S
@@ -2339,44 +2339,6 @@ csrcsi:
     csrr x14, 0xb11
 
     ##########################
-    #MTVAL testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h1a} 
-    ##########################
-    #MTVAL Write clear/set value 0x1f
-    csrrci x14, 0x343, 0x0
-    csrrsi x14, 0x343, 0x1f
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0x0
-    csrrci x14, 0x343, 0x1f
-    csrrsi x14, 0x343, 0x0
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0x15
-    csrrci x14, 0x343, 0xa
-    csrrsi x14, 0x343, 0x15
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0xa
-    csrrci x14, 0x343, 0x15
-    csrrsi x14, 0x343, 0xa
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write clear/set value 0x1a
-    csrrci x14, 0x343, 0x5
-    csrrsi x14, 0x343, 0x1a
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    ##########################
     #MHPMCOUNTERH6 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h8} 
     ##########################
     #MHPMCOUNTERH6 Write clear/set value 0x1f

--- a/verif/tests/custom/csr_embedded/csrrw_fields_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_fields_test.S
@@ -5626,45 +5626,6 @@ csrrw_fields:
     csrr x14, 0xb85
 
     ##########################
-    #MTVAL fields testing W/R
-    ##########################
-    #MTVAL.MTVAL testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'h4cdadc42} 
-    #MTVAL Write value 0xffffffff
-    li x3, 0xffffffff
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0x0
-    li x3, 0x0
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0x55555555
-    li x3, 0x55555555
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0xaaaaaaaa
-    li x3, 0xaaaaaaaa
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0x4cdadc42
-    li x3, 0x4cdadc42
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    ##########################
     #MHPMEVENT14 fields testing W/R
     ##########################
     #MHPMEVENT14.MHPMEVENT testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'h189944b1} 

--- a/verif/tests/custom/csr_embedded/csrrw_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_test.S
@@ -3489,44 +3489,6 @@ csrrw:
     csrr x14, 0x338
 
     ##########################
-    #MTVAL testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'hbec4a2c2} 
-    ##########################
-    #MTVAL Write value 0xffffffff
-    li x3, 0xffffffff
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0x0
-    li x3, 0x0
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0x55555555
-    li x3, 0x55555555
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0xaaaaaaaa
-    li x3, 0xaaaaaaaa
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write value 0xbec4a2c2
-    li x3, 0xbec4a2c2
-    csrw 0x343, x3
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    ##########################
     #MHPMCOUNTERH29 testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'h91d85d53} 
     ##########################
     #MHPMCOUNTERH29 Write value 0xffffffff

--- a/verif/tests/custom/csr_embedded/csrrwi_test.S
+++ b/verif/tests/custom/csr_embedded/csrrwi_test.S
@@ -3360,39 +3360,6 @@ csrrwi:
     csrr x14, 0x329
 
     ##########################
-    #MTVAL testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h4} 
-    ##########################
-    #MTVAL Write immediate value 0x1f
-    csrrwi x14, 0x343, 0x1f
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write immediate value 0x0
-    csrrwi x14, 0x343, 0x0
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write immediate value 0x15
-    csrrwi x14, 0x343, 0x15
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write immediate value 0xa
-    csrrwi x14, 0x343, 0xa
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    #MTVAL Write immediate value 0x4
-    csrrwi x14, 0x343, 0x4
-
-    #MTVAL read value
-    csrr x14, 0x343
-
-    ##########################
     #MCYCLEH testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'ha} 
     ##########################
     #MCYCLEH Write immediate value 0x1f


### PR DESCRIPTION
This MR removes MTVAL from CSR embedded tests and only updates the coverpoint related to this CSR because MTVAL isn't supported in embedded configuration