### PR TITLE
Table builder for specification

### DIFF
--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -18,42 +18,66 @@ module commit_stage
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
+    // Subsystem Clock - SUBSYSTEM
     input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
-    input logic halt_i,  // request to halt the core
-    input logic flush_dcache_i,  // request to flush dcache -> also flush the pipeline
-    output exception_t exception_o,  // take exception to controller
-    output logic dirty_fp_state_o,  // mark the F state as dirty
-    input logic single_step_i,  // we are in single step debug mode
-    // from scoreboard
-    input  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,     // the instruction we want to commit
-    output logic [CVA6Cfg.NrCommitPorts-1:0]              commit_ack_o,       // acknowledge that we are indeed committing
-    // to register file
-    output logic [CVA6Cfg.NrCommitPorts-1:0][4:0] waddr_o,  // register file write address
-    output logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_o,  // register file write data
-    output logic [CVA6Cfg.NrCommitPorts-1:0] we_gpr_o,  // register file write enable
-    output logic [CVA6Cfg.NrCommitPorts-1:0] we_fpr_o,  // floating point register enable
-    // Atomic memory operations
-    input amo_resp_t amo_resp_i,  // result of AMO operation
-    // to CSR file and PC Gen (because on certain CSR instructions we'll need to flush the whole pipeline)
+    // Request to halt the core - CONTROLLER
+    input logic halt_i,
+    // request to flush dcache, also flush the pipeline - CACHE
+    input logic flush_dcache_i,
+    // TO_BE_COMPLETED - EX_STAGE
+    output exception_t exception_o,
+    // Mark the F state as dirty - CSR_REGFILE
+    output logic dirty_fp_state_o,
+    // TO_BE_COMPLETED - CSR_REGFILE
+    input logic single_step_i,
+    // The instruction we want to commit - ISSUE_STAGE
+    input  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    // Acknowledge that we are indeed committing - ISSUE_STAGE
+    output logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_o,
+    // Register file write address - ID_STAGE
+    output logic [CVA6Cfg.NrCommitPorts-1:0][4:0] waddr_o,
+    // Register file write data - ID_STAGE
+    output logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_o,
+    // Register file write enable - ID_STAGE
+    output logic [CVA6Cfg.NrCommitPorts-1:0] we_gpr_o,
+    // Floating point register enable - ID_STAGE
+    output logic [CVA6Cfg.NrCommitPorts-1:0] we_fpr_o,
+    // Result of AMO operation - CACHE
+    input amo_resp_t amo_resp_i,
+    // TO_BE_COMPLETED - FRONTEND_CSR
     output logic [riscv::VLEN-1:0] pc_o,
-    // to/from CSR file
-    output fu_op csr_op_o,  // decoded CSR operation
-    output riscv::xlen_t csr_wdata_o,  // data to write to CSR
-    input riscv::xlen_t csr_rdata_i,  // data to read from CSR
-    input  exception_t                              csr_exception_i,    // exception or interrupt occurred in CSR stage (the same as commit)
-    output logic csr_write_fflags_o,  // write the fflags CSR
-    // commit signals to ex
-    output logic commit_lsu_o,  // commit the pending store
-    input logic commit_lsu_ready_i,  // commit buffer of LSU is ready
-    output logic [TRANS_ID_BITS-1:0] commit_tran_id_o,  // transaction id of first commit port
-    output logic amo_valid_commit_o,  // valid AMO in commit stage
-    input logic no_st_pending_i,  // there is no store pending
-    output logic commit_csr_o,  // commit the pending CSR instruction
-    output logic fence_i_o,  // flush I$ and pipeline
-    output logic fence_o,  // flush D$ and pipeline
-    output logic flush_commit_o,  // request a pipeline flush
-    output logic sfence_vma_o  // flush TLBs and pipeline
+    // Decoded CSR operation - CSR_REGFILE
+    output fu_op csr_op_o,
+    // Data to write to CSR - CSR_REGFILE
+    output riscv::xlen_t csr_wdata_o,
+    // Data to read from CSR - CSR_REGFILE
+    input riscv::xlen_t csr_rdata_i,
+    // Exception or interrupt occurred in CSR stage (the same as commit) - CSR_REGFILE
+    input  exception_t csr_exception_i,
+    // Write the fflags CSR - CSR_REGFILE
+    output logic csr_write_fflags_o,
+    // Commit the pending store - EX_STAGE
+    output logic commit_lsu_o,
+    // Commit buffer of LSU is ready - EX_STAGE
+    input logic commit_lsu_ready_i,
+    // Transaction id of first commit port - ID_STAGE
+    output logic [TRANS_ID_BITS-1:0] commit_tran_id_o,
+    // Valid AMO in commit stage - EX_STAGE
+    output logic amo_valid_commit_o,
+    // no store is pending - EX_STAGE
+    input logic no_st_pending_i,
+    // Commit the pending CSR instruction - EX_STAGE
+    output logic commit_csr_o,
+    // Flush I$ and pipeline - CONTROLLER
+    output logic fence_i_o,
+    // Flush D$ and pipeline - CONTROLLER
+    output logic fence_o,
+    // Request a pipeline flush - CONTROLLER
+    output logic flush_commit_o,
+    // Flush TLBs and pipeline - CONTROLLER
+    output logic sfence_vma_o
 );
 
   // ila_0 i_ila_commit (

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -33,7 +33,7 @@ module commit_stage
     // TO_BE_COMPLETED - CSR_REGFILE
     input logic single_step_i,
     // The instruction we want to commit - ISSUE_STAGE
-    input  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    input scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
     // Acknowledge that we are indeed committing - ISSUE_STAGE
     output logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_o,
     // Register file write address - ID_STAGE
@@ -55,7 +55,7 @@ module commit_stage
     // Data to read from CSR - CSR_REGFILE
     input riscv::xlen_t csr_rdata_i,
     // Exception or interrupt occurred in CSR stage (the same as commit) - CSR_REGFILE
-    input  exception_t csr_exception_i,
+    input exception_t csr_exception_i,
     // Write the fflags CSR - CSR_REGFILE
     output logic csr_write_fflags_o,
     // Commit the pending store - EX_STAGE

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -18,32 +18,56 @@ module controller
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
-    input  logic clk_i,
-    input  logic rst_ni,
-    output logic set_pc_commit_o,         // Set PC om PC Gen
-    output logic flush_if_o,              // Flush the IF stage
-    output logic flush_unissued_instr_o,  // Flush un-issued instructions of the scoreboard
-    output logic flush_id_o,              // Flush ID stage
-    output logic flush_ex_o,              // Flush EX stage
-    output logic flush_bp_o,              // Flush branch predictors
-    output logic flush_icache_o,          // Flush ICache
-    output logic flush_dcache_o,          // Flush DCache
-    input  logic flush_dcache_ack_i,      // Acknowledge the whole DCache Flush
-    output logic flush_tlb_o,             // Flush TLBs
-
-    input logic halt_csr_i,  // Halt request from CSR (WFI instruction)
-    input logic halt_acc_i,  // Halt request from accelerator dispatcher
-    output logic halt_o,  // Halt signal to commit stage
-    input logic eret_i,  // Return from exception
-    input logic ex_valid_i,  // We got an exception, flush the pipeline
-    input logic set_debug_pc_i,  // set the debug pc from CSR
-    input  bp_resolve_t     resolved_branch_i,      // We got a resolved branch, check if we need to flush the front-end
-    input logic flush_csr_i,  // We got an instruction which altered the CSR, flush the pipeline
-    input logic fence_i_i,  // fence.i in
-    input logic fence_i,  // fence in
-    input logic sfence_vma_i,  // We got an instruction to flush the TLBs and pipeline
-    input logic flush_commit_i,  // Flush request from commit stage
-    input logic flush_acc_i  // Flush request from accelerator
+    // Subsystem Clock - SUBSYSTEM
+    input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
+    input logic rst_ni,
+    // Set PC om PC Gen - FRONTEND
+    output logic set_pc_commit_o,
+    // Flush the IF stage - FRONTEND
+    output logic flush_if_o,
+    // Flush un-issued instructions of the scoreboard - FRONTEND
+    output logic flush_unissued_instr_o,
+    // Flush ID stage - ID_STAGE
+    output logic flush_id_o,
+    // Flush EX stage - EX_STAGE
+    output logic flush_ex_o,
+    // Flush branch predictors - FRONTEND
+    output logic flush_bp_o,
+    // Flush ICache - CACHE
+    output logic flush_icache_o,
+    // Flush DCache - CACHE
+    output logic flush_dcache_o,
+    // Acknowledge the whole DCache Flush - CACHE
+    input logic flush_dcache_ack_i,
+    // Flush TLBs - EX_STAGE
+    output logic flush_tlb_o,
+    // Halt request from CSR (WFI instruction) - CSR_REGFILE
+    input logic halt_csr_i,
+    // Halt request from accelerator dispatcher - ACC_DISPATCHER
+    input logic halt_acc_i,
+    // Halt signal to commit stage - COMMIT_STAGE
+    output logic halt_o,
+    // Return from exception - CSR_REGFILE
+    input logic eret_i,
+    // We got an exception, flush the pipeline - FRONTEND
+    input logic ex_valid_i,
+    // set the debug pc from CSR - FRONTEND
+    input logic set_debug_pc_i,
+    // We got a resolved branch, check if we need to flush the front-end - EX_STAGE
+    input bp_resolve_t resolved_branch_i,
+    // We got an instruction which altered the CSR, flush the pipeline - CSR_REGFILE
+    input logic flush_csr_i,
+    // fence.i in - ACC_DISPATCH
+    input logic fence_i_i,
+    // fence in - ACC_DISPATCH
+    input logic fence_i,
+    // We got an instruction to flush the TLBs and pipeline - COMMIT_STAGE
+    input logic sfence_vma_i,
+    // Flush request from commit stage - COMMIT_STAGE
+    input logic flush_commit_i,
+    // Flush request from accelerator - ACC_DISPATCHER
+    input logic flush_acc_i
 );
 
   // active fence - high if we are currently flushing the dcache

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -30,15 +30,14 @@ module csr_regfile
     output logic flush_o,
     // halt requested - CONTROLLER
     output logic halt_csr_o,
-    // commit acknowledge
-    // the instruction we want to commit - ID_STAGE
-    input  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    // Instruction to be committed - ID_STAGE
+    input scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
     // Commit acknowledged a instruction -> increase instret CSR - COMMIT_STAGE
-    input  logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
+    input logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
     // Address from which to start booting, mtvec is set to the same address - SUBSYSTEM
-    input  logic[riscv::VLEN-1:0] boot_addr_i,
+    input logic[riscv::VLEN-1:0] boot_addr_i,
     // Hart id in a multicore environment (reflected in a CSR) - SUBSYSTEM
-    input  logic[riscv::XLEN-1:0] hart_id_i,
+    input logic[riscv::XLEN-1:0] hart_id_i,
     // we are taking an exception
     // We've got an exception from the commit stage, take it - COMMIT_STAGE
     input exception_t ex_i,

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -20,81 +20,122 @@ module csr_regfile
     parameter int                    AsidWidth      = 1,
     parameter int unsigned           MHPMCounterNum = 6
 ) (
-    input logic clk_i,  // Clock
-    input logic rst_ni,  // Asynchronous reset active low
-    input logic time_irq_i,  // Timer threw a interrupt
-    // send a flush request out if a CSR with a side effect has changed (e.g. written)
+    // Subsystem Clock - SUBSYSTEM
+    input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
+    input logic rst_ni,
+    // Timer threw a interrupt - SUBSYSTEM
+    input logic time_irq_i,
+    // send a flush request out when a CSR with a side effect changes - CONTROLLER
     output logic flush_o,
-    output logic halt_csr_o,  // halt requested
+    // halt requested - CONTROLLER
+    output logic halt_csr_o,
     // commit acknowledge
-    input  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i, // the instruction we want to commit
-    input  logic [CVA6Cfg.NrCommitPorts-1:0]              commit_ack_i,   // Commit acknowledged a instruction -> increase instret CSR
-    // Core and Cluster ID
-    input  logic[riscv::VLEN-1:0] boot_addr_i,                // Address from which to start booting, mtvec is set to the same address
-    input  logic[riscv::XLEN-1:0] hart_id_i,                  // Hart id in a multicore environment (reflected in a CSR)
+    // the instruction we want to commit - ID_STAGE
+    input  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    // Commit acknowledged a instruction -> increase instret CSR - COMMIT_STAGE
+    input  logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
+    // Address from which to start booting, mtvec is set to the same address - SUBSYSTEM
+    input  logic[riscv::VLEN-1:0] boot_addr_i,
+    // Hart id in a multicore environment (reflected in a CSR) - SUBSYSTEM
+    input  logic[riscv::XLEN-1:0] hart_id_i,
     // we are taking an exception
-    input exception_t ex_i,  // We've got an exception from the commit stage, take it
-
-    input fu_op csr_op_i,  // Operation to perform on the CSR file
-    input logic [11:0] csr_addr_i,  // Address of the register to read/write
-    input logic [riscv::XLEN-1:0] csr_wdata_i,  // Write data in
-    output logic [riscv::XLEN-1:0] csr_rdata_o,  // Read data out
-    input logic dirty_fp_state_i,  // Mark the FP sate as dirty
-    input  logic                  csr_write_fflags_i,         // Write fflags register e.g.: we are retiring a floating point instruction
-    input logic dirty_v_state_i,  // Mark the V state as dirty
-    input logic [riscv::VLEN-1:0] pc_i,  // PC of instruction accessing the CSR
-    output exception_t csr_exception_o,  // attempts to access a CSR without appropriate privilege
-                                         // level or to write  a read-only register also
-                                         // raises illegal instruction exceptions.
-    // Interrupts/Exceptions
-    output logic  [riscv::VLEN-1:0] epc_o,                    // Output the exception PC to PC Gen, the correct CSR (mepc, sepc) is set accordingly
-    output logic eret_o,  // Return from exception, set the PC of epc_o
-    output logic  [riscv::VLEN-1:0] trap_vector_base_o,       // Output base of exception vector, correct CSR is output (mtvec, stvec)
-    output riscv::priv_lvl_t priv_lvl_o,  // Current privilege level the CPU is in
-    // FP Imprecise exceptions
-    input  logic            [4:0] acc_fflags_ex_i,            // Imprecise FP exception from the accelerator (fcsr.fflags format)
-    input logic acc_fflags_ex_valid_i,  // An FP exception from the accelerator occurred
-    // FPU
-    output riscv::xs_t fs_o,  // Floating point extension status
-    output logic [4:0] fflags_o,  // Floating-Point Accured Exceptions
-    output logic [2:0] frm_o,  // Floating-Point Dynamic Rounding Mode
-    output logic [6:0] fprec_o,  // Floating-Point Precision Control
-    // Vector extension
-    output riscv::xs_t vs_o,  // Vector extension status
-    // Decoder
-    output irq_ctrl_t irq_ctrl_o,  // interrupt management to id stage
-    // MMU
-    output logic en_translation_o,  // enable VA translation
-    output logic en_ld_st_translation_o,  // enable VA translation for load and stores
-    output riscv::priv_lvl_t      ld_st_priv_lvl_o,           // Privilege level at which load and stores should happen
+    // We've got an exception from the commit stage, take it - COMMIT_STAGE
+    input exception_t ex_i,
+    // Operation to perform on the CSR file - COMMIT_STAGE
+    input fu_op csr_op_i,
+    // Address of the register to read/write - EX_STAGE
+    input logic [11:0] csr_addr_i,
+    // Write data in - COMMIT_STAGE
+    input logic [riscv::XLEN-1:0] csr_wdata_i,
+    // Read data out - COMMIT_STAGE
+    output logic [riscv::XLEN-1:0] csr_rdata_o,
+    // Mark the FP sate as dirty - COMMIT_STAGE
+    input logic dirty_fp_state_i,
+    // Write fflags register e.g.: we are retiring a floating point instruction - COMMIT_STAGE
+    input  logic csr_write_fflags_i,
+    // Mark the V state as dirty - ACC_DISPATCHER
+    input logic dirty_v_state_i,
+    // PC of instruction accessing the CSR - COMMIT_STAGE
+    input logic [riscv::VLEN-1:0] pc_i,
+    // attempts to access a CSR without appropriate privilege - COMMIT_STAGE
+    output exception_t csr_exception_o,
+    // Output the exception PC to PC Gen, the correct CSR (mepc, sepc) is set accordingly - FRONTEND
+    output logic [riscv::VLEN-1:0] epc_o,
+    // Return from exception, set the PC of epc_o - FRONTEND
+    output logic eret_o,
+    // Output base of exception vector, correct CSR is output (mtvec, stvec) - FRONTEND
+    output logic [riscv::VLEN-1:0] trap_vector_base_o,
+    // Current privilege level the CPU is in - EX_STAGE
+    output riscv::priv_lvl_t priv_lvl_o,
+    // Imprecise FP exception from the accelerator (fcsr.fflags format) - ACC_DISPATCHER
+    input  logic [4:0] acc_fflags_ex_i,
+    // An FP exception from the accelerator occurred - ACC_DISPATCHER
+    input logic acc_fflags_ex_valid_i,
+    // Floating point extension status - ID_STAGE
+    output riscv::xs_t fs_o,
+    // Floating-Point Accured Exceptions - COMMIT_STAGE
+    output logic [4:0] fflags_o,
+    // Floating-Point Dynamic Rounding Mode - EX_STAGE
+    output logic [2:0] frm_o,
+    // Floating-Point Precision Control - EX_STAGE
+    output logic [6:0] fprec_o,
+    // Vector extension status - ID_STAGE
+    output riscv::xs_t vs_o,
+    // interrupt management to id stage - ID_STAGE
+    output irq_ctrl_t irq_ctrl_o,
+    // enable VA translation - EX_STAGE
+    output logic en_translation_o,
+    // enable VA translation for load and stores - EX_STAGE
+    output logic en_ld_st_translation_o,
+    // Privilege level at which load and stores should happen - EX_STAGE
+    output riscv::priv_lvl_t      ld_st_priv_lvl_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic sum_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic mxr_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic [riscv::PPNW-1:0] satp_ppn_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic [AsidWidth-1:0] asid_o,
-    // external interrupts
-    input logic [1:0] irq_i,  // external interrupt in
-    input logic ipi_i,  // inter processor interrupt -> connected to machine mode sw
-    input logic debug_req_i,  // debug request in
+    // external interrupt in - SUBSYSTEM
+    input logic [1:0] irq_i,
+    // inter processor interrupt -> connected to machine mode sw - SUBSYSTEM
+    input logic ipi_i,
+    // debug request in - ID_STAGE
+    input logic debug_req_i,
+    // TO_BE_COMPLETED - FRONTEND
     output logic set_debug_pc_o,
-    // Virtualization Support
-    output logic tvm_o,  // trap virtual memory
-    output logic tw_o,  // timeout wait
-    output logic tsr_o,  // trap sret
-    output logic debug_mode_o,  // we are in debug mode -> that will change some decoding
-    output logic single_step_o,  // we are in single-step mode
-    // Caches
-    output logic icache_en_o,  // L1 ICache Enable
-    output logic dcache_en_o,  // L1 DCache Enable
-    // Accelerator
-    output logic acc_cons_en_o,  // Accelerator memory consistent mode
+    // trap virtual memory - ID_STAGE
+    output logic tvm_o,
+    // timeout wait - ID_STAGE
+    output logic tw_o,
+    // trap sret - ID_STAGE
+    output logic tsr_o,
+    // we are in debug mode -> that will change some decoding - EX_STAGE
+    output logic debug_mode_o,
+    // we are in single-step mode - COMMIT_STAGE
+    output logic single_step_o,
+    // L1 ICache Enable - CACHE
+    output logic icache_en_o,
+    // L1 DCache Enable - CACHE
+    output logic dcache_en_o,
+    // Accelerator memory consistent mode - ACC_DISPATCHER
+    output logic acc_cons_en_o,
     // Performance Counter
-    output logic [11:0] perf_addr_o,  // read/write address to performance counter module
-    output logic [riscv::XLEN-1:0] perf_data_o,  // write data to performance counter module
-    input logic [riscv::XLEN-1:0] perf_data_i,  // read data from performance counter module
+    // read/write address to performance counter module - PERF_COUNTERS
+    output logic [11:0] perf_addr_o,
+    // write data to performance counter module - PERF_COUNTERS
+    output logic [riscv::XLEN-1:0] perf_data_o,
+    // read data from performance counter module - PERF_COUNTERS
+    input logic [riscv::XLEN-1:0] perf_data_i,
+    // TO_BE_COMPLETED - PERF_COUNTERS
     output logic perf_we_o,
-    // PMPs
-    output riscv::pmpcfg_t [15:0] pmpcfg_o,  // PMP configuration containing pmpcfg for max 16 PMPs
-    output logic [15:0][riscv::PLEN-3:0] pmpaddr_o,  // PMP addresses
+    // PMP configuration containing pmpcfg for max 16 PMPs - ACC_DISPATCHER
+    output riscv::pmpcfg_t [15:0] pmpcfg_o,
+    // PMP addresses - ACC_DISPATCHER
+    output logic [15:0][riscv::PLEN-3:0] pmpaddr_o,
+    // TO_BE_COMPLETED - PERF_COUNTERS
     output logic [31:0] mcountinhibit_o
 );
   // internal signal to keep track of access exceptions

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -21,121 +21,121 @@ module csr_regfile
     parameter int unsigned           MHPMCounterNum = 6
 ) (
     // Subsystem Clock - SUBSYSTEM
-    input logic clk_i,
+    input  logic                                                           clk_i,
     // Asynchronous reset active low - SUBSYSTEM
-    input logic rst_ni,
+    input  logic                                                           rst_ni,
     // Timer threw a interrupt - SUBSYSTEM
-    input logic time_irq_i,
+    input  logic                                                           time_irq_i,
     // send a flush request out when a CSR with a side effect changes - CONTROLLER
-    output logic flush_o,
+    output logic                                                           flush_o,
     // halt requested - CONTROLLER
-    output logic halt_csr_o,
+    output logic                                                           halt_csr_o,
     // Instruction to be committed - ID_STAGE
-    input scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    input  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0]                  commit_instr_i,
     // Commit acknowledged a instruction -> increase instret CSR - COMMIT_STAGE
