### PR TITLE
Move re-aligner doc from ID stage to IF stage.

### DIFF
--- a/docs/03_cva6_design/id_stage.md
+++ b/docs/03_cva6_design/id_stage.md
@@ -8,39 +8,10 @@ stage.
 With the introduction of compressed instructions (in general variable
 length instructions) the ID stage gets a little bit more complicated: It
 has to search the incoming data stream for potential instructions,
-re-align them and (in the case of compressed instructions) decompress
-them. Furthermore, as we will know at the end of this stage whether the
+and (in the case of compressed instructions) decompress them.
+Furthermore, as we will know at the end of this stage whether the
 decoded instruction is branch instruction it passes this information on
 to the issue stage.
-
-#### Instruction Re-aligner
-
-![Instruction re-alignment Process](_static/instr_realign.png)
-
-As mentioned above the instruction re-aligner checks the incoming data
-stream for compressed instructions. Compressed instruction have their
-last bit unequal to 11 while normal 32-bit instructions have their last
-two bit set to 11. The main complication arises from the fact that a
-compressed instruction can make a normal instruction unaligned (e.g.:
-the instruction starts at a half word boundary). This can (in the worst
-case) mandate two memory accesses before the instruction can be fully
-decoded. We therefore need to make sure that the fetch FIFO has enough
-space to keep the second part of the instruction. Therefore the
-instruction re-aligner needs to keep track of whether the previous
-instruction was unaligned or compressed to correctly decide what to do
-with the upcoming instruction.
-
-Furthermore, the branch-prediction information is used to only output
-the correct instruction to the issue stage. As we only predict on
-word-aligned PCs the passed on branch prediction information needs to be
-investigated to rule out which instruction we are actually need, in case
-there are two instructions (compressed or unaligned) present. This means
-that we potentially have to discard one of the two instructions (the
-instruction before the branch target). For that reason the instruction
-re-aligner also needs to check whether this fetch entry contains a valid
-and taken branch. Depending on whether it is predicted on the upper 16
-bit it has to discard the lower 16 bit accordingly. This process is
-illustrate in .
 
 #### Compressed Decoder
 

--- a/docs/03_cva6_design/if_stage.md
+++ b/docs/03_cva6_design/if_stage.md
@@ -36,8 +36,8 @@ faults).
 
 The data fetched at this point can contain compressed instructions,
 in order to send valid instrctions to the Instruction Decode (ID) stage,
-we need to chech for compressed instructions and re-align them.
-This is the role of the Iistruction re-aligner.
+we need to check for compressed instructions and re-align them.
+This is the role of the Instruction re-aligner.
 
 #### Instruction Re-aligner
 

--- a/docs/03_cva6_design/if_stage.md
+++ b/docs/03_cva6_design/if_stage.md
@@ -34,6 +34,40 @@ exceptions. Therefore this is the first place where exceptions can
 potentially happen (bus errors, invalid accesses and instruction page
 faults).
 
+The data fetched at this point can contain compressed instructions,
+in order to send valid instrctions to the Instruction Decode (ID) stage,
+we need to chech for compressed instructions and re-align them. This is the role
+of the Iistruction re-aligner.
+
+#### Instruction Re-aligner
+
+![Instruction re-alignment Process](_static/instr_realign.png)
+
+As mentioned above the instruction re-aligner checks the incoming data
+stream for compressed instructions. Compressed instruction have their
+last bit unequal to 11 while normal 32-bit instructions have their last
+two bit set to 11. The main complication arises from the fact that a
+compressed instruction can make a normal instruction unaligned (e.g.:
+the instruction starts at a half word boundary). This can (in the worst
+case) mandate two memory accesses before the instruction can be fully
+decoded. We therefore need to make sure that the fetch FIFO has enough
+space to keep the second part of the instruction. Therefore the
+instruction re-aligner needs to keep track of whether the previous
+instruction was unaligned or compressed to correctly decide what to do
+with the upcoming instruction.
+
+Furthermore, the branch-prediction information is used to only output
+the correct instruction to the issue stage. As we only predict on
+word-aligned PCs the passed on branch prediction information needs to be
+investigated to rule out which instruction we are actually need, in case
+there are two instructions (compressed or unaligned) present. This means
+that we potentially have to discard one of the two instructions (the
+instruction before the branch target). For that reason the instruction
+re-aligner also needs to check whether this fetch entry contains a valid
+and taken branch. Depending on whether it is predicted on the upper 16
+bit it has to discard the lower 16 bit accordingly. This process is
+illustrate in .
+
 #### Fetch FIFO
 
 The fetch FIFO contains all requested (valid) fetches from instruction

--- a/docs/03_cva6_design/if_stage.md
+++ b/docs/03_cva6_design/if_stage.md
@@ -36,8 +36,8 @@ faults).
 
 The data fetched at this point can contain compressed instructions,
 in order to send valid instrctions to the Instruction Decode (ID) stage,
-we need to chech for compressed instructions and re-align them. This is the role
-of the Iistruction re-aligner.
+we need to chech for compressed instructions and re-align them.
+This is the role of the Iistruction re-aligner.
 
 #### Instruction Re-aligner
 


### PR DESCRIPTION
# What does this PR do ?

After working on the 2024 softcore contest , I noticed that the re-aligner was not in ID but in IF, which makes more sense (the main intro CVA6 scheme also shows it).
Re-aligner doc was moved the re-aligner doc from ID stage to IF stage.
I might be wrong, looking forward getting your feedback.
