### PR TITLE
hpdcache: bump new version of the submodule

### DIFF
--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -108,7 +108,12 @@ package hpdcache_params_pkg;
 
   //  HPDcache MSHR whether uses FFs or SRAM
   localparam bit PARAM_MSHR_USE_REGBANK = (PARAM_MSHR_SETS * PARAM_MSHR_WAYS) <= 16;
+
+  //  HPDcache feedthrough FIFOs from the refill handler to the core
   localparam bit PARAM_REFILL_CORE_RSP_FEEDTHROUGH = 1'b1;
+
+  //  HPDcache depth of the refill FIFO
+  localparam int PARAM_REFILL_FIFO_DEPTH = 32'd2;
   //  }}}
 
   //  Definition of constants and types for the Write Buffer (WBUF)


### PR DESCRIPTION
Changelog:
- Add support to OpenPiton in the HPDcache
- Add new parameter to choose the depth of the REFILL fifo in the HPDcache
- Improvements and bugfixes