### PR TITLE
[RVFI] Change CSR implementation

### DIFF
--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -28,10 +28,9 @@ module cva6_rvfi
     output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_instr_o,
     output rvfi_csr_t rvfi_csr_o
 
-
 );
 
-  localparam logic [CVA6Cfg.XLEN-1:0] IsaCode = 
+  localparam logic [CVA6Cfg.XLEN-1:0] IsaCode =
     (CVA6Cfg.XLEN'(CVA6Cfg.RVA) << 0)   // A - Atomic Instructions extension
   | (CVA6Cfg.XLEN'(CVA6Cfg.RVB) << 1)  // C - Bitmanip extension
   | (CVA6Cfg.XLEN'(CVA6Cfg.RVC) << 2)  // C - Compressed extension
@@ -237,7 +236,7 @@ module cva6_rvfi
   // PACK
   //----------------------------------------------------------------------------------------------------------
 
-  always_comb begin
+  always_ff @(posedge clk_i) begin
     for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
       logic exception;
       exception = commit_instr_valid[i][0] && ex_commit_valid;
@@ -275,240 +274,108 @@ module cva6_rvfi
   //----------------------------------------------------------------------------------------------------------
 
 
-  always_comb begin
 
-    rvfi_csr_o.fflags = CVA6Cfg.FpPresent ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 5{1'b0}}, csr.fcsr_q.fflags},
-        wdata: {{CVA6Cfg.XLEN - 5{1'b0}}, csr.fcsr_q.fflags},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.frm = CVA6Cfg.FpPresent ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 3{1'b0}}, csr.fcsr_q.frm},
-        wdata: {{CVA6Cfg.XLEN - 3{1'b0}}, csr.fcsr_q.frm},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.fcsr = CVA6Cfg.FpPresent ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 8{1'b0}}, csr.fcsr_q.frm, csr.fcsr_q.fflags},
-        wdata: {{CVA6Cfg.XLEN - 8{1'b0}}, csr.fcsr_q.frm, csr.fcsr_q.fflags},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.ftran = CVA6Cfg.FpPresent ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 7{1'b0}}, csr.fcsr_q.fprec},
-        wdata: {{CVA6Cfg.XLEN - 7{1'b0}}, csr.fcsr_q.fprec},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.dcsr = CVA6Cfg.DebugEn ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.dcsr_q},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.dcsr_q},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.dpc = CVA6Cfg.DebugEn ?
-    '{rdata: csr.dpc_q, wdata: csr.dpc_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.dscratch0 = CVA6Cfg.DebugEn ?
-    '{rdata: csr.dscratch0_q, wdata: csr.dscratch0_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.dscratch1 = CVA6Cfg.DebugEn ?
-    '{rdata: csr.dscratch1_q, wdata: csr.dscratch1_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.sstatus = CVA6Cfg.RVS ?
-    '{
-        rdata: csr.mstatus_extended & SMODE_STATUS_READ_MASK[CVA6Cfg.XLEN-1:0],
-        wdata: csr.mstatus_extended & SMODE_STATUS_READ_MASK[CVA6Cfg.XLEN-1:0],
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.sie = CVA6Cfg.RVS ?
-    '{rdata: csr.mie_q & csr.mideleg_q, wdata: csr.mie_q & csr.mideleg_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.sip = CVA6Cfg.RVS ?
-    '{rdata: csr.mip_q & csr.mideleg_q, wdata: csr.mip_q & csr.mideleg_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.stvec = CVA6Cfg.RVS ?
-    '{rdata: csr.stvec_q, wdata: csr.stvec_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.scounteren = CVA6Cfg.RVS ?
-    '{rdata: csr.scounteren_q, wdata: csr.scounteren_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.sscratch = CVA6Cfg.RVS ?
-    '{rdata: csr.sscratch_q, wdata: csr.sscratch_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.sepc = CVA6Cfg.RVS ?
-    '{rdata: csr.sepc_q, wdata: csr.sepc_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.scause = CVA6Cfg.RVS ?
-    '{rdata: csr.scause_q, wdata: csr.scause_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.stval = CVA6Cfg.RVS ?
-    '{rdata: csr.stval_q, wdata: csr.stval_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.satp = CVA6Cfg.RVS ?
-    '{rdata: csr.satp_q, wdata: csr.satp_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.mstatus = '{
-        rdata: csr.mstatus_extended,
-        wdata: csr.mstatus_extended,
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.mstatush = CVA6Cfg.XLEN == 32 ?
-    '{rdata: '0, wdata: '0, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.misa = '{rdata: IsaCode, wdata: IsaCode, rmask: '1, wmask: '1};
-    rvfi_csr_o.medeleg = CVA6Cfg.RVS ?
-    '{rdata: csr.medeleg_q, wdata: csr.medeleg_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.mideleg = CVA6Cfg.RVS ?
-    '{rdata: csr.mideleg_q, wdata: csr.mideleg_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.mie = '{rdata: csr.mie_q, wdata: csr.mie_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.mtvec = '{rdata: csr.mtvec_q, wdata: csr.mtvec_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.mcounteren = '{
-        rdata: csr.mcounteren_q,
-        wdata: csr.mcounteren_q,
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.mscratch = '{rdata: csr.mscratch_q, wdata: csr.mscratch_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.mepc = '{rdata: csr.mepc_q, wdata: csr.mepc_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.mcause = '{rdata: csr.mcause_q, wdata: csr.mcause_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.mtval = '{rdata: csr.mtval_q, wdata: csr.mtval_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.mip = '{rdata: csr.mip_q, wdata: csr.mip_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.menvcfg = '{
-        rdata: {{CVA6Cfg.XLEN - 1{1'b0}}, csr.fiom_q},
-        wdata: {{CVA6Cfg.XLEN - 1{1'b0}}, csr.fiom_q},
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.menvcfgh = CVA6Cfg.XLEN == 32 ?
-    '{rdata: '0, wdata: '0, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.mvendorid = '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, OPENHWGROUP_MVENDORID},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, OPENHWGROUP_MVENDORID},
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.marchid = '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, ARIANE_MARCHID},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, ARIANE_MARCHID},
-        rmask: '1,
-        wmask: '1
-    };
+    `define CONNECT_RVFI_FULL(CSR_ENABLE_COND, CSR_NAME, CSR_SOURCE_NAME ) \
+      bit [CVA6Cfg.XLEN-1:0] ``CSR_NAME``_d; \
+      always_ff @(posedge clk_i) begin \
+        ``CSR_NAME``_d <= ``CSR_SOURCE_NAME; \
+      end \
+      always_comb begin \
+        rvfi_csr_o.``CSR_NAME = CSR_ENABLE_COND ? \
+        '{ rdata: { '0, ``CSR_NAME``_d }, \
+          wdata: { '0, ``CSR_SOURCE_NAME }, \
+          rmask: '1, wmask: '1} \
+          : '0; \
+      end
 
-    rvfi_csr_o.mhartid = '{rdata: hart_id_i, wdata: hart_id_i, rmask: '1, wmask: '1};
-    rvfi_csr_o.mcountinhibit = '{
-        rdata: {{(CVA6Cfg.XLEN - (MHPMCounterNum + 3)) {1'b0}}, csr.mcountinhibit_q},
-        wdata: {{(CVA6Cfg.XLEN - (MHPMCounterNum + 3)) {1'b0}}, csr.mcountinhibit_q},
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.mcycle = '{
-        rdata: csr.cycle_q[CVA6Cfg.XLEN-1:0],
-        wdata: csr.cycle_q[CVA6Cfg.XLEN-1:0],
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.mcycleh = CVA6Cfg.XLEN == 32 ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.cycle_q[63:32]},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.cycle_q[63:32]},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.minstret = '{
-        rdata: csr.instret_q[CVA6Cfg.XLEN-1:0],
-        wdata: csr.instret_q[CVA6Cfg.XLEN-1:0],
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.minstreth = CVA6Cfg.XLEN == 32 ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.instret_q[63:32]},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.instret_q[63:32]},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.cycle = '{
-        rdata: csr.cycle_q[CVA6Cfg.XLEN-1:0],
-        wdata: csr.cycle_q[CVA6Cfg.XLEN-1:0],
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.cycleh = CVA6Cfg.XLEN == 32 ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.cycle_q[63:32]},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.cycle_q[63:32]},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.instret = '{
-        rdata: csr.instret_q[CVA6Cfg.XLEN-1:0],
-        wdata: csr.instret_q[CVA6Cfg.XLEN-1:0],
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.instreth = CVA6Cfg.XLEN == 32 ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.instret_q[63:32]},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.instret_q[63:32]},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.dcache = '{rdata: csr.dcache_q, wdata: csr.dcache_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.icache = '{rdata: csr.icache_q, wdata: csr.icache_q, rmask: '1, wmask: '1};
-    rvfi_csr_o.acc_cons = CVA6Cfg.EnableAccelerator ?
-    '{rdata: csr.acc_cons_q, wdata: csr.acc_cons_q, rmask: '1, wmask: '1}
-    : '0;
-    rvfi_csr_o.pmpcfg0 = '{
-        rdata: csr.pmpcfg_q[CVA6Cfg.XLEN/8-1:0],
-        wdata: csr.pmpcfg_q[CVA6Cfg.XLEN/8-1:0],
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.pmpcfg1 = CVA6Cfg.XLEN == 32 ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.pmpcfg_q[7:4]},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.pmpcfg_q[7:4]},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
-    rvfi_csr_o.pmpcfg2 = '{
-        rdata: csr.pmpcfg_q[8+:CVA6Cfg.XLEN/8],
-        wdata: csr.pmpcfg_q[8+:CVA6Cfg.XLEN/8],
-        rmask: '1,
-        wmask: '1
-    };
-    rvfi_csr_o.pmpcfg3 = CVA6Cfg.XLEN == 32 ?
-    '{
-        rdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.pmpcfg_q[15:12]},
-        wdata: {{CVA6Cfg.XLEN - 32{1'b0}}, csr.pmpcfg_q[15:12]},
-        rmask: '1,
-        wmask: '1
-    }
-    : '0;
+    `define COMMA ,
 
+    `define CONNECT_RVFI_SAME(CSR_ENABLE_COND, CSR_NAME) \
+            `CONNECT_RVFI_FULL(CSR_ENABLE_COND, CSR_NAME, csr.``CSR_NAME``_q)
+
+    `CONNECT_RVFI_FULL(CVA6Cfg.FpPresent, fflags, csr.fcsr_q.fflags )
+    `CONNECT_RVFI_FULL( CVA6Cfg.FpPresent, frm , csr.fcsr_q.frm )
+    `CONNECT_RVFI_FULL( CVA6Cfg.FpPresent, fcsr , { csr.fcsr_q.frm `COMMA csr.fcsr_q.fflags} )
+
+    `CONNECT_RVFI_FULL( CVA6Cfg.FpPresent, ftran, csr.fcsr_q.fprec )
+    `CONNECT_RVFI_SAME( CVA6Cfg.FpPresent, dcsr )
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.DebugEn, dpc )
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.DebugEn, dscratch0)
+    `CONNECT_RVFI_SAME( CVA6Cfg.DebugEn, dscratch1)
+
+    `CONNECT_RVFI_FULL( CVA6Cfg.RVS , sstatus, csr.mstatus_extended & SMODE_STATUS_READ_MASK[CVA6Cfg.XLEN-1:0] )
+
+    `CONNECT_RVFI_FULL( CVA6Cfg.RVS , sie , csr.mie_q & csr.mideleg_q )
+    `CONNECT_RVFI_FULL( CVA6Cfg.RVS , sip , csr.mip_q & csr.mideleg_q )
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , stvec)
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , scounteren)
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , sscratch)
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , sepc)
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , scause)
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , stval)
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , satp)
+
+    `CONNECT_RVFI_FULL( 1'b1 , mstatus , csr.mstatus_extended )
+
+    `CONNECT_RVFI_FULL( 1'b1 , mstatush , '0 )
+
+    `CONNECT_RVFI_FULL( 1'b1 , misa, IsaCode )
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , medeleg)
+    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , mideleg)
+
+    `CONNECT_RVFI_SAME( 1'b1, mie)
+    `CONNECT_RVFI_SAME( 1'b1, mtvec)
+    `CONNECT_RVFI_SAME( 1'b1, mcounteren)
+
+    `CONNECT_RVFI_SAME( 1'b1, mscratch)
+
+    `CONNECT_RVFI_SAME( 1'b1, mepc )
+    `CONNECT_RVFI_SAME( 1'b1, mcause )
+    `CONNECT_RVFI_SAME( 1'b1, mtval )
+    `CONNECT_RVFI_SAME( 1'b1, mip)
+
+    `CONNECT_RVFI_FULL( 1'b1, menvcfg, csr.fiom_q)
+
+    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, menvcfgh, 0)
+
+    `CONNECT_RVFI_FULL( 1'b1, mvendorid, OPENHWGROUP_MVENDORID)
+    `CONNECT_RVFI_FULL( 1'b1, marchid, ARIANE_MARCHID)
+    `CONNECT_RVFI_FULL( 1'b1, mhartid, hart_id_i)
+
+    `CONNECT_RVFI_SAME( 1'b1, mcountinhibit)
+
+    `CONNECT_RVFI_FULL( 1'b1, mcycle,  csr.cycle_q[CVA6Cfg.XLEN-1:0])
+    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, mcycleh, csr.cycle_q[63:32])
+
+    `CONNECT_RVFI_FULL( 1'b1, minstret,  csr.instret_q[CVA6Cfg.XLEN-1:0])
+    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, minstreth, csr.instret_q[63:32])
+
+    `CONNECT_RVFI_FULL( 1'b1, cycle,  csr.cycle_q[CVA6Cfg.XLEN-1:0])
+    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, cycleh, csr.cycle_q[63:32])
+
+    `CONNECT_RVFI_FULL( 1'b1, instret,  csr.instret_q[CVA6Cfg.XLEN-1:0])
+    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, instreth, csr.instret_q[63:32])
+
+    `CONNECT_RVFI_SAME( 1'b1, dcache)
+    `CONNECT_RVFI_SAME( 1'b1, icache)
+
+    `CONNECT_RVFI_SAME( CVA6Cfg.EnableAccelerator, acc_cons)
+
+    `CONNECT_RVFI_FULL( 1'b1, pmpcfg0, csr.pmpcfg_q[CVA6Cfg.XLEN/8-1:0])
+    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, pmpcfg1, csr.pmpcfg_q[7:4])
+
+    `CONNECT_RVFI_FULL( 1'b1, pmpcfg2, csr.pmpcfg_q[8+:CVA6Cfg.XLEN/8])
+    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, pmpcfg3, csr.pmpcfg_q[15:12])
+
+    always_comb begin
     for (int i = 0; i < 16; i++) begin
       rvfi_csr_o.pmpaddr[i] = '{
           rdata:
@@ -538,7 +405,6 @@ module cva6_rvfi
       };
     end
     ;
-
   end
 
 

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -278,12 +278,12 @@ module cva6_rvfi
   `define CONNECT_RVFI_FULL(CSR_ENABLE_COND, CSR_NAME, CSR_SOURCE_NAME) \
       bit [CVA6Cfg.XLEN-1:0] ``CSR_NAME``_d; \
       always_ff @(posedge clk_i) begin \
-        ``CSR_NAME``_d <= ``CSR_SOURCE_NAME; \
+        ``CSR_NAME``_d <= {{CVA6Cfg.XLEN - $bits(CSR_SOURCE_NAME)}, CSR_SOURCE_NAME}; \
       end \
       always_comb begin \
         rvfi_csr_o.``CSR_NAME = CSR_ENABLE_COND ? \
-        '{ rdata: { '0, ``CSR_NAME``_d }, \
-          wdata: { '0, ``CSR_SOURCE_NAME }, \
+        '{ rdata: ``CSR_NAME``_d , \
+          wdata: { {{CVA6Cfg.XLEN-$bits(CSR_SOURCE_NAME)}, CSR_SOURCE_NAME} }, \
           rmask: '1, wmask: '1} \
           : '0; \
       end

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -275,7 +275,7 @@ module cva6_rvfi
 
 
 
-    `define CONNECT_RVFI_FULL(CSR_ENABLE_COND, CSR_NAME, CSR_SOURCE_NAME ) \
+  `define CONNECT_RVFI_FULL(CSR_ENABLE_COND, CSR_NAME, CSR_SOURCE_NAME) \
       bit [CVA6Cfg.XLEN-1:0] ``CSR_NAME``_d; \
       always_ff @(posedge clk_i) begin \
         ``CSR_NAME``_d <= ``CSR_SOURCE_NAME; \
@@ -288,96 +288,97 @@ module cva6_rvfi
           : '0; \
       end
 
-    `define COMMA ,
+  `define COMMA ,
 
-    `define CONNECT_RVFI_SAME(CSR_ENABLE_COND, CSR_NAME) \
+  `define CONNECT_RVFI_SAME(CSR_ENABLE_COND, CSR_NAME) \
             `CONNECT_RVFI_FULL(CSR_ENABLE_COND, CSR_NAME, csr.``CSR_NAME``_q)
 
-    `CONNECT_RVFI_FULL(CVA6Cfg.FpPresent, fflags, csr.fcsr_q.fflags )
-    `CONNECT_RVFI_FULL( CVA6Cfg.FpPresent, frm , csr.fcsr_q.frm )
-    `CONNECT_RVFI_FULL( CVA6Cfg.FpPresent, fcsr , { csr.fcsr_q.frm `COMMA csr.fcsr_q.fflags} )
+  `CONNECT_RVFI_FULL(CVA6Cfg.FpPresent, fflags, csr.fcsr_q.fflags)
+  `CONNECT_RVFI_FULL(CVA6Cfg.FpPresent, frm, csr.fcsr_q.frm)
+  `CONNECT_RVFI_FULL(CVA6Cfg.FpPresent, fcsr, { csr.fcsr_q.frm `COMMA csr.fcsr_q.fflags})
 
-    `CONNECT_RVFI_FULL( CVA6Cfg.FpPresent, ftran, csr.fcsr_q.fprec )
-    `CONNECT_RVFI_SAME( CVA6Cfg.FpPresent, dcsr )
+  `CONNECT_RVFI_FULL(CVA6Cfg.FpPresent, ftran, csr.fcsr_q.fprec)
+  `CONNECT_RVFI_SAME(CVA6Cfg.FpPresent, dcsr)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.DebugEn, dpc )
+  `CONNECT_RVFI_SAME(CVA6Cfg.DebugEn, dpc)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.DebugEn, dscratch0)
-    `CONNECT_RVFI_SAME( CVA6Cfg.DebugEn, dscratch1)
+  `CONNECT_RVFI_SAME(CVA6Cfg.DebugEn, dscratch0)
+  `CONNECT_RVFI_SAME(CVA6Cfg.DebugEn, dscratch1)
 
-    `CONNECT_RVFI_FULL( CVA6Cfg.RVS , sstatus, csr.mstatus_extended & SMODE_STATUS_READ_MASK[CVA6Cfg.XLEN-1:0] )
+  `CONNECT_RVFI_FULL(CVA6Cfg.RVS, sstatus,
+                     csr.mstatus_extended & SMODE_STATUS_READ_MASK[CVA6Cfg.XLEN-1:0])
 
-    `CONNECT_RVFI_FULL( CVA6Cfg.RVS , sie , csr.mie_q & csr.mideleg_q )
-    `CONNECT_RVFI_FULL( CVA6Cfg.RVS , sip , csr.mip_q & csr.mideleg_q )
+  `CONNECT_RVFI_FULL(CVA6Cfg.RVS, sie, csr.mie_q & csr.mideleg_q)
+  `CONNECT_RVFI_FULL(CVA6Cfg.RVS, sip, csr.mip_q & csr.mideleg_q)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , stvec)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, stvec)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , scounteren)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, scounteren)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , sscratch)
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , sepc)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, sscratch)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, sepc)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , scause)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, scause)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , stval)
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , satp)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, stval)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, satp)
 
-    `CONNECT_RVFI_FULL( 1'b1 , mstatus , csr.mstatus_extended )
+  `CONNECT_RVFI_FULL(1'b1, mstatus, csr.mstatus_extended)
 
-    `CONNECT_RVFI_FULL( 1'b1 , mstatush , '0 )
+  `CONNECT_RVFI_FULL(1'b1, mstatush, '0)
 
-    `CONNECT_RVFI_FULL( 1'b1 , misa, IsaCode )
+  `CONNECT_RVFI_FULL(1'b1, misa, IsaCode)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , medeleg)
-    `CONNECT_RVFI_SAME( CVA6Cfg.RVS , mideleg)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, medeleg)
+  `CONNECT_RVFI_SAME(CVA6Cfg.RVS, mideleg)
 
-    `CONNECT_RVFI_SAME( 1'b1, mie)
-    `CONNECT_RVFI_SAME( 1'b1, mtvec)
-    `CONNECT_RVFI_SAME( 1'b1, mcounteren)
+  `CONNECT_RVFI_SAME(1'b1, mie)
+  `CONNECT_RVFI_SAME(1'b1, mtvec)
+  `CONNECT_RVFI_SAME(1'b1, mcounteren)
 
-    `CONNECT_RVFI_SAME( 1'b1, mscratch)
+  `CONNECT_RVFI_SAME(1'b1, mscratch)
 
-    `CONNECT_RVFI_SAME( 1'b1, mepc )
-    `CONNECT_RVFI_SAME( 1'b1, mcause )
-    `CONNECT_RVFI_SAME( 1'b1, mtval )
-    `CONNECT_RVFI_SAME( 1'b1, mip)
+  `CONNECT_RVFI_SAME(1'b1, mepc)
+  `CONNECT_RVFI_SAME(1'b1, mcause)
+  `CONNECT_RVFI_SAME(1'b1, mtval)
+  `CONNECT_RVFI_SAME(1'b1, mip)
 
-    `CONNECT_RVFI_FULL( 1'b1, menvcfg, csr.fiom_q)
+  `CONNECT_RVFI_FULL(1'b1, menvcfg, csr.fiom_q)
 
-    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, menvcfgh, 0)
+  `CONNECT_RVFI_FULL(CVA6Cfg.XLEN == 32, menvcfgh, 0)
 
-    `CONNECT_RVFI_FULL( 1'b1, mvendorid, OPENHWGROUP_MVENDORID)
-    `CONNECT_RVFI_FULL( 1'b1, marchid, ARIANE_MARCHID)
-    `CONNECT_RVFI_FULL( 1'b1, mhartid, hart_id_i)
+  `CONNECT_RVFI_FULL(1'b1, mvendorid, OPENHWGROUP_MVENDORID)
+  `CONNECT_RVFI_FULL(1'b1, marchid, ARIANE_MARCHID)
+  `CONNECT_RVFI_FULL(1'b1, mhartid, hart_id_i)
 
-    `CONNECT_RVFI_SAME( 1'b1, mcountinhibit)
+  `CONNECT_RVFI_SAME(1'b1, mcountinhibit)
 
-    `CONNECT_RVFI_FULL( 1'b1, mcycle,  csr.cycle_q[CVA6Cfg.XLEN-1:0])
-    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, mcycleh, csr.cycle_q[63:32])
+  `CONNECT_RVFI_FULL(1'b1, mcycle, csr.cycle_q[CVA6Cfg.XLEN-1:0])
+  `CONNECT_RVFI_FULL(CVA6Cfg.XLEN == 32, mcycleh, csr.cycle_q[63:32])
 
-    `CONNECT_RVFI_FULL( 1'b1, minstret,  csr.instret_q[CVA6Cfg.XLEN-1:0])
-    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, minstreth, csr.instret_q[63:32])
+  `CONNECT_RVFI_FULL(1'b1, minstret, csr.instret_q[CVA6Cfg.XLEN-1:0])
+  `CONNECT_RVFI_FULL(CVA6Cfg.XLEN == 32, minstreth, csr.instret_q[63:32])
 
-    `CONNECT_RVFI_FULL( 1'b1, cycle,  csr.cycle_q[CVA6Cfg.XLEN-1:0])
-    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, cycleh, csr.cycle_q[63:32])
+  `CONNECT_RVFI_FULL(1'b1, cycle, csr.cycle_q[CVA6Cfg.XLEN-1:0])
+  `CONNECT_RVFI_FULL(CVA6Cfg.XLEN == 32, cycleh, csr.cycle_q[63:32])
 
-    `CONNECT_RVFI_FULL( 1'b1, instret,  csr.instret_q[CVA6Cfg.XLEN-1:0])
-    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, instreth, csr.instret_q[63:32])
+  `CONNECT_RVFI_FULL(1'b1, instret, csr.instret_q[CVA6Cfg.XLEN-1:0])
+  `CONNECT_RVFI_FULL(CVA6Cfg.XLEN == 32, instreth, csr.instret_q[63:32])
 
-    `CONNECT_RVFI_SAME( 1'b1, dcache)
-    `CONNECT_RVFI_SAME( 1'b1, icache)
+  `CONNECT_RVFI_SAME(1'b1, dcache)
+  `CONNECT_RVFI_SAME(1'b1, icache)
 
-    `CONNECT_RVFI_SAME( CVA6Cfg.EnableAccelerator, acc_cons)
+  `CONNECT_RVFI_SAME(CVA6Cfg.EnableAccelerator, acc_cons)
 
-    `CONNECT_RVFI_FULL( 1'b1, pmpcfg0, csr.pmpcfg_q[CVA6Cfg.XLEN/8-1:0])
-    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, pmpcfg1, csr.pmpcfg_q[7:4])
+  `CONNECT_RVFI_FULL(1'b1, pmpcfg0, csr.pmpcfg_q[CVA6Cfg.XLEN/8-1:0])
+  `CONNECT_RVFI_FULL(CVA6Cfg.XLEN == 32, pmpcfg1, csr.pmpcfg_q[7:4])
 
-    `CONNECT_RVFI_FULL( 1'b1, pmpcfg2, csr.pmpcfg_q[8+:CVA6Cfg.XLEN/8])
-    `CONNECT_RVFI_FULL( CVA6Cfg.XLEN == 32, pmpcfg3, csr.pmpcfg_q[15:12])
+  `CONNECT_RVFI_FULL(1'b1, pmpcfg2, csr.pmpcfg_q[8+:CVA6Cfg.XLEN/8])
+  `CONNECT_RVFI_FULL(CVA6Cfg.XLEN == 32, pmpcfg3, csr.pmpcfg_q[15:12])
 
-    bit [CVA6Cfg.XLEN-1:0] pmpaddr_q;
-    genvar i;
-    generate
+  bit [CVA6Cfg.XLEN-1:0] pmpaddr_q;
+  genvar i;
+  generate
     for (i = 0; i < 16; i++) begin
       always_ff @(posedge clk_i) begin
         pmpaddr_q[i] = (csr.pmpcfg_q[i].addr_mode[1] == 1'b1) ?
@@ -386,7 +387,7 @@ module cva6_rvfi
       end
       always_comb begin
         rvfi_csr_o.pmpaddr[i] = '{
-            rdata: { '0, pmpaddr_q[i] },
+            rdata: {'0, pmpaddr_q[i]},
             wdata:
             csr.pmpcfg_q[i].addr_mode[1]
             == 1'b1 ?
@@ -403,7 +404,7 @@ module cva6_rvfi
         };
       end
     end
-    endgenerate
-    ;
+  endgenerate
+  ;
 
 endmodule

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -722,9 +722,10 @@ module ariane_testharness #(
 
 `ifdef VERILATOR
     initial begin
-        int verbosity = 0;
+        string verbosity = 0;
         if ($value$plusargs("UVM_VERBOSITY=%s",verbosity)) begin
-            uvm_set_verbosity_level(verbosity);
+          uvm_set_verbosity_level(verbosity);
+          `uvm_info("ariane_testharness", $sformatf("Set UVM_VERBOSITY to %s", verbosity), UVM_NONE)
         end
     end
 `endif

--- a/corev_apu/tb/common/spike.sv
+++ b/corev_apu/tb/common/spike.sv
@@ -57,7 +57,6 @@ module spike #(
 
     // There is a need of delayed rvfi as the 'csr'_q signal does not have the
     // written value
-    rvfi_instr_t[CVA6Cfg.NrCommitPorts-1:0] rvfi_q;
     st_rvfi s_core, s_reference_model;
     logic [63:0] pc64;
     logic [31:0] rtl_instr;
@@ -67,38 +66,32 @@ module spike #(
 
     always_ff @(posedge clk_i) begin
         if (rst_ni) begin
-            rvfi_q <= rvfi_i;
-        end
-    end
-
-    always_ff @(posedge clk_i) begin
-        if (rst_ni) begin
 
             for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
                 longint unsigned index = 0;
 
-                if (rvfi_q[i].valid || rvfi_q[i].trap) begin
-                    s_core.order = rvfi_q[i].order;
-                    s_core.insn  = rvfi_q[i].insn;
-                    s_core.trap  = rvfi_q[i].trap;
-                    s_core.trap  |= (rvfi_q[i].cause << 1);
-                    s_core.halt  = rvfi_q[i].halt;
-                    s_core.intr  = rvfi_q[i].intr;
-                    s_core.mode  = rvfi_q[i].mode;
-                    s_core.ixl   = rvfi_q[i].ixl;
-                    s_core.rs1_addr   = rvfi_q[i].rs1_addr;
-                    s_core.rs2_addr   = rvfi_q[i].rs2_addr;
-                    s_core.rs1_rdata  = rvfi_q[i].rs1_rdata;
-                    s_core.rs2_rdata  = rvfi_q[i].rs2_rdata;
-                    s_core.rd1_addr   = rvfi_q[i].rd_addr;
-                    s_core.rd1_wdata  = rvfi_q[i].rd_wdata;
-                    s_core.pc_rdata   = rvfi_q[i].pc_rdata;
-                    s_core.pc_wdata   = rvfi_q[i].pc_wdata;
-                    s_core.mem_addr   = rvfi_q[i].mem_addr;
-                    s_core.mem_rmask  = rvfi_q[i].mem_rmask;
-                    s_core.mem_wmask  = rvfi_q[i].mem_wmask;
-                    s_core.mem_rdata  = rvfi_q[i].mem_rdata;
-                    s_core.mem_wdata  = rvfi_q[i].mem_wdata;
+                if (rvfi_i[i].valid || rvfi_i[i].trap) begin
+                    s_core.order = rvfi_i[i].order;
+                    s_core.insn  = rvfi_i[i].insn;
+                    s_core.trap  = rvfi_i[i].trap;
+                    s_core.trap  |= (rvfi_i[i].cause << 1);
+                    s_core.halt  = rvfi_i[i].halt;
+                    s_core.intr  = rvfi_i[i].intr;
+                    s_core.mode  = rvfi_i[i].mode;
+                    s_core.ixl   = rvfi_i[i].ixl;
+                    s_core.rs1_addr   = rvfi_i[i].rs1_addr;
+                    s_core.rs2_addr   = rvfi_i[i].rs2_addr;
+                    s_core.rs1_rdata  = rvfi_i[i].rs1_rdata;
+                    s_core.rs2_rdata  = rvfi_i[i].rs2_rdata;
+                    s_core.rd1_addr   = rvfi_i[i].rd_addr;
+                    s_core.rd1_wdata  = rvfi_i[i].rd_wdata;
+                    s_core.pc_rdata   = rvfi_i[i].pc_rdata;
+                    s_core.pc_wdata   = rvfi_i[i].pc_wdata;
+                    s_core.mem_addr   = rvfi_i[i].mem_addr;
+                    s_core.mem_rmask  = rvfi_i[i].mem_rmask;
+                    s_core.mem_wmask  = rvfi_i[i].mem_wmask;
+                    s_core.mem_rdata  = rvfi_i[i].mem_rdata;
+                    s_core.mem_wdata  = rvfi_i[i].mem_wdata;
 
                     `define GET_RVFI_CSR(CSR_ADDR, CSR_NAME, CSR_INDEX) \
                         s_core.csr_valid[CSR_INDEX] = 1; \

--- a/verif/sim/setup-env.sh
+++ b/verif/sim/setup-env.sh
@@ -1,5 +1,13 @@
 # CVA6 project root
-export ROOT_PROJECT=$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../..)
+if [ -n "$BASH_VERSION" ]; then
+  SCRIPT_PATH="$BASH_SOURCE[0]"
+elif [ -n "$ZSH_VERSION" ]; then
+  SCRIPT_PATH="${(%):-%N}"
+else
+  echo "Error: Non recognized shell."
+  return
+fi
+export ROOT_PROJECT=$(readlink -f $(dirname "${SCRIPT_PATH}")/../..)
 
 export RTL_PATH="$ROOT_PROJECT/"
 export TB_PATH="$ROOT_PROJECT/verif/tb/core"

--- a/verif/tests/uvmt/base-tests/uvmt_cva6_base_test.sv
+++ b/verif/tests/uvmt/base-tests/uvmt_cva6_base_test.sv
@@ -365,9 +365,6 @@ function void uvmt_cva6_base_test_c::pkg_to_cfg();
     st_core_cntrl_cfg st = env_cfg.to_struct();
     st = cva6pkg_to_core_cntrl_cfg(st);
 
-    // TODO Remove when the functionality works
-    st.disable_all_csr_checks = 1;
-
     env_cfg.from_struct(st);
 
     env_cfg.post_randomize();


### PR DESCRIPTION
- Change RVFI implementation to get the `_d` and `_q` CSRs values
- Support ZSH shell in `setup-env.sh`
- Fix `UVM_VERBOSITY` in `veri-testharness`