### PR TITLE
Mark jobs as failed when build fails

### DIFF
--- a/.gitlab-ci/scripts/report_simu.py
+++ b/.gitlab-ci/scripts/report_simu.py
@@ -32,7 +32,7 @@ for i in list_of_tests:
     else:
         metric.add_fail(*col)
 
-if job_test_total == 0:
+if re.search("ERROR", log) != None or job_test_total == 0:
     metric.fail()
 
 report = rb.Report(f'{job_test_pass}/{job_test_total}')


### PR DESCRIPTION
Jobs in dashboard were marked as passing even though the simulators build were failing.
The job will now be marked as failed when a build error happens during the CI Job execution.