### PR TITLE
cva6_icache: Allow one outstanding killed miss

### DIFF
--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -18,7 +18,7 @@ iterations = None
 # Will fail if the number of cycles is different from this one
 valid_cycles = {
     'dhrystone': 217900,
-    'coremark': 665193,
+    'coremark': 664736,
 }
 
 for arg in sys.argv[1:]:


### PR DESCRIPTION
This PR fixes issue https://github.com/openhwgroup/cva6/issues/1785, implementing the same performance enhancement proposed in PR https://github.com/openhwgroup/cva6/pull/1497.

Compared to the latter, it fixes a problematic corner case, which was likely the cause of the regression errors observed. 

Said corner case occurred when the following two conditions were met:
- We incur in a second speculated instruction cache miss during a previous outstanding killed miss
- Upon branch resolution, the second refill is killed

The second miss brought the I$ in the `MISS` state, where it was correctly waiting for the previous outstanding killed miss to complete. However, the `kill_s2` signal was not being used here, effectively ignoring the branch resolution outcome.

This PR fixes this behaviour by counting the number of outstanding killed miss requests. Max one killed refill can be handled in parallel with other requests. Thus, as the second miss is killed, we stall the cache in the `WAIT_MISS` state, as originally was the case upon the first killed miss, so long as we don't again have a single outstanding miss.

I ran the smoke-tests locally, as described in the repo's README, and it seems to pass, but I'm not sure I'm doing this correctly.