### PR TITLE
modify rvfi probes for param

### DIFF
--- a/core/cva6_rvfi_probes.sv
+++ b/core/cva6_rvfi_probes.sv
@@ -72,16 +72,32 @@ module cva6_rvfi_probes
     instr.rs1_forwarding = rs1_forwarding_i;
     instr.rs2_forwarding = rs2_forwarding_i;
 
-    instr.ex_commit = ex_commit_i;
+    instr.ex_commit_cause = ex_commit_i.cause;
+    instr.ex_commit_valid = ex_commit_i.valid;
+
     instr.priv_lvl = priv_lvl_i;
 
-    instr.lsu_ctrl = lsu_ctrl_i;
+    instr.lsu_ctrl_vaddr = lsu_ctrl_i.vaddr;
+    instr.lsu_ctrl_fu = lsu_ctrl_i.fu;
+    instr.lsu_ctrl_be = lsu_ctrl_i.be;
+    instr.lsu_ctrl_trans_id = lsu_ctrl_i.trans_id;
+
     instr.wbdata = wbdata_i;
     instr.mem_paddr = mem_paddr_i;
     instr.debug_mode = debug_mode_i;
 
     instr.commit_pointer = commit_pointer_i;
-    instr.commit_instr = commit_instr_i;
+
+    for (int i = 0; i < cva6_config_pkg::CVA6ConfigNrCommitPorts; i++) begin
+      instr.commit_instr_pc[i] = commit_instr_i[i].pc;
+      instr.commit_instr_op[i] = commit_instr_i[i].op;
+      instr.commit_instr_rs1[i] = commit_instr_i[i].rs1;
+      instr.commit_instr_rs2[i] = commit_instr_i[i].rs2;
+      instr.commit_instr_rd[i] = commit_instr_i[i].rd;
+      instr.commit_instr_result[i] = commit_instr_i[i].result;
+      instr.commit_instr_valid[i] = commit_instr_i[i].valid;
+    end
+
     instr.commit_ack = commit_ack_i;
     instr.wdata = wdata_i;
 

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -846,10 +846,20 @@ package ariane_pkg;
     logic is_compressed;
     riscv::xlen_t rs1_forwarding;
     riscv::xlen_t rs2_forwarding;
-    scoreboard_entry_t [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0] commit_instr;
-    exception_t ex_commit;
+    logic [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0][riscv::VLEN-1:0] commit_instr_pc;
+    fu_op [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0][TRANS_ID_BITS-1:0] commit_instr_op;
+    logic [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0][REG_ADDR_SIZE-1:0] commit_instr_rs1;
+    logic [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0][REG_ADDR_SIZE-1:0] commit_instr_rs2;
+    logic [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0][REG_ADDR_SIZE-1:0] commit_instr_rd;
+    riscv::xlen_t [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0] commit_instr_result;
+    logic [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0][riscv::VLEN-1:0] commit_instr_valid;
+    riscv::xlen_t ex_commit_cause;
+    logic ex_commit_valid;
     riscv::priv_lvl_t priv_lvl;
-    lsu_ctrl_t lsu_ctrl;
+    logic [riscv::VLEN-1:0] lsu_ctrl_vaddr;
+    fu_t lsu_ctrl_fu;
+    logic [(riscv::XLEN/8)-1:0] lsu_ctrl_be;
+    logic [TRANS_ID_BITS-1:0] lsu_ctrl_trans_id;
     logic [((cva6_config_pkg::CVA6ConfigCvxifEn || cva6_config_pkg::CVA6ConfigVExtEn) ? 5 : 4)-1:0][riscv::XLEN-1:0] wbdata;
     logic [cva6_config_pkg::CVA6ConfigNrCommitPorts-1:0] commit_ack;
     logic [riscv::PLEN-1:0] mem_paddr;
@@ -956,13 +966,9 @@ package ariane_pkg;
     rvfi_csr_elmt_t pmpcfg2;
     rvfi_csr_elmt_t pmpcfg3;
     rvfi_csr_elmt_t [15:0] pmpaddr;
-
   } rvfi_csr_t;
 
-
   localparam RVFI = cva6_config_pkg::CVA6ConfigRvfiTrace;
-
-
 
   // ----------------------
   // Arithmetic Functions

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -154,8 +154,6 @@ module ariane_xilinx (
   output logic        tx
 );
 
-// CVA6 config
-localparam bit IsRVFI = bit'(0);
 // CVA6 Xilinx configuration
 localparam config_pkg::cva6_user_cfg_t CVA6UserCfg = '{
   NrCommitPorts:         cva6_config_pkg::CVA6ConfigNrCommitPorts,

--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -30,7 +30,6 @@ module ariane_tb;
 
     // cva6 configuration
     localparam config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg);
-    localparam bit IsRVFI = bit'(cva6_config_pkg::CVA6ConfigRvfiTrace);
 
     static uvm_cmdline_processor uvcl = uvm_cmdline_processor::get_inst();
 
@@ -52,7 +51,6 @@ module ariane_tb;
 
     ariane_testharness #(
         .CVA6Cfg ( CVA6Cfg ),
-        .IsRVFI ( IsRVFI ),
         //
         .NUM_WORDS         ( NUM_WORDS ),
         .InclSimDTM        ( 1'b1      ),

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -17,7 +17,6 @@
 
 module ariane_testharness #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = build_config_pkg::build_config(cva6_config_pkg::cva6_cfg),
-  parameter bit IsRVFI = bit'(cva6_config_pkg::CVA6ConfigRvfiTrace),
   //
   parameter int unsigned AXI_USER_WIDTH    = ariane_pkg::AXI_USER_WIDTH,
   parameter int unsigned AXI_USER_EN       = ariane_pkg::AXI_USER_EN,


### PR DESCRIPTION
This PR makes sure that no instances of parametrized types go outside of CVA6, except RVFI-related types.
It will ease parametrization as types such as `scoreboard_entry_t` does not have to be transformed into a macro.

It additionally removes unused `IsRVFI` parameters.