-    input logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
+    input  logic              [CVA6Cfg.NrCommitPorts-1:0]                  commit_ack_i,
     // Address from which to start booting, mtvec is set to the same address - SUBSYSTEM
-    input logic[riscv::VLEN-1:0] boot_addr_i,
+    input  logic              [          riscv::VLEN-1:0]                  boot_addr_i,
     // Hart id in a multicore environment (reflected in a CSR) - SUBSYSTEM
-    input logic[riscv::XLEN-1:0] hart_id_i,
+    input  logic              [          riscv::XLEN-1:0]                  hart_id_i,
     // we are taking an exception
     // We've got an exception from the commit stage, take it - COMMIT_STAGE
-    input exception_t ex_i,
+    input  exception_t                                                     ex_i,
     // Operation to perform on the CSR file - COMMIT_STAGE
-    input fu_op csr_op_i,
+    input  fu_op                                                           csr_op_i,
     // Address of the register to read/write - EX_STAGE
-    input logic [11:0] csr_addr_i,
+    input  logic              [                     11:0]                  csr_addr_i,
     // Write data in - COMMIT_STAGE
-    input logic [riscv::XLEN-1:0] csr_wdata_i,
+    input  logic              [          riscv::XLEN-1:0]                  csr_wdata_i,
     // Read data out - COMMIT_STAGE
-    output logic [riscv::XLEN-1:0] csr_rdata_o,
+    output logic              [          riscv::XLEN-1:0]                  csr_rdata_o,
     // Mark the FP sate as dirty - COMMIT_STAGE
-    input logic dirty_fp_state_i,
+    input  logic                                                           dirty_fp_state_i,
     // Write fflags register e.g.: we are retiring a floating point instruction - COMMIT_STAGE
-    input  logic csr_write_fflags_i,
+    input  logic                                                           csr_write_fflags_i,
     // Mark the V state as dirty - ACC_DISPATCHER
-    input logic dirty_v_state_i,
+    input  logic                                                           dirty_v_state_i,
     // PC of instruction accessing the CSR - COMMIT_STAGE
-    input logic [riscv::VLEN-1:0] pc_i,
+    input  logic              [          riscv::VLEN-1:0]                  pc_i,
     // attempts to access a CSR without appropriate privilege - COMMIT_STAGE
-    output exception_t csr_exception_o,
+    output exception_t                                                     csr_exception_o,
     // Output the exception PC to PC Gen, the correct CSR (mepc, sepc) is set accordingly - FRONTEND
-    output logic [riscv::VLEN-1:0] epc_o,
+    output logic              [          riscv::VLEN-1:0]                  epc_o,
     // Return from exception, set the PC of epc_o - FRONTEND
-    output logic eret_o,
+    output logic                                                           eret_o,
     // Output base of exception vector, correct CSR is output (mtvec, stvec) - FRONTEND
-    output logic [riscv::VLEN-1:0] trap_vector_base_o,
+    output logic              [          riscv::VLEN-1:0]                  trap_vector_base_o,
     // Current privilege level the CPU is in - EX_STAGE
-    output riscv::priv_lvl_t priv_lvl_o,
+    output riscv::priv_lvl_t                                               priv_lvl_o,
     // Imprecise FP exception from the accelerator (fcsr.fflags format) - ACC_DISPATCHER
-    input  logic [4:0] acc_fflags_ex_i,
+    input  logic              [                      4:0]                  acc_fflags_ex_i,
     // An FP exception from the accelerator occurred - ACC_DISPATCHER
-    input logic acc_fflags_ex_valid_i,
+    input  logic                                                           acc_fflags_ex_valid_i,
     // Floating point extension status - ID_STAGE
-    output riscv::xs_t fs_o,
+    output riscv::xs_t                                                     fs_o,
     // Floating-Point Accured Exceptions - COMMIT_STAGE
-    output logic [4:0] fflags_o,
+    output logic              [                      4:0]                  fflags_o,
     // Floating-Point Dynamic Rounding Mode - EX_STAGE
-    output logic [2:0] frm_o,
+    output logic              [                      2:0]                  frm_o,
     // Floating-Point Precision Control - EX_STAGE
-    output logic [6:0] fprec_o,
+    output logic              [                      6:0]                  fprec_o,
     // Vector extension status - ID_STAGE
-    output riscv::xs_t vs_o,
+    output riscv::xs_t                                                     vs_o,
     // interrupt management to id stage - ID_STAGE
-    output irq_ctrl_t irq_ctrl_o,
+    output irq_ctrl_t                                                      irq_ctrl_o,
     // enable VA translation - EX_STAGE
-    output logic en_translation_o,
+    output logic                                                           en_translation_o,
     // enable VA translation for load and stores - EX_STAGE
-    output logic en_ld_st_translation_o,
+    output logic                                                           en_ld_st_translation_o,
     // Privilege level at which load and stores should happen - EX_STAGE
-    output riscv::priv_lvl_t      ld_st_priv_lvl_o,
+    output riscv::priv_lvl_t                                               ld_st_priv_lvl_o,
     // TO_BE_COMPLETED - EX_STAGE
-    output logic sum_o,
+    output logic                                                           sum_o,
     // TO_BE_COMPLETED - EX_STAGE
-    output logic mxr_o,
+    output logic                                                           mxr_o,
     // TO_BE_COMPLETED - EX_STAGE
-    output logic [riscv::PPNW-1:0] satp_ppn_o,
+    output logic              [          riscv::PPNW-1:0]                  satp_ppn_o,
     // TO_BE_COMPLETED - EX_STAGE
-    output logic [AsidWidth-1:0] asid_o,
+    output logic              [            AsidWidth-1:0]                  asid_o,
     // external interrupt in - SUBSYSTEM
-    input logic [1:0] irq_i,
+    input  logic              [                      1:0]                  irq_i,
     // inter processor interrupt -> connected to machine mode sw - SUBSYSTEM
-    input logic ipi_i,
+    input  logic                                                           ipi_i,
     // debug request in - ID_STAGE
-    input logic debug_req_i,
+    input  logic                                                           debug_req_i,
     // TO_BE_COMPLETED - FRONTEND
-    output logic set_debug_pc_o,
+    output logic                                                           set_debug_pc_o,
     // trap virtual memory - ID_STAGE
-    output logic tvm_o,
+    output logic                                                           tvm_o,
     // timeout wait - ID_STAGE
-    output logic tw_o,
+    output logic                                                           tw_o,
     // trap sret - ID_STAGE
-    output logic tsr_o,
+    output logic                                                           tsr_o,
     // we are in debug mode -> that will change some decoding - EX_STAGE
-    output logic debug_mode_o,
+    output logic                                                           debug_mode_o,
     // we are in single-step mode - COMMIT_STAGE
-    output logic single_step_o,
+    output logic                                                           single_step_o,
     // L1 ICache Enable - CACHE
-    output logic icache_en_o,
+    output logic                                                           icache_en_o,
     // L1 DCache Enable - CACHE
-    output logic dcache_en_o,
+    output logic                                                           dcache_en_o,
     // Accelerator memory consistent mode - ACC_DISPATCHER
-    output logic acc_cons_en_o,
+    output logic                                                           acc_cons_en_o,
     // Performance Counter
     // read/write address to performance counter module - PERF_COUNTERS
-    output logic [11:0] perf_addr_o,
+    output logic              [                     11:0]                  perf_addr_o,
     // write data to performance counter module - PERF_COUNTERS
-    output logic [riscv::XLEN-1:0] perf_data_o,
+    output logic              [          riscv::XLEN-1:0]                  perf_data_o,
     // read data from performance counter module - PERF_COUNTERS
-    input logic [riscv::XLEN-1:0] perf_data_i,
+    input  logic              [          riscv::XLEN-1:0]                  perf_data_i,
     // TO_BE_COMPLETED - PERF_COUNTERS
-    output logic perf_we_o,
+    output logic                                                           perf_we_o,
     // PMP configuration containing pmpcfg for max 16 PMPs - ACC_DISPATCHER
-    output riscv::pmpcfg_t [15:0] pmpcfg_o,
+    output riscv::pmpcfg_t    [                     15:0]                  pmpcfg_o,
     // PMP addresses - ACC_DISPATCHER
-    output logic [15:0][riscv::PLEN-3:0] pmpaddr_o,
+    output logic              [                     15:0][riscv::PLEN-3:0] pmpaddr_o,
     // TO_BE_COMPLETED - PERF_COUNTERS
-    output logic [31:0] mcountinhibit_o
+    output logic              [                     31:0]                  mcountinhibit_o
 );
   // internal signal to keep track of access exceptions
   logic read_access_exception, update_access_exception, privilege_violation;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -159,7 +159,7 @@ module ex_stage
     // TO_BE_COMPLETED - CSR_REGFILE
     input logic [ASID_WIDTH-1:0] asid_i,
     // icache translation response - CACHE
-    input  icache_arsp_t icache_areq_i,
+    input icache_arsp_t icache_areq_i,
     // icache translation request - CACHE
     output icache_areq_t icache_areq_o,
     // TO_BE_COMPLETED - CACHE

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -20,111 +20,173 @@ module ex_stage
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter int unsigned ASID_WIDTH = 1
 ) (
-    input logic clk_i,        // Clock
-    input logic rst_ni,       // Asynchronous reset active low
+    // Subsystem Clock - SUBSYSTEM
+    input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
+    input logic rst_ni,
+    // Fetch flush request - CONTROLLER
     input logic flush_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
     input logic debug_mode_i,
-
+    // TO_BE_COMPLETED - ID_STAGE
     input logic [riscv::VLEN-1:0] rs1_forwarding_i,
+    // TO_BE_COMPLETED - ID_STAGE
     input logic [riscv::VLEN-1:0] rs2_forwarding_i,
+    // TO_BE_COMPLETED - ID_STAGE
     input fu_data_t fu_data_i,
-    input logic [riscv::VLEN-1:0] pc_i,  // PC of current instruction
-    input logic is_compressed_instr_i,  // we need to know if this was a compressed instruction
-                                        // in order to calculate the next PC on a mis-predict
-    // Fixed latency unit(s)
+    // PC of the current instruction - ID_STAGE
+    input logic [riscv::VLEN-1:0] pc_i,
+    // Report whether isntruction is compressed - ID_STAGE
+    input logic is_compressed_instr_i,
+    // TO_BE_COMPLETED - ID_STAGE
     output riscv::xlen_t flu_result_o,
-    output logic [TRANS_ID_BITS-1:0]               flu_trans_id_o,        // ID of scoreboard entry at which to write back
+    // ID of the scoreboard entry at which a=to write back - ID_STAGE
+    output logic [TRANS_ID_BITS-1:0] flu_trans_id_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output exception_t flu_exception_o,
-    output logic flu_ready_o,  // FLU is ready
-    output logic flu_valid_o,  // FLU result is valid
-    // Branches and Jumps
-    // ALU 1
-    input logic alu_valid_i,  // Output is valid
-    // Branch Unit
-    input logic branch_valid_i,  // we are using the branch unit
+    // FLU is ready - ID_STAGE
+    output logic flu_ready_o,
+    // FLU result is valid - ID_STAGE
+    output logic flu_valid_o,
+    // ALU result is valid - ID_STAGE
+    input logic alu_valid_i,
+    // Branch unit result is valid - ID_STAGE
+    input logic branch_valid_i,
+    // TO_BE_COMPLETED - ID_STAGE
     input branchpredict_sbe_t branch_predict_i,
-    output bp_resolve_t resolved_branch_o,  // the branch engine uses the write back from the ALU
-    output logic resolve_branch_o,  // to ID signaling that we resolved the branch
-    // CSR
+    // The branch engine uses the write back from the ALU - CONTROLLER PERF_COUNTER FRONTEND ISSUE_STAGE
+    output bp_resolve_t resolved_branch_o,
+    // ID signaling that we resolved the branch - ID_STAGE
+    output logic resolve_branch_o,
+    // TO_BE_COMPLETED - ID_STAGE
     input logic csr_valid_i,
+    // TO_BE_COMPLETED - CSR_REGISTERS
     output logic [11:0] csr_addr_o,
+    // TO_BE_COMPLETED - COMMIT_STAGE
     input logic csr_commit_i,
-    // MULT
-    input logic mult_valid_i,  // Output is valid
-    // LSU
-    output logic lsu_ready_o,  // FU is ready
-    input logic lsu_valid_i,  // Input is valid
-
-    output logic                             load_valid_o,
-    output riscv::xlen_t                     load_result_o,
-    output logic         [TRANS_ID_BITS-1:0] load_trans_id_o,
-    output exception_t                       load_exception_o,
-    output logic                             store_valid_o,
-    output riscv::xlen_t                     store_result_o,
-    output logic         [TRANS_ID_BITS-1:0] store_trans_id_o,
-    output exception_t                       store_exception_o,
-
+    // MULT result is valid - ID_STAGE
+    input logic mult_valid_i,
+    // FU is ready - ID_STAGE
+    output logic lsu_ready_o,
+    // LSU result is valid - ID_STAGE
+    input logic lsu_valid_i,
+    // TO_BE_COMPLETED - ID_STAGE
+    output logic load_valid_o,
+    // TO_BE_COMPLETED - ID_STAGE
+    output riscv::xlen_t load_result_o,
+    // TO_BE_COMPLETED - ID_STAGE
+    output logic [TRANS_ID_BITS-1:0] load_trans_id_o,
+    // TO_BE_COMPLETED - ID_STAGE
+    output exception_t load_exception_o,
+    // TO_BE_COMPLETED - ID_STAGE
+    output logic store_valid_o,
+    // TO_BE_COMPLETED - ID_STAGE
+    output riscv::xlen_t store_result_o,
+    // TO_BE_COMPLETED - ID_STAGE
+    output logic [TRANS_ID_BITS-1:0] store_trans_id_o,
+    // TO_BE_COMPLETED - ID_STAGE
+    output exception_t store_exception_o,
+    // TO_BE_COMPLETED - COMMIT_STAGE
     input logic lsu_commit_i,
-    output logic lsu_commit_ready_o,  // commit queue is ready to accept another commit request
+    // Commit queue is ready to accept another commit request - COMMIT_STAGE
+    output logic lsu_commit_ready_o,
+    // TO_BE_COMPLETED - COMMIT_STAGE
     input logic [TRANS_ID_BITS-1:0] commit_tran_id_i,
+    // TO_BE_COMPLETED - ACC_DISPATCHER
     input logic stall_st_pending_i,
+    // TO_BE_COMPLETED - COMMIT_STAGE
     output logic no_st_pending_o,
+    // TO_BE_COMPLETED - COMMIT_STAGE
     input logic amo_valid_commit_i,
-    // FPU
-    output logic fpu_ready_o,  // FU is ready
-    input logic fpu_valid_i,  // Output is valid
-    input logic [1:0] fpu_fmt_i,  // FP format
-    input logic [2:0] fpu_rm_i,  // FP rm
-    input logic [2:0] fpu_frm_i,  // FP frm csr
-    input logic [6:0] fpu_prec_i,  // FP precision control
+    // FU is ready - ID_STAGE
+    output logic fpu_ready_o,
+    // Output is ready - ID_STAGE
+    input logic fpu_valid_i,
+    // report FP format - ID_STAGE
+    input logic [1:0] fpu_fmt_i,
+    // FP rm - ID_STAGE
+    input logic [2:0] fpu_rm_i,
+    // FP frm - ID_STAGE
+    input logic [2:0] fpu_frm_i,
+    // FP precision control - CSR_REGFILE
+    input logic [6:0] fpu_prec_i,
+    // TO_BE_COMPLETED - ID_STAGE
     output logic [TRANS_ID_BITS-1:0] fpu_trans_id_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output riscv::xlen_t fpu_result_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output logic fpu_valid_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output exception_t fpu_exception_o,
-    // CoreV-X-Interface
+    // TO_BE_COMPLETED - ID_STAGE
     input logic x_valid_i,
+    // TO_BE_COMPLETED - ID_STAGE
     output logic x_ready_o,
+    // TO_BE_COMPLETED - ID_STAGE
     input logic [31:0] x_off_instr_i,
+    // TO_BE_COMPLETED - ID_STAGE
     output logic [TRANS_ID_BITS-1:0] x_trans_id_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output exception_t x_exception_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output riscv::xlen_t x_result_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output logic x_valid_o,
+    // TO_BE_COMPLETED - ID_STAGE
     output logic x_we_o,
+    // TO_BE_COMPLETED - SUBSYSTEM
     output cvxif_pkg::cvxif_req_t cvxif_req_o,
+    // TO_BE_COMPLETED - SUBSYSTEM
     input cvxif_pkg::cvxif_resp_t cvxif_resp_i,
-    input logic acc_valid_i,  // Output is valid
-    // Memory Management
+    // TO_BE_COMPLETED - ACC_DISPATCHER
+    input logic acc_valid_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
     input logic enable_translation_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
     input logic en_ld_st_translation_i,
+    // TO_BE_COMPLETED - CONTROLLER
     input logic flush_tlb_i,
-
-    input  riscv::priv_lvl_t                   priv_lvl_i,
-    input  riscv::priv_lvl_t                   ld_st_priv_lvl_i,
-    input  logic                               sum_i,
-    input  logic                               mxr_i,
-    input  logic             [riscv::PPNW-1:0] satp_ppn_i,
-    input  logic             [ ASID_WIDTH-1:0] asid_i,
-    // icache translation requests
-    input  icache_arsp_t                       icache_areq_i,
-    output icache_areq_t                       icache_areq_o,
-
+    // TO_BE_COMPLETED - CSR_REGFILE
+    input riscv::priv_lvl_t priv_lvl_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
+    input riscv::priv_lvl_t ld_st_priv_lvl_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
+    input logic sum_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
+    input logic mxr_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
+    input logic [riscv::PPNW-1:0] satp_ppn_i,
+    // TO_BE_COMPLETED - CSR_REGFILE
+    input logic [ASID_WIDTH-1:0] asid_i,
+    // icache translation response - CACHE
+    input  icache_arsp_t icache_areq_i,
+    // icache translation request - CACHE
+    output icache_areq_t icache_areq_o,
+    // TO_BE_COMPLETED - CACHE
     // interface to dcache
     input dcache_req_o_t [2:0] dcache_req_ports_i,
+    // TO_BE_COMPLETED - CACHE
     output dcache_req_i_t [2:0] dcache_req_ports_o,
+    // TO_BE_COMPLETED - CACHE
     input logic dcache_wbuffer_empty_i,
+    // TO_BE_COMPLETED - CACHE
     input logic dcache_wbuffer_not_ni_i,
-    output amo_req_t amo_req_o,  // request to cache subsytem
-    input amo_resp_t amo_resp_i,  // response from cache subsystem
-    // Performance counters
+    // AMO request - CACHE
+    output amo_req_t amo_req_o,
+    // AMO response from cache - CACHE
+    input amo_resp_t amo_resp_i,
+    // To count the instruction TLB misses - PERF_COUNTERS
     output logic itlb_miss_o,
+    // To count the data TLB misses - PERF_COUNTERS
     output logic dtlb_miss_o,
-    // PMPs
+    // Report the PMP configuration - CSR_REGFILE
     input riscv::pmpcfg_t [15:0] pmpcfg_i,
+    // Report the PMP addresses - CSR_REGFILE
     input logic [15:0][riscv::PLEN-3:0] pmpaddr_i,
-
-    // RVFI
-    output lsu_ctrl_t                   rvfi_lsu_ctrl_o,
-    output            [riscv::PLEN-1:0] rvfi_mem_paddr_o
+    // Information dedicated to RVFI - SUBSYSTEM
+    output lsu_ctrl_t rvfi_lsu_ctrl_o,
+    // Information dedicated to RVFI - SUBSYSTEM
+    output [riscv::PLEN-1:0] rvfi_mem_paddr_o
 );
 
   // -------------------------

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -54,11 +54,11 @@ module frontend
     output icache_dreq_t icache_dreq_o,
     // Handshake between CACHE and FRONTEND (fetch) - CACHES
     input icache_drsp_t icache_dreq_i,
