### PR TITLE
Allow single-stepping of commit stage from acc dispatcher

### DIFF
--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -60,6 +60,7 @@ module acc_dispatcher
     input logic flush_unissued_instr_i,
     input logic flush_ex_i,
     output logic flush_pipeline_o,
+    output logic single_step_o,
     // Interface with cache subsystem
     output dcache_req_i_t [1:0] acc_dcache_req_ports_o,
     input dcache_req_o_t [1:0] acc_dcache_req_ports_i,
@@ -418,6 +419,7 @@ module acc_dispatcher
 
   assign acc_stall_st_pending_o = 1'b0;
   assign flush_pipeline_o       = 1'b0;
+  assign single_step_o          = 1'b0;
   assign acc_dcache_req_ports_o = '0;
 
 endmodule : acc_dispatcher

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -315,6 +315,7 @@ module cva6
   logic halt_acc_ctrl;
   logic [4:0] acc_resp_fflags;
   logic acc_resp_fflags_valid;
+  logic single_step_acc_commit;
   // CSR
   logic csr_valid_id_ex;
   // CVXIF
@@ -781,7 +782,7 @@ module cva6
       .flush_dcache_i    (dcache_flush_ctrl_cache),
       .exception_o       (ex_commit),
       .dirty_fp_state_o  (dirty_fp_state),
-      .single_step_i     (single_step_csr_commit),
+      .single_step_i     (single_step_csr_commit || single_step_acc_commit),
       .commit_instr_i    (commit_instr_id_commit),
       .commit_ack_o      (commit_ack),
       .no_st_pending_i   (no_st_pending_commit),
@@ -1135,6 +1136,7 @@ module cva6
         .flush_unissued_instr_i(flush_unissued_instr_ctrl_id),
         .flush_ex_i            (flush_ctrl_ex),
         .flush_pipeline_o      (flush_acc),
+        .single_step_o         (single_step_acc_commit),
         .acc_cons_en_i         (acc_cons_en_csr),
         .acc_fflags_valid_o    (acc_resp_fflags_valid),
         .acc_fflags_o          (acc_resp_fflags),


### PR DESCRIPTION
This PR gives the accelerator dispatcher the ability to single-step the commit stage, which avoids retiring instructions on another commit port than port 0. This is needed if the acc dispatcher cannot keep up with simultaneous commits on both commit ports, as well as for precise timing of pipeline flushes.