### PR TITLE
Generate separate per-target logs when simulating.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,7 +163,7 @@ coremark:
     DASHBOARD_JOB_CATEGORY: "Performance"
   script:
     - bash verif/regress/coremark.sh --no-print
-    - python3 .gitlab-ci/scripts/report_benchmark.py --coremark verif/sim/out_*/veri-testharness_sim/core_main.log
+    - python3 .gitlab-ci/scripts/report_benchmark.py --coremark verif/sim/out_*/veri-testharness_sim/core_main.*.log
 
 hwconfig:
   extends:
@@ -264,7 +264,7 @@ dhrystone:
     DASHBOARD_JOB_CATEGORY: "Performance"
   script:
     - bash verif/regress/dhrystone.sh
-    - python3 .gitlab-ci/scripts/report_benchmark.py --dhrystone verif/sim/out_*/veri-testharness_sim/dhrystone_main.log
+    - python3 .gitlab-ci/scripts/report_benchmark.py --dhrystone verif/sim/out_*/veri-testharness_sim/dhrystone_main.*.log
 
 riscv_arch_test:
   extends:

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -145,8 +145,8 @@ veri-testharness:
 	  +elf_file=$(elf) +tohost_addr=$(shell $$RISCV/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1)
 	# If present, move default waveform files to log directory.
 	# Keep track of target in waveform file name.
-	[ ! -f verilator.fst ] || mv verilator.fst `dirname $(log)`/`basename $(log) .log`.$(target).fst
-	[ ! -f verilator.vcd ] || mv verilator.vcd `dirname $(log)`/`basename $(log) .log`.$(target).vcd
+	[ ! -f verilator.fst ] || mv verilator.fst `dirname $(log)`/`basename $(log) .log`.fst
+	[ ! -f verilator.vcd ] || mv verilator.vcd `dirname $(log)`/`basename $(log) .log`.vcd
 	# Generate disassembled log.
 	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
@@ -260,9 +260,9 @@ vcs-uvm:
 	# If present, move default waveform files to log directory.
 	# Keep track of target in waveform file name.
 	[ ! -f $(VCS_WORK_DIR)/novas.vpd  ] || \
-	  mv $(VCS_WORK_DIR)/novas.vpd  `dirname $(log)`/`basename $(log) .log`.$(target).vpd
+	  mv $(VCS_WORK_DIR)/novas.vpd  `dirname $(log)`/`basename $(log) .log`.vpd
 	[ ! -f $(VCS_WORK_DIR)/novas.fsdb ] || \
-	  mv $(VCS_WORK_DIR)/novas.fsdb `dirname $(log)`/`basename $(log) .log`.$(target).fsdb
+	  mv $(VCS_WORK_DIR)/novas.fsdb `dirname $(log)`/`basename $(log) .log`.fsdb
 	# Generate disassembled log.
 	$(tool_path)/spike-dasm --isa=$(variant) < ./vcs_results/default/vcs.d/trace_rvfi_hart_00.dasm > $(log)
 

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -677,7 +677,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
           logging.debug(cmd)
 
 
-def iss_cmp(test_list, iss, output_dir, stop_on_first_error, exp, debug_cmd):
+def iss_cmp(test_list, iss, target, output_dir, stop_on_first_error, exp, debug_cmd):
   """Compare ISS simulation reult
 
   Args:
@@ -1281,7 +1281,7 @@ def main():
 
         # Compare ISS simulation result
         if args.steps == "all" or re.match(".*iss_cmp.*", args.steps):
-          iss_cmp(matched_list, args.iss, output_dir, args.stop_on_first_error,
+          iss_cmp(matched_list, args.iss, args.target, output_dir, args.stop_on_first_error,
                   args.exp, args.debug)
 
     sys.exit(RET_SUCCESS)

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -457,9 +457,9 @@ def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, outp
   for iss in iss_list:
     run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
     if log_format == 1:
-      log = ("%s/%s_sim/%s_%d.log" % (output_dir, iss, asm, test_iteration))
+      log = ("%s/%s_sim/%s_%d.%s.log" % (output_dir, iss, asm, test_iteration, target))
     else:
-      log = ("%s/%s_sim/%s.log" % (output_dir, iss, asm))
+      log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, asm, target))
     log_list.append(log)
     base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
@@ -535,7 +535,7 @@ def run_elf(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
   # ISS simulation
   for iss in iss_list:
     run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
-    log = ("%s/%s_sim/%s.log" % (output_dir, iss, c))
+    log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, c, target))
     log_list.append(log)
     base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
@@ -594,9 +594,9 @@ def run_c(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
   for iss in iss_list:
     run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
     if log_format == 1:
-      log = ("%s/%s_sim/%s_%d.log" % (output_dir, iss, c, test_iteration))
+      log = ("%s/%s_sim/%s_%d.%s.log" % (output_dir, iss, c, test_iteration, target))
     else:
-      log = ("%s/%s_sim/%s.log" % (output_dir, iss, c))
+      log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, c, target))
     log_list.append(log)
     base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
@@ -664,7 +664,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
         for i in range(0, test['iterations']):
           prefix = ("%s/asm_tests/%s_%d" % (output_dir, test['test'], i))
           elf = prefix + ".o"
-          log = ("%s/%s.%d.log" % (log_dir, test['test'], i))
+          log = ("%s/%s.%d.%s.log" % (log_dir, test['test'], i, target))
           cmd = get_iss_cmd(base_cmd, elf, target, log)
           if 'iss_opts' in test:
             cmd += ' '
@@ -702,7 +702,7 @@ def iss_cmp(test_list, iss, output_dir, stop_on_first_error, exp, debug_cmd):
       log_list = []
       run_cmd(("echo 'Test binary: %s' >> %s" % (elf, report)))
       for iss in iss_list:
-        log_list.append("%s/%s_sim/%s.%d.log" % (output_dir, iss, test['test'], i))
+        log_list.append("%s/%s_sim/%s.%d.%s.log" % (output_dir, iss, test['test'], i, target))
       compare_iss_log(iss_list, log_list, report, stop_on_first_error, exp)
   save_regr_report(report)
 


### PR DESCRIPTION
* verif/sim/Makefile (veri-testharness): Don't add target name to waveform
  file name.<br>
  (vcs-uvm): Ditto.
* verif/sim/cva6.py (run_assembly): Add target name to log file name.<br>
  (run_elf): Ditto.<br>
  (run_c): Ditto.<br>
  (iss_sim): Ditto.<br>
  (iss_cmp): Ditto.