### PR TITLE
Fix CI smoke-gate test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -459,6 +459,7 @@ smoke-gate:
     DASHBOARD_SORT_INDEX: 6
     DASHBOARD_JOB_CATEGORY: "Post Synthesis"
   script:
+    - git -C verif/core-v-verif fetch --unshallow
     - mkdir -p tools
     - mv artifacts/tools/spike tools
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC


### PR DESCRIPTION
The Smoke-gate test is broken in CI because of https://github.com/openhwgroup/cva6/pull/1899 .

The Spike version check is failing because it cannot get the appropriate hash version of spike files in core-v-verif.

Fixed it by unshallowing core-v-verif in the smoke-gate job.