### PR TITLE
hpdcache: update submodule, interface and parameters

### DIFF
--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -139,7 +139,7 @@ module cva6_hpdcache_subsystem
   //    NumPorts + 1: Hardware Memory Prefetcher (hwpf)
   localparam int HPDCACHE_NREQUESTERS = NumPorts + 2;
 
-  typedef logic [CVA6Cfg.AxiAddrWidth-1:0] hpdcache_mem_addr_t;
+  typedef logic [riscv::PLEN-1:0] hpdcache_mem_addr_t;
   typedef logic [ariane_pkg::MEM_TID_WIDTH-1:0] hpdcache_mem_id_t;
   typedef logic [CVA6Cfg.AxiDataWidth-1:0] hpdcache_mem_data_t;
   typedef logic [CVA6Cfg.AxiDataWidth/8-1:0] hpdcache_mem_be_t;
@@ -378,13 +378,10 @@ module cva6_hpdcache_subsystem
   );
 
   hpdcache #(
-      .NREQUESTERS          (HPDCACHE_NREQUESTERS),
-      .HPDcacheMemIdWidth   (ariane_pkg::MEM_TID_WIDTH),
-      .HPDcacheMemDataWidth (CVA6Cfg.AxiDataWidth),
-      .hpdcache_mem_req_t   (hpdcache_mem_req_t),
-      .hpdcache_mem_req_w_t (hpdcache_mem_req_w_t),
-      .hpdcache_mem_resp_r_t(hpdcache_mem_resp_r_t),
-      .hpdcache_mem_resp_w_t(hpdcache_mem_resp_w_t)
+      .NREQUESTERS         (HPDCACHE_NREQUESTERS),
+      .HPDcacheMemAddrWidth(riscv::PLEN),
+      .HPDcacheMemIdWidth  (ariane_pkg::MEM_TID_WIDTH),
+      .HPDcacheMemDataWidth(CVA6Cfg.AxiDataWidth)
   ) i_hpdcache (
       .clk_i,
       .rst_ni,

--- a/core/include/cva6_hpdcache_default_config_pkg.sv
+++ b/core/include/cva6_hpdcache_default_config_pkg.sv
@@ -65,6 +65,11 @@ package hpdcache_params_pkg;
 
   //  HPDcache request source ID width (bits)
   localparam int unsigned PARAM_REQ_SRC_ID_WIDTH = 3;
+
+  //  HPDcache victim selection policy
+  //  0: (Pseudo) RANDOM
+  //  1: (Pseudo) LRU
+  localparam int unsigned PARAM_VICTIM_SEL = 0;
   //  }}}
 
   //  Definition of constants and types for HPDcache data memory
@@ -90,10 +95,10 @@ package hpdcache_params_pkg;
   //  Definition of constants and types for the Miss Status Holding Register (MSHR)
   //  {{{
   //  HPDcache MSHR number of sets
-  localparam int unsigned PARAM_MSHR_SETS = 2;
+  localparam int unsigned PARAM_MSHR_SETS = 1;
 
   //  HPDcache MSHR number of ways
-  localparam int unsigned PARAM_MSHR_WAYS = (CVA6ConfigNrLoadBufEntries > 4) ? 4 : 2;
+  localparam int unsigned PARAM_MSHR_WAYS = CVA6ConfigNrLoadBufEntries;
 
   //  HPDcache MSHR number of ways in the same SRAM word
   localparam int unsigned PARAM_MSHR_WAYS_PER_RAM_WORD = (PARAM_MSHR_WAYS > 1) ? 2 : 1;


### PR DESCRIPTION
- Updates the interface of the HPDcache to match the latest version
- Adds a parameter allowing to select the replacement policy in the HPDcache. By default, the package uses the (pseudo)  random victim selection policy.
- By default, the HPDcache uses a fully-associative MSHR. The number of entries depends on the maximum number of loads that the CVA6 can have in-flight.