### PR TITLE
Bugfix/riscv dv cyclic dependency

### DIFF
--- a/verif/env/corev-dv/cva6-files.f
+++ b/verif/env/corev-dv/cva6-files.f
@@ -10,11 +10,16 @@
 // ------------------------------------------------------------------------------ //
 
 // HEADERS
++incdir+${RISCV_DV_ROOT}/src
++incdir+${RISCV_DV_ROOT}/test
 +incdir+${CVA6_DV_ROOT}/
 +incdir+${CVA6_DV_ROOT}/custom
 +incdir+${CVA6_DV_ROOT}/user_extension
 
 // SOURCES
+${RISCV_DV_ROOT}/src/riscv_signature_pkg.sv
+${RISCV_DV_ROOT}/src/riscv_instr_pkg.sv
+${RISCV_DV_ROOT}/test/riscv_instr_test_pkg.sv
 ${CVA6_DV_ROOT}/cva6_signature_pkg.sv
 ${CVA6_DV_ROOT}/cva6_instr_test_pkg.sv
-
+${RISCV_DV_ROOT}/test/riscv_instr_gen_tb_top.sv

--- a/verif/env/corev-dv/simulator.yaml
+++ b/verif/env/corev-dv/simulator.yaml
@@ -23,7 +23,6 @@
       - "vcs -file <cwd>/dv/vcs.compile.option.f
               +incdir+<setting>
               +incdir+<user_extension>
-             -f <cwd>/dv/files.f
              -f <cwd>/../env/corev-dv/cva6-files.f
              -full64
              -l <out>/compile.log


### PR DESCRIPTION
The following PR provides a solution to resolve Github Issue #1815.

It allows to use only one file list when using _riscv-dv_: `cva6/verif/env/corev-dv/cva6-files.f`. It is done by merging `cva6/verif/sim/dv/files.f` content into _cva6-files.f_.
It also updates the `cva6/verif/env/corev-dv/simulator.yaml` to only use that file list when compiling.