### PR TITLE
Mmu user manual

### DIFF
--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -169,11 +169,25 @@ CV64A6 supports the RISC-V **Sv39** virtual memory when the ``MMUEn`` parameter 
 Within CV64A6, the hypervisor extension is enabled and supports **Sv39x4** virtual memory when the ``CVA6ConfigHExtEn`` parameter is set to 1 (and ``Xlen`` is set to 64).
 
 
-By default, CV32A6 and CV64A6 are in RISC-V **Bare** mode. **Sv32** or **Sv39** are enabled by writing 1 to ``satp[0]`` register bit.
+By default, CV32A6 and CV64A6 are in RISC-V **Bare** mode. **Sv32** or **Sv39** are enabled by writing the required configuration to satp register mode bits.
 
-When the ``MMUEn`` parameter is set to 0, CV32A6 and CV64A6 are always in RISC-V **Bare** mode; ``satp[0]`` remains at 0 and writes to this register are ignored.
+In CV32A6 the mode bit of satp register is bit 31.  **Sv32** is enabled by writing 1 to ``satp[31]``.
 
-**PENDING: THE HYPERVISOR EXTENSION? HOW IS IT ENABLED VIA SW?**
+In CV64A6 the mode bits of satp register are bits [63:60]. **Sv39** is enabled by writing ``8`` to ``satp[63:60]``.
+
+When the ``MMUEn`` parameter is set to 0, CV32A6 and CV64A6 are always in RISC-V **Bare** mode; satp mode bit(s) remain at 0 and writes to this register are ignored.
+
+
+By default, the hypervisor extension is disabled. It can be enabled by setting bit 7 in the ``misa CSR``, which corresponds to the letter H.
+
+When ``CVA6ConfigHExtEn`` parameter is set to 0, the hypervisor extension is always disabled; bit 7 in the ``misa CSR`` remains at 0 and writes to this register are ignored.
+
+Even if Hypervisor extension is enabled, by default, address translation for Supervisor, Hypervisor and Virtual Supervisor are disabled. They can be enabled by writing the required configuration to satp, hgatp and vsatp registers respectively.
+
+**Sv39** is enabled for Supervisor or Virtual Supervisor by writing ``8`` to ``satp[63:60]`` or ``vsatp[63:60]`` respectively.
+
+**Sv39x4** is enabled for Hypervisor by writing  ``8`` to ``hgatp[63:60]``.
+
 
 Notes for the integrator:
 

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -193,9 +193,7 @@ Notes for the integrator:
 
 * The virtual memory is implemented by a memory management unit (MMU) that accelerates the translation from virtual memory addresses (as handled by the core) to physical memory addresses. The MMU integrates translation lookaside buffers (TLB) and a hardware page table walker (PTW). The number of instruction and data TLB entries are configured with ``InstrTlbEntries`` and ``DataTlbEntries``.
 
-* The MMU will integrate a microarchitectural optimization featuring two levels of TLB: level 1 TBL (sized by ``InstrTlbEntries`` and ``DataTlbEntries``) and a shared level 2 TLB. The optimization has no consequences on the programmer's view.
-
-* The MMU is implemented with a microarchitectural optimization featuring two levels of TLB: level 1 TBL (sized by ``InstrTlbEntries`` and ``DataTlbEntries``) and a shared level 2 TLB. The optimization has no consequences on the programmer's view.
+* The MMU is implemented with a microarchitectural optimization featuring two levels of TLB: level 1 TLB (sized by ``InstrTlbEntries`` and ``DataTlbEntries``) and a shared level 2 TLB. The optimization has no consequences on the programmer's view.
 
 CV32A60AX virtual memory
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -166,9 +166,14 @@ CV32A6 supports the RISC-V **Sv32** virtual memory when the ``MMUEn`` parameter 
 
 CV64A6 supports the RISC-V **Sv39** virtual memory when the ``MMUEn`` parameter is set to 1 (and ``Xlen`` is set to 64).
 
+Within CV64A6, the hypervisor extension is enabled and supports **Sv39x4** virtual memory when the ``CVA6ConfigHExtEn`` parameter is set to 1 (and ``Xlen`` is set to 64).
+
+
 By default, CV32A6 and CV64A6 are in RISC-V **Bare** mode. **Sv32** or **Sv39** are enabled by writing 1 to ``satp[0]`` register bit.
 
 When the ``MMUEn`` parameter is set to 0, CV32A6 and CV64A6 are always in RISC-V **Bare** mode; ``satp[0]`` remains at 0 and writes to this register are ignored.
+
+**PENDING: THE HYPERVISOR EXTENSION? HOW IS IT ENABLED VIA SW?**
 
 Notes for the integrator:
 
@@ -176,9 +181,7 @@ Notes for the integrator:
 
 * The MMU will integrate a microarchitectural optimization featuring two levels of TLB: level 1 TBL (sized by ``InstrTlbEntries`` and ``DataTlbEntries``) and a shared level 2 TLB. The optimization has no consequences on the programmer's view.
 
-* The addition of the hypervisor support will come with **Sv39x4** virtual memory that is not yet documented here.
-
-*These are the addressing modes supported by the various CVA6 configurations:*
+* The MMU is implemented with a microarchitectural optimization featuring two levels of TLB: level 1 TBL (sized by ``InstrTlbEntries`` and ``DataTlbEntries``) and a shared level 2 TLB. The optimization has no consequences on the programmer's view.
 
 CV32A60AX virtual memory
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Update the “RISC-V Virtual Memory” section in the CVA6 user manual with Sv32, Sv39 and Sv39x4 information after MMU merge