### PR TITLE
[Bugfix hpdcache] axi struct usage

### DIFF
--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -19,6 +19,12 @@ module cva6_hpdcache_subsystem
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter int NumPorts = 4,
     parameter int NrHwPrefetchers = 4,
+    // AXI types
+    parameter type axi_ar_chan_t = logic,
+    parameter type axi_aw_chan_t = logic,
+    parameter type axi_w_chan_t = logic,
+    parameter type axi_b_chan_t = logic,
+    parameter type axi_r_chan_t = logic,
     parameter type noc_req_t = logic,
     parameter type noc_resp_t = logic,
     parameter type cmo_req_t = logic,
@@ -86,8 +92,6 @@ module cva6_hpdcache_subsystem
     //  }}}
 );
   //  }}}
-
-  `include "axi/typedef.svh"
 
   //  I$ instantiation
   //  {{{
@@ -472,17 +476,7 @@ module cva6_hpdcache_subsystem
 
   //  AXI arbiter instantiation
   //  {{{
-  typedef logic [CVA6Cfg.AxiAddrWidth-1:0] axi_addr_t;
-  typedef logic [CVA6Cfg.AxiDataWidth-1:0] axi_data_t;
-  typedef logic [CVA6Cfg.AxiDataWidth/8-1:0] axi_strb_t;
-  typedef logic [CVA6Cfg.AxiIdWidth-1:0] axi_id_t;
-  typedef logic [CVA6Cfg.AxiUserWidth-1:0] axi_user_t;
-  `AXI_TYPEDEF_AW_CHAN_T(axi_aw_chan_t, axi_addr_t, axi_id_t, axi_user_t)
-  `AXI_TYPEDEF_W_CHAN_T(axi_w_chan_t, axi_data_t, axi_strb_t, axi_user_t)
-  `AXI_TYPEDEF_B_CHAN_T(axi_b_chan_t, axi_id_t, axi_user_t)
-  `AXI_TYPEDEF_AR_CHAN_T(axi_ar_chan_t, axi_addr_t, axi_id_t, axi_user_t)
-  `AXI_TYPEDEF_R_CHAN_T(axi_r_chan_t, axi_data_t, axi_id_t, axi_user_t)
-
+  
   cva6_hpdcache_subsystem_axi_arbiter #(
       .HPDcacheMemIdWidth   (ariane_pkg::MEM_TID_WIDTH),
       .HPDcacheMemDataWidth (CVA6Cfg.AxiDataWidth),
@@ -498,6 +492,8 @@ module cva6_hpdcache_subsystem
       .axi_ar_chan_t(axi_ar_chan_t),
       .axi_aw_chan_t(axi_aw_chan_t),
       .axi_w_chan_t (axi_w_chan_t),
