### PR TITLE
Support Spike Parameters in cva6.py and bump core-v-verif

### DIFF
--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -121,7 +121,7 @@ endif
 ###############################################################################
 spike:
 	LD_LIBRARY_PATH="$$(realpath ../../tools/spike/lib):$$LD_LIBRARY_PATH" \
-		$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) --priv=$(priv) -l $(elf)
+		$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) --priv=$(priv) $(spike_params) -l $(elf)
 	cp $(log).iss $(log)
 
 ###############################################################################

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -114,7 +114,7 @@ def get_generator_cmd(simulator, simulator_yaml, cov, exp, debug_cmd):
   sys.exit(RET_FAIL)
 
 
-def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv):
+def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spike_params):
   """Parse ISS YAML to get the simulation command
 
   Args:
@@ -145,6 +145,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv):
       cmd = re.sub(r"\<isscomp_opts\>", isscomp_opts, cmd)
       cmd = re.sub(r"\<issrun_opts\>", issrun_opts, cmd)
       cmd = re.sub(r"\<isspostrun_opts\>", isspostrun_opts, cmd)
+      cmd = re.sub(r"\<spike_params\>", spike_params, cmd)
       if m: cmd = re.sub(r"\<xlen\>", m.group('xlen'), cmd)
       if iss == "ovpsim":
         cmd = re.sub(r"\<cfg_path\>", setting_dir, cmd)
@@ -156,7 +157,6 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv):
       else:
         cmd = re.sub(r"\<variant\>", isa, cmd)
         cmd = re.sub(r"\<priv\>", priv, cmd)
-
       return cmd
   logging.error("Cannot find ISS %0s" % iss)
   sys.exit(RET_FAIL)
@@ -411,7 +411,7 @@ def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd, linker):
 
 
 def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
-                 setting_dir, debug_cmd, linker, priv):
+                 setting_dir, debug_cmd, linker, priv, spike_params):
   """Run a directed assembly test with ISS
 
   Args:
@@ -462,7 +462,7 @@ def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, outp
     else:
       log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, asm, target))
     log_list.append(log)
-    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv)
+    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spike_params)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
     logging.info("[%0s] Running ISS simulation: %s" % (iss, cmd))
     run_cmd(cmd, 500, debug_cmd = debug_cmd)
@@ -502,7 +502,7 @@ def run_assembly_from_dir(asm_test_dir, iss_yaml, isa, mabi, gcc_opts, iss,
 
 # python3 run.py --target rv64gc --iss=spike,verilator --elf_tests bbl.o
 def run_elf(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
-          setting_dir, debug_cmd):
+          setting_dir, debug_cmd, priv, spike_params):
   """Run a directed c test with ISS
 
   Args:
@@ -538,7 +538,7 @@ def run_elf(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
     run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
     log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, c, target))
     log_list.append(log)
-    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv)
+    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spike_params)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
     logging.info("[%0s] Running ISS simulation: %s" % (iss, cmd))
     if "veri" in iss: ratio = 35
@@ -550,7 +550,7 @@ def run_elf(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
 
 
 def run_c(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
-          setting_dir, debug_cmd, linker, priv):
+          setting_dir, debug_cmd, linker, priv, spike_params):
   """Run a directed c test with ISS
 
   Args:
@@ -599,7 +599,7 @@ def run_c(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
     else:
       log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, c, target))
     log_list.append(log)
-    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv)
+    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spike_params)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
     logging.info("[%0s] Running ISS simulation: %s" % (iss, cmd))
     run_cmd(cmd, 300, debug_cmd = debug_cmd)
@@ -639,7 +639,7 @@ def run_c_from_dir(c_test_dir, iss_yaml, isa, mabi, gcc_opts, iss,
 
 
 def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
-            isa, target, setting_dir, timeout_s, debug_cmd, priv):
+            isa, target, setting_dir, timeout_s, debug_cmd, priv, spike_params):
   """Run ISS simulation with the generated test program
 
   Args:
@@ -655,7 +655,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
   """
   for iss in iss_list.split(","):
     log_dir = ("%s/%s_sim" % (output_dir, iss))
-    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv)
+    base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spike_params)
     logging.info("%s sim log dir: %s" % (iss, log_dir))
     run_cmd_output(["mkdir", "-p", log_dir])
     for test in test_list:
