### PR TITLE
Add cva6 specific riscv_instr_gen_tb_top 

### DIFF
--- a/verif/env/corev-dv/cva6-files.f
+++ b/verif/env/corev-dv/cva6-files.f
@@ -22,4 +22,4 @@ ${RISCV_DV_ROOT}/src/riscv_instr_pkg.sv
 ${RISCV_DV_ROOT}/test/riscv_instr_test_pkg.sv
 ${CVA6_DV_ROOT}/cva6_signature_pkg.sv
 ${CVA6_DV_ROOT}/cva6_instr_test_pkg.sv
-${RISCV_DV_ROOT}/test/riscv_instr_gen_tb_top.sv
+${CVA6_DV_ROOT}/cva6_instr_gen_tb_top.sv

--- a/verif/env/corev-dv/cva6_instr_gen_tb_top.sv
+++ b/verif/env/corev-dv/cva6_instr_gen_tb_top.sv
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-----------------------------------------------------------------------------
+// Copy/Modify version of riscv-dv/tests/riscv_instr_gen_tb_top.sv to add the
+// corev specific tests.
+//-----------------------------------------------------------------------------
+module cva6_instr_gen_tb_top;
+
+  import uvm_pkg::*;
+  import riscv_instr_test_pkg::*;
+  import cva6_instr_test_pkg::*;
+
+  initial begin
+    run_test();
+  end
+
+endmodule


### PR DESCRIPTION
This PR aims to resolve issue #1816 

The chosen solution is the same one than the other cores: adapting the riscv_instr_gen_tb_top to cva6.
That module could not be extended as suggested, since it is not a class.

This has been check with VCS 2021.09: the behavior is the same than previous on our side.