### PR TITLE
Modify the params order inside the cva6_user_cfg_t

### DIFF
--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -48,30 +48,6 @@ package config_pkg;
   typedef struct packed {
     // General Purpose Register Size (in bits)
     int unsigned                 XLEN;
-    // Is FPGA optimization of CV32A6
-    bit                          FPGA_EN;
-    // Number of commit ports
-    int unsigned                 NrCommitPorts;
-    // AXI address width
-    int unsigned                 AxiAddrWidth;
-    // AXI data width
-    int unsigned                 AxiDataWidth;
-    // AXI ID width
-    int unsigned                 AxiIdWidth;
-    // AXI User width
-    int unsigned                 AxiUserWidth;
-    // TODO
-    int unsigned                 MemTidWidth;
-    // Load buffer entry buffer
-    int unsigned                 NrLoadBufEntries;
-    // Floating Point
-    bit                          FpuEn;
-    // Non standard 16bits Floating Point
-    bit                          XF16;
-    // Non standard 16bits Floating Point Alt
-    bit                          XF16ALT;
-    // Non standard 8bits Floating Point
-    bit                          XF8;
     // Atomic RISC-V extension
     bit                          RVA;
     // Bit manipulation RISC-V extension
@@ -86,33 +62,33 @@ package config_pkg;
     bit                          RVZCB;
     // Zcmp RISC-V extension
     bit                          RVZCMP;
-    // Non standard Vector Floating Point
-    bit                          XFVec;
-    // CV-X-IF coprocessor interface is supported
-    bit                          CvxifEn;
     // Zicond RISC-V extension
     bit                          ZiCondExtEn;
+    // Floating Point
+    bit                          FpuEn;
+    // Non standard 16bits Floating Point extension
+    bit                          XF16;
+    // Non standard 16bits Floating Point Alt extension
+    bit                          XF16ALT;
+    // Non standard 8bits Floating Point extension
+    bit                          XF8;
+    // Non standard Vector Floating Point extension
+    bit                          XFVec;
     // Supervisor mode
     bit                          RVS;
     // User mode
     bit                          RVU;
-    // Scoreboard length
-    int unsigned                 NrScoreboardEntries;
+    // Debug support
+    bit                          DebugEn;
+    // Base address of the debug module
+    logic [63:0]                 DmBaseAddress;
     // Address to jump when halt request
     logic [63:0]                 HaltAddress;
     // Address to jump when exception
     logic [63:0]                 ExceptionAddress;
-    // Return address stack depth
-    int unsigned                 RASDepth;
-    // Branch target buffer entries
-    int unsigned                 BTBEntries;
-    // Branch history entries
-    int unsigned                 BHTEntries;
-    // Base address of the debug module
-    logic [63:0]                 DmBaseAddress;
     // Tval Support Enable
     bit                          TvalEn;
-    // Number of PMP entries
+    // PMP entries number
     int unsigned                 NrPMPEntries;
     // PMP CSR configuration reset values
     logic [15:0][63:0]           PMPCfgRstVal;
@@ -120,50 +96,74 @@ package config_pkg;
     logic [15:0][63:0]           PMPAddrRstVal;
     // PMP CSR read-only bits
     bit [15:0]                   PMPEntryReadOnly;
-    // NOC bus type
-    noc_type_e                   NOCType;
-    // Number of PMA non idempotent rules
+    // PMA non idempotent rules number
     int unsigned                 NrNonIdempotentRules;
     // PMA NonIdempotent region base address
     logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
     // PMA NonIdempotent region length
     logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
-    // Number of PMA regions with execute rules
+    // PMA regions with execute rules number
     int unsigned                 NrExecuteRegionRules;
     // PMA Execute region base address
     logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
     // PMA Execute region address base
     logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
-    // Number of PMA regions with cache rules
+    // PMA regions with cache rules number
     int unsigned                 NrCachedRegionRules;
     // PMA cache region base address
     logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
     // PMA cache region rules
     logic [NrMaxRules-1:0][63:0] CachedRegionLength;
-    // Maximum number of outstanding stores
-    int unsigned                 MaxOutstandingStores;
-    // Debug support
-    bit                          DebugEn;
+    // CV-X-IF coprocessor interface enable
+    bit                          CvxifEn;
+    // NOC bus type
+    noc_type_e                   NOCType;
+    // AXI address width
+    int unsigned                 AxiAddrWidth;
+    // AXI data width
+    int unsigned                 AxiDataWidth;
+    // AXI ID width
+    int unsigned                 AxiIdWidth;
+    // AXI User width
+    int unsigned                 AxiUserWidth;
     // AXI burst in write
     bit                          AxiBurstWriteEn;
+    // TODO
+    int unsigned                 MemTidWidth;
     // Instruction cache size (in bytes)
     int unsigned                 IcacheByteSize;
     // Instruction cache associativity (number of ways)
     int unsigned                 IcacheSetAssoc;
-    // Instruction line width
+    // Instruction cache line width
     int unsigned                 IcacheLineWidth;
     // Data cache size (in bytes)
     int unsigned                 DcacheByteSize;
     // Data cache associativity (number of ways)
     int unsigned                 DcacheSetAssoc;
-    // Data line width
+    // Data cache line width
     int unsigned                 DcacheLineWidth;
-    // TODO
+    // User field on data bus enable
     int unsigned                 DataUserEn;
-    // TODO
-    int unsigned                 FetchUserWidth;
-    // TODO
+    // User field on fetch bus enable
     int unsigned                 FetchUserEn;
+    // Width of fetch user field
+    int unsigned                 FetchUserWidth;
+    // Is FPGA optimization of CV32A6
+    bit                          FPGA_EN;
+    // Number of commit ports
+    int unsigned                 NrCommitPorts;
+    // Scoreboard length
+    int unsigned                 NrScoreboardEntries;
+    // Load buffer entry buffer
+    int unsigned                 NrLoadBufEntries;
+    // Maximum number of outstanding stores
+    int unsigned                 MaxOutstandingStores;
+    // Return address stack depth
+    int unsigned                 RASDepth;
+    // Branch target buffer entries
+    int unsigned                 BTBEntries;
+    // Branch history entries
+    int unsigned                 BHTEntries;
   } cva6_user_cfg_t;
 
   typedef struct packed {

--- a/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
+++ b/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
@@ -20,54 +20,6 @@
      - General Purpose Register Size (in bits)
      - 32
 
-   * - FPGA_EN
-     - Is FPGA optimization of CV32A6
-     - 0
-
-   * - NrCommitPorts
-     - Number of commit ports
-     - 1
-
-   * - AxiAddrWidth
-     - AXI address width
-     - 64
-
-   * - AxiDataWidth
-     - AXI data width
-     - 64
-
-   * - AxiIdWidth
-     - AXI ID width
-     - 4
-
-   * - AxiUserWidth
-     - AXI User width
-     - 32
-
-   * - MemTidWidth
-     - TODO
-     - 2
-
-   * - NrLoadBufEntries
-     - Load buffer entry buffer
-     - 1
-
-   * - FpuEn
-     - Floating Point
-     - 0
-
-   * - XF16
-     - Non standard 16bits Floating Point
-     - 0
-
-   * - XF16ALT
-     - Non standard 16bits Floating Point Alt
-     - 0
-
-   * - XF8
-     - Non standard 8bits Floating Point
-     - 0
-
    * - RVA
      - Atomic RISC-V extension
      - 0
@@ -96,16 +48,28 @@
      - Zcmp RISC-V extension
      - 0
 
-   * - XFVec
-     - Non standard Vector Floating Point
-     - 0
-
-   * - CvxifEn
-     - CV-X-IF coprocessor interface is supported
-     - 1
-
    * - ZiCondExtEn
      - Zicond RISC-V extension
+     - 0
+
+   * - FpuEn
+     - Floating Point
+     - 0
+
+   * - XF16
+     - Non standard 16bits Floating Point extension
+     - 0
+
+   * - XF16ALT
+     - Non standard 16bits Floating Point Alt extension
+     - 0
+
+   * - XF8
+     - Non standard 8bits Floating Point extension
+     - 0
+
+   * - XFVec
+     - Non standard Vector Floating Point extension
      - 0
 
    * - RVS
@@ -116,9 +80,13 @@
      - User mode
      - 0
 
-   * - NrScoreboardEntries
-     - Scoreboard length
-     - 4
+   * - DebugEn
+     - Debug support
+     - 0
+
+   * - DmBaseAddress
+     - Base address of the debug module
+     - 64'h0
 
    * - HaltAddress
      - Address to jump when halt request
@@ -128,28 +96,12 @@
      - Address to jump when exception
      - 64'h808
 
-   * - RASDepth
-     - Return address stack depth
-     - 2
-
-   * - BTBEntries
-     - Branch target buffer entries
-     - 0
-
-   * - BHTEntries
-     - Branch history entries
-     - 32
-
-   * - DmBaseAddress
-     - Base address of the debug module
-     - 64'h0
-
    * - TvalEn
      - Tval Support Enable
      - 0
 
    * - NrPMPEntries
-     - Number of PMP entries
+     - PMP entries number
      - 8
 
    * - PMPCfgRstVal
@@ -164,12 +116,8 @@
      - PMP CSR read-only bits
      - 16'd0
 
-   * - NOCType
-     - NOC bus type
-     - config_pkg::NOC_TYPE_AXI4_ATOP
-
    * - NrNonIdempotentRules
-     - Number of PMA non idempotent rules
+     - PMA non idempotent rules number
      - 2
 
    * - NonIdempotentAddrBase
@@ -181,7 +129,7 @@
      - {64'b0 64'b0}
 
    * - NrExecuteRegionRules
-     - Number of PMA regions with execute rules
+     - PMA regions with execute rules number
      - 3
 
    * - ExecuteRegionAddrBase
@@ -193,7 +141,7 @@
      - {64'h40000000 64'h10000 64'h1000}
 
    * - NrCachedRegionRules
-     - Number of PMA regions with cache rules
+     - PMA regions with cache rules number
      - 1
 
    * - CachedRegionAddrBase
@@ -204,17 +152,37 @@
      - PMA cache region rules
      - {64'h40000000}
 
-   * - MaxOutstandingStores
-     - Maximum number of outstanding stores
-     - 7
+   * - CvxifEn
+     - CV-X-IF coprocessor interface enable
+     - 1
 
-   * - DebugEn
-     - Debug support
-     - 0
+   * - NOCType
+     - NOC bus type
+     - config_pkg::NOC_TYPE_AXI4_ATOP
+
+   * - AxiAddrWidth
+     - AXI address width
+     - 64
+
+   * - AxiDataWidth
+     - AXI data width
+     - 64
+
+   * - AxiIdWidth
+     - AXI ID width
+     - 4
+
+   * - AxiUserWidth
+     - AXI User width
+     - 32
 
    * - AxiBurstWriteEn
      - AXI burst in write
      - 0
+
+   * - MemTidWidth
+     - TODO
+     - 2
 
    * - IcacheByteSize
      - Instruction cache size (in bytes)
@@ -225,7 +193,7 @@
      - 2
 
    * - IcacheLineWidth
-     - Instruction line width
+     - Instruction cache line width
      - 128
 
    * - DcacheByteSize
@@ -237,17 +205,49 @@
      - 8
 
    * - DcacheLineWidth
-     - Data line width
+     - Data cache line width
      - 128
 
    * - DataUserEn
-     - TODO
+     - User field on data bus enable
+     - 0
+
+   * - FetchUserEn
+     - User field on fetch bus enable
      - 0
 
    * - FetchUserWidth
-     - TODO
+     - Width of fetch user field
      - 32
 
-   * - FetchUserEn
-     - TODO
+   * - FPGA_EN
+     - Is FPGA optimization of CV32A6
      - 0
+
+   * - NrCommitPorts
+     - Number of commit ports
+     - 1
+
+   * - NrScoreboardEntries
+     - Scoreboard length
+     - 4
+
+   * - NrLoadBufEntries
+     - Load buffer entry buffer
+     - 1
+
+   * - MaxOutstandingStores
+     - Maximum number of outstanding stores
+     - 7
+
+   * - RASDepth
+     - Return address stack depth
+     - 2
+
+   * - BTBEntries
+     - Branch target buffer entries
+     - 0
+
+   * - BHTEntries
+     - Branch history entries
+     - 32


### PR DESCRIPTION
Modify the params order inside the cva6_user_cfg_t to gather extension params in top of structure and micro-architecture params in the bottom