@@ -762,6 +762,7 @@ def read_seed(arg):
         raise argparse.ArgumentTypeError('Bad seed ({}): '
                                          'must be a non-negative integer.'
                                          .format(arg))
+
 
 def parse_args(cwd):
   """Create a command line parser.
@@ -871,7 +872,8 @@ def parse_args(cwd):
                       help="Run test with a specific seed")
   parser.add_argument("--isa_extension", type=str, default="",
                       help="Choose additional z, s, x extensions")
-
+  parser.add_argument("--spike_params", type=str, default="",
+                      help="Spike command line parameters, run spike --help and spike --print-params to see more")
   rsg = parser.add_argument_group('Random seeds',
                                   'To control random seeds, use at most one '
                                   'of the --start_seed, --seed or --seed_yaml '
@@ -907,11 +909,12 @@ def parse_args(cwd):
                     'greater than 1.')
       sys.exit(RET_FAIL)
 
-  # We've parsed all the arguments from the command line; default values
-  # can be set in the config file. Read that here.
-  load_config(args, cwd)
-
   return args
+
+
+def get_full_spike_param_args(spike_params: list[str]):
+  return ' '.join(list(map(lambda s: "--param=" + s, spike_params.split(','))))
+
 
 def load_config(args, cwd):
   """
@@ -1026,9 +1029,13 @@ def load_config(args, cwd):
     if not args.testlist:
       args.testlist = args.custom_target + "/testlist.yaml"
 
+  args.spike_params = get_full_spike_param_args(args.spike_params)
+
+
 def incorrect_version_exit(tool, tool_version, required_version):
   logging.error(f"You are currently using version {tool_version} of {tool}, should be: {required_version}. Please install or reinstall it with the installation script." )
   sys.exit(RET_FAIL)
+
 
 def check_gcc_version():
   REQUIRED_GCC_VERSION = 11
@@ -1041,6 +1048,7 @@ def check_gcc_version():
 
   if int(gcc_version_number[0]) < REQUIRED_GCC_VERSION:
     incorrect_version_exit("GCC", gcc_version_string, f">={REQUIRED_GCC_VERSION}")
+
 
 def check_spike_version():
   # Get Spike hash from core-v-verif submodule
@@ -1060,6 +1068,7 @@ def check_spike_version():
   if user_spike_version_string != spike_version:
     incorrect_version_exit("Spike", user_spike_version_string, spike_version)
 
+
 def check_verilator_version():
   REQUIRED_VERILATOR_VERSION = "5.008"
 
@@ -1070,10 +1079,12 @@ def check_verilator_version():
   if REQUIRED_VERILATOR_VERSION != verilator_version:
     incorrect_version_exit("Verilator", verilator_version, REQUIRED_VERILATOR_VERSION)
 
+
 def check_tools_version():
   check_gcc_version()
   check_spike_version()
   check_verilator_version()
+
 
 def main():
   """This is the main entry point."""
@@ -1085,6 +1096,10 @@ def main():
     os.environ["RISCV_DV_ROOT"] = cwd + "/dv"
     os.environ["CVA6_DV_ROOT"]  = cwd + "/../env/corev-dv"
     args = parse_args(cwd)
+    # We've parsed all the arguments from the command line; default values
+    # can be set in the config file. Read that here.
+    load_config(args, cwd)
+
     if args.axi_active == "yes":
       args.issrun_opts = args.issrun_opts + " +uvm_set_config_int=*uvm_test_top,force_axi_mode,1"
     elif args.axi_active == "no":
@@ -1154,7 +1169,8 @@ def main():
           # path_asm_test is an assembly file
           elif os.path.isfile(full_path) or args.debug:
             run_assembly(full_path, args.iss_yaml, args.isa, args.target, args.mabi, args.gcc_opts,
-                         args.iss, output_dir, args.core_setting_dir, args.debug, args.linker, args.priv)
+                         args.iss, output_dir, args.core_setting_dir, args.debug, args.linker,
+                         args.priv, args.spike_params)
           else:
             logging.error('%s does not exist' % full_path)
             sys.exit(RET_FAIL)
