### PR TITLE
Fix Verilator detection by tests

### DIFF
--- a/verif/regress/install-spike.sh
+++ b/verif/regress/install-spike.sh
@@ -18,13 +18,13 @@ ROOT_PROJECT=$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)
 # Use the in-tree vendorized Spike if SPIKE_SRC_DIR is not set
 # or when a fully local installation was requested.
 if [ -z "$SPIKE_SRC_DIR" -o "$SPIKE_INSTALL_DIR" = "__local__" ]; then
-  SPIKE_SRC_DIR=$ROOT_PROJECT/verif/core-v-verif/vendor/riscv/riscv-isa-sim
+  export SPIKE_SRC_DIR=$ROOT_PROJECT/verif/core-v-verif/vendor/riscv/riscv-isa-sim
 fi
 
 # Expect/perform Spike installation in directory $SPIKE_INSTALL_DIR.
 # which defaults to $ROOT_PROJECT/tools/spike.
 if [ -z "$SPIKE_INSTALL_DIR" -o "$SPIKE_INSTALL_DIR" = "__local__" ]; then
-  SPIKE_INSTALL_DIR="$ROOT_PROJECT/tools/spike"
+  export SPIKE_INSTALL_DIR="$ROOT_PROJECT/tools/spike"
 fi
 
 # Do not clean up the destination directory: leave that to the user (real or CI job).

--- a/verif/regress/install-verilator.sh
+++ b/verif/regress/install-verilator.sh
@@ -29,7 +29,7 @@ fi
 # Define the default src+build location of Verilator.
 # No need to force this location in Continuous Integration scripts.
 if [ -z "$VERILATOR_BUILD_DIR" ]; then
-  VERILATOR_BUILD_DIR="$ROOT_PROJECT"/tools/verilator-$VERILATOR_HASH/verilator
+  export VERILATOR_BUILD_DIR="$ROOT_PROJECT"/tools/verilator-$VERILATOR_HASH/verilator
 fi
 
 # Define the default installation location of Verilator: one level up
@@ -37,7 +37,7 @@ fi
 # Continuous Integration may need to override this particular variable
 # to use a preinstalled build of Verilator.
 if [ -z "$VERILATOR_INSTALL_DIR" ]; then
-  VERILATOR_INSTALL_DIR="$(dirname $VERILATOR_BUILD_DIR)"
+  export VERILATOR_INSTALL_DIR="$(dirname $VERILATOR_BUILD_DIR)"
 fi
 
 # Build and install Verilator only if not already installed at the expected

--- a/verif/regress/linux.sh
+++ b/verif/regress/linux.sh
@@ -20,9 +20,8 @@ if ! [ -n "$BBL_ROOT" ]; then
   return 1
 fi
 
-# install the required tools
-source verif/regress/install-cva6.sh
-source verif/regress/install-riscv-dv.sh
+# setup sim env
+source verif/sim/setup-env.sh
 
 if ! [ -n "$DV_SIMULATORS" ]; then
   DV_SIMULATORS=veri-testharness

--- a/verif/regress/smoke-tests.sh
+++ b/verif/regress/smoke-tests.sh
@@ -13,14 +13,20 @@ if ! [ -n "$RISCV" ]; then
   return
 fi
 
-source ./verif/sim/setup-env.sh
 
 # install the required tools
 source ./verif/regress/install-verilator.sh
 source ./verif/regress/install-spike.sh
+
+# install the required test suites
 source ./verif/regress/install-riscv-compliance.sh
 source ./verif/regress/install-riscv-tests.sh
 source ./verif/regress/install-riscv-arch-test.sh
+
+# setup sim env
+source ./verif/sim/setup-env.sh
+
+echo "$SPIKE_INSTALL_DIR$"
 
 if ! [ -n "$DV_SIMULATORS" ]; then
   DV_SIMULATORS=vcs-testharness,spike

--- a/verif/sim/setup-env.sh
+++ b/verif/sim/setup-env.sh
@@ -30,7 +30,7 @@ fi
 
 # Set verilator and spike related variables
 if [ -z "$VERILATOR_INSTALL_DIR" ]; then
-    export VERILATOR_INSTALL_DIR="$ROOT_PROJECT"/tools/$(ls $ROOT_PROJECT/tools | grep verilator)
+    export VERILATOR_INSTALL_DIR="$ROOT_PROJECT"/tools/$(ls $ROOT_PROJECT/tools | grep verilator | head -n 1)
 fi
 
 if [ -z "$SPIKE_SRC_DIR" -o "$SPIKE_INSTALL_DIR" = "__local__" ]; then


### PR DESCRIPTION
Related to : https://github.com/openhwgroup/cva6/issues/1795.

* The detection of the tools should now work as expected. 
* Also moved the `setup-env.sh` execution in the smoke-tests since it is intended to be ran when tools are installed. 
* Added a failsafe in `install-verilator.sh` in case several verilator directories are installed in the `tools` directory (the first one returned by `grep` is picked). 
* Use `setup-env.sh` instead of `install-cva6.sh` and `install-riscv-dv.sh` in `linux.sh` test since they no longer exist in the repo