### PR TITLE
Functional coverage : no need for cvxif directed tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ workflow:
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
   DASHBOARD: cva6
-  DV_TARGET: cv32a6_embedded
+  DV_TARGET: cv32a65x
 
 default:
   tags: [$TAGS_RUNNER]
@@ -428,23 +428,6 @@ csr_embedded_tests:
     - mv verif/sim/vcs_results/default/vcs.d/simv.vdb artifacts/coverage
     - python3 .gitlab-ci/scripts/report_pass.py
 
-directed_xif-tests:
-  extends:
-    - .verif_test
-  variables:
-    DASHBOARD_SORT_INDEX: 16
-    DASHBOARD_JOB_CATEGORY: "Functional Coverage"
-  parallel:
-    matrix:
-      - list_num: 0
-        DASHBOARD_JOB_TITLE: "Directed tests"
-        DASHBOARD_JOB_DESCRIPTION: "Execute directed tests to improve functional coverage of cvxif"
-  script:
-    - mkdir -p artifacts/coverage
-    - source verif/regress/dv-generated-xif-tests.sh
-    - mv verif/sim/vcs_results/default/vcs.d/simv.vdb artifacts/coverage
-    - python3 .gitlab-ci/scripts/report_pass.py
-
 .backend_test:
   stage: backend tests
   before_script:
@@ -508,7 +491,6 @@ code_coverage-report:
     - generated_tests
     - directed_isacov-tests
     - generated_xif_tests
-    - directed_xif-tests
     - csr_embedded_tests
   variables:
     DASHBOARD_JOB_TITLE: "Report merge coverage"

--- a/verif/env/uvme/uvme_cva6_cfg.sv
+++ b/verif/env/uvme/uvme_cva6_cfg.sv
@@ -83,12 +83,15 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
       soft sys_clk_period          == uvme_cva6_sys_default_clk_period; // see uvme_cva6_constants.sv
    }
 
-   constraint cvxif_feature { //CV32A60X do not support dual read & write also the memory interface
-      cvxif_cfg.dual_read_write_support_x == 0;
-      cvxif_cfg.load_store_support_x == 0;
-      cvxif_cfg.seq_cus_instr_x2_enabled == 1;
-      cvxif_cfg.reg_cus_crosses_enabled == 0;
+   constraint cvxif_feature { //CV32A65X do not support dual read & write also the memory interface
+      cvxif_cfg.dual_read_write_support_x  == 0;
+      cvxif_cfg.load_store_support_x       == 0;
+      cvxif_cfg.seq_cus_instr_x2_enabled   == 1;
+      cvxif_cfg.reg_cus_crosses_enabled    == 0;
+      cvxif_cfg.mode_s_supported           == mode_s_supported;
+      cvxif_cfg.mode_u_supported           == mode_u_supported;
    }
+
    constraint cva6_riscv_cons {
       xlen == uvma_core_cntrl_pkg::MXL_32;
       ilen == 32;


### PR DESCRIPTION
Hello, this MR remove cvxif directed tests, because the CVA32A65X doesn't support S or U mode, and as it known the cvxif directed test has one job to cover S & U mode request from the CVA6 to co-pro.

A [MR in core-v-verif](https://gitlab-tss.gemalto.com/riscv/ohg-pr/core-v-verif/-/merge_requests/93/diffs) ignore this bins if we don't support S or U mode