@@ -1173,7 +1189,8 @@ def main():
           # path_c_test is a c file
           elif os.path.isfile(full_path) or args.debug:
             run_c(full_path, args.iss_yaml, args.isa, args.target, args.mabi, args.gcc_opts,
-                  args.iss, output_dir, args.core_setting_dir, args.debug, args.linker, args.priv)
+                  args.iss, output_dir, args.core_setting_dir, args.debug, args.linker,
+                  args.priv, args.spike_params)
           else:
             logging.error('%s does not exist' % full_path)
             sys.exit(RET_FAIL)
@@ -1187,7 +1204,7 @@ def main():
           # path_elf_test is an elf file
           if os.path.isfile(full_path) or args.debug:
             run_elf(full_path, args.iss_yaml, args.isa, args.target, args.mabi, args.gcc_opts,
-                  args.iss, output_dir, args.core_setting_dir, args.debug)
+                  args.iss, output_dir, args.core_setting_dir, args.debug, args.spike_params)
           else:
             logging.error('%s does not exist' % full_path)
             sys.exit(RET_FAIL)
@@ -1266,7 +1283,8 @@ def main():
               # path_asm_test is an assembly file
               elif os.path.isfile(path_asm_test):
                 run_assembly(path_asm_test, args.iss_yaml, args.isa, args.target, args.mabi, gcc_opts,
-                             args.iss, output_dir, args.core_setting_dir, args.debug, args.linker, args.priv)
+                             args.iss, output_dir, args.core_setting_dir, args.debug, args.linker,
+                             args.priv, args.spike_params)
               else:
                 if not args.debug:
                   logging.error('%s does not exist' % path_asm_test)
@@ -1295,7 +1313,8 @@ def main():
               # path_c_test is a C file
               elif os.path.isfile(path_c_test):
                 run_c(path_c_test, args.iss_yaml, args.isa, args.target, args.mabi, gcc_opts,
-                      args.iss, output_dir, args.core_setting_dir, args.debug, args.linker, args.priv)
+                      args.iss, output_dir, args.core_setting_dir, args.debug, args.linker,
+                      args.priv, args.spike_params)
               else:
                 if not args.debug:
                   logging.error('%s does not exist' % path_c_test)
@@ -1313,7 +1332,8 @@ def main():
         # Run ISS simulation
         if args.steps == "all" or re.match(".*iss_sim.*", args.steps):
           iss_sim(matched_list, output_dir, args.iss, args.iss_yaml, args.iss_opts,
-                  args.isa, args.target, args.core_setting_dir, args.iss_timeout, args.debug, args.priv)
+                  args.isa, args.target, args.core_setting_dir, args.iss_timeout, args.debug,
+                  args.priv, args.spike_params)
 
         # Compare ISS simulation result
         if args.steps == "all" or re.match(".*iss_cmp.*", args.steps):

--- a/verif/sim/cva6.yaml
+++ b/verif/sim/cva6.yaml
@@ -18,7 +18,7 @@
   # Always keep this value in sync with the settings of RTL simulators (cf.
   # <issrun_opts> values below).
   cmd: >
-    make spike steps=2000000 variant=<variant> priv=<priv> elf=<elf> tool_path=<tool_path> log=<log>
+    make spike steps=2000000 variant=<variant> priv=<priv> elf=<elf> tool_path=<tool_path> log=<log> spike_params='<spike_params>'
 
 ###############################################################################
 # Verilator

--- a/verif/tests/custom/spike_params/misa_csr_we.S
+++ b/verif/tests/custom/spike_params/misa_csr_we.S
@@ -1,0 +1,14 @@
+.globl main
+main:
+    # Disable extension C in MISA Extensions field
+    li x1, 0x00141100
+    csrw 0x301, x1
+    # If misa_we=true, following code should provoke illegal instruction exceptions
+    # And test should timeout
+    c.li x2, 0
+    c.addi x2, 2
+    c.addi x2, -2
+    li x1, 0
+    slli x1, x1, 1
+    addi x1, x1, 1
+    sw x1, tohost, t5


### PR DESCRIPTION
Add support for Spike cmd line parameters, bump core-v-verif to https://github.com/openhwgroup/core-v-verif/pull/2387. 

Add a test to test if misa_we Spike parameters is taken into account.