### PR TITLE
Enable reads on `CSR_HPM_COUNTERx`

### DIFF
--- a/core/perf_counters.sv
+++ b/core/perf_counters.sv
@@ -174,6 +174,25 @@ module perf_counters
             riscv::CSR_MHPM_EVENT_7,
             riscv::CSR_MHPM_EVENT_8   :
       data_o = mhpmevent_q[addr_i-riscv::CSR_MHPM_EVENT_3+1];
+      riscv::CSR_HPM_COUNTER_3,
+            riscv::CSR_HPM_COUNTER_4,
+            riscv::CSR_HPM_COUNTER_5,
+            riscv::CSR_HPM_COUNTER_6,
+            riscv::CSR_HPM_COUNTER_7,
+            riscv::CSR_HPM_COUNTER_8  :begin
+        if (riscv::XLEN == 32) data_o = generic_counter_q[addr_i-riscv::CSR_HPM_COUNTER_3+1][31:0];
+        else data_o = generic_counter_q[addr_i-riscv::CSR_HPM_COUNTER_3+1];
+      end
+      riscv::CSR_HPM_COUNTER_3H,
+            riscv::CSR_HPM_COUNTER_4H,
+            riscv::CSR_HPM_COUNTER_5H,
+            riscv::CSR_HPM_COUNTER_6H,
+            riscv::CSR_HPM_COUNTER_7H,
+            riscv::CSR_HPM_COUNTER_8H :begin
+        if (riscv::XLEN == 32)
+          data_o = generic_counter_q[addr_i-riscv::CSR_HPM_COUNTER_3H+1][63:32];
+        else read_access_exception = 1'b1;
+      end
       default: data_o = 'b0;
     endcase
 


### PR DESCRIPTION
The privilege check is already in place in the `csr_regfile.sv`, but a read to `CSR_HPM_COUNTERx` should not return 0s.