### PR TITLE
miss_handler: Fix AMO AXI ID mapping

### DIFF
--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -179,7 +179,7 @@ module miss_handler
     amo_bypass_req.wdata        = '0;
     amo_bypass_req.be           = '0;
     amo_bypass_req.size         = 2'b11;
-    amo_bypass_req.id           = 4'b1011;
+    amo_bypass_req.id           = 4'b1000 | 4'(NR_PORTS);  // map AMO id to the first non-MSHR id
     // core
     flush_ack_o                 = 1'b0;
     miss_o                      = 1'b0;  // to performance counter


### PR DESCRIPTION
In #1361, the default number of MSHR ports was increasesed by one. This mapped AXI IDs for bypassed stores from previously `4'b1010` to `4'b1011`, colliding with the AXI IDs for AMOs. Apart from performance implications, this may conflict with A7.4.4 of the AMBA AXI protocol spec K ("ID use for Atomic transactions").

Fix this by assigning AMOs the next free AXI ID.