### PR TITLE
Fix waveform generation using vcs-uvm.  Add waveforms section to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Simulating the CVA6 is done by using `verif/sim/cva6.py`.
 
 The environment variable `DV_SIMULATORS` allows you to specify which simulator to use.
 
-4 simulation types are supported:
+Four simulation types are supported:
 - **veri-testharness**: verilator with corev_apu/testharness testbench
 - **vcs-testharness**: vcs with corev_apu/testharness testbench
 - **vcs-uvm**: vcs with UVM testbench
@@ -141,7 +141,7 @@ bash verif/regress/dv-riscv-arch-test.sh
 
 # Logs
 
-The logs from cva6.py are located in `./verif/sim/out-year-month-day`.
+The logs from cva6.py are located in `./verif/sim/out_YEAR-MONTH-DAY`.
 
 Assuming you ran the smoke-tests scripts in the previous step, here is the log directory hierarchy:
 
@@ -152,6 +152,36 @@ Assuming you ran the smoke-tests scripts in the previous step, here is the log d
 - **iss_regr.log**: The regression test log 
 
 The regression test log summarizes the comparison between the simulator trace and the Spike trace. Beware that a if a test fails before the comparison step, it will not appear in this log, check the output of cva6.py and the logs of the simulation instead.
+
+
+# Waveform generation
+
+Waveform generation is currently supported for Verilator (`veri-testharness`)
+and VCS with full UVM testbench (`vcs-uvm`) simulation types.  It is disabled
+by default to save simulation time and storage space.
+
+To enable waveform generation for a supported simulation mode, set either
+of the two shell variables that control tracing before running any of the
+test scripts under `verif/regress`:
+- `export TRACE_FAST=1` enables "fast" waveform generation (keep simulation
+   time low at the expense of space).  This will produce VCD files when using
+   Verilator, and VPD files when using Synopsys VCS with UVM testbench (`vcs-uvm`).
+- `export TRACE_COMPACT=1` enables "compact" waveform generation (keep waveform
+   files smaller at the expense of increased simulation time).  This will
+   produce FST files when using Verilator, and FSDB files when using Synopsys
+   VCS with UVM testbench (`vcs-uvm`).
+
+To generate VCD waveforms of the `smoke-tests` regression suite using Verilator, use:
+```sh
+export DV_SIMULATORS=veri-testharness,spike
+export TRACE_FAST=1
+bash verif/regress/smoke-tests.sh
+```
+
+After each simulation run involving Verilator or VCS, the generated waveforms
+will be copied  to the directory containing the log files (see above,) with
+the name of the current HW configuration added to the file name right before
+the file type suffix (e.g., `I-ADD-01.cv32a60x.vcd`).
 
 
 # Physical Implementation

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -134,6 +134,8 @@ vcs-testharness:
 	  +tohost_addr=$(shell $$RISCV/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
 	  +elf_file=$(elf) +permissive-off ++$(elf) $(issrun_opts) $(if $(spike-tandem),-sv_lib $(SPIKE_INSTALL_DIR)/lib/libriscv) \
 	  -sv_lib $(SPIKE_INSTALL_DIR)/lib/libfesvr
+	# TODO: Add support for waveform collection.
+	# Generate disassembled log.
 	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 
@@ -141,15 +143,18 @@ veri-testharness:
 	make -C $(path_var) verilate verilator="verilator --no-timing" target=$(target) defines=$(subst +define+,,$(isscomp_opts))
 	$(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) $(elf) $(issrun_opts) \
 	  +elf_file=$(elf) +tohost_addr=$(shell $$RISCV/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1)
-	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
-	# If present, move default trace files to per-test directory.
+	# If present, move default waveform files to log directory.
+	# Keep track of target in waveform file name.
 	[ ! -f verilator.fst ] || mv verilator.fst `dirname $(log)`/`basename $(log) .log`.$(target).fst
 	[ ! -f verilator.vcd ] || mv verilator.vcd `dirname $(log)`/`basename $(log) .log`.$(target).vcd
+	# Generate disassembled log.
+	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 
 questa-testharness:
 	mkdir -p $(path_var)/tmp
 	make -C $(path_var) sim target=$(target) defines=$(subst +define+,,$(isscomp_opts)) batch-mode=1 $(issrun_opts)
+	# TODO: Add support for waveform collection.
 	$(tool_path)/spike-dasm --isa=$(variant) < $(path_var)/trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) $(path_var)/trace_rvfi_hart_00.dasm
 
@@ -251,6 +256,13 @@ vcs_uvm_run:
 vcs-uvm:
 	make vcs_uvm_comp
 	make vcs_uvm_run
+	# If present, move default waveform files to log directory.
+	# Keep track of target in waveform file name.
+	[ ! -f $(VCS_WORK_DIR)/novas.vpd  ] || \
+	  mv $(VCS_WORK_DIR)/novas.vpd  `dirname $(log)`/`basename $(log) .log`.$(target).vpd
+	[ ! -f $(VCS_WORK_DIR)/novas.fsdb ] || \
+	  mv $(VCS_WORK_DIR)/novas.fsdb `dirname $(log)`/`basename $(log) .log`.$(target).fsdb
+	# Generate disassembled log.
 	$(tool_path)/spike-dasm --isa=$(variant) < ./vcs_results/default/vcs.d/trace_rvfi_hart_00.dasm > $(log)
 
 generate_cov_dash:


### PR DESCRIPTION
Update user-level instructions.  Re-introduce waveform generation in vcs-uvm mode.

* README.md: Add section on waveform generation.  Improve readability.
* verif/sim/Makefile (vcs-testharness): Add comment and TODO.
  (veri-testharness): Save waveforms prior to disassembling the hex log.
  (questa-testharness): Add TODO comment.
  (vcs-uvm): Save waveforms prior to disassembling the hex log.