### PR TITLE
Parametrization step 1

### DIFF
--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -68,6 +68,7 @@ ${CVA6_REPO_DIR}/core/include/wt_cache_pkg.sv
 ${CVA6_REPO_DIR}/core/include/std_cache_pkg.sv
 ${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
 ${CVA6_REPO_DIR}/core/include/acc_pkg.sv
+${CVA6_REPO_DIR}/core/include/build_config_pkg.sv
 
 //CVXIF
 ${CVA6_REPO_DIR}/core/include/cvxif_pkg.sv

--- a/core/Flist.cva6_gate
+++ b/core/Flist.cva6_gate
@@ -19,6 +19,7 @@ ${CVA6_REPO_DIR}/core/include/cvxif_pkg.sv
 ${CVA6_REPO_DIR}/core/include/wt_cache_pkg.sv
 ${CVA6_REPO_DIR}/core/include/std_cache_pkg.sv
 ${CVA6_REPO_DIR}/core/include/instr_tracer_pkg.sv
+${CVA6_REPO_DIR}/core/include/build_config_pkg.sv
 
 ${LIB_VERILOG}
 ${CVA6_REPO_DIR}/pd/synth/cva6_${TARGET_CFG}_synth_modified.v

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -124,105 +124,15 @@ module cva6
 );
 
   // ------------------------------------------
-  // CVA6 configuration
-  // ------------------------------------------
-  // Extended config
-  localparam bit RVF = (riscv::IS_XLEN64 | riscv::IS_XLEN32) & CVA6Cfg.FpuEn;
-  localparam bit RVD = (riscv::IS_XLEN64 ? 1 : 0) & CVA6Cfg.FpuEn;
-  localparam bit FpPresent = RVF | RVD | CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8;
-  localparam bit NSX = CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8 | CVA6Cfg.XFVec;  // Are non-standard extensions present?
-  localparam int unsigned FLen = RVD ? 64 :  // D ext.
-  RVF ? 32 :  // F ext.
-  CVA6Cfg.XF16 ? 16 :  // Xf16 ext.
-  CVA6Cfg.XF16ALT ? 16 :  // Xf16alt ext.
-  CVA6Cfg.XF8 ? 8 :  // Xf8 ext.
-  1;  // Unused in case of no FP
-
-  // Transprecision floating-point extensions configuration
-  localparam bit RVFVec     = RVF             & CVA6Cfg.XFVec & FLen>32; // FP32 vectors available if vectors and larger fmt enabled
-  localparam bit XF16Vec    = CVA6Cfg.XF16    & CVA6Cfg.XFVec & FLen>16; // FP16 vectors available if vectors and larger fmt enabled
-  localparam bit XF16ALTVec = CVA6Cfg.XF16ALT & CVA6Cfg.XFVec & FLen>16; // FP16ALT vectors available if vectors and larger fmt enabled
-  localparam bit XF8Vec     = CVA6Cfg.XF8     & CVA6Cfg.XFVec & FLen>8;  // FP8 vectors available if vectors and larger fmt enabled
-
-  localparam bit EnableAccelerator = CVA6Cfg.RVV;  // Currently only used by V extension (Ara)
-  localparam int unsigned NrWbPorts = (CVA6Cfg.CvxifEn || EnableAccelerator) ? 5 : 4;
-
-  localparam NrRgprPorts = 2;
-
-  localparam bit NonIdemPotenceEn = CVA6Cfg.NrNonIdempotentRules && CVA6Cfg.NonIdempotentLength;  // Currently only used by V extension (Ara)
-
-  localparam config_pkg::cva6_cfg_t CVA6ExtendCfg = {
-    CVA6Cfg.NrCommitPorts,
-    CVA6Cfg.AxiAddrWidth,
-    CVA6Cfg.AxiDataWidth,
-    CVA6Cfg.AxiIdWidth,
-    CVA6Cfg.AxiUserWidth,
-    CVA6Cfg.NrLoadBufEntries,
-    CVA6Cfg.FpuEn,
-    CVA6Cfg.XF16,
-    CVA6Cfg.XF16ALT,
-    CVA6Cfg.XF8,
-    CVA6Cfg.RVA,
-    CVA6Cfg.RVB,
-    CVA6Cfg.RVV,
-    CVA6Cfg.RVC,
-    CVA6Cfg.RVZCB,
-    CVA6Cfg.XFVec,
-    CVA6Cfg.CvxifEn,
-    CVA6Cfg.ZiCondExtEn,
-    // Extended
-    bit'(RVF),
-    bit'(RVD),
-    bit'(FpPresent),
-    bit'(NSX),
-    unsigned'(FLen),
-    bit'(RVFVec),
-    bit'(XF16Vec),
-    bit'(XF16ALTVec),
-    bit'(XF8Vec),
-    unsigned'(NrRgprPorts),
-    unsigned'(NrWbPorts),
-    bit'(EnableAccelerator),
-    CVA6Cfg.RVS,
-    CVA6Cfg.RVU,
-    CVA6Cfg.HaltAddress,
-    CVA6Cfg.ExceptionAddress,
-    CVA6Cfg.RASDepth,
-    CVA6Cfg.BTBEntries,
-    CVA6Cfg.BHTEntries,
-    CVA6Cfg.DmBaseAddress,
-    CVA6Cfg.TvalEn,
-    CVA6Cfg.NrPMPEntries,
-    CVA6Cfg.PMPCfgRstVal,
-    CVA6Cfg.PMPAddrRstVal,
-    CVA6Cfg.PMPEntryReadOnly,
-    CVA6Cfg.NOCType,
-    CVA6Cfg.NrNonIdempotentRules,
-    CVA6Cfg.NonIdempotentAddrBase,
-    CVA6Cfg.NonIdempotentLength,
-    CVA6Cfg.NrExecuteRegionRules,
-    CVA6Cfg.ExecuteRegionAddrBase,
-    CVA6Cfg.ExecuteRegionLength,
-    CVA6Cfg.NrCachedRegionRules,
-    CVA6Cfg.CachedRegionAddrBase,
-    CVA6Cfg.CachedRegionLength,
-    CVA6Cfg.MaxOutstandingStores,
-    CVA6Cfg.DebugEn,
-    NonIdemPotenceEn,
-    CVA6Cfg.AxiBurstWriteEn
-  };
-
-
-  // ------------------------------------------
   // Global Signals
   // Signals connecting more than one module
   // ------------------------------------------