-    // Handshake's data between fetch and decode - DECODE
+    // Handshake's data between fetch and decode - ID_STAGE
     output fetch_entry_t fetch_entry_o,
-    // Handshake's valid between fetch and decode - DECODE
+    // Handshake's valid between fetch and decode - ID_STAGE
     output logic fetch_entry_valid_o,
-    // Handshake's ready between fetch and decode - DECODE
+    // Handshake's ready between fetch and decode - ID_STAGE
     input logic fetch_entry_ready_i
 );
   // Instruction Cache Registers, from I$

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -62,7 +62,7 @@ module instr_queue
     input logic [ariane_pkg::INSTR_PER_FETCH-1:0] valid_i,
     // Handshake’s ready with CACHE - CACHE
     output logic ready_o,
-    // Indicates instructions consummed, or popped by DECODE - FRONTEND
+    // Indicates instructions consummed, or popped by ID_STAGE - FRONTEND
     output logic [ariane_pkg::INSTR_PER_FETCH-1:0] consumed_o,
     // Exception (which is page-table fault) - CACHE
     input ariane_pkg::frontend_exception_t exception_i,
@@ -76,11 +76,11 @@ module instr_queue
     output logic replay_o,
     // Address at which to replay the fetch - FRONTEND
     output logic [riscv::VLEN-1:0] replay_addr_o,
-    // Handshake’s data with DECODE - DECODE
+    // Handshake’s data with ID_STAGE - ID_STAGE
     output ariane_pkg::fetch_entry_t fetch_entry_o,
-    // Handshake’s valid with DECODE - DECODE
+    // Handshake’s valid with ID_STAGE - ID_STAGE
     output logic fetch_entry_valid_o,
-    // Handshake’s ready with DECODE - DECODE
+    // Handshake’s ready with ID_STAGE - ID_STAGE
     input logic fetch_entry_ready_i
 );
 

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -16,32 +16,51 @@
 module id_stage #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
+    // Subsystem Clock - SUBSYSTEM
     input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
-
+    // Fetch flush request - CONTROLLER
     input logic flush_i,
+    // Debug (async) request - SUBSYSTEM
     input logic debug_req_i,
-    // from IF
+    // Handshake's data between fetch and decode - FRONTEND
     input ariane_pkg::fetch_entry_t fetch_entry_i,
+    // Handshake's valid between fetch and decode - FRONTEND
     input logic fetch_entry_valid_i,
-    output logic fetch_entry_ready_o,  // acknowledge the instruction (fetch entry)
-    // to ID
-    output ariane_pkg::scoreboard_entry_t issue_entry_o,  // a decoded instruction
+    // Handshake's ready between fetch and decode - FRONTEND
+    output logic fetch_entry_ready_o,
+    // Handshake's data between decode and issue - ISSUE
+    output ariane_pkg::scoreboard_entry_t issue_entry_o,
+    // instruction value - ISSUE
     output logic [31:0] orig_instr_o,
-    output logic issue_entry_valid_o,  // issue entry is valid
-    output logic is_ctrl_flow_o,  // the instruction we issue is a ctrl flow instructions
-    input logic issue_instr_ack_i,  // issue stage acknowledged sampling of instructions
+    // Handshake's valid between decode and issue - ISSUE
+    output logic issue_entry_valid_o,
+    // Report if instruction is a control flow instruction - ISSUE
+    output logic is_ctrl_flow_o,
+    // Handshake's acknowlege between decode and issue - ISSUE
+    input logic issue_instr_ack_i,
+    // Information dedicated to RVFI- SUBSYSTEM
     output logic rvfi_is_compressed_o,
-    // from CSR file
-    input riscv::priv_lvl_t priv_lvl_i,  // current privilege level
-    input riscv::xs_t fs_i,  // floating point extension status
-    input logic [2:0] frm_i,  // floating-point dynamic rounding mode
-    input riscv::xs_t vs_i,  // vector extension status
+    // Report current privilege level - CSR
+    input riscv::priv_lvl_t priv_lvl_i,
+    // Report floating point extension status - CSR
+    input riscv::xs_t fs_i,
+    // Report floating point dynamic rounding mode - CSR
+    input logic [2:0] frm_i,
+    // Report vector extension status - CSR
+    input riscv::xs_t vs_i,
+    // Level sensitive (async) interrupts - SUBSYSTEM
     input logic [1:0] irq_i,
+    // TBD - CSR
     input ariane_pkg::irq_ctrl_t irq_ctrl_i,
-    input logic debug_mode_i,  // we are in debug mode
+    // Report if current mode is debug - CSR
+    input logic debug_mode_i,
+    // TBD - CSR
     input logic tvm_i,
+    // TBD - CSR
     input logic tw_i,
+    // TBD- CSR
     input logic tsr_i
 );
   // ID/ISSUE register stage

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -36,90 +36,119 @@ package config_pkg;
   localparam NrMaxRules = 16;
 
   typedef struct packed {
-    /// Number of commit ports, i.e., maximum number of instructions that the
-    /// core can retire per cycle. It can be beneficial to have more commit
-    /// ports than issue ports, for the scoreboard to empty out in case one
-    /// instruction stalls a little longer.
+    // Number of commit ports
     int unsigned                 NrCommitPorts;
-    /// AXI parameters.
+    // AXI address width
     int unsigned                 AxiAddrWidth;
+    // AXI data width
     int unsigned                 AxiDataWidth;
+    // AXI ID width
     int unsigned                 AxiIdWidth;
+    // AXI User width
     int unsigned                 AxiUserWidth;
+    // TO_BE_COMPLETED
     int unsigned                 NrLoadBufEntries;
+    // FPU is enabled
     bit                          FpuEn;
+    // TO_BE_COMPLETED
     bit                          XF16;
+    // TO_BE_COMPLETED
     bit                          XF16ALT;
+    // TO_BE_COMPLETED
     bit                          XF8;
+    // Atomic RISC-V extension
     bit                          RVA;
+    // Bit manipulation RISC-V extension
     bit                          RVB;
+    // Vector RISC-V extension
     bit                          RVV;
+    // Compress RISC-V extension
     bit                          RVC;
+    // Zcb RISC-V extension
     bit                          RVZCB;
+    // TO_BE_COMPLETED
     bit                          XFVec;
+    // CV-X-IF coprocessor interface is supported
     bit                          CvxifEn;
+    // Zicond RISC-V extension is enabled
     bit                          ZiCondExtEn;
-    // Calculated
+    // Single precision FP RISC-V extension
     bit                          RVF;
+    // Double precision FP RISC-V extension
     bit                          RVD;
+    // Floating point is present
     bit                          FpPresent;
+    // TO_BE_COMPLETED
     bit                          NSX;
+    // TO_BE_COMPLETED
     int unsigned                 FLen;
+    // Vector floating point extension
     bit                          RVFVec;
+    // 16 bits vector floating point extension
     bit                          XF16Vec;
+    // TO_BE_COMPLETED
     bit                          XF16ALTVec;
+    // 8 bits vector floating point extension
     bit                          XF8Vec;
+    // TO_BE_COMPLETED
     int unsigned                 NrRgprPorts;
+    // TO_BE_COMPLETED
     int unsigned                 NrWbPorts;
+    // Accelerate Port coprocessor interface
     bit                          EnableAccelerator;
-    bit                          RVS;                    //Supervisor mode
-    bit                          RVU;                    //User mode
-    // Debug Module
-    // address to which a hart should jump when it was requested to halt
+    // Supervisor mode is enabled
+    bit                          RVS;
+    // User mode is enabled
+    bit                          RVU;
+    // Address to jump when halt request
     logic [63:0]                 HaltAddress;
+    // Address to jump when exception 
     logic [63:0]                 ExceptionAddress;
-    /// Return address stack depth, good values are around 2 to 4.
+    // Address stack depth
     int unsigned                 RASDepth;
-    /// Branch target buffer entries.
+    // Branch target buffer entries
     int unsigned                 BTBEntries;
-    /// Branch history (2-bit saturation counter) size, to keep track of
-    /// branch otucomes.
+    // Branch history entries
     int unsigned                 BHTEntries;
-    /// Offset of the debug module.
+    // Base address of the debug module.
     logic [63:0]                 DmBaseAddress;
-    /// Tval Support Enable
+    // Tval Support Enable
     bit                          TvalEn;
-    /// Number of PMP entries.
+    // Number of PMP entries.
     int unsigned                 NrPMPEntries;
-    /// Physical Memory Protection (PMP) CSR reset values and read-only bits
+    // PMP CSR configuration reset values
     logic [15:0][63:0]           PMPCfgRstVal;
+    // PMP CSR address reset values
     logic [15:0][63:0]           PMPAddrRstVal;
+    // PMP CSR read-only bits
     bit [15:0]                   PMPEntryReadOnly;
-    /// Set to the bus type in use.
+    // NOC bus type, can be AXI or Open Piton
     noc_type_e                   NOCType;
-    /// Physical Memory Attributes (PMAs)
-    /// Number of non idempotent rules.
+    // Number of PMA non idempotent rules
     int unsigned                 NrNonIdempotentRules;
-    /// Base which needs to match.
+    // PMA NonIdempotent region base address
     logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
-    /// Bit mask which bits to consider when matching the rule.
+    // PMA NonIdempotent region length
     logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
-    /// Number of regions which have execute property.
+    // PMA Execute region rules
     int unsigned                 NrExecuteRegionRules;
-    /// Base which needs to match.
+    // PMA Execute region base address
     logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
-    /// Bit mask which bits to consider when matching the rule.
+    // PMA Execute region address base
     logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
-    /// Number of regions which have cached property.
+    // PMA cache region properties
     int unsigned                 NrCachedRegionRules;
-    /// Base which needs to match.
+    // PMA cache region base address
     logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
-    /// Bit mask which bits to consider when matching the rule.
+    // PMA cache region rules
     logic [NrMaxRules-1:0][63:0] CachedRegionLength;
-    /// Maximum number of outstanding stores.
+    // Maximum number of outstanding stores
     int unsigned                 MaxOutstandingStores;
+    // Debug mode is enabled
     bit                          DebugEn;
+    // Non idem potency is enabled
     bit                          NonIdemPotenceEn;
+    // AXI burst in write is enabled
     bit                          AxiBurstWriteEn;
   } cva6_cfg_t;
 

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -96,25 +96,25 @@ package config_pkg;
     int unsigned                 NrWbPorts;
     // Accelerate Port coprocessor interface
     bit                          EnableAccelerator;
-    // Supervisor mode is enabled
+    // Supervisor mode
     bit                          RVS;
-    // User mode is enabled
+    // User mode
     bit                          RVU;
     // Address to jump when halt request
     logic [63:0]                 HaltAddress;
     // Address to jump when exception 
     logic [63:0]                 ExceptionAddress;
-    // Address stack depth
+    // Return address stack depth
     int unsigned                 RASDepth;
     // Branch target buffer entries
     int unsigned                 BTBEntries;
     // Branch history entries
     int unsigned                 BHTEntries;
-    // Base address of the debug module.
+    // Base address of the debug module
     logic [63:0]                 DmBaseAddress;
     // Tval Support Enable
     bit                          TvalEn;
-    // Number of PMP entries.
+    // Number of PMP entries
     int unsigned                 NrPMPEntries;
     // PMP CSR configuration reset values
     logic [15:0][63:0]           PMPCfgRstVal;
@@ -122,7 +122,7 @@ package config_pkg;
     logic [15:0][63:0]           PMPAddrRstVal;
     // PMP CSR read-only bits
     bit [15:0]                   PMPEntryReadOnly;
-    // NOC bus type, can be AXI or Open Piton
+    // NOC bus type
     noc_type_e                   NOCType;
     // Number of PMA non idempotent rules
     int unsigned                 NrNonIdempotentRules;
@@ -130,13 +130,13 @@ package config_pkg;
     logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
     // PMA NonIdempotent region length
     logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
-    // PMA Execute region rules
+    // Number of PMA regions with execute rules
     int unsigned                 NrExecuteRegionRules;
     // PMA Execute region base address
     logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
     // PMA Execute region address base
     logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
-    // PMA cache region properties
+    // Number of PMA regions with cache rules
     int unsigned                 NrCachedRegionRules;
     // PMA cache region base address
     logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
@@ -144,11 +144,11 @@ package config_pkg;
     logic [NrMaxRules-1:0][63:0] CachedRegionLength;
     // Maximum number of outstanding stores
     int unsigned                 MaxOutstandingStores;
-    // Debug mode is enabled
+    // Debug mode
     bit                          DebugEn;
-    // Non idem potency is enabled
+    // Non idem potency
     bit                          NonIdemPotenceEn;
-    // AXI burst in write is enabled
+    // AXI burst in write
     bit                          AxiBurstWriteEn;
   } cva6_cfg_t;
 

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -29,9 +29,9 @@ package cva6_config_pkg;
   localparam CVA6ConfigAxiAddrWidth = 64;
   localparam CVA6ConfigAxiDataWidth = 64;
   localparam CVA6ConfigFetchUserEn = 0;
-  localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
+  localparam CVA6ConfigFetchUserWidth = 32;
   localparam CVA6ConfigDataUserEn = 0;
-  localparam CVA6ConfigDataUserWidth = CVA6ConfigXlen;
+  localparam CVA6ConfigDataUserWidth = 32;
 
   localparam CVA6ConfigIcacheByteSize = 2048;
   localparam CVA6ConfigIcacheSetAssoc = 2;
@@ -93,10 +93,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
       // Extended
-      RVF:
-      bit'(
-      0
-      ),
+      RVF: bit'(0),
       RVD: bit'(0),
       FpPresent: bit'(0),
       NSX: bit'(0),
@@ -123,24 +120,15 @@ package cva6_config_pkg;
       PMPEntryReadOnly: 16'd0,
       NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
       // idempotent region
-      NrNonIdempotentRules:
-      unsigned'(
-      2
-      ),
+      NrNonIdempotentRules: unsigned'(2),
       NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
       NonIdempotentLength: 1024'({64'b0, 64'b0}),
       NrExecuteRegionRules: unsigned'(3),
       //                      DRAM,          Boot ROM,   Debug Module
-      ExecuteRegionAddrBase:
-      1024'(
-      {64'h8000_0000, 64'h1_0000, 64'h0}
-      ),
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
       ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
       // cached region
-      NrCachedRegionRules:
-      unsigned'(
-      1
-      ),
+      NrCachedRegionRules: unsigned'(1),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -92,7 +92,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
       RVF: bit'(0),
       RVD: bit'(0),
       FpPresent: bit'(0),
