### PR TITLE
Fix FPGA build report in Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,11 +242,12 @@ fpga-build:
     - source $VIVADO_SETUP
     - source ./verif/sim/setup-env.sh
     - mkdir -p artifacts/logs
-    - make fpga target=$TARGET 2>&1 | tee artifacts/logs/logfile.log
+    - make fpga target=$TARGET &> artifacts/logs/logfile.log
     - tail -20 artifacts/logs/logfile.log > artifacts/logs/logfile.log.tail
+    - rm -f artifacts/logs/logfile.log
     - mkdir -p artifacts/reports
     - mv corev_apu/fpga/work-fpga/ariane_xilinx.bit artifacts/ariane_xilinx_$TARGET.bit
-    - python3 .gitlab-ci/scripts/report_fpga.py corev_apu/fpga/reports/ariane.utilization.rpt artifacts/logs/logfile.tail
+    - python3 .gitlab-ci/scripts/report_fpga.py corev_apu/fpga/reports/ariane.utilization.rpt artifacts/logs/logfile.log.tail
 
 .regress_test:
   stage: heavy tests


### PR DESCRIPTION
Fixed a typo in the fpga build job (introduced by fd12ee596c6cdec887a464dc9c8e2ad0125687ea) which was making the job fail.

Removed the output of the fpga build to avoid polluting the CI Job output.