### PR TITLE
Code coverage : Exclude unread module form CC (fix issue #1903)

### DIFF
--- a/verif/sim/cov-exclude-mod.lst
+++ b/verif/sim/cov-exclude-mod.lst
@@ -12,3 +12,4 @@
 -tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.tracer_if
 -tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.genblk6.i_cva6_rvfi_combi
 -tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.i_cva6_rvfi_probes
+-tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.i_frontend.i_instr_queue.i_unread_*


### PR DESCRIPTION
This MR, remove **unread ** module from Code coverage (unread is only used for connection no need to compute it in CC)