+      .axi_b_chan_t (axi_b_chan_t),
+      .axi_r_chan_t (axi_r_chan_t),
       .axi_req_t    (noc_req_t),
       .axi_rsp_t    (noc_resp_t)
   ) i_axi_arbiter (

--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -476,7 +476,6 @@ module cva6_hpdcache_subsystem
 
   //  AXI arbiter instantiation
   //  {{{
-  
   cva6_hpdcache_subsystem_axi_arbiter #(
       .HPDcacheMemIdWidth   (ariane_pkg::MEM_TID_WIDTH),
       .HPDcacheMemDataWidth (CVA6Cfg.AxiDataWidth),

--- a/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv
@@ -30,6 +30,8 @@ module cva6_hpdcache_subsystem_axi_arbiter
     parameter type axi_ar_chan_t = logic,
     parameter type axi_aw_chan_t = logic,
     parameter type axi_w_chan_t = logic,
+    parameter type axi_b_chan_t = logic,
+    parameter type axi_r_chan_t = logic,
     parameter type axi_req_t = logic,
     parameter type axi_rsp_t = logic,
 
@@ -112,19 +114,6 @@ module cva6_hpdcache_subsystem_axi_arbiter
 
   //  Internal type definitions
   //  {{{
-  typedef struct packed {
-    logic [AxiIdWidth-1:0]   id;
-    logic [AxiDataWidth-1:0] data;
-    axi_pkg::resp_t          resp;
-    logic                    last;
-    logic [AxiUserWidth-1:0] user;
-  } axi_r_chan_t;
-
-  typedef struct packed {
-    logic [AxiIdWidth-1:0]   id;
-    axi_pkg::resp_t          resp;
-    logic [AxiUserWidth-1:0] user;
-  } axi_b_chan_t;
 
   localparam int MEM_RESP_RT_DEPTH = (1 << HPDcacheMemIdWidth);
   typedef hpdcache_mem_id_t [MEM_RESP_RT_DEPTH-1:0] mem_resp_rt_t;
@@ -493,8 +482,6 @@ module cva6_hpdcache_subsystem_axi_arbiter
 
   //  AXI adapters
   //  {{{
-  axi_req_t axi_req;
-  axi_rsp_t axi_resp;
 
   hpdcache_mem_to_axi_write #(
       .hpdcache_mem_req_t   (hpdcache_mem_req_t),
@@ -516,17 +503,17 @@ module cva6_hpdcache_subsystem_axi_arbiter
       .resp_valid_o(mem_resp_write_valid),
       .resp_o      (mem_resp_write),
 
-      .axi_aw_valid_o(axi_req.aw_valid),
-      .axi_aw_o      (axi_req.aw),
-      .axi_aw_ready_i(axi_resp.aw_ready),
+      .axi_aw_valid_o(axi_req_o.aw_valid),
+      .axi_aw_o      (axi_req_o.aw),
+      .axi_aw_ready_i(axi_resp_i.aw_ready),
 
-      .axi_w_valid_o(axi_req.w_valid),
-      .axi_w_o      (axi_req.w),
-      .axi_w_ready_i(axi_resp.w_ready),
+      .axi_w_valid_o(axi_req_o.w_valid),
+      .axi_w_o      (axi_req_o.w),
+      .axi_w_ready_i(axi_resp_i.w_ready),
 
-      .axi_b_valid_i(axi_resp.b_valid),
-      .axi_b_i      (axi_resp.b),
-      .axi_b_ready_o(axi_req.b_ready)
+      .axi_b_valid_i(axi_resp_i.b_valid),
+      .axi_b_i      (axi_resp_i.b),
+      .axi_b_ready_o(axi_req_o.b_ready)
   );
 
   hpdcache_mem_to_axi_read #(
@@ -543,17 +530,15 @@ module cva6_hpdcache_subsystem_axi_arbiter
       .resp_valid_o(mem_resp_read_valid),
       .resp_o      (mem_resp_read),
 
-      .axi_ar_valid_o(axi_req.ar_valid),
-      .axi_ar_o      (axi_req.ar),
-      .axi_ar_ready_i(axi_resp.ar_ready),
+      .axi_ar_valid_o(axi_req_o.ar_valid),
+      .axi_ar_o      (axi_req_o.ar),
+      .axi_ar_ready_i(axi_resp_i.ar_ready),
 
-      .axi_r_valid_i(axi_resp.r_valid),
-      .axi_r_i      (axi_resp.r),
-      .axi_r_ready_o(axi_req.r_ready)
+      .axi_r_valid_i(axi_resp_i.r_valid),
+      .axi_r_i      (axi_resp_i.r),
+      .axi_r_ready_o(axi_req_o.r_ready)
   );
 
-  assign axi_req_o = axi_req;
-  assign axi_resp  = axi_resp_i;
   //  }}}
 
   //  Assertions

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1031,6 +1031,11 @@ module cva6
     cva6_hpdcache_subsystem #(
         .CVA6Cfg   (CVA6ExtendCfg),
         .NumPorts  (NumPorts),
+        .axi_ar_chan_t(axi_ar_chan_t),
+        .axi_aw_chan_t(axi_aw_chan_t),
+        .axi_w_chan_t (axi_w_chan_t),
+        .axi_b_chan_t (b_chan_t),
+        .axi_r_chan_t (r_chan_t),
         .noc_req_t (noc_req_t),
         .noc_resp_t(noc_resp_t),
         .cmo_req_t (logic  /*FIXME*/),


### PR DESCRIPTION
Suggested fixes for _HDPcache_ integration in CVA6.
_HPDCache_ is **defining again the typedef for AXI protocol**, with exactly the sames names than the ones in _package ariane_axi_. Using Cadence Xcelium simulator, the usage of several typedef with identical names is forbidden.

This fix suggests to **propagate the AXI typedef** given to cva6 top (through parameter types) to hdpcache. As a consequence, local definition of AXI typedef are removed.

@cfuguet , could you give me your opinion about it?

NB: Feedbacks are welcome, since this is the first PR from Bosch!