@@ -119,15 +118,12 @@ package cva6_config_pkg;
       PMPAddrRstVal: {16{64'h0}},
       PMPEntryReadOnly: 16'd0,
       NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
-      // idempotent region
       NrNonIdempotentRules: unsigned'(2),
       NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
       NonIdempotentLength: 1024'({64'b0, 64'b0}),
       NrExecuteRegionRules: unsigned'(3),
-      //                      DRAM,          Boot ROM,   Debug Module
       ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
       ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
-      // cached region
       NrCachedRegionRules: unsigned'(1),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -19,76 +19,103 @@ module issue_stage
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
-    input logic clk_i,  // Clock
-    input logic rst_ni, // Asynchronous reset active low
-
+    // Subsystem Clock - SUBSYSTEM
+    input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
+    input logic rst_ni,
+    // TO_BE_COMPLETED - PERF_COUNTERS
     output logic sb_full_o,
+    // TO_BE_COMPLETED - CONTROLLER
     input logic flush_unissued_instr_i,
+    // TO_BE_COMPLETED - CONTROLLER
     input logic flush_i,
-    input logic stall_i,  // Stall issue stage
-    // from ISSUE
+    // zero when accelerate port is disable - ACC_DISPATCHER
+    input logic stall_i,
+    // Handshake's data between decode and issue - ID_STAGE
     input scoreboard_entry_t decoded_instr_i,
+    // instruction value - ID_STAGE
     input logic [31:0] orig_instr_i,
+    // Handshake's valid between decode and issue - ID_STAGE
     input logic decoded_instr_valid_i,
+    // Report if instruction is a control flow instruction - ID_STAGE
     input logic is_ctrl_flow_i,
+    // Handshake's acknowlege between decode and issue - ID_STAGE
     output logic decoded_instr_ack_o,
-    // to EX
-    output [riscv::VLEN-1:0] rs1_forwarding_o,  // unregistered version of fu_data_o.operanda
-    output [riscv::VLEN-1:0] rs2_forwarding_o,  // unregistered version of fu_data_o.operandb
+    // TO_BE_COMPLETED - EX_STAGE
+    output [riscv::VLEN-1:0] rs1_forwarding_o,
+    // TO_BE_COMPLETED - EX_STAGE
+    output [riscv::VLEN-1:0] rs2_forwarding_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output fu_data_t fu_data_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic [riscv::VLEN-1:0] pc_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic is_compressed_instr_o,
+    // TO_BE_COMPLETED - EX_STAGE
     input logic flu_ready_i,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic alu_valid_o,
-    // ex just resolved our predicted branch, we are ready to accept new requests
+    // TO_BE_COMPLETED - EX_STAGE
     input logic resolve_branch_i,
-
-    input  logic               lsu_ready_i,
-    output logic               lsu_valid_o,
-    // branch prediction
-    output logic               branch_valid_o,   // use branch prediction unit
-    output branchpredict_sbe_t branch_predict_o, // Branch predict Out
-
+    // TO_BE_COMPLETED - EX_STAGE
+    input logic lsu_ready_i,
+    // TO_BE_COMPLETED - EX_STAGE
+    output logic lsu_valid_o,
+    // TO_BE_COMPLETED - EX_STAGE
+    output logic branch_valid_o,
+    // TO_BE_COMPLETED - EX_STAGE
+    output branchpredict_sbe_t branch_predict_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic mult_valid_o,
-
-    input  logic       fpu_ready_i,
-    output logic       fpu_valid_o,
-    output logic [1:0] fpu_fmt_o,    // FP fmt field from instr.
-    output logic [2:0] fpu_rm_o,     // FP rm field from instr.
-
+    // TO_BE_COMPLETED - EX_STAGE
+    input logic fpu_ready_i,
+    // TO_BE_COMPLETED - EX_STAGE
+    output logic fpu_valid_o,
+    // Report FP fmt field - EX_STAGE
+    output logic [1:0] fpu_fmt_o,
+    // report FP rm field - EX_STAGE
+    output logic [2:0] fpu_rm_o,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic csr_valid_o,
-
-    // CVXIF
-    //Issue interface
-    output logic        x_issue_valid_o,
-    input  logic        x_issue_ready_i,
+    // TO_BE_COMPLETED - EX_STAGE
+    output logic x_issue_valid_o,
+    // TO_BE_COMPLETED - EX_STAGE
+    input logic x_issue_ready_i,
+    // TO_BE_COMPLETED - EX_STAGE
     output logic [31:0] x_off_instr_o,
-
-    // to accelerator dispatcher
+    // TO_BE_COMPLETED - ACC_DISPATCHER
     output scoreboard_entry_t issue_instr_o,
-    output logic              issue_instr_hs_o,
-
-    // write back port
+    // TO_BE_COMPLETED - ACC_DISPATCHER
+    output logic issue_instr_hs_o,
+    // TO_BE_COMPLETED - EX_STAGE
     input logic [CVA6Cfg.NrWbPorts-1:0][TRANS_ID_BITS-1:0] trans_id_i,
+    // TO_BE_COMPLETED - EX_STAGE
     input bp_resolve_t resolved_branch_i,
+    // TO_BE_COMPLETED - EX_STAGE
     input logic [CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0] wbdata_i,
-    input exception_t [CVA6Cfg.NrWbPorts-1:0]              ex_ex_i, // exception from execute stage or CVXIF offloaded instruction
+    // exception from execute stage or CVXIF offloaded instruction - EX_STAGE
+    input exception_t [CVA6Cfg.NrWbPorts-1:0] ex_ex_i,
+    // TO_BE_COMPLETED - EX_STAGE
     input logic [CVA6Cfg.NrWbPorts-1:0] wt_valid_i,
+    // TO_BE_COMPLETED - EX_STAGE
     input logic x_we_i,
-
-    // commit port
-    input logic [CVA6Cfg.NrCommitPorts-1:0][            4:0] waddr_i,
+    // TO_BE_COMPLETED - EX_STAGE
+    input logic [CVA6Cfg.NrCommitPorts-1:0][4:0] waddr_i,
+    // TO_BE_COMPLETED - EX_STAGE
     input logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_i,
-    input logic [CVA6Cfg.NrCommitPorts-1:0]                  we_gpr_i,
-    input logic [CVA6Cfg.NrCommitPorts-1:0]                  we_fpr_i,
-
-    output scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_o,
-    input  logic              [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
-
-    output logic stall_issue_o,  // Used in Performance Counters
-
-    //RVFI
+    // TO_BE_COMPLETED - EX_STAGE
+    input logic [CVA6Cfg.NrCommitPorts-1:0] we_gpr_i,
+    // TO_BE_COMPLETED - EX_STAGE
+    input logic [CVA6Cfg.NrCommitPorts-1:0] we_fpr_i,
+    // TO_BE_COMPLETED - COMMIT_STAGE
+    output scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] COMMIT_STAGE,
+    // TO_BE_COMPLETED - COMMIT_STAGE
+    input logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
+    // Issue stall - PERF_COUNTERS
+    output logic stall_issue_o,
+    // Information dedicated to RVFI - SUBSYSTEM
     output logic [TRANS_ID_BITS-1:0] rvfi_issue_pointer_o,
+    // Information dedicated to RVFI - SUBSYSTEM
     output logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] rvfi_commit_pointer_o
 );
   // ---------------------------------------------------

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -108,7 +108,7 @@ module issue_stage
     // TO_BE_COMPLETED - EX_STAGE
     input logic [CVA6Cfg.NrCommitPorts-1:0] we_fpr_i,
     // TO_BE_COMPLETED - COMMIT_STAGE
-    output scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] COMMIT_STAGE,
+    output scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_o,
     // TO_BE_COMPLETED - COMMIT_STAGE
     input logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
     // Issue stall - PERF_COUNTERS

--- a/docs/04_cv32a65x_design/source/architecture.rst
+++ b/docs/04_cv32a65x_design/source/architecture.rst
@@ -34,4 +34,6 @@ Connections between modules are illustrated in the following block diagram. FRON
    :hidden:
 
    cv32a6_frontend
+   cva6_id_stage
+   cva6_issue_stage
    cv32a6_execute

--- a/docs/04_cv32a65x_design/source/architecture.rst
+++ b/docs/04_cv32a65x_design/source/architecture.rst
@@ -37,3 +37,4 @@ Connections between modules are illustrated in the following block diagram. FRON
    cva6_id_stage
    cva6_issue_stage
    cv32a6_execute
+   cva6_commit_stage

--- a/docs/04_cv32a65x_design/source/architecture.rst
+++ b/docs/04_cv32a65x_design/source/architecture.rst
@@ -39,3 +39,4 @@ Connections between modules are illustrated in the following block diagram. FRON
    cv32a6_execute
    cva6_commit_stage
    cva6_controller
+   cva6_csr_regfile

--- a/docs/04_cv32a65x_design/source/architecture.rst
+++ b/docs/04_cv32a65x_design/source/architecture.rst
@@ -38,3 +38,4 @@ Connections between modules are illustrated in the following block diagram. FRON
    cva6_issue_stage
    cv32a6_execute
    cva6_commit_stage
+   cva6_controller

--- a/docs/04_cv32a65x_design/source/cv32a6_execute.rst
+++ b/docs/04_cv32a65x_design/source/cv32a6_execute.rst
@@ -1,16 +1,26 @@
-.. _CV32A6_EXECUTE:
+.. _CVA6_EX_STAGE:
 
-##############
-Execute Module
-##############
+###############
+EX_STAGE Module
+###############
 
 ***********
 Description
 ***********
 
+The EX_STAGE module implements ... TO BE COMPLETED
+
+The module is connected to:
+
+* TO BE COMPLETED
+
+.. include:: port_ex_stage.rst
+
 *************
 Functionality
 *************
+
+TO BE COMPLETED
 
 ***************************
 Architecture and Submodules

--- a/docs/04_cv32a65x_design/source/cva6_commit_stage.rst
+++ b/docs/04_cv32a65x_design/source/cva6_commit_stage.rst
@@ -1,0 +1,29 @@
+..
+   Copyright 2021 Thales DIS design services SAS
+   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_COMMIT_STAGE:
+
+COMMIT_STAGE Module
+===================
+
+Description
+-----------
+
+The COMMIT_STAGE module implements ... TO BE COMPLETED
+
+The module is connected to:
+
+* TO BE COMPLETED
+
+.. include:: port_commit_stage.rst
+
+Functionality
+-------------
+
+TO BE COMPLETED

--- a/docs/04_cv32a65x_design/source/cva6_commit_stage.rst
+++ b/docs/04_cv32a65x_design/source/cva6_commit_stage.rst
@@ -1,8 +1,8 @@
 ..
-   Copyright 2021 Thales DIS design services SAS
-   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
    you may not use this file except in compliance with the License.
-   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
    You may obtain a copy of the License at https://solderpad.org/licenses/
 
    Original Author: Jean-Roch COULON - Thales

--- a/docs/04_cv32a65x_design/source/cva6_controller.rst
+++ b/docs/04_cv32a65x_design/source/cva6_controller.rst
@@ -1,0 +1,29 @@
+..
+   Copyright 2021 Thales DIS design services SAS
+   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_CONTROLLER:
+
+CONTROLLER Module
+=================
+
+Description
+-----------
+
+The CONTROLLER module implements ... TO BE COMPLETED
+
+The module is connected to:
+
+* TO BE COMPLETED
+
+.. include:: port_controller.rst
+
+Functionality
+-------------
+
+TO BE COMPLETED

--- a/docs/04_cv32a65x_design/source/cva6_controller.rst
+++ b/docs/04_cv32a65x_design/source/cva6_controller.rst
@@ -1,8 +1,8 @@
 ..
-   Copyright 2021 Thales DIS design services SAS
-   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
    you may not use this file except in compliance with the License.
-   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
    You may obtain a copy of the License at https://solderpad.org/licenses/
 
    Original Author: Jean-Roch COULON - Thales

--- a/docs/04_cv32a65x_design/source/cva6_csr_regfile.rst
+++ b/docs/04_cv32a65x_design/source/cva6_csr_regfile.rst
@@ -1,0 +1,29 @@
+..
+   Copyright 2021 Thales DIS design services SAS
+   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_CSR_REGFILE:
+
+CSR_REGFILE Module
+==================
+
+Description
+-----------
+
+The CSR_REGFILE module implements ... TO BE COMPLETED
+
+The module is connected to:
+
+* TO BE COMPLETED
+
+.. include:: port_csr_regfile.rst
+
+Functionality
+-------------
+
+TO BE COMPLETED

--- a/docs/04_cv32a65x_design/source/cva6_csr_regfile.rst
+++ b/docs/04_cv32a65x_design/source/cva6_csr_regfile.rst
@@ -1,8 +1,8 @@
 ..
-   Copyright 2021 Thales DIS design services SAS
-   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
    you may not use this file except in compliance with the License.
-   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
    You may obtain a copy of the License at https://solderpad.org/licenses/
 
    Original Author: Jean-Roch COULON - Thales

--- a/docs/04_cv32a65x_design/source/cva6_id_stage.rst
+++ b/docs/04_cv32a65x_design/source/cva6_id_stage.rst
@@ -1,0 +1,29 @@
+..
+   Copyright 2021 Thales DIS design services SAS
+   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_ID_STAGE:
+
+ID_STAGE Module
+===============
+
+Description
+-----------
+
+The ID_STAGE module implements ... TO BE COMPLETED
+
+The module is connected to:
+
+* TO BE COMPLETED
+
+.. include:: port_id_stage.rst
+
+Functionality
+-------------
+
+TO BE COMPLETED

--- a/docs/04_cv32a65x_design/source/cva6_id_stage.rst
+++ b/docs/04_cv32a65x_design/source/cva6_id_stage.rst
@@ -1,8 +1,8 @@
 ..
-   Copyright 2021 Thales DIS design services SAS
-   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
    you may not use this file except in compliance with the License.
-   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
    You may obtain a copy of the License at https://solderpad.org/licenses/
 
    Original Author: Jean-Roch COULON - Thales

--- a/docs/04_cv32a65x_design/source/cva6_issue_stage.rst
+++ b/docs/04_cv32a65x_design/source/cva6_issue_stage.rst
@@ -1,0 +1,29 @@
+..
+   Copyright 2021 Thales DIS design services SAS
+   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_ISSUE_STAGE:
+
+ID_STAGE Module
+===============
+
+Description
+-----------
+
+The ISSUE_STAGE module implements ... TO BE COMPLETED
+
+The module is connected to:
+
+* TO BE COMPLETED
+
+.. include:: port_issue_stage.rst
+
+Functionality
+-------------
+
+TO BE COMPLETED

--- a/docs/04_cv32a65x_design/source/cva6_issue_stage.rst
+++ b/docs/04_cv32a65x_design/source/cva6_issue_stage.rst
@@ -1,8 +1,8 @@
 ..
-   Copyright 2021 Thales DIS design services SAS
-   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
    you may not use this file except in compliance with the License.
-   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
    You may obtain a copy of the License at https://solderpad.org/licenses/
 
    Original Author: Jean-Roch COULON - Thales

--- a/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
+++ b/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
@@ -13,7 +13,7 @@
    :header-rows: 1
 
    * - Name
-     - description
+     - Description
      - Value
 
    * - NrCommitPorts
@@ -34,7 +34,7 @@
 
    * - AxiUserWidth
      - AXI User width
-     - CVA6ConfigXlen
+     - 32
 
    * - NrLoadBufEntries
      - TO_BE_COMPLETED
@@ -90,7 +90,7 @@
 
    * - RVF
      - Single precision FP RISC-V extension
-     - TO_BE_COMPLETED
+     - 0
 
    * - RVD
      - Double precision FP RISC-V extension
@@ -137,11 +137,11 @@
      - 0
 
    * - RVS
-     - Supervisor mode is enabled
+     - Supervisor mode
      - 0
 
    * - RVU
-     - User mode is enabled
+     - User mode
      - 0
 
    * - HaltAddress
@@ -153,7 +153,7 @@
      - 64'h808
 
    * - RASDepth
-     - Address stack depth
+     - Return address stack depth
      - 2
 
    * - BTBEntries
@@ -165,7 +165,7 @@
      - 32
 
    * - DmBaseAddress
-     - Base address of the debug module.
+     - Base address of the debug module
      - 64'h0
 
    * - TvalEn
@@ -173,7 +173,7 @@
      - 0
 
    * - NrPMPEntries
-     - Number of PMP entries.
+     - Number of PMP entries
      - 8
 
    * - PMPCfgRstVal
@@ -189,12 +189,12 @@
      - 16'd0
 
    * - NOCType
-     - NOC bus type, can be AXI or Open Piton
+     - NOC bus type
      - config_pkg::NOC_TYPE_AXI4_ATOP
 
    * - NrNonIdempotentRules
      - Number of PMA non idempotent rules
-     - TO_BE_COMPLETED
+     - 2
 
    * - NonIdempotentAddrBase
      - PMA NonIdempotent region base address
@@ -205,20 +205,20 @@
      - {64'b0 64'b0}
 
    * - NrExecuteRegionRules
-     - PMA Execute region rules
+     - Number of PMA regions with execute rules
      - 3
 
    * - ExecuteRegionAddrBase
      - PMA Execute region base address