-  riscv::priv_lvl_t                                   priv_lvl;
-  exception_t                                         ex_commit;  // exception from commit stage
-  bp_resolve_t                                        resolved_branch;
-  logic             [                riscv::VLEN-1:0] pc_commit;
-  logic                                               eret;
-  logic             [CVA6ExtendCfg.NrCommitPorts-1:0] commit_ack;
+  riscv::priv_lvl_t                             priv_lvl;
+  exception_t                                   ex_commit;  // exception from commit stage
+  bp_resolve_t                                  resolved_branch;
+  logic             [          riscv::VLEN-1:0] pc_commit;
+  logic                                         eret;
+  logic             [CVA6Cfg.NrCommitPorts-1:0] commit_ack;
 
   localparam NumPorts = 4;
   cvxif_pkg::cvxif_req_t cvxif_req;
@@ -337,19 +247,19 @@ module cva6
   // --------------
   // ID <-> COMMIT
   // --------------
-  scoreboard_entry_t [CVA6ExtendCfg.NrCommitPorts-1:0] commit_instr_id_commit;
+  scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_id_commit;
   // --------------
   // RVFI
   // --------------
   logic [TRANS_ID_BITS-1:0] rvfi_issue_pointer;
-  logic [CVA6ExtendCfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] rvfi_commit_pointer;
+  logic [CVA6Cfg.NrCommitPorts-1:0][TRANS_ID_BITS-1:0] rvfi_commit_pointer;
   // --------------
   // COMMIT <-> ID
   // --------------
