### PR TITLE
03 doc is deprecated

### DIFF
--- a/docs/03_cva6_design/index.rst
+++ b/docs/03_cva6_design/index.rst
@@ -15,8 +15,8 @@
 
    SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-CVA6 Design Document
-====================
+CVA6 Design Document (deprecated)
+=================================
 Editor: **Florian Zaruba**
 `florian@openhwgroup.org <mailto:florian@openhwgroup.org?subject=CVA6%20Design%20Document>`__
 


### PR DESCRIPTION
GitHub Issues report 03 doc limitations. As it is not the main design document, we would like to notify that it is deprecated.