-     - TO_BE_COMPLETED
+     - {64'h8000_0000 64'h1_0000 64'h0}
 
    * - ExecuteRegionLength
      - PMA Execute region address base
      - {64'h40000000 64'h10000 64'h1000}
 
    * - NrCachedRegionRules
-     - PMA cache region properties
-     - TO_BE_COMPLETED
+     - Number of PMA regions with cache rules
+     - 1
 
    * - CachedRegionAddrBase
      - PMA cache region base address
@@ -233,13 +233,13 @@
      - 7
 
    * - DebugEn
-     - Debug mode is enabled
+     - Debug mode
      - 0
 
    * - NonIdemPotenceEn
-     - Non idem potency is enabled
+     - Non idem potency
      - 0
 
    * - AxiBurstWriteEn
-     - AXI burst in write is enabled
+     - AXI burst in write
      - 0

--- a/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
+++ b/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
@@ -1,0 +1,245 @@
+..
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _cv32a65x_PARAMETERS:
+
+.. list-table:: cv32a65x parameter configuration
+   :header-rows: 1
+
+   * - Name
+     - description
+     - Value
+
+   * - NrCommitPorts
+     - Number of commit ports
+     - 1
+
+   * - AxiAddrWidth
+     - AXI address width
+     - 64
+
+   * - AxiDataWidth
+     - AXI data width
+     - 64
+
+   * - AxiIdWidth
+     - AXI ID width
+     - 4
+
+   * - AxiUserWidth
+     - AXI User width
+     - CVA6ConfigXlen
+
+   * - NrLoadBufEntries
+     - TO_BE_COMPLETED
+     - 1
+
+   * - FpuEn
+     - FPU is enabled
+     - 0
+
+   * - XF16
+     - TO_BE_COMPLETED
+     - 0
+
+   * - XF16ALT
+     - TO_BE_COMPLETED
+     - 0
+
+   * - XF8
+     - TO_BE_COMPLETED
+     - 0
+
+   * - RVA
+     - Atomic RISC-V extension
+     - 0
+
+   * - RVB
+     - Bit manipulation RISC-V extension
+     - 1
+
+   * - RVV
+     - Vector RISC-V extension
+     - 0
+
+   * - RVC
+     - Compress RISC-V extension
+     - 1
+
+   * - RVZCB
+     - Zcb RISC-V extension
+     - 1
+
+   * - XFVec
+     - TO_BE_COMPLETED
+     - 0
+
+   * - CvxifEn
+     - CV-X-IF coprocessor interface is supported
+     - 1
+
+   * - ZiCondExtEn
+     - Zicond RISC-V extension is enabled
+     - 0
+
+   * - RVF
+     - Single precision FP RISC-V extension
+     - TO_BE_COMPLETED
+
+   * - RVD
+     - Double precision FP RISC-V extension
+     - 0
+
+   * - FpPresent
+     - Floating point is present
+     - 0
+
+   * - NSX
+     - TO_BE_COMPLETED
+     - 0
+
+   * - FLen
+     - TO_BE_COMPLETED
+     - 0
+
+   * - RVFVec
+     - Vector floating point extension
+     - 0
+
+   * - XF16Vec
+     - 16 bits vector floating point extension
+     - 0
+
+   * - XF16ALTVec
+     - TO_BE_COMPLETED
+     - 0
+
+   * - XF8Vec
+     - 8 bits vector floating point extension
+     - 0
+
+   * - NrRgprPorts
+     - TO_BE_COMPLETED
+     - 0
+
+   * - NrWbPorts
+     - TO_BE_COMPLETED
+     - 0
+
+   * - EnableAccelerator
+     - Accelerate Port coprocessor interface
+     - 0
+
+   * - RVS
+     - Supervisor mode is enabled
+     - 0
+
+   * - RVU
+     - User mode is enabled
+     - 0
+
+   * - HaltAddress
+     - Address to jump when halt request
+     - 64'h800
+
+   * - ExceptionAddress
+     - Address to jump when exception 
+     - 64'h808
+
+   * - RASDepth
+     - Address stack depth
+     - 2
+
+   * - BTBEntries
+     - Branch target buffer entries
+     - 0
+
+   * - BHTEntries
+     - Branch history entries
+     - 32
+
+   * - DmBaseAddress
+     - Base address of the debug module.
+     - 64'h0
+
+   * - TvalEn
+     - Tval Support Enable
+     - 0
+
+   * - NrPMPEntries
+     - Number of PMP entries.
+     - 8
+
+   * - PMPCfgRstVal
+     - PMP CSR configuration reset values
+     - {16{64'h0}}
+
+   * - PMPAddrRstVal
+     - PMP CSR address reset values
+     - {16{64'h0}}
+
+   * - PMPEntryReadOnly
+     - PMP CSR read-only bits
+     - 16'd0
+
+   * - NOCType
+     - NOC bus type, can be AXI or Open Piton
+     - config_pkg::NOC_TYPE_AXI4_ATOP
+
+   * - NrNonIdempotentRules
+     - Number of PMA non idempotent rules
+     - TO_BE_COMPLETED
+
+   * - NonIdempotentAddrBase
+     - PMA NonIdempotent region base address
+     - {64'b0 64'b0}
+
+   * - NonIdempotentLength
+     - PMA NonIdempotent region length
+     - {64'b0 64'b0}
+
+   * - NrExecuteRegionRules
+     - PMA Execute region rules
+     - 3
+
+   * - ExecuteRegionAddrBase
+     - PMA Execute region base address
+     - TO_BE_COMPLETED
+
+   * - ExecuteRegionLength
+     - PMA Execute region address base
+     - {64'h40000000 64'h10000 64'h1000}
+
+   * - NrCachedRegionRules
+     - PMA cache region properties
+     - TO_BE_COMPLETED
+
+   * - CachedRegionAddrBase
+     - PMA cache region base address
+     - {64'h8000_0000}
+
+   * - CachedRegionLength
+     - PMA cache region rules
+     - {64'h40000000}
+
+   * - MaxOutstandingStores
+     - Maximum number of outstanding stores
+     - 7
+
+   * - DebugEn
+     - Debug mode is enabled
+     - 0
+
+   * - NonIdemPotenceEn
+     - Non idem potency is enabled
+     - 0
+
+   * - AxiBurstWriteEn
+     - AXI burst in write is enabled
+     - 0

--- a/docs/04_cv32a65x_design/source/port_bht.rst
+++ b/docs/04_cv32a65x_design/source/port_bht.rst
@@ -45,7 +45,7 @@
    * - ``vpc_i``
      - in
      - CACHE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Virtual PC
 
    * - ``bht_update_i``
@@ -57,5 +57,5 @@
    * - ``bht_prediction_o``
      - out
      - FRONTEND
-     - ariane_pkg::bht_prediction_t [ariane_pkg::INSTR_PER_FETCH-1:0]
+     - ariane_pkg::bht_prediction_t[ariane_pkg::INSTR_PER_FETCH-1:0]
      - Prediction from bht

--- a/docs/04_cv32a65x_design/source/port_bht.rst
+++ b/docs/04_cv32a65x_design/source/port_bht.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_bht:
+.. _CVA6_bht_ports:
 
 .. list-table:: bht module IO ports
    :header-rows: 1

--- a/docs/04_cv32a65x_design/source/port_btb.rst
+++ b/docs/04_cv32a65x_design/source/port_btb.rst
@@ -45,7 +45,7 @@
    * - ``vpc_i``
      - in
      - CACHE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Virtual PC
 
    * - ``btb_update_i``
@@ -57,5 +57,5 @@
    * - ``btb_prediction_o``
      - out
      - FRONTEND
-     - ariane_pkg::btb_prediction_t [ariane_pkg::INSTR_PER_FETCH-1:0]
+     - ariane_pkg::btb_prediction_t[ariane_pkg::INSTR_PER_FETCH-1:0]
      - BTB Prediction

--- a/docs/04_cv32a65x_design/source/port_btb.rst
+++ b/docs/04_cv32a65x_design/source/port_btb.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_btb:
+.. _CVA6_btb_ports:
 
 .. list-table:: btb module IO ports
    :header-rows: 1

--- a/docs/04_cv32a65x_design/source/port_commit_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_commit_stage.rst
@@ -1,0 +1,193 @@
+..
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_commit_stage_ports:
+
+.. list-table:: commit_stage module IO ports
+   :header-rows: 1
+
+   * - Signal
+     - IO
+     - Connection
+     - Type
+     - Description
+
+   * - ``clk_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Subsystem Clock
+
+   * - ``rst_ni``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Asynchronous reset active low
+
+   * - ``halt_i``
+     - in
+     - CONTROLLER
+     - logic
+     - Request to halt the core
+
+   * - ``flush_dcache_i``
+     - in
+     - CACHE
+     - logic
+     - request to flush dcache, also flush the pipeline
+
+   * - ``exception_o``
+     - out
+     - EX_STAGE
+     - exception_t
+     - TO_BE_COMPLETED
+
+   * - ``dirty_fp_state_o``
+     - out
+     - CSR_REGFILE
+     - logic
+     - Mark the F state as dirty
+
+   * - ``single_step_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``commit_ack_o``
+     - out
+     - ISSUE_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - Acknowledge that we are indeed committing
+
+   * - ``waddr_o``
+     - out
+     - ID_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0][4:0]
+     - Register file write address
+
+   * - ``wdata_o``
+     - out
+     - ID_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0]
+     - Register file write data
+
+   * - ``we_gpr_o``
+     - out
+     - ID_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - Register file write enable
+
+   * - ``we_fpr_o``
+     - out
+     - ID_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - Floating point register enable
+
+   * - ``amo_resp_i``
+     - in
+     - CACHE
+     - amo_resp_t
+     - Result of AMO operation
+
+   * - ``pc_o``
+     - out
+     - FRONTEND_CSR
+     - logic [riscv::VLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``csr_op_o``
+     - out
+     - CSR_REGFILE
+     - fu_op
+     - Decoded CSR operation
+
+   * - ``csr_wdata_o``
+     - out
+     - CSR_REGFILE
+     - riscv::xlen_t
+     - Data to write to CSR
+
+   * - ``csr_rdata_i``
+     - in
+     - CSR_REGFILE
+     - riscv::xlen_t
+     - Data to read from CSR
+
+   * - ``csr_exception_i``
+     - in
+     - CSR_REGFILE
+     -  exception_t
+     - Exception or interrupt occurred in CSR stage (the same as commit)
+
+   * - ``csr_write_fflags_o``
+     - out
+     - CSR_REGFILE
+     - logic
+     - Write the fflags CSR
+
+   * - ``commit_lsu_o``
+     - out
+     - EX_STAGE
+     - logic
+     - Commit the pending store
+
+   * - ``commit_lsu_ready_i``
+     - in
+     - EX_STAGE
+     - logic
+     - Commit buffer of LSU is ready
+
+   * - ``commit_tran_id_o``
+     - out
+     - ID_STAGE
+     - logic [TRANS_ID_BITS-1:0]
+     - Transaction id of first commit port
+
+   * - ``amo_valid_commit_o``
+     - out
+     - EX_STAGE
+     - logic
+     - Valid AMO in commit stage
+
+   * - ``no_st_pending_i``
+     - in
+     - EX_STAGE
+     - logic
+     - no store is pending
+
+   * - ``commit_csr_o``
+     - out
+     - EX_STAGE
+     - logic
+     - Commit the pending CSR instruction
+
+   * - ``fence_i_o``
+     - out
+     - CONTROLLER
+     - logic
+     - Flush I$ and pipeline
+
+   * - ``fence_o``
+     - out
+     - CONTROLLER
+     - logic
+     - Flush D$ and pipeline
+
+   * - ``flush_commit_o``
+     - out
+     - CONTROLLER
+     - logic
+     - Request a pipeline flush
+
+   * - ``sfence_vma_o``
+     - out
+     - CONTROLLER
+     - logic
+     - Flush TLBs and pipeline

--- a/docs/04_cv32a65x_design/source/port_commit_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_commit_stage.rst
@@ -60,34 +60,40 @@
      - logic
      - TO_BE_COMPLETED
 
+   * - ``commit_instr_i``
+     - in
+     - ISSUE_STAGE
+     - scoreboard_entry_t[CVA6Cfg.NrCommitPorts-1:0]
+     - The instruction we want to commit
+
    * - ``commit_ack_o``
      - out
      - ISSUE_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0]
      - Acknowledge that we are indeed committing
 
    * - ``waddr_o``
      - out
      - ID_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0][4:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0][4:0]
      - Register file write address
 
    * - ``wdata_o``
      - out
      - ID_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0]
      - Register file write data
 
    * - ``we_gpr_o``
      - out
      - ID_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0]
      - Register file write enable
 
    * - ``we_fpr_o``
      - out
      - ID_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0]
      - Floating point register enable
 
    * - ``amo_resp_i``
@@ -99,7 +105,7 @@
    * - ``pc_o``
      - out
      - FRONTEND_CSR
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - TO_BE_COMPLETED
 
    * - ``csr_op_o``
@@ -123,7 +129,7 @@
    * - ``csr_exception_i``
      - in
      - CSR_REGFILE
-     -  exception_t
+     - exception_t
      - Exception or interrupt occurred in CSR stage (the same as commit)
 
    * - ``csr_write_fflags_o``
@@ -147,7 +153,7 @@
    * - ``commit_tran_id_o``
      - out
      - ID_STAGE
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - Transaction id of first commit port
 
    * - ``amo_valid_commit_o``

--- a/docs/04_cv32a65x_design/source/port_controller.rst
+++ b/docs/04_cv32a65x_design/source/port_controller.rst
@@ -1,0 +1,169 @@
+..
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_controller_ports:
+
+.. list-table:: controller module IO ports
+   :header-rows: 1
+
+   * - Signal
+     - IO
+     - Connection
+     - Type
+     - Description
+
+   * - ``clk_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Subsystem Clock
+
+   * - ``rst_ni``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Asynchronous reset active low
+
+   * - ``set_pc_commit_o``
+     - out
+     - FRONTEND
+     - logic
+     - Set PC om PC Gen
+
+   * - ``flush_if_o``
+     - out
+     - FRONTEND
+     - logic
+     - Flush the IF stage
+
+   * - ``flush_unissued_instr_o``
+     - out
+     - FRONTEND
+     - logic
+     - Flush un-issued instructions of the scoreboard
+
+   * - ``flush_id_o``
+     - out
+     - ID_STAGE
+     - logic
+     - Flush ID stage
+
+   * - ``flush_ex_o``
+     - out
+     - EX_STAGE
+     - logic
+     - Flush EX stage
+
+   * - ``flush_bp_o``
+     - out
+     - FRONTEND
+     - logic
+     - Flush branch predictors
+
+   * - ``flush_icache_o``
+     - out
+     - CACHE
+     - logic
+     - Flush ICache
+
+   * - ``flush_dcache_o``
+     - out
+     - CACHE
+     - logic
+     - Flush DCache
+
+   * - ``flush_dcache_ack_i``
+     - in
+     - CACHE
+     - logic
+     - Acknowledge the whole DCache Flush
+
+   * - ``flush_tlb_o``
+     - out
+     - EX_STAGE
+     - logic
+     - Flush TLBs
+
+   * - ``halt_csr_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - Halt request from CSR (WFI instruction)
+
+   * - ``halt_acc_i``
+     - in
+     - ACC_DISPATCHER
+     - logic
+     - Halt request from accelerator dispatcher
+
+   * - ``halt_o``
+     - out
+     - COMMIT_STAGE
+     - logic
+     - Halt signal to commit stage
+
+   * - ``eret_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - Return from exception
+
+   * - ``ex_valid_i``
+     - in
+     - FRONTEND
+     - logic
+     - We got an exception, flush the pipeline
+
+   * - ``set_debug_pc_i``
+     - in
+     - FRONTEND
+     - logic
+     - set the debug pc from CSR
+
+   * - ``resolved_branch_i``
+     - in
+     - EX_STAGE
+     - bp_resolve_t
+     - We got a resolved branch, check if we need to flush the front-end
+
+   * - ``flush_csr_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - We got an instruction which altered the CSR, flush the pipeline
+
+   * - ``fence_i_i``
+     - in
+     - ACC_DISPATCH
+     - logic
+     - fence.i in
+
+   * - ``fence_i``
+     - in
+     - ACC_DISPATCH
+     - logic
+     - fence in
+
+   * - ``sfence_vma_i``
+     - in
+     - COMMIT_STAGE
+     - logic
+     - We got an instruction to flush the TLBs and pipeline
+
+   * - ``flush_commit_i``
+     - in
+     - COMMIT_STAGE
+     - logic
+     - Flush request from commit stage
+
+   * - ``flush_acc_i``
+     - in
+     - ACC_DISPATCHER
+     - logic
+     - Flush request from accelerator

--- a/docs/04_cv32a65x_design/source/port_csr_regfile.rst
+++ b/docs/04_cv32a65x_design/source/port_csr_regfile.rst
@@ -48,16 +48,28 @@
      - logic
      - halt requested
 
+   * - ``commit_instr_i``
+     - in
+     - ID_STAGE
+     - scoreboard_entry_t[CVA6Cfg.NrCommitPorts-1:0]
+     - Instruction to be committed
+
+   * - ``commit_ack_i``
+     - in
+     - COMMIT_STAGE
+     - logic[CVA6Cfg.NrCommitPorts-1:0]
+     - Commit acknowledged a instruction -> increase instret CSR
+
    * - ``boot_addr_i``
      - in
      - SUBSYSTEM
-     -  logic[riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Address from which to start booting, mtvec is set to the same address
 
    * - ``hart_id_i``
      - in
      - SUBSYSTEM
-     -  logic[riscv::XLEN-1:0]
+     - logic[riscv::XLEN-1:0]
      - Hart id in a multicore environment (reflected in a CSR)
 
    * - ``ex_i``
@@ -75,19 +87,19 @@
    * - ``csr_addr_i``
      - in
      - EX_STAGE
-     - logic [11:0]
+     - logic[11:0]
      - Address of the register to read/write
 
    * - ``csr_wdata_i``
      - in
      - COMMIT_STAGE
-     - logic [riscv::XLEN-1:0]
+     - logic[riscv::XLEN-1:0]
      - Write data in
 
    * - ``csr_rdata_o``
      - out
      - COMMIT_STAGE
-     - logic [riscv::XLEN-1:0]
+     - logic[riscv::XLEN-1:0]
      - Read data out
 
    * - ``dirty_fp_state_i``
@@ -99,7 +111,7 @@
    * - ``csr_write_fflags_i``
      - in
      - COMMIT_STAGE
-     -  logic
+     - logic
      - Write fflags register e.g.: we are retiring a floating point instruction
 
    * - ``dirty_v_state_i``
@@ -111,7 +123,7 @@
    * - ``pc_i``
      - in
      - COMMIT_STAGE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - PC of instruction accessing the CSR
 
    * - ``csr_exception_o``
@@ -123,7 +135,7 @@
    * - ``epc_o``
      - out
      - FRONTEND
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Output the exception PC to PC Gen, the correct CSR (mepc, sepc) is set accordingly
 
    * - ``eret_o``
@@ -135,7 +147,7 @@
    * - ``trap_vector_base_o``
      - out
      - FRONTEND
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Output base of exception vector, correct CSR is output (mtvec, stvec)
 
    * - ``priv_lvl_o``
@@ -143,6 +155,12 @@
      - EX_STAGE
      - riscv::priv_lvl_t
      - Current privilege level the CPU is in
+
+   * - ``acc_fflags_ex_i``
+     - in
+     - ACC_DISPATCHER
+     - logic[4:0]
+     - Imprecise FP exception from the accelerator (fcsr.fflags format)
 
    * - ``acc_fflags_ex_valid_i``
      - in
@@ -159,19 +177,19 @@
    * - ``fflags_o``
      - out
      - COMMIT_STAGE
-     - logic [4:0]
+     - logic[4:0]
      - Floating-Point Accured Exceptions
 
    * - ``frm_o``
      - out
      - EX_STAGE
-     - logic [2:0]
+     - logic[2:0]
      - Floating-Point Dynamic Rounding Mode
 
    * - ``fprec_o``
      - out
      - EX_STAGE
-     - logic [6:0]
+     - logic[6:0]
      - Floating-Point Precision Control
 
    * - ``vs_o``
@@ -198,6 +216,12 @@
      - logic
      - enable VA translation for load and stores
 
+   * - ``ld_st_priv_lvl_o``
+     - out
+     - EX_STAGE
+     - riscv::priv_lvl_t
+     - Privilege level at which load and stores should happen
+
    * - ``sum_o``
      - out
      - EX_STAGE
@@ -213,19 +237,19 @@
    * - ``satp_ppn_o``
      - out
      - EX_STAGE
-     - logic [riscv::PPNW-1:0]
+     - logic[riscv::PPNW-1:0]
      - TO_BE_COMPLETED
 
    * - ``asid_o``
      - out
      - EX_STAGE
-     - logic [AsidWidth-1:0]
+     - logic[AsidWidth-1:0]
      - TO_BE_COMPLETED
 
    * - ``irq_i``
      - in
      - SUBSYSTEM
-     - logic [1:0]
+     - logic[1:0]
      - external interrupt in
 
    * - ``ipi_i``
@@ -297,19 +321,19 @@
    * - ``perf_addr_o``
      - out
      - PERF_COUNTERS
-     - logic [11:0]
+     - logic[11:0]
      - read/write address to performance counter module
 
    * - ``perf_data_o``
      - out
      - PERF_COUNTERS
-     - logic [riscv::XLEN-1:0]
+     - logic[riscv::XLEN-1:0]
      - write data to performance counter module
 
    * - ``perf_data_i``
      - in
      - PERF_COUNTERS
-     - logic [riscv::XLEN-1:0]
+     - logic[riscv::XLEN-1:0]
      - read data from performance counter module
 
    * - ``perf_we_o``
@@ -321,17 +345,17 @@
    * - ``pmpcfg_o``
      - out
      - ACC_DISPATCHER
-     - riscv::pmpcfg_t [15:0]
+     - riscv::pmpcfg_t[15:0]
      - PMP configuration containing pmpcfg for max 16 PMPs
 
    * - ``pmpaddr_o``
      - out
      - ACC_DISPATCHER
-     - logic [15:0][riscv::PLEN-3:0]
+     - logic[15:0][riscv::PLEN-3:0]
      - PMP addresses
 
    * - ``mcountinhibit_o``
      - out
      - PERF_COUNTERS
-     - logic [31:0]
+     - logic[31:0]
      - TO_BE_COMPLETED

--- a/docs/04_cv32a65x_design/source/port_csr_regfile.rst
+++ b/docs/04_cv32a65x_design/source/port_csr_regfile.rst
@@ -1,0 +1,337 @@
+..
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_csr_regfile_ports:
+
+.. list-table:: csr_regfile module IO ports
+   :header-rows: 1
+
+   * - Signal
+     - IO
+     - Connection
+     - Type
+     - Description
+
+   * - ``clk_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Subsystem Clock
+
+   * - ``rst_ni``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Asynchronous reset active low
+
+   * - ``time_irq_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Timer threw a interrupt
+
+   * - ``flush_o``
+     - out
+     - CONTROLLER
+     - logic
+     - send a flush request out when a CSR with a side effect changes
+
+   * - ``halt_csr_o``
+     - out
+     - CONTROLLER
+     - logic
+     - halt requested
+
+   * - ``boot_addr_i``
+     - in
+     - SUBSYSTEM
+     -  logic[riscv::VLEN-1:0]
+     - Address from which to start booting, mtvec is set to the same address
+
+   * - ``hart_id_i``
+     - in
+     - SUBSYSTEM
+     -  logic[riscv::XLEN-1:0]
+     - Hart id in a multicore environment (reflected in a CSR)
+
+   * - ``ex_i``
+     - in
+     - COMMIT_STAGE
+     - exception_t
+     - We've got an exception from the commit stage, take it
+
+   * - ``csr_op_i``
+     - in
+     - COMMIT_STAGE
+     - fu_op
+     - Operation to perform on the CSR file
+
+   * - ``csr_addr_i``
+     - in
+     - EX_STAGE
+     - logic [11:0]
+     - Address of the register to read/write
+
+   * - ``csr_wdata_i``
+     - in
+     - COMMIT_STAGE
+     - logic [riscv::XLEN-1:0]
+     - Write data in
+
+   * - ``csr_rdata_o``
+     - out
+     - COMMIT_STAGE
+     - logic [riscv::XLEN-1:0]
+     - Read data out
+
+   * - ``dirty_fp_state_i``
+     - in
+     - COMMIT_STAGE
+     - logic
+     - Mark the FP sate as dirty
+
+   * - ``csr_write_fflags_i``
+     - in
+     - COMMIT_STAGE
+     -  logic
+     - Write fflags register e.g.: we are retiring a floating point instruction
+
+   * - ``dirty_v_state_i``
+     - in
+     - ACC_DISPATCHER
+     - logic
+     - Mark the V state as dirty
+
+   * - ``pc_i``
+     - in
+     - COMMIT_STAGE
+     - logic [riscv::VLEN-1:0]
+     - PC of instruction accessing the CSR
+
+   * - ``csr_exception_o``
+     - out
+     - COMMIT_STAGE
+     - exception_t
+     - attempts to access a CSR without appropriate privilege
+
+   * - ``epc_o``
+     - out
+     - FRONTEND
+     - logic [riscv::VLEN-1:0]
+     - Output the exception PC to PC Gen, the correct CSR (mepc, sepc) is set accordingly
+
+   * - ``eret_o``
+     - out
+     - FRONTEND
+     - logic
+     - Return from exception, set the PC of epc_o
+
+   * - ``trap_vector_base_o``
+     - out
+     - FRONTEND
+     - logic [riscv::VLEN-1:0]
+     - Output base of exception vector, correct CSR is output (mtvec, stvec)
+
+   * - ``priv_lvl_o``
+     - out
+     - EX_STAGE
+     - riscv::priv_lvl_t
+     - Current privilege level the CPU is in
+
+   * - ``acc_fflags_ex_valid_i``
+     - in
+     - ACC_DISPATCHER
+     - logic
+     - An FP exception from the accelerator occurred
+
+   * - ``fs_o``
+     - out
+     - ID_STAGE
+     - riscv::xs_t
+     - Floating point extension status
+
+   * - ``fflags_o``
+     - out
+     - COMMIT_STAGE
+     - logic [4:0]
+     - Floating-Point Accured Exceptions
+
+   * - ``frm_o``
+     - out
+     - EX_STAGE
+     - logic [2:0]
+     - Floating-Point Dynamic Rounding Mode
+
+   * - ``fprec_o``
+     - out
+     - EX_STAGE
+     - logic [6:0]
+     - Floating-Point Precision Control
+
+   * - ``vs_o``
+     - out
+     - ID_STAGE
+     - riscv::xs_t
+     - Vector extension status
+
+   * - ``irq_ctrl_o``
+     - out
+     - ID_STAGE
+     - irq_ctrl_t
+     - interrupt management to id stage
+
+   * - ``en_translation_o``
+     - out
+     - EX_STAGE
+     - logic
+     - enable VA translation
+
+   * - ``en_ld_st_translation_o``
+     - out
+     - EX_STAGE
+     - logic
+     - enable VA translation for load and stores
+
+   * - ``sum_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``mxr_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``satp_ppn_o``
+     - out
+     - EX_STAGE
+     - logic [riscv::PPNW-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``asid_o``
+     - out
+     - EX_STAGE
+     - logic [AsidWidth-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``irq_i``
+     - in
+     - SUBSYSTEM
+     - logic [1:0]
+     - external interrupt in
+
+   * - ``ipi_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - inter processor interrupt -> connected to machine mode sw
+
+   * - ``debug_req_i``
+     - in
+     - ID_STAGE
+     - logic
+     - debug request in
+
+   * - ``set_debug_pc_o``
+     - out
+     - FRONTEND
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``tvm_o``
+     - out
+     - ID_STAGE
+     - logic
+     - trap virtual memory
+
+   * - ``tw_o``
+     - out
+     - ID_STAGE
+     - logic
+     - timeout wait
+
+   * - ``tsr_o``
+     - out
+     - ID_STAGE
+     - logic
+     - trap sret
+
+   * - ``debug_mode_o``
+     - out
+     - EX_STAGE
+     - logic
+     - we are in debug mode -> that will change some decoding
+
+   * - ``single_step_o``
+     - out
+     - COMMIT_STAGE
+     - logic
+     - we are in single-step mode
+
+   * - ``icache_en_o``
+     - out
+     - CACHE
+     - logic
+     - L1 ICache Enable
+
+   * - ``dcache_en_o``
+     - out
+     - CACHE
+     - logic
+     - L1 DCache Enable
+
+   * - ``acc_cons_en_o``
+     - out
+     - ACC_DISPATCHER
+     - logic
+     - Accelerator memory consistent mode
+
+   * - ``perf_addr_o``
+     - out
+     - PERF_COUNTERS
+     - logic [11:0]
+     - read/write address to performance counter module
+
+   * - ``perf_data_o``
+     - out
+     - PERF_COUNTERS
+     - logic [riscv::XLEN-1:0]
+     - write data to performance counter module
+
+   * - ``perf_data_i``
+     - in
+     - PERF_COUNTERS
+     - logic [riscv::XLEN-1:0]
+     - read data from performance counter module
+
+   * - ``perf_we_o``
+     - out
+     - PERF_COUNTERS
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``pmpcfg_o``
+     - out
+     - ACC_DISPATCHER
+     - riscv::pmpcfg_t [15:0]
+     - PMP configuration containing pmpcfg for max 16 PMPs
+
+   * - ``pmpaddr_o``
+     - out
+     - ACC_DISPATCHER
+     - logic [15:0][riscv::PLEN-3:0]
+     - PMP addresses
+
+   * - ``mcountinhibit_o``
+     - out
+     - PERF_COUNTERS
+     - logic [31:0]
+     - TO_BE_COMPLETED

--- a/docs/04_cv32a65x_design/source/port_cva6.rst
+++ b/docs/04_cv32a65x_design/source/port_cva6.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_cva6:
+.. _CVA6_cva6_ports:
 
 .. list-table:: cva6 module IO ports
    :header-rows: 1

--- a/docs/04_cv32a65x_design/source/port_cva6.rst
+++ b/docs/04_cv32a65x_design/source/port_cva6.rst
@@ -33,19 +33,19 @@
    * - ``boot_addr_i``
      - in
      - SUBSYSTEM
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Reset boot address
 
    * - ``hart_id_i``
      - in
      - SUBSYSTEM
-     - logic [riscv::XLEN-1:0]
+     - logic[riscv::XLEN-1:0]
      - Hard ID reflected as CSR
 
    * - ``irq_i``
      - in
      - SUBSYSTEM
-     - logic [1:0]
+     - logic[1:0]
      - Level sensitive (async) interrupts
 
    * - ``ipi_i``

--- a/docs/04_cv32a65x_design/source/port_ex_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_ex_stage.rst
@@ -1,0 +1,517 @@
+..
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_ex_stage_ports:
+
+.. list-table:: ex_stage module IO ports
+   :header-rows: 1
+
+   * - Signal
+     - IO
+     - Connection
+     - Type
+     - Description
+
+   * - ``clk_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Subsystem Clock
+
+   * - ``rst_ni``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Asynchronous reset active low
+
+   * - ``flush_i``
+     - in
+     - CONTROLLER
+     - logic
+     - Fetch flush request
+
+   * - ``debug_mode_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``rs1_forwarding_i``
+     - in
+     - ID_STAGE
+     - logic [riscv::VLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``rs2_forwarding_i``
+     - in
+     - ID_STAGE
+     - logic [riscv::VLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``fu_data_i``
+     - in
+     - ID_STAGE
+     - fu_data_t
+     - TO_BE_COMPLETED
+
+   * - ``pc_i``
+     - in
+     - ID_STAGE
+     - logic [riscv::VLEN-1:0]
+     - PC of the current instruction
+
+   * - ``is_compressed_instr_i``
+     - in
+     - ID_STAGE
+     - logic
+     - Report whether isntruction is compressed
+
+   * - ``flu_result_o``
+     - out
+     - ID_STAGE
+     - riscv::xlen_t
+     - TO_BE_COMPLETED
+
+   * - ``flu_trans_id_o``
+     - out
+     - ID_STAGE
+     - logic [TRANS_ID_BITS-1:0]
+     - ID of the scoreboard entry at which a=to write back
+
+   * - ``flu_exception_o``
+     - out
+     - ID_STAGE
+     - exception_t
+     - TO_BE_COMPLETED
+
+   * - ``flu_ready_o``
+     - out
+     - ID_STAGE
+     - logic
+     - FLU is ready
+
+   * - ``flu_valid_o``
+     - out
+     - ID_STAGE
+     - logic
+     - FLU result is valid
+
+   * - ``alu_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - ALU result is valid
+
+   * - ``branch_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - Branch unit result is valid
+
+   * - ``branch_predict_i``
+     - in
+     - ID_STAGE
+     - branchpredict_sbe_t
+     - TO_BE_COMPLETED
+
+   * - ``resolved_branch_o``
+     - out
+     - none
+     - bp_resolve_t
+     - none
+
+   * - ``resolve_branch_o``
+     - out
+     - ID_STAGE
+     - logic
+     - ID signaling that we resolved the branch
+
+   * - ``csr_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``csr_addr_o``
+     - out
+     - CSR_REGISTERS
+     - logic [11:0]
+     - TO_BE_COMPLETED
+
+   * - ``csr_commit_i``
+     - in
+     - COMMIT_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``mult_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - MULT result is valid
+
+   * - ``lsu_ready_o``
+     - out
+     - ID_STAGE
+     - logic
+     - FU is ready
+
+   * - ``lsu_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - LSU result is valid
+
+   * - ``load_valid_o``
+     - out
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``load_result_o``
+     - out
+     - ID_STAGE
+     - riscv::xlen_t
+     - TO_BE_COMPLETED
+
+   * - ``load_trans_id_o``
+     - out
+     - ID_STAGE
+     - logic [TRANS_ID_BITS-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``load_exception_o``
+     - out
+     - ID_STAGE
+     - exception_t
+     - TO_BE_COMPLETED
+
+   * - ``store_valid_o``
+     - out
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``store_result_o``
+     - out
+     - ID_STAGE
+     - riscv::xlen_t
+     - TO_BE_COMPLETED
+
+   * - ``store_trans_id_o``
+     - out
+     - ID_STAGE
+     - logic [TRANS_ID_BITS-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``store_exception_o``
+     - out
+     - ID_STAGE
+     - exception_t
+     - TO_BE_COMPLETED
+
+   * - ``lsu_commit_i``
+     - in
+     - COMMIT_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``lsu_commit_ready_o``
+     - out
+     - COMMIT_STAGE
+     - logic
+     - Commit queue is ready to accept another commit request
+
+   * - ``commit_tran_id_i``
+     - in
+     - COMMIT_STAGE
+     - logic [TRANS_ID_BITS-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``stall_st_pending_i``
+     - in
+     - ACC_DISPATCHER
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``no_st_pending_o``
+     - out
+     - COMMIT_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``amo_valid_commit_i``
+     - in
+     - COMMIT_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``fpu_ready_o``
+     - out
+     - ID_STAGE
+     - logic
+     - FU is ready
+
+   * - ``fpu_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - Output is ready
+
+   * - ``fpu_fmt_i``
+     - in
+     - ID_STAGE
+     - logic [1:0]
+     - report FP format
+
+   * - ``fpu_rm_i``
+     - in
+     - ID_STAGE
+     - logic [2:0]
+     - FP rm
+
+   * - ``fpu_frm_i``
+     - in
+     - ID_STAGE
+     - logic [2:0]
+     - FP frm
+
+   * - ``fpu_prec_i``
+     - in
+     - CSR_REGFILE
+     - logic [6:0]
+     - FP precision control
+
+   * - ``fpu_trans_id_o``
+     - out
+     - ID_STAGE
+     - logic [TRANS_ID_BITS-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``fpu_result_o``
+     - out
+     - ID_STAGE
+     - riscv::xlen_t
+     - TO_BE_COMPLETED
+
+   * - ``fpu_valid_o``
+     - out
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``fpu_exception_o``
+     - out
+     - ID_STAGE
+     - exception_t
+     - TO_BE_COMPLETED
+
+   * - ``x_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``x_ready_o``
+     - out
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``x_off_instr_i``
+     - in
+     - ID_STAGE
+     - logic [31:0]
+     - TO_BE_COMPLETED
+
+   * - ``x_trans_id_o``
+     - out
+     - ID_STAGE
+     - logic [TRANS_ID_BITS-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``x_exception_o``
+     - out
+     - ID_STAGE
+     - exception_t
+     - TO_BE_COMPLETED
+
+   * - ``x_result_o``
+     - out
+     - ID_STAGE
+     - riscv::xlen_t
+     - TO_BE_COMPLETED
+
+   * - ``x_valid_o``
+     - out
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``x_we_o``
+     - out
+     - ID_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``cvxif_req_o``
+     - out
+     - SUBSYSTEM
+     - cvxif_pkg::cvxif_req_t
+     - TO_BE_COMPLETED
+
+   * - ``cvxif_resp_i``
+     - in
+     - SUBSYSTEM
+     - cvxif_pkg::cvxif_resp_t
+     - TO_BE_COMPLETED
+
+   * - ``acc_valid_i``
+     - in
+     - ACC_DISPATCHER
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``enable_translation_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``en_ld_st_translation_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``flush_tlb_i``
+     - in
+     - CONTROLLER
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``priv_lvl_i``
+     - in
+     - CSR_REGFILE
+     - riscv::priv_lvl_t
+     - TO_BE_COMPLETED
+
+   * - ``ld_st_priv_lvl_i``
+     - in
+     - CSR_REGFILE
+     - riscv::priv_lvl_t
+     - TO_BE_COMPLETED
+
+   * - ``sum_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``mxr_i``
+     - in
+     - CSR_REGFILE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``satp_ppn_i``
+     - in
+     - CSR_REGFILE
+     - logic [riscv::PPNW-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``asid_i``
+     - in
+     - CSR_REGFILE
+     - logic [ASID_WIDTH-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``icache_areq_i``
+     - in
+     - CACHE
+     -  icache_arsp_t
+     - icache translation response
+
+   * - ``icache_areq_o``
+     - out
+     - CACHE
+     - icache_areq_t
+     - icache translation request
+
+   * - ``dcache_req_ports_i``
+     - in
+     - CACHE
+     - dcache_req_o_t [2:0]
+     - TO_BE_COMPLETED
+
+   * - ``dcache_req_ports_o``
+     - out
+     - CACHE
+     - dcache_req_i_t [2:0]
+     - TO_BE_COMPLETED
+
+   * - ``dcache_wbuffer_empty_i``
+     - in
+     - CACHE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``dcache_wbuffer_not_ni_i``
+     - in
+     - CACHE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``amo_req_o``
+     - out
+     - CACHE
+     - amo_req_t
+     - AMO request
+
+   * - ``amo_resp_i``
+     - in
+     - CACHE
+     - amo_resp_t
+     - AMO response from cache
+
+   * - ``itlb_miss_o``
+     - out
+     - PERF_COUNTERS
+     - logic
+     - To count the instruction TLB misses
+
+   * - ``dtlb_miss_o``
+     - out
+     - PERF_COUNTERS
+     - logic
+     - To count the data TLB misses
+
+   * - ``pmpcfg_i``
+     - in
+     - CSR_REGFILE
+     - riscv::pmpcfg_t [15:0]
+     - Report the PMP configuration
+
+   * - ``pmpaddr_i``
+     - in
+     - CSR_REGFILE
+     - logic [15:0][riscv::PLEN-3:0]
+     - Report the PMP addresses
+
+   * - ``rvfi_lsu_ctrl_o``
+     - out
+     - SUBSYSTEM
+     - lsu_ctrl_t
+     - Information dedicated to RVFI
+
+   * - ``rvfi_mem_paddr_o``
+     - out
+     - SUBSYSTEM
+     - [riscv::PLEN-1:0]
+     - Information dedicated to RVFI

--- a/docs/04_cv32a65x_design/source/port_ex_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_ex_stage.rst
@@ -45,13 +45,13 @@
    * - ``rs1_forwarding_i``
      - in
      - ID_STAGE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - TO_BE_COMPLETED
 
    * - ``rs2_forwarding_i``
      - in
      - ID_STAGE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - TO_BE_COMPLETED
 
    * - ``fu_data_i``
@@ -63,7 +63,7 @@
    * - ``pc_i``
      - in
      - ID_STAGE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - PC of the current instruction
 
    * - ``is_compressed_instr_i``
@@ -81,7 +81,7 @@
    * - ``flu_trans_id_o``
      - out
      - ID_STAGE
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - ID of the scoreboard entry at which a=to write back
 
    * - ``flu_exception_o``
@@ -141,7 +141,7 @@
    * - ``csr_addr_o``
      - out
      - CSR_REGISTERS
-     - logic [11:0]
+     - logic[11:0]
      - TO_BE_COMPLETED
 
    * - ``csr_commit_i``
@@ -183,7 +183,7 @@
    * - ``load_trans_id_o``
      - out
      - ID_STAGE
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - TO_BE_COMPLETED
 
    * - ``load_exception_o``
@@ -207,7 +207,7 @@
    * - ``store_trans_id_o``
      - out
      - ID_STAGE
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - TO_BE_COMPLETED
 
    * - ``store_exception_o``
@@ -231,7 +231,7 @@
    * - ``commit_tran_id_i``
      - in
      - COMMIT_STAGE
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - TO_BE_COMPLETED
 
    * - ``stall_st_pending_i``
@@ -267,31 +267,31 @@
    * - ``fpu_fmt_i``
      - in
      - ID_STAGE
-     - logic [1:0]
+     - logic[1:0]
      - report FP format
 
    * - ``fpu_rm_i``
      - in
      - ID_STAGE
-     - logic [2:0]
+     - logic[2:0]
      - FP rm
 
    * - ``fpu_frm_i``
      - in
      - ID_STAGE
-     - logic [2:0]
+     - logic[2:0]
      - FP frm
 
    * - ``fpu_prec_i``
      - in
      - CSR_REGFILE
-     - logic [6:0]
+     - logic[6:0]
      - FP precision control
 
    * - ``fpu_trans_id_o``
      - out
      - ID_STAGE
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - TO_BE_COMPLETED
 
    * - ``fpu_result_o``
@@ -327,13 +327,13 @@
    * - ``x_off_instr_i``
      - in
      - ID_STAGE
-     - logic [31:0]
+     - logic[31:0]
      - TO_BE_COMPLETED
 
    * - ``x_trans_id_o``
      - out
      - ID_STAGE
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - TO_BE_COMPLETED
 
    * - ``x_exception_o``
@@ -423,19 +423,19 @@
    * - ``satp_ppn_i``
      - in
      - CSR_REGFILE
-     - logic [riscv::PPNW-1:0]
+     - logic[riscv::PPNW-1:0]
      - TO_BE_COMPLETED
 
    * - ``asid_i``
      - in
      - CSR_REGFILE
-     - logic [ASID_WIDTH-1:0]
+     - logic[ASID_WIDTH-1:0]
      - TO_BE_COMPLETED
 
    * - ``icache_areq_i``
      - in
      - CACHE
-     -  icache_arsp_t
+     - icache_arsp_t
      - icache translation response
 
    * - ``icache_areq_o``
@@ -447,13 +447,13 @@
    * - ``dcache_req_ports_i``
      - in
      - CACHE
-     - dcache_req_o_t [2:0]
+     - dcache_req_o_t[2:0]
      - TO_BE_COMPLETED
 
    * - ``dcache_req_ports_o``
      - out
      - CACHE
-     - dcache_req_i_t [2:0]
+     - dcache_req_i_t[2:0]
      - TO_BE_COMPLETED
 
    * - ``dcache_wbuffer_empty_i``
@@ -495,13 +495,13 @@
    * - ``pmpcfg_i``
      - in
      - CSR_REGFILE
-     - riscv::pmpcfg_t [15:0]
+     - riscv::pmpcfg_t[15:0]
      - Report the PMP configuration
 
    * - ``pmpaddr_i``
      - in
      - CSR_REGFILE
-     - logic [15:0][riscv::PLEN-3:0]
+     - logic[15:0][riscv::PLEN-3:0]
      - Report the PMP addresses
 
    * - ``rvfi_lsu_ctrl_o``

--- a/docs/04_cv32a65x_design/source/port_frontend.rst
+++ b/docs/04_cv32a65x_design/source/port_frontend.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_frontend:
+.. _CVA6_frontend_ports:
 
 .. list-table:: frontend module IO ports
    :header-rows: 1
@@ -122,18 +122,18 @@
 
    * - ``fetch_entry_o``
      - out
-     - DECODE
+     - ID_STAGE
      - fetch_entry_t
      - Handshake's data between fetch and decode
 
    * - ``fetch_entry_valid_o``
      - out
-     - DECODE
+     - ID_STAGE
      - logic
      - Handshake's valid between fetch and decode
 
    * - ``fetch_entry_ready_i``
      - in
-     - DECODE
+     - ID_STAGE
      - logic
      - Handshake's ready between fetch and decode

--- a/docs/04_cv32a65x_design/source/port_frontend.rst
+++ b/docs/04_cv32a65x_design/source/port_frontend.rst
@@ -57,7 +57,7 @@
    * - ``boot_addr_i``
      - in
      - SUBSYSTEM
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Next PC when reset
 
    * - ``resolved_branch_i``
@@ -75,13 +75,13 @@
    * - ``pc_commit_i``
      - in
      - COMMIT
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Next PC when flushing pipeline
 
    * - ``epc_i``
      - in
      - CSR
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Next PC when returning from exception
 
    * - ``eret_i``
@@ -93,7 +93,7 @@
    * - ``trap_vector_base_i``
      - in
      - CSR
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Next PC when jumping into exception
 
    * - ``ex_valid_i``

--- a/docs/04_cv32a65x_design/source/port_id_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_id_stage.rst
@@ -69,7 +69,7 @@
    * - ``orig_instr_o``
      - out
      - ISSUE
-     - logic [31:0]
+     - logic[31:0]
      - instruction value
 
    * - ``issue_entry_valid_o``
@@ -111,7 +111,7 @@
    * - ``frm_i``
      - in
      - CSR
-     - logic [2:0]
+     - logic[2:0]
      - Report floating point dynamic rounding mode
 
    * - ``vs_i``
@@ -123,7 +123,7 @@
    * - ``irq_i``
      - in
      - SUBSYSTEM
-     - logic [1:0]
+     - logic[1:0]
      - Level sensitive (async) interrupts
 
    * - ``irq_ctrl_i``

--- a/docs/04_cv32a65x_design/source/port_id_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_id_stage.rst
@@ -1,0 +1,157 @@
+..
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_id_stage_ports:
+
+.. list-table:: id_stage module IO ports
+   :header-rows: 1
+
+   * - Signal
+     - IO
+     - Connection
+     - Type
+     - Description
+
+   * - ``clk_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Subsystem Clock
+
+   * - ``rst_ni``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Asynchronous reset active low
+
+   * - ``flush_i``
+     - in
+     - CONTROLLER
+     - logic
+     - Fetch flush request
+
+   * - ``debug_req_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Debug (async) request
+
+   * - ``fetch_entry_i``
+     - in
+     - FRONTEND
+     - ariane_pkg::fetch_entry_t
+     - Handshake's data between fetch and decode
+
+   * - ``fetch_entry_valid_i``
+     - in
+     - FRONTEND
+     - logic
+     - Handshake's valid between fetch and decode
+
+   * - ``fetch_entry_ready_o``
+     - out
+     - FRONTEND
+     - logic
+     - Handshake's ready between fetch and decode
+
+   * - ``issue_entry_o``
+     - out
+     - ISSUE
+     - ariane_pkg::scoreboard_entry_t
+     - Handshake's data between decode and issue
+
+   * - ``orig_instr_o``
+     - out
+     - ISSUE
+     - logic [31:0]
+     - instruction value
+
+   * - ``issue_entry_valid_o``
+     - out
+     - ISSUE
+     - logic
+     - Handshake's valid between decode and issue
+
+   * - ``is_ctrl_flow_o``
+     - out
+     - ISSUE
+     - logic
+     - Report if instruction is a control flow instruction
+
+   * - ``issue_instr_ack_i``
+     - in
+     - ISSUE
+     - logic
+     - Handshake's acknowlege between decode and issue
+
+   * - ``rvfi_is_compressed_o``
+     - out
+     - none
+     - logic
+     - none
+
+   * - ``priv_lvl_i``
+     - in
+     - CSR
+     - riscv::priv_lvl_t
+     - Report current privilege level
+
+   * - ``fs_i``
+     - in
+     - CSR
+     - riscv::xs_t
+     - Report floating point extension status
+
+   * - ``frm_i``
+     - in
+     - CSR
+     - logic [2:0]
+     - Report floating point dynamic rounding mode
+
+   * - ``vs_i``
+     - in
+     - CSR
+     - riscv::xs_t
+     - Report vector extension status
+
+   * - ``irq_i``
+     - in
+     - SUBSYSTEM
+     - logic [1:0]
+     - Level sensitive (async) interrupts
+
+   * - ``irq_ctrl_i``
+     - in
+     - CSR
+     - ariane_pkg::irq_ctrl_t
+     - TBD
+
+   * - ``debug_mode_i``
+     - in
+     - CSR
+     - logic
+     - Report if current mode is debug
+
+   * - ``tvm_i``
+     - in
+     - CSR
+     - logic
+     - TBD
+
+   * - ``tw_i``
+     - in
+     - CSR
+     - logic
+     - TBD
+
+   * - ``tsr_i``
+     - in
+     - none
+     - logic
+     - none

--- a/docs/04_cv32a65x_design/source/port_instr_queue.rst
+++ b/docs/04_cv32a65x_design/source/port_instr_queue.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_instr_queue:
+.. _CVA6_instr_queue_ports:
 
 .. list-table:: instr_queue module IO ports
    :header-rows: 1
@@ -64,7 +64,7 @@
      - out
      - FRONTEND
      - logic [ariane_pkg::INSTR_PER_FETCH-1:0]
-     - Indicates instructions consummed, or popped by DECODE
+     - Indicates instructions consummed, or popped by ID_STAGE
 
    * - ``exception_i``
      - in
@@ -104,18 +104,18 @@
 
    * - ``fetch_entry_o``
      - out
-     - DECODE
+     - ID_STAGE
      - ariane_pkg::fetch_entry_t
-     - Handshake’s data with DECODE
+     - Handshake’s data with ID_STAGE
 
    * - ``fetch_entry_valid_o``
      - out
-     - DECODE
+     - ID_STAGE
      - logic
-     - Handshake’s valid with DECODE
+     - Handshake’s valid with ID_STAGE
 
    * - ``fetch_entry_ready_i``
      - in
-     - DECODE
+     - ID_STAGE
      - logic
-     - Handshake’s ready with DECODE
+     - Handshake’s ready with ID_STAGE

--- a/docs/04_cv32a65x_design/source/port_instr_queue.rst
+++ b/docs/04_cv32a65x_design/source/port_instr_queue.rst
@@ -39,19 +39,19 @@
    * - ``instr_i``
      - in
      - instr_realign
-     - logic [ariane_pkg::INSTR_PER_FETCH-1:0][31:0]
+     - logic[ariane_pkg::INSTR_PER_FETCH-1:0][31:0]
      - Instruction
 
    * - ``addr_i``
      - in
      - instr_realign
-     - logic [ariane_pkg::INSTR_PER_FETCH-1:0][riscv::VLEN-1:0]
+     - logic[ariane_pkg::INSTR_PER_FETCH-1:0][riscv::VLEN-1:0]
      - Instruction address
 
    * - ``valid_i``
      - in
      - instr_realign
-     - logic [ariane_pkg::INSTR_PER_FETCH-1:0]
+     - logic[ariane_pkg::INSTR_PER_FETCH-1:0]
      - Instruction is valid
 
    * - ``ready_o``
@@ -63,7 +63,7 @@
    * - ``consumed_o``
      - out
      - FRONTEND
-     - logic [ariane_pkg::INSTR_PER_FETCH-1:0]
+     - logic[ariane_pkg::INSTR_PER_FETCH-1:0]
      - Indicates instructions consummed, or popped by ID_STAGE
 
    * - ``exception_i``
@@ -75,19 +75,19 @@
    * - ``exception_addr_i``
      - in
      - CACHE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Exception address
 
    * - ``predict_address_i``
      - in
      - FRONTEND
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Branch predict
 
    * - ``cf_type_i``
      - in
      - FRONTEND
-     - ariane_pkg::cf_t [ariane_pkg::INSTR_PER_FETCH-1:0]
+     - ariane_pkg::cf_t[ariane_pkg::INSTR_PER_FETCH-1:0]
      - Instruction predict address
 
    * - ``replay_o``
@@ -99,7 +99,7 @@
    * - ``replay_addr_o``
      - out
      - FRONTEND
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Address at which to replay the fetch
 
    * - ``fetch_entry_o``

--- a/docs/04_cv32a65x_design/source/port_instr_realign.rst
+++ b/docs/04_cv32a65x_design/source/port_instr_realign.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_instr_realign:
+.. _CVA6_instr_realign_ports:
 
 .. list-table:: instr_realign module IO ports
    :header-rows: 1

--- a/docs/04_cv32a65x_design/source/port_instr_realign.rst
+++ b/docs/04_cv32a65x_design/source/port_instr_realign.rst
@@ -51,29 +51,29 @@
    * - ``address_i``
      - in
      - CACHE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - 32-bit block address
 
    * - ``data_i``
      - in
      - CACHE
-     - logic [FETCH_WIDTH-1:0]
+     - logic[FETCH_WIDTH-1:0]
      - 32-bit block
 
    * - ``valid_o``
      - out
      - FRONTEND
-     - logic [INSTR_PER_FETCH-1:0]
+     - logic[INSTR_PER_FETCH-1:0]
      - instruction is valid
 
    * - ``addr_o``
      - out
      - FRONTEND
-     - logic [INSTR_PER_FETCH-1:0][riscv::VLEN-1:0]
+     - logic[INSTR_PER_FETCH-1:0][riscv::VLEN-1:0]
      - Instruction address
 
    * - ``instr_o``
      - out
      - none
-     - logic [INSTR_PER_FETCH-1:0][31:0]
+     - logic[INSTR_PER_FETCH-1:0][31:0]
      - none

--- a/docs/04_cv32a65x_design/source/port_instr_scan.rst
+++ b/docs/04_cv32a65x_design/source/port_instr_scan.rst
@@ -21,7 +21,7 @@
    * - ``instr_i``
      - in
      - instr_realign
-     - logic [31:0]
+     - logic[31:0]
      - Instruction to be predecoded
 
    * - ``rvi_return_o``
@@ -57,7 +57,7 @@
    * - ``rvi_imm_o``
      - out
      - FRONTEND
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Instruction immediat
 
    * - ``rvc_branch_o``
@@ -99,5 +99,5 @@
    * - ``rvc_imm_o``
      - out
      - FRONTEND
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Instruction compressed immediat

--- a/docs/04_cv32a65x_design/source/port_instr_scan.rst
+++ b/docs/04_cv32a65x_design/source/port_instr_scan.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_instr_scan:
+.. _CVA6_instr_scan_ports:
 
 .. list-table:: instr_scan module IO ports
    :header-rows: 1

--- a/docs/04_cv32a65x_design/source/port_issue_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_issue_stage.rst
@@ -63,7 +63,7 @@
    * - ``orig_instr_i``
      - in
      - ID_STAGE
-     - logic [31:0]
+     - logic[31:0]
      - instruction value
 
    * - ``decoded_instr_valid_i``
@@ -105,7 +105,7 @@
    * - ``pc_o``
      - out
      - EX_STAGE
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - TO_BE_COMPLETED
 
    * - ``is_compressed_instr_o``
@@ -177,13 +177,13 @@
    * - ``fpu_fmt_o``
      - out
      - EX_STAGE
-     - logic [1:0]
+     - logic[1:0]
      - Report FP fmt field
 
    * - ``fpu_rm_o``
      - out
      - EX_STAGE
-     - logic [2:0]
+     - logic[2:0]
      - report FP rm field
 
    * - ``csr_valid_o``
@@ -207,7 +207,7 @@
    * - ``x_off_instr_o``
      - out
      - EX_STAGE
-     - logic [31:0]
+     - logic[31:0]
      - TO_BE_COMPLETED
 
    * - ``issue_instr_o``
@@ -225,7 +225,7 @@
    * - ``trans_id_i``
      - in
      - EX_STAGE
-     - logic [CVA6Cfg.NrWbPorts-1:0][TRANS_ID_BITS-1:0]
+     - logic[CVA6Cfg.NrWbPorts-1:0][TRANS_ID_BITS-1:0]
      - TO_BE_COMPLETED
 
    * - ``resolved_branch_i``
@@ -237,19 +237,19 @@
    * - ``wbdata_i``
      - in
      - EX_STAGE
-     - logic [CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0]
+     - logic[CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0]
      - TO_BE_COMPLETED
 
    * - ``ex_ex_i``
      - in
      - EX_STAGE
-     - exception_t [CVA6Cfg.NrWbPorts-1:0]
+     - exception_t[CVA6Cfg.NrWbPorts-1:0]
      - exception from execute stage or CVXIF offloaded instruction
 
    * - ``wt_valid_i``
      - in
      - EX_STAGE
-     - logic [CVA6Cfg.NrWbPorts-1:0]
+     - logic[CVA6Cfg.NrWbPorts-1:0]
      - TO_BE_COMPLETED
 
    * - ``x_we_i``
@@ -261,37 +261,37 @@
    * - ``waddr_i``
      - in
      - EX_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0][4:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0][4:0]
      - TO_BE_COMPLETED
 
    * - ``wdata_i``
      - in
      - EX_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0]
      - TO_BE_COMPLETED
 
    * - ``we_gpr_i``
      - in
      - EX_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0]
      - TO_BE_COMPLETED
 
    * - ``we_fpr_i``
      - in
      - EX_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0]
      - TO_BE_COMPLETED
 
-   * - ``COMMIT_STAGE``
+   * - ``commit_instr_o``
      - out
      - COMMIT_STAGE
-     - scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0]
+     - scoreboard_entry_t[CVA6Cfg.NrCommitPorts-1:0]
      - TO_BE_COMPLETED
 
    * - ``commit_ack_i``
      - in
      - COMMIT_STAGE
-     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0]
      - TO_BE_COMPLETED
 
    * - ``stall_issue_o``
@@ -303,11 +303,11 @@
    * - ``rvfi_issue_pointer_o``
      - out
      - SUBSYSTEM
-     - logic [TRANS_ID_BITS-1:0]
+     - logic[TRANS_ID_BITS-1:0]
      - Information dedicated to RVFI
 
    * - ``rvfi_commit_pointer_o``
      - out
      - SUBSYSTEM
-     - logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0]
+     - logic[CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0]
      - Information dedicated to RVFI

--- a/docs/04_cv32a65x_design/source/port_issue_stage.rst
+++ b/docs/04_cv32a65x_design/source/port_issue_stage.rst
@@ -1,0 +1,313 @@
+..
+   Copyright 2024 Thales DIS France SAS
+   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+.. _CVA6_issue_stage_ports:
+
+.. list-table:: issue_stage module IO ports
+   :header-rows: 1
+
+   * - Signal
+     - IO
+     - Connection
+     - Type
+     - Description
+
+   * - ``clk_i``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Subsystem Clock
+
+   * - ``rst_ni``
+     - in
+     - SUBSYSTEM
+     - logic
+     - Asynchronous reset active low
+
+   * - ``sb_full_o``
+     - out
+     - PERF_COUNTERS
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``flush_unissued_instr_i``
+     - in
+     - CONTROLLER
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``flush_i``
+     - in
+     - CONTROLLER
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``stall_i``
+     - in
+     - ACC_DISPATCHER
+     - logic
+     - zero when accelerate port is disable
+
+   * - ``decoded_instr_i``
+     - in
+     - ID_STAGE
+     - scoreboard_entry_t
+     - Handshake's data between decode and issue
+
+   * - ``orig_instr_i``
+     - in
+     - ID_STAGE
+     - logic [31:0]
+     - instruction value
+
+   * - ``decoded_instr_valid_i``
+     - in
+     - ID_STAGE
+     - logic
+     - Handshake's valid between decode and issue
+
+   * - ``is_ctrl_flow_i``
+     - in
+     - ID_STAGE
+     - logic
+     - Report if instruction is a control flow instruction
+
+   * - ``decoded_instr_ack_o``
+     - out
+     - ID_STAGE
+     - logic
+     - Handshake's acknowlege between decode and issue
+
+   * - ``rs1_forwarding_o``
+     - out
+     - EX_STAGE
+     - [riscv::VLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``rs2_forwarding_o``
+     - out
+     - EX_STAGE
+     - [riscv::VLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``fu_data_o``
+     - out
+     - EX_STAGE
+     - fu_data_t
+     - TO_BE_COMPLETED
+
+   * - ``pc_o``
+     - out
+     - EX_STAGE
+     - logic [riscv::VLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``is_compressed_instr_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``flu_ready_i``
+     - in
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``alu_valid_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``resolve_branch_i``
+     - in
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``lsu_ready_i``
+     - in
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``lsu_valid_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``branch_valid_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``branch_predict_o``
+     - out
+     - EX_STAGE
+     - branchpredict_sbe_t
+     - TO_BE_COMPLETED
+
+   * - ``mult_valid_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``fpu_ready_i``
+     - in
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``fpu_valid_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``fpu_fmt_o``
+     - out
+     - EX_STAGE
+     - logic [1:0]
+     - Report FP fmt field
+
+   * - ``fpu_rm_o``
+     - out
+     - EX_STAGE
+     - logic [2:0]
+     - report FP rm field
+
+   * - ``csr_valid_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``x_issue_valid_o``
+     - out
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``x_issue_ready_i``
+     - in
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``x_off_instr_o``
+     - out
+     - EX_STAGE
+     - logic [31:0]
+     - TO_BE_COMPLETED
+
+   * - ``issue_instr_o``
+     - out
+     - ACC_DISPATCHER
+     - scoreboard_entry_t
+     - TO_BE_COMPLETED
+
+   * - ``issue_instr_hs_o``
+     - out
+     - ACC_DISPATCHER
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``trans_id_i``
+     - in
+     - EX_STAGE
+     - logic [CVA6Cfg.NrWbPorts-1:0][TRANS_ID_BITS-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``resolved_branch_i``
+     - in
+     - EX_STAGE
+     - bp_resolve_t
+     - TO_BE_COMPLETED
+
+   * - ``wbdata_i``
+     - in
+     - EX_STAGE
+     - logic [CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``ex_ex_i``
+     - in
+     - EX_STAGE
+     - exception_t [CVA6Cfg.NrWbPorts-1:0]
+     - exception from execute stage or CVXIF offloaded instruction
+
+   * - ``wt_valid_i``
+     - in
+     - EX_STAGE
+     - logic [CVA6Cfg.NrWbPorts-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``x_we_i``
+     - in
+     - EX_STAGE
+     - logic
+     - TO_BE_COMPLETED
+
+   * - ``waddr_i``
+     - in
+     - EX_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0][4:0]
+     - TO_BE_COMPLETED
+
+   * - ``wdata_i``
+     - in
+     - EX_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``we_gpr_i``
+     - in
+     - EX_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``we_fpr_i``
+     - in
+     - EX_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``COMMIT_STAGE``
+     - out
+     - COMMIT_STAGE
+     - scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``commit_ack_i``
+     - in
+     - COMMIT_STAGE
+     - logic [CVA6Cfg.NrCommitPorts-1:0]
+     - TO_BE_COMPLETED
+
+   * - ``stall_issue_o``
+     - out
+     - PERF_COUNTERS
+     - logic
+     - Issue stall
+
+   * - ``rvfi_issue_pointer_o``
+     - out
+     - SUBSYSTEM
+     - logic [TRANS_ID_BITS-1:0]
+     - Information dedicated to RVFI
+
+   * - ``rvfi_commit_pointer_o``
+     - out
+     - SUBSYSTEM
+     - logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0]
+     - Information dedicated to RVFI

--- a/docs/04_cv32a65x_design/source/port_ras.rst
+++ b/docs/04_cv32a65x_design/source/port_ras.rst
@@ -51,7 +51,7 @@
    * - ``data_i``
      - in
      - FRONTEND
-     - logic [riscv::VLEN-1:0]
+     - logic[riscv::VLEN-1:0]
      - Data to be pushed
 
    * - ``data_o``

--- a/docs/04_cv32a65x_design/source/port_ras.rst
+++ b/docs/04_cv32a65x_design/source/port_ras.rst
@@ -7,7 +7,7 @@
 
    Original Author: Jean-Roch COULON - Thales
 
-.. _CVA6_ras:
+.. _CVA6_ras_ports:
 
 .. list-table:: ras module IO ports
    :header-rows: 1

--- a/docs/04_cv32a65x_design/source/subsystem.rst
+++ b/docs/04_cv32a65x_design/source/subsystem.rst
@@ -29,105 +29,12 @@ Connection with other sub-systems
 [TO BE COMPLETED]
 
 
-Parameter list
---------------
-
-[TO BE COMPLETED]
-
-
 Parameter configuration
 -----------------------
 
-.. list-table:: Risc-V Configuration
-   :header-rows: 1
 
-   * - Standard Extension
-     - Specification
-     - Configurability
+.. include:: parameters_cv32a65x.rst
 
-   * - **I**: RV32i Base Integer Instruction Set
-     - [RVunpriv]
-     - ON
-
-   * - **C**: Standard Extension for Compressed Instructions
-     - [RVunpriv]
-     - ON
-
-   * - **M**: Standard Extension for Integer Multiplication and Division
-     - [RVunpriv]
-     - ON
-
-   * - **A**: Standard Extension for Atomic transaction
-     - [RVunpriv]
-     - OFF
-
-   * - **F and D**: Single and Double Precision Floating-Point
-     - [RVunpriv]
-     - OFF
-
-   * - **Zicount**: Performance Counters
-     - [RVunpriv]
-     - OFF
-
-   * - **Zicsr**: Control and Status Register Instructions
-     - [RVpriv]
-     - ON
-
-   * - **Zifencei**: Instruction-Fetch Fence
-     - [RVunpriv]
-     - ON
-
-   * - **Privilege**: Standard privilege modes M, S and U
-     - [RVpriv]
-     - ON
-
-   * - **SV39, SV32, SV0**: MMU capability
-     - [RVpriv]
-     - OFF
-
-   * - **PMP**: Memory Protection Unit
-     - [RVpriv]
-     - OFF
-
-   * - **CSR**: Control and Status Registers
-     - [RVpriv]
-     - ON
-
-   * - **AXI**: AXI interface
-     - [CV-X-IF]
-     - ON
-
-   * - **TRI**: Translation Response Interface (TRI)
-     - [OpenPiton]
-     - OFF
-
-
-.. list-table:: Micro-Architecture Configuration
-   :header-rows: 1
-
-   * - Micro-architecture
-     - Specification
-     - Configurability
-
-   * - **I$**: Instruction cache
-     - current spec
-     - ON
-
-   * - **D$**: Data cache
-     - current spec
-     - OFF
-
-   * - **Rename**: register Renaming
-     - current spec
-     - OFF
-
-   * - **Double Commit**: out of order pipeline execute stage
-     - current spec
-     - ON
-
-   * - **BP**: Branch Prediction
-     - current spec
-     - ON with no info storage
 
 
 IO ports

--- a/docs/scripts/table_parameter_builder.py
+++ b/docs/scripts/table_parameter_builder.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
     parameters = {}
     FILE_IN = "../core/include/config_pkg.sv"
 
+    print("Input file " + FILE_IN)
     with open(FILE_IN, "r", encoding="utf-8") as fin:
         PRINT_ENABLE = 0
         DESCRIPT = "TO_BE_COMPLETED"
@@ -46,7 +47,6 @@ if __name__ == "__main__":
                     d.group(1), DESCRIPT, "TO_BE_COMPLETED"
                 )
                 DESCRIPT = "TO_BE_COMPLETED"
-    fin.close()
 
     FILE_IN = "../core/include/cv32a65x_config_pkg.sv"
     a = re.match(r".*\/(.*)_config_pkg.sv", FILE_IN)
@@ -60,7 +60,6 @@ if __name__ == "__main__":
             e = re.match(r"^ +([\S]*): (.*)(?:,|)\n", line)
             if e:
                 parameters[e.group(1)].value = e.group(2)
-    fin.close()
 
     with open(FILE_IN, "r", encoding="utf-8") as fin:
         for line in fin:
@@ -70,7 +69,6 @@ if __name__ == "__main__":
                     if c.group(1) in parameters[name].value:
                         parameters[name].value = c.group(2)
                         break
-    fin.close()
 
     for name in parameters:
         variable = parameters[name].value
@@ -80,7 +78,6 @@ if __name__ == "__main__":
         variable = variable.replace(")", "")
         variable = variable.replace(",", "")
         parameters[name].value = variable
-        print(name, parameters[name].value, parameters[name].description)
 
     with open(fileout, "w") as fout:
         fout.write("..\n")
@@ -101,7 +98,7 @@ if __name__ == "__main__":
         fout.write("   :header-rows: 1\n")
         fout.write("\n")
         fout.write("   * - Name\n")
-        fout.write("     - description\n")
+        fout.write("     - Description\n")
         fout.write("     - Value\n")
         for name in parameters:
             fout.write("\n")

--- a/docs/scripts/table_parameter_builder.py
+++ b/docs/scripts/table_parameter_builder.py
@@ -33,14 +33,18 @@ if __name__ == "__main__":
         print_enable = 0
         description = "TO_BE_COMPLETED"
         for line in fin:
-            if "typedef struct packed" in line: print_enable = 1
-            if "cva6_cfg_t" in line: print_enable = 0
+            if "typedef struct packed" in line:
+                print_enable = 1
+            if "cva6_cfg_t" in line:
+                print_enable = 0
             d = re.match("^ *(.*) ([\S]*);\n", line)
             h = re.match("^ *\/\/ (.*)\n", line)
             if h and print_enable:
                 description = h.group(1)
             if d and print_enable:
-                parameters[d.group(2)] = Parameter(d.group(1), description, "TO_BE_COMPLETED")
+                parameters[d.group(2)] = Parameter(
+                    d.group(1), description, "TO_BE_COMPLETED"
+                )
                 description = "TO_BE_COMPLETED"
     fin.close()
 

--- a/docs/scripts/table_parameter_builder.py
+++ b/docs/scripts/table_parameter_builder.py
@@ -27,44 +27,44 @@ class Parameter:
 if __name__ == "__main__":
 
     parameters = {}
-    filein = "../core/include/config_pkg.sv"
+    FILE_IN = "../core/include/config_pkg.sv"
 
-    with open(filein, "r", encoding="utf-8") as fin:
-        print_enable = 0
-        description = "TO_BE_COMPLETED"
+    with open(FILE_IN, "r", encoding="utf-8") as fin:
+        PRINT_ENABLE = 0
+        DESCRIPT = "TO_BE_COMPLETED"
         for line in fin:
             if "typedef struct packed" in line:
-                print_enable = 1
+                PRINT_ENABLE = 1
             if "cva6_cfg_t" in line:
-                print_enable = 0
-            d = re.match("^ *(.*) ([\S]*);\n", line)
-            h = re.match("^ *\/\/ (.*)\n", line)
-            if h and print_enable:
-                description = h.group(1)
-            if d and print_enable:
+                PRINT_ENABLE = 0
+            d = re.match(r"^ *(.*) ([\S]*);\n", line)
+            h = re.match(r"^ *\/\/ (.*)\n", line)
+            if h and PRINT_ENABLE:
+                DESCRIPT = h.group(1)
+            if d and PRINT_ENABLE:
                 parameters[d.group(2)] = Parameter(
-                    d.group(1), description, "TO_BE_COMPLETED"
+                    d.group(1), DESCRIPT, "TO_BE_COMPLETED"
                 )
-                description = "TO_BE_COMPLETED"
+                DESCRIPT = "TO_BE_COMPLETED"
     fin.close()
 
-    filein = "../core/include/cv32a65x_config_pkg.sv"
-    a = re.match(r".*\/(.*)_config_pkg.sv", filein)
+    FILE_IN = "../core/include/cv32a65x_config_pkg.sv"
+    a = re.match(r".*\/(.*)_config_pkg.sv", FILE_IN)
     module = a.group(1)
     fileout = "./04_cv32a65x_design/source/parameters_" + module + ".rst"
-    print("Input file " + filein)
+    print("Input file " + FILE_IN)
     print("Output file " + fileout)
 
-    with open(filein, "r", encoding="utf-8") as fin:
+    with open(FILE_IN, "r", encoding="utf-8") as fin:
         for line in fin:
-            e = re.match("^ +([\S]*): (.*)(?:,|)\n", line)
+            e = re.match(r"^ +([\S]*): (.*)(?:,|)\n", line)
             if e:
                 parameters[e.group(1)].value = e.group(2)
     fin.close()
 
-    with open(filein, "r", encoding="utf-8") as fin:
+    with open(FILE_IN, "r", encoding="utf-8") as fin:
         for line in fin:
-            c = re.match("^ +localparam ([\S]*) = (.*);\n", line)
+            c = re.match(r"^ +localparam ([\S]*) = (.*);\n", line)
             if c:
                 for name in parameters:
                     if c.group(1) in parameters[name].value:

--- a/docs/scripts/table_parameter_builder.py
+++ b/docs/scripts/table_parameter_builder.py
@@ -1,0 +1,106 @@
+# Copyright 2024 Thales DIS France SAS
+#
+# Licensed under the Solderpad Hardware License, Version 2.1 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Jean-Roch COULON - Thales
+
+#!/usr/bin/python3
+
+import re
+
+
+class Parameter:
+    def __init__(
+        self,
+        datatype,
+        description,
+        value,
+    ):
+        self.datatype = datatype
+        self.description = description
+        self.value = value
+
+
+if __name__ == "__main__":
+
+    parameters = {}
+    filein = "../core/include/config_pkg.sv"
+
+    with open(filein, "r", encoding="utf-8") as fin:
+        print_enable = 0
+        description = "TO_BE_COMPLETED"
+        for line in fin:
+            if "typedef struct packed" in line: print_enable = 1
+            if "cva6_cfg_t" in line: print_enable = 0
+            d = re.match("^ *(.*) ([\S]*);\n", line)
+            h = re.match("^ *\/\/ (.*)\n", line)
+            if h and print_enable:
+                description = h.group(1)
+            if d and print_enable:
+                parameters[d.group(2)] = Parameter(d.group(1), description, "TO_BE_COMPLETED")
+                description = "TO_BE_COMPLETED"
+    fin.close()
+
+    filein = "../core/include/cv32a65x_config_pkg.sv"
+    a = re.match(r".*\/(.*)_config_pkg.sv", filein)
+    module = a.group(1)
+    fileout = "./04_cv32a65x_design/source/parameters_" + module + ".rst"
+    print("Input file " + filein)
+    print("Output file " + fileout)
+
+    with open(filein, "r", encoding="utf-8") as fin:
+        for line in fin:
+            e = re.match("^ +([\S]*): (.*)(?:,|)\n", line)
+            if e:
+                parameters[e.group(1)].value = e.group(2)
+    fin.close()
+
+    with open(filein, "r", encoding="utf-8") as fin:
+        for line in fin:
+            c = re.match("^ +localparam ([\S]*) = (.*);\n", line)
+            if c:
+                for name in parameters:
+                    if c.group(1) in parameters[name].value:
+                        parameters[name].value = c.group(2)
+                        break
+    fin.close()
+
+    for name in parameters:
+        variable = parameters[name].value
+        variable = variable.replace("1024'(", "")
+        variable = variable.replace("bit'(", "")
+        variable = variable.replace("unsigned'(", "")
+        variable = variable.replace(")", "")
+        variable = variable.replace(",", "")
+        parameters[name].value = variable
+        print(name, parameters[name].value, parameters[name].description)
+
+    with open(fileout, "w") as fout:
+        fout.write("..\n")
+        fout.write("   Copyright 2024 Thales DIS France SAS\n")
+        fout.write(
+            '   Licensed under the Solderpad Hardware License, Version 2.1 (the "License");\n'
+        )
+        fout.write(
+            "   you may not use this file except in compliance with the License.\n"
+        )
+        fout.write("   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1\n")
+        fout.write(
+            "   You may obtain a copy of the License at https://solderpad.org/licenses/\n\n"
+        )
+        fout.write("   Original Author: Jean-Roch COULON - Thales\n\n")
+        fout.write(f".. _{module}_PARAMETERS:\n\n")
+        fout.write(f".. list-table:: {module} parameter configuration\n")
+        fout.write("   :header-rows: 1\n")
+        fout.write("\n")
+        fout.write("   * - Name\n")
+        fout.write("     - description\n")
+        fout.write("     - Value\n")
+        for name in parameters:
+            fout.write("\n")
+            fout.write(f"   * - {name}\n")
+            fout.write(f"     - {parameters[name].description}\n")
+            fout.write(f"     - {parameters[name].value}\n")

--- a/docs/scripts/table_port_builder.py
+++ b/docs/scripts/table_port_builder.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
     file.append("../core/id_stage.sv")
     file.append("../core/issue_stage.sv")
     file.append("../core/ex_stage.sv")
+    file.append("../core/commit_stage.sv")
 
     for filein in file:
         a = re.match(r".*\/(.*).sv", filein)

--- a/docs/scripts/table_port_builder.py
+++ b/docs/scripts/table_port_builder.py
@@ -42,6 +42,7 @@ if __name__ == "__main__":
     file.append("../core/issue_stage.sv")
     file.append("../core/ex_stage.sv")
     file.append("../core/commit_stage.sv")
+    file.append("../core/controller.sv")
 
     for filein in file:
         a = re.match(r".*\/(.*).sv", filein)

--- a/docs/scripts/table_port_builder.py
+++ b/docs/scripts/table_port_builder.py
@@ -56,16 +56,18 @@ if __name__ == "__main__":
             description = "none"
             connection = "none"
             for line in fin:
-                e = re.match(r"^ +(?:(in|out))put ([\S]*(?: [\S]*|)) ([\S]*)\n", line)
+                e = re.match(r"^ +(?:(in|out))put +([\S]*(?: +.* *|)) ([\S]*)\n", line)
                 d = re.match(r"^ +\/\/ (.*) - ([\S]*)\n", line)
                 if d:
                     description = d.group(1)
                     connection = d.group(2)
                 if e:
                     name = e.group(3)
-                    name = name.split(",")
+                    name = name.replace(",", "")
+                    data_type = e.group(2)
+                    data_type = data_type.replace(" ", "")
                     ports.append(
-                        PortIO(name[0], e.group(1), e.group(2), description, connection)
+                        PortIO(name, e.group(1), data_type, description, connection)
                     )
                     description = "none"
                     connection = "none"

--- a/docs/scripts/table_port_builder.py
+++ b/docs/scripts/table_port_builder.py
@@ -38,6 +38,9 @@ if __name__ == "__main__":
     file.append("../core/frontend/instr_queue.sv")
     file.append("../core/frontend/instr_scan.sv")
     file.append("../core/instr_realign.sv")
+    file.append("../core/id_stage.sv")
+    file.append("../core/issue_stage.sv")
+    file.append("../core/ex_stage.sv")
 
     for filein in file:
         a = re.match(r".*\/(.*).sv", filein)
@@ -78,7 +81,7 @@ if __name__ == "__main__":
                 "   You may obtain a copy of the License at https://solderpad.org/licenses/\n\n"
             )
             fout.write("   Original Author: Jean-Roch COULON - Thales\n\n")
-            fout.write(f".. _CVA6_{module}:\n\n")
+            fout.write(f".. _CVA6_{module}_ports:\n\n")
             fout.write(f".. list-table:: {module} module IO ports\n")
             fout.write("   :header-rows: 1\n")
             fout.write("\n")

--- a/docs/scripts/table_port_builder.py
+++ b/docs/scripts/table_port_builder.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
     file.append("../core/ex_stage.sv")
     file.append("../core/commit_stage.sv")
     file.append("../core/controller.sv")
+    file.append("../core/csr_regfile.sv")
 
     for filein in file:
         a = re.match(r".*\/(.*).sv", filein)


### PR DESCRIPTION
In this MR:
- Commit, csr and controller modules are post processed to generate port IO tables in Design Document
- Config package to generate the parameter table in Design Document

@jquevremont   This PR setup a flow to generate the "parameter configuration" table to be inserted in cv32a65x design documentation. It is generated from RTL.