-  logic [CVA6ExtendCfg.NrCommitPorts-1:0][4:0] waddr_commit_id;
-  logic [CVA6ExtendCfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_commit_id;
-  logic [CVA6ExtendCfg.NrCommitPorts-1:0] we_gpr_commit_id;
-  logic [CVA6ExtendCfg.NrCommitPorts-1:0] we_fpr_commit_id;
+  logic [CVA6Cfg.NrCommitPorts-1:0][4:0] waddr_commit_id;
+  logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_commit_id;
+  logic [CVA6Cfg.NrCommitPorts-1:0] we_gpr_commit_id;
+  logic [CVA6Cfg.NrCommitPorts-1:0] we_fpr_commit_id;
   // --------------
   // CSR <-> *
   // --------------
@@ -453,7 +363,7 @@ module cva6
   // Frontend
   // --------------
   frontend #(
-      .CVA6Cfg(CVA6ExtendCfg)
+      .CVA6Cfg(CVA6Cfg)
   ) i_frontend (
       .flush_i            (flush_ctrl_if),                  // not entirely correct
       .flush_bp_i         (1'b0),
@@ -480,7 +390,7 @@ module cva6
   // ID
   // ---------
   id_stage #(
-      .CVA6Cfg(CVA6ExtendCfg)
+      .CVA6Cfg(CVA6Cfg)
   ) id_stage_i (
       .clk_i,
       .rst_ni,
@@ -511,12 +421,12 @@ module cva6
       .tsr_i       (tsr_csr_id)
   );
 
-  logic [NrWbPorts-1:0][TRANS_ID_BITS-1:0] trans_id_ex_id;
-  logic [NrWbPorts-1:0][riscv::XLEN-1:0] wbdata_ex_id;
-  exception_t [NrWbPorts-1:0] ex_ex_ex_id;  // exception from execute, ex_stage to id_stage
-  logic [NrWbPorts-1:0] wt_valid_ex_id;
+  logic [CVA6Cfg.NrWbPorts-1:0][TRANS_ID_BITS-1:0] trans_id_ex_id;
+  logic [CVA6Cfg.NrWbPorts-1:0][riscv::XLEN-1:0] wbdata_ex_id;
+  exception_t [CVA6Cfg.NrWbPorts-1:0] ex_ex_ex_id;  // exception from execute, ex_stage to id_stage
+  logic [CVA6Cfg.NrWbPorts-1:0] wt_valid_ex_id;
 
-  if (CVA6ExtendCfg.CvxifEn) begin
+  if (CVA6Cfg.CvxifEn) begin
     assign trans_id_ex_id = {
       x_trans_id_ex_id,
       flu_trans_id_ex_id,
@@ -537,7 +447,7 @@ module cva6
     assign wt_valid_ex_id = {
       x_valid_ex_id, flu_valid_ex_id, load_valid_ex_id, store_valid_ex_id, fpu_valid_ex_id
     };
-  end else if (CVA6ExtendCfg.EnableAccelerator) begin
+  end else if (CVA6Cfg.EnableAccelerator) begin
     assign trans_id_ex_id = {
       flu_trans_id_ex_id,
       load_trans_id_ex_id,
@@ -571,7 +481,7 @@ module cva6
     assign wt_valid_ex_id = {flu_valid_ex_id, load_valid_ex_id, store_valid_ex_id, fpu_valid_ex_id};
   end
 
-  if (CVA6ExtendCfg.CvxifEn && CVA6ExtendCfg.EnableAccelerator) begin : gen_err_xif_and_acc
+  if (CVA6Cfg.CvxifEn && CVA6Cfg.EnableAccelerator) begin : gen_err_xif_and_acc
     $error("X-interface and accelerator port cannot be enabled at the same time.");
   end
 
@@ -579,7 +489,7 @@ module cva6
   // Issue
   // ---------
   issue_stage #(
-      .CVA6Cfg(CVA6ExtendCfg)
+      .CVA6Cfg(CVA6Cfg)
   ) issue_stage_i (
       .clk_i,
       .rst_ni,
@@ -652,7 +562,7 @@ module cva6
   // EX
   // ---------
   ex_stage #(
-      .CVA6Cfg   (CVA6ExtendCfg),
+      .CVA6Cfg   (CVA6Cfg),
       .ASID_WIDTH(ASID_WIDTH)
   ) ex_stage_i (
       .clk_i                (clk_i),
@@ -766,7 +676,7 @@ module cva6
   assign no_st_pending_commit = no_st_pending_ex & dcache_commit_wbuffer_empty;
 
   commit_stage #(
-      .CVA6Cfg(CVA6ExtendCfg)
+      .CVA6Cfg(CVA6Cfg)
   ) commit_stage_i (
       .clk_i,
       .rst_ni,
@@ -805,7 +715,7 @@ module cva6
   // CSR
   // ---------
   csr_regfile #(
-      .CVA6Cfg       (CVA6ExtendCfg),
+      .CVA6Cfg       (CVA6Cfg),
       .AsidWidth     (ASID_WIDTH),
       .MHPMCounterNum(MHPMCounterNum)
   ) csr_regfile_i (
@@ -874,7 +784,7 @@ module cva6
   // ------------------------
   if (PERF_COUNTER_EN) begin : gen_perf_counter
     perf_counters #(
-        .CVA6Cfg (CVA6ExtendCfg),
+        .CVA6Cfg (CVA6Cfg),
         .NumPorts(NumPorts)
     ) perf_counters_i (
         .clk_i         (clk_i),
@@ -913,7 +823,7 @@ module cva6
   // Controller
   // ------------
   controller #(
-      .CVA6Cfg(CVA6ExtendCfg)
+      .CVA6Cfg(CVA6Cfg)
   ) controller_i (
       // flush ports
       .set_pc_commit_o       (set_pc_ctrl_pcgen),
@@ -977,7 +887,7 @@ module cva6
   if (DCACHE_TYPE == int'(config_pkg::WT)) begin : gen_cache_wt
     // this is a cache subsystem that is compatible with OpenPiton
     wt_cache_subsystem #(
-        .CVA6Cfg   (CVA6ExtendCfg),
+        .CVA6Cfg   (CVA6Cfg),
         .NumPorts  (NumPorts),
         .noc_req_t (noc_req_t),
         .noc_resp_t(noc_resp_t)
@@ -1017,7 +927,7 @@ module cva6
     );
   end else if (DCACHE_TYPE == int'(config_pkg::HPDCACHE)) begin : gen_cache_hpd
     cva6_hpdcache_subsystem #(
-        .CVA6Cfg   (CVA6ExtendCfg),
+        .CVA6Cfg   (CVA6Cfg),
         .NumPorts  (NumPorts),
         .axi_ar_chan_t(axi_ar_chan_t),
         .axi_aw_chan_t(axi_aw_chan_t),
@@ -1077,7 +987,7 @@ module cva6
         // note: this only works with one cacheable region
         // not as important since this cache subsystem is about to be
         // deprecated
-        .CVA6Cfg      (CVA6ExtendCfg),
+        .CVA6Cfg      (CVA6Cfg),
         .NumPorts     (NumPorts),
         .axi_ar_chan_t(axi_ar_chan_t),
         .axi_aw_chan_t(axi_aw_chan_t),
@@ -1122,9 +1032,9 @@ module cva6
   // Accelerator
   // ----------------
 
-  if (CVA6ExtendCfg.EnableAccelerator) begin : gen_accelerator
+  if (CVA6Cfg.EnableAccelerator) begin : gen_accelerator
     acc_dispatcher #(
-        .CVA6Cfg   (CVA6ExtendCfg),
+        .CVA6Cfg   (CVA6Cfg),
         .acc_cfg_t (acc_cfg_t),
         .AccCfg    (AccCfg),
         .acc_req_t (cvxif_req_t),
@@ -1212,12 +1122,12 @@ module cva6
 `ifdef PITON_ARIANE
   localparam PC_QUEUE_DEPTH = 16;
 
-  logic                                                    piton_pc_vld;
-  logic [                riscv::VLEN-1:0]                  piton_pc;
-  logic [CVA6ExtendCfg.NrCommitPorts-1:0][riscv::VLEN-1:0] pc_data;
-  logic [CVA6ExtendCfg.NrCommitPorts-1:0] pc_pop, pc_empty;
+  logic                                              piton_pc_vld;
+  logic [          riscv::VLEN-1:0]                  piton_pc;
+  logic [CVA6Cfg.NrCommitPorts-1:0][riscv::VLEN-1:0] pc_data;
+  logic [CVA6Cfg.NrCommitPorts-1:0] pc_pop, pc_empty;
 
-  for (genvar i = 0; i < CVA6ExtendCfg.NrCommitPorts; i++) begin : gen_pc_fifo
+  for (genvar i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin : gen_pc_fifo
     fifo_v3 #(
         .DATA_WIDTH(64),
         .DEPTH(PC_QUEUE_DEPTH)
@@ -1237,7 +1147,7 @@ module cva6
   end
 
   rr_arb_tree #(
-      .NumIn(CVA6ExtendCfg.NrCommitPorts),
+      .NumIn(CVA6Cfg.NrCommitPorts),
       .DataWidth(64)
   ) i_rr_arb_tree (
       .clk_i  (clk_i),
@@ -1323,7 +1233,7 @@ module cva6
           default: ;  // Do nothing
         endcase
       end
-      for (int i = 0; i < CVA6ExtendCfg.NrCommitPorts; i++) begin
+      for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
         if (commit_ack[i] && !commit_instr_id_commit[i].ex.valid) begin
           $fwrite(f, "%d 0x%0h %s (0x%h) DASM(%h)\n", cycles, commit_instr_id_commit[i].pc, mode,
                   commit_instr_id_commit[i].ex.tval[31:0], commit_instr_id_commit[i].ex.tval[31:0]);
@@ -1358,7 +1268,7 @@ module cva6
   //RVFI INSTR
 
   cva6_rvfi_probes #(
-      .CVA6Cfg      (CVA6ExtendCfg),
+      .CVA6Cfg      (CVA6Cfg),
       .rvfi_probes_t(rvfi_probes_t)
   ) i_cva6_rvfi_probes (
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -17,7 +17,9 @@ module cva6
   import ariane_pkg::*;
 #(
     // CVA6 config
-    parameter config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg),
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(
+        cva6_config_pkg::cva6_cfg
+    ),
 
     parameter type rvfi_probes_t = struct packed {
       logic csr;  //disabled 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -17,7 +17,7 @@ module cva6
   import ariane_pkg::*;
 #(
     // CVA6 config
-    parameter config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg,
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg),
 
     parameter type rvfi_probes_t = struct packed {
       logic csr;  //disabled 

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -1,0 +1,89 @@
+package build_config_pkg;
+
+  function automatic config_pkg::cva6_cfg_t build_config(config_pkg::cva6_user_cfg_t CVA6Cfg);
+    bit RVF = (riscv::IS_XLEN64 | riscv::IS_XLEN32) & CVA6Cfg.FpuEn;
+    bit RVD = (riscv::IS_XLEN64 ? 1 : 0) & CVA6Cfg.FpuEn;
+    bit FpPresent = RVF | RVD | CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8;
+    bit NSX = CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8 | CVA6Cfg.XFVec;  // Are non-standard extensions present?
+    int unsigned FLen = RVD ? 64 :  // D ext.
+    RVF ? 32 :  // F ext.
+    CVA6Cfg.XF16 ? 16 :  // Xf16 ext.
+    CVA6Cfg.XF16ALT ? 16 :  // Xf16alt ext.
+    CVA6Cfg.XF8 ? 8 :  // Xf8 ext.
+    1;  // Unused in case of no FP
+
+    // Transprecision floating-point extensions configuration
+    bit RVFVec     = RVF             & CVA6Cfg.XFVec & FLen>32; // FP32 vectors available if vectors and larger fmt enabled
+    bit XF16Vec    = CVA6Cfg.XF16    & CVA6Cfg.XFVec & FLen>16; // FP16 vectors available if vectors and larger fmt enabled
+    bit XF16ALTVec = CVA6Cfg.XF16ALT & CVA6Cfg.XFVec & FLen>16; // FP16ALT vectors available if vectors and larger fmt enabled
+    bit XF8Vec     = CVA6Cfg.XF8     & CVA6Cfg.XFVec & FLen>8;  // FP8 vectors available if vectors and larger fmt enabled
+
+    bit EnableAccelerator = CVA6Cfg.RVV;  // Currently only used by V extension (Ara)
+    int unsigned NrWbPorts = (CVA6Cfg.CvxifEn || EnableAccelerator) ? 5 : 4;
+
+    config_pkg::cva6_cfg_t cfg;
+
+    cfg.NrCommitPorts = CVA6Cfg.NrCommitPorts;
+    cfg.AxiAddrWidth = CVA6Cfg.AxiAddrWidth;
+    cfg.AxiDataWidth = CVA6Cfg.AxiDataWidth;
+    cfg.AxiIdWidth = CVA6Cfg.AxiIdWidth;
+    cfg.AxiUserWidth = CVA6Cfg.AxiUserWidth;
+    cfg.NrLoadBufEntries = CVA6Cfg.NrLoadBufEntries;
+    cfg.FpuEn = CVA6Cfg.FpuEn;
+    cfg.XF16 = CVA6Cfg.XF16;
+    cfg.XF16ALT = CVA6Cfg.XF16ALT;
+    cfg.XF8 = CVA6Cfg.XF8;
+    cfg.RVA = CVA6Cfg.RVA;
+    cfg.RVB = CVA6Cfg.RVB;
+    cfg.RVV = CVA6Cfg.RVV;
+    cfg.RVC = CVA6Cfg.RVC;
+    cfg.RVZCB = CVA6Cfg.RVZCB;
+    cfg.XFVec = CVA6Cfg.XFVec;
+    cfg.CvxifEn = CVA6Cfg.CvxifEn;
+    cfg.ZiCondExtEn = CVA6Cfg.ZiCondExtEn;
+
+    cfg.RVF = bit'(RVF);
+    cfg.RVD = bit'(RVD);
+    cfg.FpPresent = bit'(FpPresent);
+    cfg.NSX = bit'(NSX);
+    cfg.FLen = unsigned'(FLen);
+    cfg.RVFVec = bit'(RVFVec);
+    cfg.XF16Vec = bit'(XF16Vec);
+    cfg.XF16ALTVec = bit'(XF16ALTVec);
+    cfg.XF8Vec = bit'(XF8Vec);
+    cfg.NrRgprPorts = unsigned'(2);
+    cfg.NrWbPorts = unsigned'(NrWbPorts);
+    cfg.EnableAccelerator = bit'(EnableAccelerator);
+    cfg.RVS = CVA6Cfg.RVS;
+    cfg.RVU = CVA6Cfg.RVU;
+
+    cfg.HaltAddress = CVA6Cfg.HaltAddress;
+    cfg.ExceptionAddress = CVA6Cfg.ExceptionAddress;
+    cfg.RASDepth = CVA6Cfg.RASDepth;
+    cfg.BTBEntries = CVA6Cfg.BTBEntries;
+    cfg.BHTEntries = CVA6Cfg.BHTEntries;
+    cfg.DmBaseAddress = CVA6Cfg.DmBaseAddress;
+    cfg.TvalEn = CVA6Cfg.TvalEn;
+    cfg.NrPMPEntries = CVA6Cfg.NrPMPEntries;
+    cfg.PMPCfgRstVal = CVA6Cfg.PMPCfgRstVal;
+    cfg.PMPAddrRstVal = CVA6Cfg.PMPAddrRstVal;
+    cfg.PMPEntryReadOnly = CVA6Cfg.PMPEntryReadOnly;
+    cfg.NOCType = CVA6Cfg.NOCType;
+    cfg.NrNonIdempotentRules = CVA6Cfg.NrNonIdempotentRules;
+    cfg.NonIdempotentAddrBase = CVA6Cfg.NonIdempotentAddrBase;
+    cfg.NonIdempotentLength = CVA6Cfg.NonIdempotentLength;
+    cfg.NrExecuteRegionRules = CVA6Cfg.NrExecuteRegionRules;
+    cfg.ExecuteRegionAddrBase = CVA6Cfg.ExecuteRegionAddrBase;
+    cfg.ExecuteRegionLength = CVA6Cfg.ExecuteRegionLength;
+    cfg.NrCachedRegionRules = CVA6Cfg.NrCachedRegionRules;
+    cfg.CachedRegionAddrBase = CVA6Cfg.CachedRegionAddrBase;
+    cfg.CachedRegionLength = CVA6Cfg.CachedRegionLength;
+    cfg.MaxOutstandingStores = CVA6Cfg.MaxOutstandingStores;
+    cfg.DebugEn = CVA6Cfg.DebugEn;
+    cfg.NonIdemPotenceEn = CVA6Cfg.NrNonIdempotentRules && CVA6Cfg.NonIdempotentLength;
+    cfg.AxiBurstWriteEn = CVA6Cfg.AxiBurstWriteEn;
+
+    return cfg;
+  endfunction
+
+endpackage

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -131,40 +131,40 @@ package config_pkg;
     /// core can retire per cycle. It can be beneficial to have more commit
     /// ports than issue ports, for the scoreboard to empty out in case one
     /// instruction stalls a little longer.
-    int unsigned                 NrCommitPorts;
+    int unsigned NrCommitPorts;
     /// AXI parameters.
-    int unsigned                 AxiAddrWidth;
-    int unsigned                 AxiDataWidth;
-    int unsigned                 AxiIdWidth;
-    int unsigned                 AxiUserWidth;
-    int unsigned                 NrLoadBufEntries;
-    bit                          FpuEn;
-    bit                          XF16;
-    bit                          XF16ALT;
-    bit                          XF8;
-    bit                          RVA;
-    bit                          RVB;
-    bit                          RVV;
-    bit                          RVC;
-    bit                          RVZCB;
-    bit                          XFVec;
-    bit                          CvxifEn;
-    bit                          ZiCondExtEn;
+    int unsigned AxiAddrWidth;
+    int unsigned AxiDataWidth;
+    int unsigned AxiIdWidth;
+    int unsigned AxiUserWidth;
+    int unsigned NrLoadBufEntries;
+    bit          FpuEn;
+    bit          XF16;
+    bit          XF16ALT;
+    bit          XF8;
+    bit          RVA;
+    bit          RVB;
+    bit          RVV;
+    bit          RVC;
+    bit          RVZCB;
+    bit          XFVec;
+    bit          CvxifEn;
+    bit          ZiCondExtEn;
     // Calculated
-    bit                          RVF;
-    bit                          RVD;
-    bit                          FpPresent;
-    bit                          NSX;
-    int unsigned                 FLen;
-    bit                          RVFVec;
-    bit                          XF16Vec;
-    bit                          XF16ALTVec;
-    bit                          XF8Vec;
-    int unsigned                 NrRgprPorts;
-    int unsigned                 NrWbPorts;
-    bit                          EnableAccelerator;
-    bit                          RVS;    //Supervisor mode
-    bit                          RVU;    //User mode
+    bit          RVF;
+    bit          RVD;
+    bit          FpPresent;
+    bit          NSX;
+    int unsigned FLen;
+    bit          RVFVec;
+    bit          XF16Vec;
+    bit          XF16ALTVec;
+    bit          XF8Vec;
+    int unsigned NrRgprPorts;
+    int unsigned NrWbPorts;
+    bit          EnableAccelerator;
+    bit          RVS;                //Supervisor mode
+    bit          RVU;                //User mode
 
     logic [63:0]                 HaltAddress;
     logic [63:0]                 ExceptionAddress;
@@ -189,7 +189,7 @@ package config_pkg;
     logic [NrMaxRules-1:0][63:0] CachedRegionLength;
     int unsigned                 MaxOutstandingStores;
     bit                          DebugEn;
-    bit                          NonIdemPotenceEn;  // Currently only used by V extension (Ara)
+    bit                          NonIdemPotenceEn;       // Currently only used by V extension (Ara)
     bit                          AxiBurstWriteEn;
   } cva6_cfg_t;
 

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -72,30 +72,6 @@ package config_pkg;
     bit                          CvxifEn;
     // Zicond RISC-V extension
     bit                          ZiCondExtEn;
-    // Single precision FP RISC-V extension
-    bit                          RVF;
-    // Double precision FP RISC-V extension
-    bit                          RVD;
-    // Floating Point is present
-    bit                          FpPresent;
-    // Non standard Floating is Point present
-    bit                          NSX;
-    // Floating Point lenght
-    int unsigned                 FLen;
-    // Vector Floating Point extension
-    bit                          RVFVec;
-    // 16 bits vector Floating Point extension
-    bit                          XF16Vec;
-    // 16 bits vector Floating Point Alt extension
-    bit                          XF16ALTVec;
-    // 8 bits vector Floating Point extension
-    bit                          XF8Vec;
-    // TO_BE_COMPLETED
-    int unsigned                 NrRgprPorts;
-    // Function Unit write back port number
-    int unsigned                 NrWbPorts;
-    // Accelerate Port coprocessor interface
-    bit                          EnableAccelerator;
     // Supervisor mode
     bit                          RVS;
     // User mode
@@ -146,17 +122,80 @@ package config_pkg;
     int unsigned                 MaxOutstandingStores;
     // Debug support
     bit                          DebugEn;
-    // Non idem potency
-    bit                          NonIdemPotenceEn;
     // AXI burst in write
     bit                          AxiBurstWriteEn;
-  } cva6_cfg_t;
+  } cva6_user_cfg_t;
 
+  typedef struct packed {
+    /// Number of commit ports, i.e., maximum number of instructions that the
+    /// core can retire per cycle. It can be beneficial to have more commit
+    /// ports than issue ports, for the scoreboard to empty out in case one
+    /// instruction stalls a little longer.
+    int unsigned                 NrCommitPorts;
+    /// AXI parameters.
+    int unsigned                 AxiAddrWidth;
+    int unsigned                 AxiDataWidth;
+    int unsigned                 AxiIdWidth;
+    int unsigned                 AxiUserWidth;
+    int unsigned                 NrLoadBufEntries;
+    bit                          FpuEn;
+    bit                          XF16;
+    bit                          XF16ALT;
+    bit                          XF8;
+    bit                          RVA;
+    bit                          RVB;
+    bit                          RVV;
+    bit                          RVC;
+    bit                          RVZCB;
+    bit                          XFVec;
+    bit                          CvxifEn;
+    bit                          ZiCondExtEn;
+    // Calculated
+    bit                          RVF;
+    bit                          RVD;
+    bit                          FpPresent;
+    bit                          NSX;
+    int unsigned                 FLen;
+    bit                          RVFVec;
+    bit                          XF16Vec;
+    bit                          XF16ALTVec;
+    bit                          XF8Vec;
+    int unsigned                 NrRgprPorts;
+    int unsigned                 NrWbPorts;
+    bit                          EnableAccelerator;
+    bit                          RVS;    //Supervisor mode
+    bit                          RVU;    //User mode
+
+    logic [63:0]                 HaltAddress;
+    logic [63:0]                 ExceptionAddress;
+    int unsigned                 RASDepth;
+    int unsigned                 BTBEntries;
+    int unsigned                 BHTEntries;
+    logic [63:0]                 DmBaseAddress;
+    bit                          TvalEn;
+    int unsigned                 NrPMPEntries;
+    logic [15:0][63:0]           PMPCfgRstVal;
+    logic [15:0][63:0]           PMPAddrRstVal;
+    bit [15:0]                   PMPEntryReadOnly;
+    noc_type_e                   NOCType;
+    int unsigned                 NrNonIdempotentRules;
+    logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
+    logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
+    int unsigned                 NrExecuteRegionRules;
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
+    int unsigned                 NrCachedRegionRules;
+    logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
+    logic [NrMaxRules-1:0][63:0] CachedRegionLength;
+    int unsigned                 MaxOutstandingStores;
+    bit                          DebugEn;
+    bit                          NonIdemPotenceEn;  // Currently only used by V extension (Ara)
+    bit                          AxiBurstWriteEn;
+  } cva6_cfg_t;
 
   /// Empty configuration to sanity check proper parameter passing. Whenever
   /// you develop a module that resides within the core, assign this constant.
   localparam cva6_cfg_t cva6_cfg_empty = '0;
-
 
   /// Utility function being called to check parameters. Not all values make
   /// sense for all parameters, here is the place to sanity check them.

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -73,7 +73,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -92,18 +92,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      RVF: bit'(0),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(0),
       RVU: bit'(0),
       HaltAddress: 64'h800,
@@ -129,7 +117,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(0),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -73,7 +73,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -92,22 +92,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(0),
       RVU: bit'(0),
       HaltAddress: 64'h800,
@@ -145,7 +129,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(0),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -123,30 +107,18 @@ package cva6_config_pkg;
       PMPAddrRstVal: {16{64'h0}},
       PMPEntryReadOnly: 16'd0,
       NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
-      // idempotent region
-      NrNonIdempotentRules:
-      unsigned'(
-      2
-      ),
+      NrNonIdempotentRules: unsigned'(2),
       NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
       NonIdempotentLength: 1024'({64'b0, 64'b0}),
       NrExecuteRegionRules: unsigned'(3),
       //                      DRAM,          Boot ROM,   Debug Module
-      ExecuteRegionAddrBase:
-      1024'(
-      {64'h8000_0000, 64'h1_0000, 64'h0}
-      ),
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
       ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
-      // cached region
-      NrCachedRegionRules:
-      unsigned'(
-      1
-      ),
+      NrCachedRegionRules: unsigned'(1),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 endpackage

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -112,7 +112,10 @@ package cva6_config_pkg;
       NonIdempotentLength: 1024'({64'b0, 64'b0}),
       NrExecuteRegionRules: unsigned'(3),
       //                      DRAM,          Boot ROM,   Debug Module
-      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionAddrBase:
+      1024'(
+      {64'h8000_0000, 64'h1_0000, 64'h0}
+      ),
       ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
       NrCachedRegionRules: unsigned'(1),
       CachedRegionAddrBase: 1024'({64'h8000_0000}),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -81,7 +81,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -100,22 +100,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -153,7 +137,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -74,7 +74,7 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
@@ -93,22 +93,6 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
-      // Extended
-      RVF:
-      bit'(
-      0
-      ),
-      RVD: bit'(0),
-      FpPresent: bit'(0),
-      NSX: bit'(0),
-      FLen: unsigned'(0),
-      RVFVec: bit'(0),
-      XF16Vec: bit'(0),
-      XF16ALTVec: bit'(0),
-      XF8Vec: bit'(0),
-      NrRgprPorts: unsigned'(0),
-      NrWbPorts: unsigned'(0),
-      EnableAccelerator: bit'(0),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,
@@ -146,7 +130,6 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      NonIdemPotenceEn: bit'(0),
       AxiBurstWriteEn: bit'(0)
   };
 endpackage

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -157,7 +157,7 @@ module ariane_xilinx (
 // CVA6 config
 localparam bit IsRVFI = bit'(0);
 // CVA6 Xilinx configuration
-localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
+localparam config_pkg::cva6_user_cfg_t CVA6UserCfg = '{
   NrCommitPorts:         cva6_config_pkg::CVA6ConfigNrCommitPorts,
   AxiAddrWidth:          cva6_config_pkg::CVA6ConfigAxiAddrWidth,
   AxiDataWidth:          cva6_config_pkg::CVA6ConfigAxiDataWidth,
@@ -179,18 +179,6 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   XFVec:                 bit'(cva6_config_pkg::CVA6ConfigFVecEn),
   CvxifEn:               bit'(cva6_config_pkg::CVA6ConfigCvxifEn),
   ZiCondExtEn:           bit'(0),
-  RVF:                   bit'(0),
-  RVD:                   bit'(0),
-  FpPresent:             bit'(0),
-  NSX:                   bit'(0),
-  FLen:                  unsigned'(0),
-  RVFVec:                bit'(0),
-  XF16Vec:               bit'(0),
-  XF16ALTVec:            bit'(0),
-  XF8Vec:                bit'(0),
-  NrRgprPorts:           unsigned'(0),
-  NrWbPorts:             unsigned'(0),
-  EnableAccelerator:     bit'(0),
   RVS:                   bit'(1),
   RVU:                   bit'(1),
   HaltAddress:           dm::HaltAddress,
@@ -215,9 +203,9 @@ localparam config_pkg::cva6_cfg_t CVA6Cfg = '{
   CachedRegionLength:    1024'({ariane_soc::DRAMLength}),
   MaxOutstandingStores:  unsigned'(7),
   DebugEn: bit'(1),
-  NonIdemPotenceEn: bit'(0),
   AxiBurstWriteEn: bit'(0)
 };
+localparam config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(CVA6UserCfg);
 
 localparam type rvfi_probes_t = struct packed { 
       logic csr;

--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -29,7 +29,7 @@ import "DPI-C" context function void read_section_sv(input longint address, inou
 module ariane_tb;
 
     // cva6 configuration
-    localparam config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg;
+    localparam config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg);
     localparam bit IsRVFI = bit'(cva6_config_pkg::CVA6ConfigRvfiTrace);
 
     static uvm_cmdline_processor uvcl = uvm_cmdline_processor::get_inst();

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -16,7 +16,7 @@
 `include "axi/assign.svh"
 
 module ariane_testharness #(
-  parameter config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg,
+  parameter config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg),
   parameter bit IsRVFI = bit'(cva6_config_pkg::CVA6ConfigRvfiTrace),
   //
   parameter int unsigned AXI_USER_WIDTH    = ariane_pkg::AXI_USER_WIDTH,

--- a/verif/env/uvme/cov/uvme_cva6_config_covg.sv
+++ b/verif/env/uvme/cov/uvme_cva6_config_covg.sv
@@ -153,43 +153,6 @@ covergroup cg_cva6_config(string name) with function sample();
    cp_RvfiTrace : coverpoint cva6_config_pkg::CVA6ConfigRvfiTrace {
       bins RvfiTrace ={1};
    }
-   // Extended
-   cp_RVF : coverpoint cva6_config_pkg::cva6_cfg.RVF {
-      bins RVF ={0};
-   }
-   cp_RVD : coverpoint cva6_config_pkg::cva6_cfg.RVD {
-      bins RVD ={0};
-   }
-   cp_FpPresent : coverpoint cva6_config_pkg::cva6_cfg.FpPresent {
-      bins FpPresent ={0};
-   }
-   cp_NSX : coverpoint cva6_config_pkg::cva6_cfg.NSX {
-      bins NSX ={0};
-   }
-   cp_FLen : coverpoint cva6_config_pkg::cva6_cfg.FLen {
-      bins FLen ={0};
-   }
-   cp_RVFVec : coverpoint cva6_config_pkg::cva6_cfg.RVFVec {
-      bins RVFVec ={0};
-   }
-   cp_XF16Vec : coverpoint cva6_config_pkg::cva6_cfg.XF16Vec {
-      bins XF16Vec ={0};
-   }
-   cp_XF16ALTVec : coverpoint cva6_config_pkg::cva6_cfg.XF16ALTVec {
-      bins XF16ALTVec ={0};
-   }
-   cp_XF8Vec : coverpoint cva6_config_pkg::cva6_cfg.XF8Vec {
-      bins XF8Vec ={0};
-   }
-   cp_NrRgprPorts : coverpoint cva6_config_pkg::cva6_cfg.NrRgprPorts {
-      bins NrRgprPorts ={0};
-   }
-   cp_NrWbPorts : coverpoint cva6_config_pkg::cva6_cfg.NrWbPorts {
-      bins NrWbPorts ={0};
-   }
-   cp_EnableAccelerator : coverpoint cva6_config_pkg::cva6_cfg.EnableAccelerator {
-      bins EnableAccelerator ={0};
-   }
    cp_HaltAddress : coverpoint cva6_config_pkg::cva6_cfg.HaltAddress {
       bins HaltAddress ={64'h800};
    }

--- a/verif/tb/core/uvma_cva6pkg_utils.sv
+++ b/verif/tb/core/uvma_cva6pkg_utils.sv
@@ -1,18 +1,20 @@
 
 function st_core_cntrl_cfg cva6pkg_to_core_cntrl_cfg(st_core_cntrl_cfg base);
 
+    automatic config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg);
+
     $cast(base.xlen, cva6_config_pkg::CVA6ConfigXlen);
 
     base.ilen = cva6_config_pkg::CVA6ConfigXlen;
 
     base.ext_i_supported = 1;
-    base.ext_a_supported = cva6_config_pkg::cva6_cfg.RVA;
+    base.ext_a_supported = CVA6Cfg.RVA;
     base.ext_m_supported = 1;
-    base.ext_c_supported = cva6_config_pkg::cva6_cfg.RVC;
+    base.ext_c_supported = CVA6Cfg.RVC;
     base.ext_p_supported = 1;
-    base.ext_v_supported = cva6_config_pkg::cva6_cfg.RVV;
-    base.ext_f_supported = cva6_config_pkg::cva6_cfg.RVF | cva6_config_pkg::cva6_cfg.FpuEn;
-    base.ext_d_supported = cva6_config_pkg::cva6_cfg.RVD;
+    base.ext_v_supported = CVA6Cfg.RVV;
+    base.ext_f_supported = CVA6Cfg.RVF | CVA6Cfg.FpuEn;
+    base.ext_d_supported = CVA6Cfg.RVD;
     base.ext_zba_supported = cva6_config_pkg::CVA6ConfigBExtEn;
     base.ext_zbb_supported = cva6_config_pkg::CVA6ConfigBExtEn;
     base.ext_zbc_supported = cva6_config_pkg::CVA6ConfigBExtEn;
@@ -23,17 +25,17 @@ function st_core_cntrl_cfg cva6pkg_to_core_cntrl_cfg(st_core_cntrl_cfg base);
     base.ext_zbr_supported = 0;
     base.ext_zbs_supported = cva6_config_pkg::CVA6ConfigBExtEn;
     base.ext_zbt_supported = 0;
-    base.ext_zcb_supported = cva6_config_pkg::cva6_cfg.RVZCB;
+    base.ext_zcb_supported = CVA6Cfg.RVZCB;
     base.ext_zifencei_supported = 1;
     base.ext_zicsr_supported = 1;
     base.ext_zicntr_supported = 1;
 
-    base.mode_s_supported = cva6_config_pkg::cva6_cfg.RVS;
-    base.mode_u_supported = cva6_config_pkg::cva6_cfg.RVU;
+    base.mode_s_supported = CVA6Cfg.RVS;
+    base.mode_u_supported = CVA6Cfg.RVU;
 
-    base.pmp_supported = (cva6_config_pkg::cva6_cfg.NrPMPEntries > 0);
-    base.pmp_regions = cva6_config_pkg::cva6_cfg.NrPMPEntries;
-    base.debug_supported = cva6_config_pkg::cva6_cfg.DebugEn;
+    base.pmp_supported = (CVA6Cfg.NrPMPEntries > 0);
+    base.pmp_regions = CVA6Cfg.NrPMPEntries;
+    base.debug_supported = CVA6Cfg.DebugEn;
 
     return base;
 

--- a/verif/tb/uvmt/uvmt_cva6_tb.sv
+++ b/verif/tb/uvmt/uvmt_cva6_tb.sv
@@ -33,7 +33,7 @@ module uvmt_cva6_tb;
    localparam RVFI_NRET = cva6_config_pkg::CVA6ConfigNrCommitPorts;
 
    // CVA6 config
-   localparam config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg;
+   localparam config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg);
 
     // RVFI
  


### PR DESCRIPTION
This PR splits the configuration structure so that the user configuration does not contain dummy values.

This is the first step for #1451

It partially replaces PR #1704

See also [the announcement on Mattermost](https://mattermost.openhwgroup.org/all-users/pl/mr3aereappdt58f8ag8p11r9nr)