### PR TITLE
Improve environment setup.  Fix Verilator installation process.

### DIFF
--- a/verif/regress/install-verilator.sh
+++ b/verif/regress/install-verilator.sh
@@ -26,29 +26,37 @@ if [ -n "$VERILATOR_ROOT" ]; then
   unset VERILATOR_ROOT
 fi
 
-# Define the default src+build location of Verilator.
-# No need to force this location in Continuous Integration scripts.
-if [ -z "$VERILATOR_BUILD_DIR" ]; then
-  export VERILATOR_BUILD_DIR="$ROOT_PROJECT"/tools/verilator-$VERILATOR_HASH/verilator
-fi
+echo "[install-verilator.sh] Entry values:"
+echo "    VERILATOR_BUILD_DIR='$VERILATOR_BUILD_DIR'"
+echo "    VERILATOR_INSTALL_DIR='$VERILATOR_INSTALL_DIR'"
 
-# Define the default installation location of Verilator: one level up
-# from the source tree in the core-v-verif tree.
+# If not set, define the installation location of Verilator to the local path
+#
+#    <top>/tools/verilator-<hash>
+#
 # Continuous Integration may need to override this particular variable
 # to use a preinstalled build of Verilator.
 if [ -z "$VERILATOR_INSTALL_DIR" ]; then
-  export VERILATOR_INSTALL_DIR="$(dirname $VERILATOR_BUILD_DIR)"
+  export VERILATOR_INSTALL_DIR="$ROOT_PROJECT/tools/verilator-$VERILATOR_HASH"
+  echo "Setting VERILATOR_INSTALL_DIR to '$VERILATOR_INSTALL_DIR'..."
+fi
+
+# Define the default src+build location of Verilator in case it needs to be (re)built.
+# No need to force this location in Continuous Integration scripts.
+if [ -z "$VERILATOR_BUILD_DIR" ]; then
+  export VERILATOR_BUILD_DIR="$VERILATOR_INSTALL_DIR/build-$VERILATOR_HASH"
+  echo "Setting VERILATOR_BUILD_DIR to '$VERILATOR_BUILD_DIR'..."
 fi
 
 # Build and install Verilator only if not already installed at the expected
 # location $VERILATOR_INSTALL_DIR.
 if [ ! -f "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
-    echo "Building Verilator in $VERILATOR_BUILD_DIR..."
-    echo "Verilator will be installed in $VERILATOR_INSTALL_DIR"
+    echo "Building Verilator in '$VERILATOR_BUILD_DIR'..."
+    echo "Verilator will be installed in '$VERILATOR_INSTALL_DIR'"
     echo "VERILATOR_REPO=$VERILATOR_REPO"
     echo "VERILATOR_BRANCH=$VERILATOR_BRANCH"
     echo "VERILATOR_HASH=$VERILATOR_HASH"
-    echo "VERILATOR_PATCH=$VERILATOR_PATCH"
+    echo "VERILATOR_PATCH='$VERILATOR_PATCH'"
     echo "NUM_JOBS=$NUM_JOBS"
     mkdir -p $VERILATOR_BUILD_DIR
     cd $VERILATOR_BUILD_DIR
@@ -69,5 +77,9 @@ if [ ! -f "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
     #make test || echo "### 'make test' in $VERILATOR_ROOT: some tests failed."
     cd -
 else
-    echo "Verilator already installed in $VERILATOR_INSTALL_DIR."
+    echo "Verilator already installed in '$VERILATOR_INSTALL_DIR'."
 fi
+
+# Add Verilator bin directory to PATH if not already present.
+echo $PATH | grep -q "$VERILATOR_INSTALL_DIR/bin:" || \
+  export PATH="$VERILATOR_INSTALL_DIR/bin:$PATH"

--- a/verif/sim/setup-env.sh
+++ b/verif/sim/setup-env.sh
@@ -1,9 +1,9 @@
 # CVA6 project root
 export ROOT_PROJECT=$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)
 
-export RTL_PATH=$ROOT_PROJECT/
-export TB_PATH=$ROOT_PROJECT/verif/tb/core
-export TESTS_PATH=$ROOT_PROJECT/verif/tests
+export RTL_PATH="$ROOT_PROJECT/"
+export TB_PATH="$ROOT_PROJECT/verif/tb/core"
+export TESTS_PATH="$ROOT_PROJECT/verif/tests"
 
 if [ -z "$RISCV" ]; then
   echo "Error: RISCV variable undefined."
@@ -21,27 +21,27 @@ if [ -z "$CV_SW_PREFIX" ]; then
 fi
 # Default to auto-detected GCC name if not explicitly given.
 if [ -z "$RISCV_GCC" ]; then
-    export RISCV_GCC=$RISCV/bin/${CV_SW_PREFIX}gcc
+    export RISCV_GCC="$RISCV/bin/${CV_SW_PREFIX}gcc"
 fi
 # Default to auto-detected OBJCOPY name if not explicitly given.
 if [ -z "$RISCV_OBJCOPY" ]; then
-    export RISCV_OBJCOPY=$RISCV/bin/${CV_SW_PREFIX}objcopy
+    export RISCV_OBJCOPY="$RISCV/bin/${CV_SW_PREFIX}objcopy"
 fi
 
 # Set verilator and spike related variables
 if [ -z "$VERILATOR_INSTALL_DIR" ]; then
-    export VERILATOR_INSTALL_DIR="$ROOT_PROJECT"/tools/$(ls $ROOT_PROJECT/tools | grep verilator | head -n 1)
+    export VERILATOR_INSTALL_DIR="$ROOT_PROJECT"/tools/verilator
 fi
 
 if [ -z "$SPIKE_SRC_DIR" -o "$SPIKE_INSTALL_DIR" = "__local__" ]; then
-  export SPIKE_SRC_DIR=$ROOT_PROJECT/verif/core-v-verif/vendor/riscv/riscv-isa-sim
+  export SPIKE_SRC_DIR="$ROOT_PROJECT"/verif/core-v-verif/vendor/riscv/riscv-isa-sim
 fi
 
 if [ -z "$SPIKE_INSTALL_DIR" -o "$SPIKE_INSTALL_DIR" = "__local__" ]; then
     export SPIKE_INSTALL_DIR="$ROOT_PROJECT"/tools/spike
 fi
 
-export SPIKE_PATH=$SPIKE_INSTALL_DIR/bin
+export SPIKE_PATH="$SPIKE_INSTALL_DIR"/bin
 
 # Update the PATH to add all the tools
 export PATH="$VERILATOR_INSTALL_DIR/bin:$RISCV/bin:$PATH"


### PR DESCRIPTION
* verif/sim/setup-env.sh: Double-quote variable values.  Install Verilator
  in 'tools/verilator' by default.  Add SPIKE_PATH to PATH.
* verif/regress/install-verilator.sh: By default use per-version dirs to
  build and install Verilator.  Add and improve configuration messages.