### PR TITLE
Check tools version before simulations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,6 +110,7 @@ build_tools:
   stage: light tests
   rules: *on_dev
   before_script:
+    - git -C verif/core-v-verif fetch --unshallow
     - mkdir -p tools
     - mv artifacts/tools/spike tools
     - rm -rf artifacts/

--- a/verif/regress/install-verilator.sh
+++ b/verif/regress/install-verilator.sh
@@ -18,7 +18,7 @@ fi
 VERILATOR_REPO="https://github.com/verilator/verilator.git"
 VERILATOR_BRANCH="master"
 # Use the release tag instead of a full SHA1 hash.
-VERILATOR_HASH="v5.018"
+VERILATOR_HASH="v5.008"
 VERILATOR_PATCH="$ROOT_PROJECT/verif/regress/verilator-v5.patch"
 
 # Unset historical variable VERILATOR_ROOT as it collides with the build process.


### PR DESCRIPTION
Related to : https://github.com/openhwgroup/cva6/issues/1796

Check tools version when running `verif/sim/cva6.py` to avoid tools version-related issues.

Set verilator to version 5.008 to be coherent between users, Gitlab and Github CI.