### PR TITLE
feat: extended hpdc cache subsystem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/openhwgroup/core-v-verif
 [submodule "core/cache_subsystem/hpdcache"]
 	path = core/cache_subsystem/hpdcache
-	url = https://github.com/openhwgroup/cv-hpdcache.git
+	url = https://github.com/takeshiho0531/cv-hpdcache.git
 [submodule "verif/sim/dv"]
 	path = verif/sim/dv
 	url = https://github.com/google/riscv-dv.git

--- a/core/cache_subsystem/extended_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/extended_hpdcache_subsystem.sv
@@ -162,52 +162,51 @@ module extended_hpdcache_subsystem
   //  I$ instantiation
   //  {{{
 
-  logic                                                         icache_miss_ready;
-  logic                                                         icache_miss_valid;
-  hpdcache_mem_req_t                                            icache_miss;
+  logic                 icache_miss_ready;
+  logic                 icache_miss_valid;
+  hpdcache_mem_req_t    icache_miss;
 
-  logic                                                         icache_miss_resp_ready;
-  logic                                                         icache_miss_resp_valid;
-  hpdcache_mem_resp_r_t                                         icache_miss_resp;
+  logic                 icache_miss_resp_ready;
+  logic                 icache_miss_resp_valid;
+  hpdcache_mem_resp_r_t icache_miss_resp;
 
-  logic                                                         icache_uc_read_ready;
-  logic                                                         icache_uc_read_valid;
-  hpdcache_mem_req_t                                            icache_uc_read;
+  logic                 icache_uc_read_ready;
+  logic                 icache_uc_read_valid;
+  hpdcache_mem_req_t    icache_uc_read;
 
-  logic                                                         icache_uc_read_ready;
-  logic                                                         icache_uc_read_valid;
-  hpdcache_mem_req_t                                            icache_uc_read;
+  logic                 icache_uc_read_ready;
+  logic                 icache_uc_read_valid;
+  hpdcache_mem_req_t    icache_uc_read;
 
-  logic                                                         icache_uc_read_resp_ready;
-  logic                                                         icache_uc_read_resp_valid;
-  hpdcache_mem_resp_r_t                                         icache_uc_read_resp;
+  logic                 icache_uc_read_resp_ready;
+  logic                 icache_uc_read_resp_valid;
+  hpdcache_mem_resp_r_t icache_uc_read_resp;
 
 
   //  {{{
-  hpdcache_icache_with_adapter # (
-  ) i_hpdcache_dcache (
-      .icache_enable_i(icache_enable_i), //
-      .icache_flush_i(icache_flush_i), //
-      .icache_flush_ack_o(icache_flush_ack_o), //
-      .icache_miss_o(icache_miss_o), //
-      .icache_amo_req_i(icache_amo_req_i), //
-      .icache_amo_resp_o(icache_amo_resp_o), //
-      .icache_cmo_req_i(icache_cmo_req_i), //
-      .icache_cmo_resp_o(icache_cmo_resp_o), //
-      .icache_req_ports_i(icache_req_ports_i), //
-      .icache_req_ports_o(icache_req_ports_o), //
-      .wbuffer_empty_o(/**/),  //
-      .wbuffer_not_ni_o(/**/),//
-      .hwpf_base_set_i(icache_hwpf_base_set_i),//
-      .hwpf_base_i(icache_hwpf_base_i),//
-      .hwpf_base_o(icache_hwpf_base_o),//
-      .hwpf_param_set_i(icache_hwpf_param_set_i), //
-      .hwpf_param_i(icache_hwpf_param_i),//
-      .hwpf_param_o(icache_hwpf_param_o),//
-      .hwpf_throttle_set_i(icache_hwpf_throttle_set_i),//
-      .hwpf_throttle_i(icache_hwpf_throttle_i),//
-      .hwpf_throttle_o(icache_hwpf_throttle_o), //
-      .hwpf_status_o(icache_hwpf_status_o),//
+  hpdcache_icache_with_adapter #() i_hpdcache_dcache (
+      .icache_enable_i(icache_enable_i),  //
+      .icache_flush_i(icache_flush_i),  //
+      .icache_flush_ack_o(icache_flush_ack_o),  //
+      .icache_miss_o(icache_miss_o),  //
+      .icache_amo_req_i(icache_amo_req_i),  //
+      .icache_amo_resp_o(icache_amo_resp_o),  //
+      .icache_cmo_req_i(icache_cmo_req_i),  //
+      .icache_cmo_resp_o(icache_cmo_resp_o),  //
+      .icache_req_ports_i(icache_req_ports_i),  //
+      .icache_req_ports_o(icache_req_ports_o),  //
+      .wbuffer_empty_o(  /**/),  //
+      .wbuffer_not_ni_o(  /**/),  //
+      .hwpf_base_set_i(icache_hwpf_base_set_i),  //
+      .hwpf_base_i(icache_hwpf_base_i),  //
+      .hwpf_base_o(icache_hwpf_base_o),  //
+      .hwpf_param_set_i(icache_hwpf_param_set_i),  //
+      .hwpf_param_i(icache_hwpf_param_i),  //
+      .hwpf_param_o(icache_hwpf_param_o),  //
+      .hwpf_throttle_set_i(icache_hwpf_throttle_set_i),  //
+      .hwpf_throttle_i(icache_hwpf_throttle_i),  //
+      .hwpf_throttle_o(icache_hwpf_throttle_o),  //
+      .hwpf_status_o(icache_hwpf_status_o),  //
 
       .icache_miss_ready_i(icache_miss_ready),
       .icache_miss_valid_o(icache_miss_valid),
@@ -226,51 +225,51 @@ module extended_hpdcache_subsystem
       .icache_miss_resp_i(icache_miss_resp)
   );
 
-//   //  D$ instantiation
+  //   //  D$ instantiation
 
-  logic                                                         dcache_miss_ready;
-  logic                                                         dcache_miss_valid;
-  hpdcache_mem_req_t                                            dcache_miss;
+  logic                 dcache_miss_ready;
+  logic                 dcache_miss_valid;
+  hpdcache_mem_req_t    dcache_miss;
 
-  logic                                                         dcache_miss_resp_ready;
-  logic                                                         dcache_miss_resp_valid;
-  hpdcache_mem_resp_r_t                                         dcache_miss_resp;
+  logic                 dcache_miss_resp_ready;
+  logic                 dcache_miss_resp_valid;
+  hpdcache_mem_resp_r_t dcache_miss_resp;
 
-  logic                                                         dcache_wbuf_ready;
-  logic                                                         dcache_wbuf_valid;
-  hpdcache_mem_req_t                                            dcache_wbuf;
+  logic                 dcache_wbuf_ready;
+  logic                 dcache_wbuf_valid;
+  hpdcache_mem_req_t    dcache_wbuf;
 
-  logic                                                         dcache_wbuf_data_ready;
-  logic                                                         dcache_wbuf_data_valid;
-  hpdcache_mem_req_w_t                                          dcache_wbuf_data;
+  logic                 dcache_wbuf_data_ready;
+  logic                 dcache_wbuf_data_valid;
+  hpdcache_mem_req_w_t  dcache_wbuf_data;
 
-  logic                                                         dcache_wbuf_resp_ready;
-  logic                                                         dcache_wbuf_resp_valid;
-  hpdcache_mem_resp_w_t                                         dcache_wbuf_resp;
+  logic                 dcache_wbuf_resp_ready;
+  logic                 dcache_wbuf_resp_valid;
+  hpdcache_mem_resp_w_t dcache_wbuf_resp;
 
-  logic                                                         dcache_uc_read_ready;
-  logic                                                         dcache_uc_read_valid;
-  hpdcache_mem_req_t                                            dcache_uc_read;
+  logic                 dcache_uc_read_ready;
+  logic                 dcache_uc_read_valid;
+  hpdcache_mem_req_t    dcache_uc_read;
 
-  logic                                                         dcache_uc_read_resp_ready;
-  logic                                                         dcache_uc_read_resp_valid;
-  hpdcache_mem_resp_r_t                                         dcache_uc_read_resp;
+  logic                 dcache_uc_read_resp_ready;
+  logic                 dcache_uc_read_resp_valid;
+  hpdcache_mem_resp_r_t dcache_uc_read_resp;
 
-  logic                                                         dcache_uc_write_ready;
-  logic                                                         dcache_uc_write_valid;
-  hpdcache_mem_req_t                                            dcache_uc_write;
+  logic                 dcache_uc_write_ready;
+  logic                 dcache_uc_write_valid;
+  hpdcache_mem_req_t    dcache_uc_write;
 
-  logic                                                         dcache_uc_write_data_ready;
-  logic                                                         dcache_uc_write_data_valid;
-  hpdcache_mem_req_w_t                                          dcache_uc_write_data;
+  logic                 dcache_uc_write_data_ready;
+  logic                 dcache_uc_write_data_valid;
+  hpdcache_mem_req_w_t  dcache_uc_write_data;
 
-  logic                                                         dcache_uc_write_resp_ready;
-  logic                                                         dcache_uc_write_resp_valid;
-  hpdcache_mem_resp_w_t                                         dcache_uc_write_resp;
+  logic                 dcache_uc_write_resp_ready;
+  logic                 dcache_uc_write_resp_valid;
+  hpdcache_mem_resp_w_t dcache_uc_write_resp;
 
 
   //  {{{
-  hpdcache_dcache_with_adapter # () i_hpdcache_dcache (
+  hpdcache_dcache_with_adapter #() i_hpdcache_dcache (
       .dcache_enable_i(dcache_enable_i),
       .dcache_flush_i(dcache_flush_i),
       .dcache_flush_ack_o(dcache_flush_ack_o),

--- a/core/cache_subsystem/extended_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/extended_hpdcache_subsystem.sv
@@ -519,7 +519,7 @@ module extended_hpdcache_subsystem
 
   //  AXI arbiter instantiation
   //  {{{
-  cva6_hpdcache_subsystem_axi_arbiter #(
+  extended_hpdcache_subsystem_axi_arbiter #(
       .CVA6Cfg              (CVA6Cfg),
       .hpdcache_mem_req_t   (hpdcache_mem_req_t),
       .hpdcache_mem_req_w_t (hpdcache_mem_req_w_t),
@@ -543,17 +543,28 @@ module extended_hpdcache_subsystem
       .clk_i,
       .rst_ni,
 
-      .icache_miss_valid_i(icache_miss_valid),
       .icache_miss_ready_o(icache_miss_ready),
+      .icache_miss_valid_i(icache_miss_valid),
       .icache_miss_i      (icache_miss),
-      .icache_miss_id_i   (hpdcache_mem_id_t'(ICACHE_RDTXID)),
+      .icache_miss_id_i   ('1),                 // TODO
 
+      .icache_miss_resp_ready_i(icache_miss_resp_ready),
       .icache_miss_resp_valid_o(icache_miss_resp_valid),
       .icache_miss_resp_o      (icache_miss_resp),
+
+      .icache_uc_read_ready_o(icache_uc_read_ready),
+      .icache_uc_read_valid_i(icache_uc_read_valid),
+      .icache_uc_read_i      (icache_uc_read),
+      .icache_uc_read_id_i   ('1),                    // TODO
+
+      .icache_uc_read_resp_ready_i(icache_uc_read_resp_ready),
+      .icache_uc_read_resp_valid_o(icache_uc_read_resp_valid),
+      .icache_uc_read_resp_o      (icache_uc_read_resp),
 
       .dcache_miss_ready_o(dcache_miss_ready),
       .dcache_miss_valid_i(dcache_miss_valid),
       .dcache_miss_i      (dcache_miss),
+      .dcache_miss_id_i   ('1),                 // TODO
 
       .dcache_miss_resp_ready_i(dcache_miss_resp_ready),
       .dcache_miss_resp_valid_o(dcache_miss_resp_valid),
@@ -571,11 +582,10 @@ module extended_hpdcache_subsystem
       .dcache_wbuf_resp_valid_o(dcache_wbuf_resp_valid),
       .dcache_wbuf_resp_o      (dcache_wbuf_resp),
 
-      .dcache_uc_read_ready_o(dcache_uc_read_ready),
-      .dcache_uc_read_valid_i(dcache_uc_read_valid),
-      .dcache_uc_read_i      (dcache_uc_read),
-      .dcache_uc_read_id_i   ('1),
-
+      .dcache_uc_read_ready_o     (dcache_uc_read_ready),
+      .dcache_uc_read_valid_i     (dcache_uc_read_valid),
+      .dcache_uc_read_i           (dcache_uc_read),
+      .dcache_uc_read_id_i        ('1),                         // TODO
       .dcache_uc_read_resp_ready_i(dcache_uc_read_resp_ready),
       .dcache_uc_read_resp_valid_o(dcache_uc_read_resp_valid),
       .dcache_uc_read_resp_o      (dcache_uc_read_resp),

--- a/core/cache_subsystem/extended_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/extended_hpdcache_subsystem.sv
@@ -1,0 +1,648 @@
+// Copyright 2023 Commissariat a l'Energie Atomique et aux Energies
+//                Alternatives (CEA)
+//
+// Licensed under the Solderpad Hardware License, Version 2.1 (the “License”);
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Authors: Cesar Fuguet
+// Date: February, 2023
+// Description: CVA6 cache subsystem integrating standard CVA6's
+//              instruction cache and the Core-V High-Performance L1
+//              data cache (CV-HPDcache).
+
+module extended_hpdcache_subsystem
+//  Parameters
+//  {{{
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type icache_areq_t = logic,
+    parameter type icache_arsp_t = logic,
+    parameter type icache_dreq_t = logic,
+    parameter type icache_drsp_t = logic,
+    parameter type icache_req_t = logic,
+    parameter type icache_rtrn_t = logic,
+    parameter type dcache_req_i_t = logic,
+    parameter type dcache_req_o_t = logic,
+    parameter int NumPorts = 4,
+    parameter int NrHwPrefetchers = 4,
+    // AXI types
+    parameter type axi_ar_chan_t = logic,
+    parameter type axi_aw_chan_t = logic,
+    parameter type axi_w_chan_t = logic,
+    parameter type axi_b_chan_t = logic,
+    parameter type axi_r_chan_t = logic,
+    parameter type noc_req_t = logic,
+    parameter type noc_resp_t = logic,
+    parameter type cmo_req_t = logic,
+    parameter type cmo_rsp_t = logic
+)
+//  }}}
+
+//  Ports
+//  {{{
+(
+
+    // Subsystem Clock - SUBSYSTEM
+    input logic clk_i,
+    // Asynchronous reset active low - SUBSYSTEM
+    input logic rst_ni,
+
+    //  AXI port to upstream memory/peripherals
+    //  {{{
+    // noc request, can be AXI or OpenPiton - SUBSYSTEM
+    output noc_req_t  noc_req_o,
+    // noc response, can be AXI or OpenPiton - SUBSYSTEM
+    input  noc_resp_t noc_resp_i,
+    //  }}}
+
+    //  I$
+    //  {{{
+    // Instruction cache enable - CSR_REGFILE
+    input logic icache_en_i,
+    // Flush the instruction cache - CONTROLLER
+    input logic icache_flush_i,
+    // instructino cache miss - PERF_COUNTERS
+    output logic icache_miss_o,
+    // Input address translation request - EX_STAGE
+    input icache_areq_t icache_areq_i,
+    // Output address translation request - EX_STAGE
+    output icache_arsp_t icache_areq_o,
+    // Input data translation request - FRONTEND
+    input icache_dreq_t icache_dreq_i,
+    // Output data translation request - FRONTEND
+    output icache_drsp_t icache_dreq_o,
+    //   }}}
+
+    //  D$
+    //  {{{
+    //    Cache management
+    // Data cache enable - CSR_REGFILE
+    input  logic dcache_enable_i,
+    // Data cache flush - CONTROLLER
+    input  logic dcache_flush_i,
+    // Flush acknowledge - CONTROLLER
+    output logic dcache_flush_ack_o,
+    // Load or store miss - PERF_COUNTERS
+    output logic dcache_miss_o,
+
+    // AMO request - EX_STAGE
+    input  ariane_pkg::amo_req_t                 dcache_amo_req_i,
+    // AMO response - EX_STAGE
+    output ariane_pkg::amo_resp_t                dcache_amo_resp_o,
+    // CMO interface request - TO_BE_COMPLETED
+    input  cmo_req_t                             dcache_cmo_req_i,
+    // CMO interface response - TO_BE_COMPLETED
+    output cmo_rsp_t                             dcache_cmo_resp_o,
+    // Data cache input request ports - EX_STAGE
+    input  dcache_req_i_t         [NumPorts-1:0] dcache_req_ports_i,
+    // Data cache output request ports - EX_STAGE
+    output dcache_req_o_t         [NumPorts-1:0] dcache_req_ports_o,
+    // Write buffer status to know if empty - EX_STAGE
+    output logic                                 wbuffer_empty_o,
+    // Write buffer status to know if not non idempotent - EX_STAGE
+    output logic                                 wbuffer_not_ni_o,
+
+    //  Hardware memory prefetcher configuration
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_base_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_base_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_base_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_param_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_param_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_param_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_throttle_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_throttle_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_throttle_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [               63:0]       hwpf_status_o
+    //  }}}
+);
+  //  }}}
+
+  //  I$ instantiation
+  //  {{{
+  logic icache_miss_valid, icache_miss_ready;
+  icache_req_t icache_miss;
+
+  logic icache_miss_resp_valid;
+  icache_rtrn_t icache_miss_resp;
+
+  localparam int ICACHE_RDTXID = 1 << (CVA6Cfg.MEM_TID_WIDTH - 1);
+
+  cva6_icache #(
+      .CVA6Cfg(CVA6Cfg),
+      .icache_areq_t(icache_areq_t),
+      .icache_arsp_t(icache_arsp_t),
+      .icache_dreq_t(icache_dreq_t),
+      .icache_drsp_t(icache_drsp_t),
+      .icache_req_t(icache_req_t),
+      .icache_rtrn_t(icache_rtrn_t),
+      .RdTxId(ICACHE_RDTXID)
+  ) i_cva6_icache (
+      .clk_i         (clk_i),
+      .rst_ni        (rst_ni),
+      .flush_i       (icache_flush_i),
+      .en_i          (icache_en_i),
+      .miss_o        (icache_miss_o),
+      .areq_i        (icache_areq_i),
+      .areq_o        (icache_areq_o),
+      .dreq_i        (icache_dreq_i),
+      .dreq_o        (icache_dreq_o),
+      .mem_rtrn_vld_i(icache_miss_resp_valid),
+      .mem_rtrn_i    (icache_miss_resp),
+      .mem_data_req_o(icache_miss_valid),
+      .mem_data_ack_i(icache_miss_ready),
+      .mem_data_o    (icache_miss)
+  );
+  //  }}}
+
+  //  D$ instantiation
+  //  {{{
+  `include "hpdcache_typedef.svh"
+
+  //    0: Page-Table Walk (PTW)
+  //    1: Load unit
+  //    2: Accelerator load
+  //    3: Store/AMO
+  //    .
+  //    .
+  //    .
+  //    NumPorts: CMO
+  //    NumPorts + 1: Hardware Memory Prefetcher (hwpf)
+  localparam int HPDCACHE_NREQUESTERS = NumPorts + 2;
+
+  typedef logic [CVA6Cfg.PLEN-1:0] hpdcache_mem_addr_t;
+  typedef logic [CVA6Cfg.MEM_TID_WIDTH-1:0] hpdcache_mem_id_t;
+  typedef logic [CVA6Cfg.AxiDataWidth-1:0] hpdcache_mem_data_t;
+  typedef logic [CVA6Cfg.AxiDataWidth/8-1:0] hpdcache_mem_be_t;
+  `HPDCACHE_TYPEDEF_MEM_REQ_T(hpdcache_mem_req_t, hpdcache_mem_addr_t, hpdcache_mem_id_t);
+  `HPDCACHE_TYPEDEF_MEM_RESP_R_T(hpdcache_mem_resp_r_t, hpdcache_mem_id_t, hpdcache_mem_data_t);
+  `HPDCACHE_TYPEDEF_MEM_REQ_W_T(hpdcache_mem_req_w_t, hpdcache_mem_data_t, hpdcache_mem_be_t);
+  `HPDCACHE_TYPEDEF_MEM_RESP_W_T(hpdcache_mem_resp_w_t, hpdcache_mem_id_t);
+
+  typedef logic [63:0] hwpf_stride_param_t;
+
+  logic                        dcache_req_valid[HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_req_ready[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_req_t dcache_req      [HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_req_abort[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_tag_t dcache_req_tag  [HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_pma_t dcache_req_pma  [HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_rsp_valid[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_rsp_t dcache_rsp      [HPDCACHE_NREQUESTERS-1:0];
+  logic dcache_read_miss, dcache_write_miss;
+
+  logic                                   [                2:0] snoop_valid;
+  logic                                   [                2:0] snoop_abort;
+  hpdcache_pkg::hpdcache_req_offset_t     [                2:0] snoop_addr_offset;
+  hpdcache_pkg::hpdcache_tag_t            [                2:0] snoop_addr_tag;
+  logic                                   [                2:0] snoop_phys_indexed;
+
+  logic                                                         dcache_cmo_req_is_prefetch;
+
+  logic                                                         dcache_miss_ready;
+  logic                                                         dcache_miss_valid;
+  hpdcache_mem_req_t                                            dcache_miss;
+
+  logic                                                         dcache_miss_resp_ready;
+  logic                                                         dcache_miss_resp_valid;
+  hpdcache_mem_resp_r_t                                         dcache_miss_resp;
+
+  logic                                                         dcache_wbuf_ready;
+  logic                                                         dcache_wbuf_valid;
+  hpdcache_mem_req_t                                            dcache_wbuf;
+
+  logic                                                         dcache_wbuf_data_ready;
+  logic                                                         dcache_wbuf_data_valid;
+  hpdcache_mem_req_w_t                                          dcache_wbuf_data;
+
+  logic                                                         dcache_wbuf_resp_ready;
+  logic                                                         dcache_wbuf_resp_valid;
+  hpdcache_mem_resp_w_t                                         dcache_wbuf_resp;
+
+  logic                                                         dcache_uc_read_ready;
+  logic                                                         dcache_uc_read_valid;
+  hpdcache_mem_req_t                                            dcache_uc_read;
+
+  logic                                                         dcache_uc_read_resp_ready;
+  logic                                                         dcache_uc_read_resp_valid;
+  hpdcache_mem_resp_r_t                                         dcache_uc_read_resp;
+
+  logic                                                         dcache_uc_write_ready;
+  logic                                                         dcache_uc_write_valid;
+  hpdcache_mem_req_t                                            dcache_uc_write;
+
+  logic                                                         dcache_uc_write_data_ready;
+  logic                                                         dcache_uc_write_data_valid;
+  hpdcache_mem_req_w_t                                          dcache_uc_write_data;
+
+  logic                                                         dcache_uc_write_resp_ready;
+  logic                                                         dcache_uc_write_resp_valid;
+  hpdcache_mem_resp_w_t                                         dcache_uc_write_resp;
+
+  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_in;
+  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_out;
+
+  generate
+    dcache_req_i_t dcache_req_ports[HPDCACHE_NREQUESTERS-1:0];
+
+    for (genvar r = 0; r < (NumPorts - 1); r++) begin : cva6_hpdcache_load_if_adapter_gen
+      assign dcache_req_ports[r] = dcache_req_ports_i[r];
+
+      cva6_hpdcache_if_adapter #(
+          .CVA6Cfg       (CVA6Cfg),
+          .dcache_req_i_t(dcache_req_i_t),
+          .dcache_req_o_t(dcache_req_o_t),
+          .is_load_port  (1'b1)
+      ) i_cva6_hpdcache_load_if_adapter (
+          .clk_i,
+          .rst_ni,
+
+          .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(r)),
+
+          .cva6_req_i     (dcache_req_ports[r]),
+          .cva6_req_o     (dcache_req_ports_o[r]),
+          .cva6_amo_req_i ('0),
+          .cva6_amo_resp_o(  /* unused */),
+
+          .hpdcache_req_valid_o(dcache_req_valid[r]),
+          .hpdcache_req_ready_i(dcache_req_ready[r]),
+          .hpdcache_req_o      (dcache_req[r]),
+          .hpdcache_req_abort_o(dcache_req_abort[r]),
+          .hpdcache_req_tag_o  (dcache_req_tag[r]),
+          .hpdcache_req_pma_o  (dcache_req_pma[r]),
+
+          .hpdcache_rsp_valid_i(dcache_rsp_valid[r]),
+          .hpdcache_rsp_i      (dcache_rsp[r])
+      );
+    end
+
+    cva6_hpdcache_if_adapter #(
+        .CVA6Cfg       (CVA6Cfg),
+        .dcache_req_i_t(dcache_req_i_t),
+        .dcache_req_o_t(dcache_req_o_t),
+        .is_load_port  (1'b0)
+    ) i_cva6_hpdcache_store_if_adapter (
+        .clk_i,
+        .rst_ni,
+
+        .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts - 1)),
+
+        .cva6_req_i     (dcache_req_ports_i[NumPorts-1]),
+        .cva6_req_o     (dcache_req_ports_o[NumPorts-1]),
+        .cva6_amo_req_i (dcache_amo_req_i),
+        .cva6_amo_resp_o(dcache_amo_resp_o),
+
+        .hpdcache_req_valid_o(dcache_req_valid[NumPorts-1]),
+        .hpdcache_req_ready_i(dcache_req_ready[NumPorts-1]),
+        .hpdcache_req_o      (dcache_req[NumPorts-1]),
+        .hpdcache_req_abort_o(dcache_req_abort[NumPorts-1]),
+        .hpdcache_req_tag_o  (dcache_req_tag[NumPorts-1]),
+        .hpdcache_req_pma_o  (dcache_req_pma[NumPorts-1]),
+
+        .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts-1]),
+        .hpdcache_rsp_i      (dcache_rsp[NumPorts-1])
+    );
+
+`ifdef HPDCACHE_ENABLE_CMO
+    cva6_hpdcache_cmo_if_adapter #(
+        .cmo_req_t(cmo_req_t),
+        .cmo_rsp_t(cmo_rsp_t)
+    ) i_cva6_hpdcache_cmo_if_adapter (
+        .clk_i,
+        .rst_ni,
+
+        .dcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts)),
+
+        .cva6_cmo_req_i (dcache_cmo_req_i),
+        .cva6_cmo_resp_o(dcache_cmo_resp_o),
+
+        .dcache_req_valid_o(dcache_req_valid[NumPorts]),
+        .dcache_req_ready_i(dcache_req_ready[NumPorts]),
+        .dcache_req_o      (dcache_req[NumPorts]),
+        .dcache_req_abort_o(dcache_req_abort[NumPorts]),
+        .dcache_req_tag_o  (dcache_req_tag[NumPorts]),
+        .dcache_req_pma_o  (dcache_req_pma[NumPorts]),
+
+        .dcache_rsp_valid_i(dcache_rsp_valid[NumPorts]),
+        .dcache_rsp_i      (dcache_rsp[NumPorts])
+    );
+`else
+    assign dcache_req_valid[NumPorts] = 1'b0,
+        dcache_req[NumPorts] = '0,
+        dcache_req_abort[NumPorts] = 1'b0,
+        dcache_req_tag[NumPorts] = '0,
+        dcache_req_pma[NumPorts] = '0;
+`endif
+  endgenerate
+
+  //  Snoop load port
+  assign snoop_valid[0] = dcache_req_valid[1] & dcache_req_ready[1],
+      snoop_abort[0] = dcache_req_abort[1],
+      snoop_addr_offset[0] = dcache_req[1].addr_offset,
+      snoop_addr_tag[0] = dcache_req_tag[1],
+      snoop_phys_indexed[0] = dcache_req[1].phys_indexed;
+
+  //  Snoop Store/AMO port
+  assign snoop_valid[1] = dcache_req_valid[NumPorts-1] & dcache_req_ready[NumPorts-1],
+      snoop_abort[1] = dcache_req_abort[NumPorts-1],
+      snoop_addr_offset[1] = dcache_req[NumPorts-1].addr_offset,
+      snoop_addr_tag[1] = dcache_req_tag[NumPorts-1],
+      snoop_phys_indexed[1] = dcache_req[NumPorts-1].phys_indexed;
+
+`ifdef HPDCACHE_ENABLE_CMO
+  //  Snoop CMO port (in case of read prefetch accesses)
+  assign dcache_cmo_req_is_prefetch = hpdcache_pkg::is_cmo_prefetch(
+      dcache_req[NumPorts].op, dcache_req[NumPorts].size
+  );
+  assign snoop_valid[2]        = dcache_req_valid[NumPorts]
+                               & dcache_req_ready[NumPorts]
+                               & dcache_cmo_req_is_prefetch,
+      snoop_abort[2] = dcache_req_abort[NumPorts],
+      snoop_addr_offset[2] = dcache_req[NumPorts].addr_offset,
+      snoop_addr_tag[2] = dcache_req_tag[NumPorts],
+      snoop_phys_indexed[2] = dcache_req[NumPorts].phys_indexed;
+`else
+  assign snoop_valid[2] = 1'b0,
+      snoop_abort[2] = 1'b0,
+      snoop_addr_offset[2] = '0,
+      snoop_addr_tag[2] = '0,
+      snoop_phys_indexed[2] = 1'b0;
+`endif
+
+  generate
+    for (genvar h = 0; h < NrHwPrefetchers; h++) begin : hwpf_throttle_gen
+      assign hwpf_throttle_in[h] = hwpf_stride_pkg::hwpf_stride_throttle_t'(hwpf_throttle_i[h]),
+          hwpf_throttle_o[h] = hwpf_stride_pkg::hwpf_stride_param_t'(hwpf_throttle_out[h]);
+    end
+  endgenerate
+
+  hwpf_stride_wrapper #(
+      .NUM_HW_PREFETCH(NrHwPrefetchers),
+      .NUM_SNOOP_PORTS(3)
+  ) i_hwpf_stride_wrapper (
+      .clk_i,
+      .rst_ni,
+
+      .hwpf_stride_base_set_i    (hwpf_base_set_i),
+      .hwpf_stride_base_i        (hwpf_base_i),
+      .hwpf_stride_base_o        (hwpf_base_o),
+      .hwpf_stride_param_set_i   (hwpf_param_set_i),
+      .hwpf_stride_param_i       (hwpf_param_i),
+      .hwpf_stride_param_o       (hwpf_param_o),
+      .hwpf_stride_throttle_set_i(hwpf_throttle_set_i),
+      .hwpf_stride_throttle_i    (hwpf_throttle_in),
+      .hwpf_stride_throttle_o    (hwpf_throttle_out),
+      .hwpf_stride_status_o      (hwpf_status_o),
+
+      .snoop_valid_i       (snoop_valid),
+      .snoop_abort_i       (snoop_abort),
+      .snoop_addr_offset_i (snoop_addr_offset),
+      .snoop_addr_tag_i    (snoop_addr_tag),
+      .snoop_phys_indexed_i(snoop_phys_indexed),
+
+      .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts + 1)),
+
+      .hpdcache_req_valid_o(dcache_req_valid[NumPorts+1]),
+      .hpdcache_req_ready_i(dcache_req_ready[NumPorts+1]),
+      .hpdcache_req_o      (dcache_req[NumPorts+1]),
+      .hpdcache_req_abort_o(dcache_req_abort[NumPorts+1]),
+      .hpdcache_req_tag_o  (dcache_req_tag[NumPorts+1]),
+      .hpdcache_req_pma_o  (dcache_req_pma[NumPorts+1]),
+      .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts+1]),
+      .hpdcache_rsp_i      (dcache_rsp[NumPorts+1])
+  );
+
+  hpdcache #(
+      .NREQUESTERS         (HPDCACHE_NREQUESTERS),
+      .HPDcacheMemAddrWidth(CVA6Cfg.PLEN),
+      .HPDcacheMemIdWidth  (CVA6Cfg.MEM_TID_WIDTH),
+      .HPDcacheMemDataWidth(CVA6Cfg.AxiDataWidth)
+  ) i_hpdcache (
+      .clk_i,
+      .rst_ni,
+
+      .wbuf_flush_i(dcache_flush_i),
+
+      .core_req_valid_i(dcache_req_valid),
+      .core_req_ready_o(dcache_req_ready),
+      .core_req_i      (dcache_req),
+      .core_req_abort_i(dcache_req_abort),
+      .core_req_tag_i  (dcache_req_tag),
+      .core_req_pma_i  (dcache_req_pma),
+
+      .core_rsp_valid_o(dcache_rsp_valid),
+      .core_rsp_o      (dcache_rsp),
+
+      .mem_req_miss_read_ready_i(dcache_miss_ready),
+      .mem_req_miss_read_valid_o(dcache_miss_valid),
+      .mem_req_miss_read_o      (dcache_miss),
+
+      .mem_resp_miss_read_ready_o(dcache_miss_resp_ready),
+      .mem_resp_miss_read_valid_i(dcache_miss_resp_valid),
+      .mem_resp_miss_read_i      (dcache_miss_resp),
+
+      .mem_req_wbuf_write_ready_i(dcache_wbuf_ready),
+      .mem_req_wbuf_write_valid_o(dcache_wbuf_valid),
+      .mem_req_wbuf_write_o      (dcache_wbuf),
+
+      .mem_req_wbuf_write_data_ready_i(dcache_wbuf_data_ready),
+      .mem_req_wbuf_write_data_valid_o(dcache_wbuf_data_valid),
+      .mem_req_wbuf_write_data_o      (dcache_wbuf_data),
+
+      .mem_resp_wbuf_write_ready_o(dcache_wbuf_resp_ready),
+      .mem_resp_wbuf_write_valid_i(dcache_wbuf_resp_valid),
+      .mem_resp_wbuf_write_i      (dcache_wbuf_resp),
+
+      .mem_req_uc_read_ready_i(dcache_uc_read_ready),
+      .mem_req_uc_read_valid_o(dcache_uc_read_valid),
+      .mem_req_uc_read_o      (dcache_uc_read),
+
+      .mem_resp_uc_read_ready_o(dcache_uc_read_resp_ready),
+      .mem_resp_uc_read_valid_i(dcache_uc_read_resp_valid),
+      .mem_resp_uc_read_i      (dcache_uc_read_resp),
+
+      .mem_req_uc_write_ready_i(dcache_uc_write_ready),
+      .mem_req_uc_write_valid_o(dcache_uc_write_valid),
+      .mem_req_uc_write_o      (dcache_uc_write),
+
+      .mem_req_uc_write_data_ready_i(dcache_uc_write_data_ready),
+      .mem_req_uc_write_data_valid_o(dcache_uc_write_data_valid),
+      .mem_req_uc_write_data_o      (dcache_uc_write_data),
+
+      .mem_resp_uc_write_ready_o(dcache_uc_write_resp_ready),
+      .mem_resp_uc_write_valid_i(dcache_uc_write_resp_valid),
+      .mem_resp_uc_write_i      (dcache_uc_write_resp),
+
+      .evt_cache_write_miss_o(dcache_write_miss),
+      .evt_cache_read_miss_o (dcache_read_miss),
+      .evt_uncached_req_o    (  /* unused */),
+      .evt_cmo_req_o         (  /* unused */),
+      .evt_write_req_o       (  /* unused */),
+      .evt_read_req_o        (  /* unused */),
+      .evt_prefetch_req_o    (  /* unused */),
+      .evt_req_on_hold_o     (  /* unused */),
+      .evt_rtab_rollback_o   (  /* unused */),
+      .evt_stall_refill_o    (  /* unused */),
+      .evt_stall_o           (  /* unused */),
+
+      .wbuf_empty_o(wbuffer_empty_o),
+
+      .cfg_enable_i                       (dcache_enable_i),
+      .cfg_wbuf_threshold_i               (4'd2),
+      .cfg_wbuf_reset_timecnt_on_write_i  (1'b1),
+      .cfg_wbuf_sequential_waw_i          (1'b0),
+      .cfg_wbuf_inhibit_write_coalescing_i(1'b0),
+      .cfg_prefetch_updt_plru_i           (1'b1),
+      .cfg_error_on_cacheable_amo_i       (1'b0),
+      .cfg_rtab_single_entry_i            (1'b0)
+  );
+
+  assign dcache_miss_o = dcache_read_miss, wbuffer_not_ni_o = wbuffer_empty_o;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : dcache_flush_ff
+    if (!rst_ni) dcache_flush_ack_o <= 1'b0;
+    else dcache_flush_ack_o <= ~dcache_flush_ack_o & dcache_flush_i;
+  end
+
+  //  }}}
+
+  //  AXI arbiter instantiation
+  //  {{{
+  cva6_hpdcache_subsystem_axi_arbiter #(
+      .CVA6Cfg              (CVA6Cfg),
+      .hpdcache_mem_req_t   (hpdcache_mem_req_t),
+      .hpdcache_mem_req_w_t (hpdcache_mem_req_w_t),
+      .hpdcache_mem_resp_r_t(hpdcache_mem_resp_r_t),
+      .hpdcache_mem_resp_w_t(hpdcache_mem_resp_w_t),
+      .icache_req_t         (icache_req_t),
+      .icache_rtrn_t        (icache_rtrn_t),
+
+      .AxiAddrWidth (CVA6Cfg.AxiAddrWidth),
+      .AxiDataWidth (CVA6Cfg.AxiDataWidth),
+      .AxiIdWidth   (CVA6Cfg.AxiIdWidth),
+      .AxiUserWidth (CVA6Cfg.AxiUserWidth),
+      .axi_ar_chan_t(axi_ar_chan_t),
+      .axi_aw_chan_t(axi_aw_chan_t),
+      .axi_w_chan_t (axi_w_chan_t),
+      .axi_b_chan_t (axi_b_chan_t),
+      .axi_r_chan_t (axi_r_chan_t),
+      .axi_req_t    (noc_req_t),
+      .axi_rsp_t    (noc_resp_t)
+  ) i_axi_arbiter (
+      .clk_i,
+      .rst_ni,
+
+      .icache_miss_valid_i(icache_miss_valid),
+      .icache_miss_ready_o(icache_miss_ready),
+      .icache_miss_i      (icache_miss),
+      .icache_miss_id_i   (hpdcache_mem_id_t'(ICACHE_RDTXID)),
+
+      .icache_miss_resp_valid_o(icache_miss_resp_valid),
+      .icache_miss_resp_o      (icache_miss_resp),
+
+      .dcache_miss_ready_o(dcache_miss_ready),
+      .dcache_miss_valid_i(dcache_miss_valid),
+      .dcache_miss_i      (dcache_miss),
+
+      .dcache_miss_resp_ready_i(dcache_miss_resp_ready),
+      .dcache_miss_resp_valid_o(dcache_miss_resp_valid),
+      .dcache_miss_resp_o      (dcache_miss_resp),
+
+      .dcache_wbuf_ready_o(dcache_wbuf_ready),
+      .dcache_wbuf_valid_i(dcache_wbuf_valid),
+      .dcache_wbuf_i      (dcache_wbuf),
+
+      .dcache_wbuf_data_ready_o(dcache_wbuf_data_ready),
+      .dcache_wbuf_data_valid_i(dcache_wbuf_data_valid),
+      .dcache_wbuf_data_i      (dcache_wbuf_data),
+
+      .dcache_wbuf_resp_ready_i(dcache_wbuf_resp_ready),
+      .dcache_wbuf_resp_valid_o(dcache_wbuf_resp_valid),
+      .dcache_wbuf_resp_o      (dcache_wbuf_resp),
+
+      .dcache_uc_read_ready_o(dcache_uc_read_ready),
+      .dcache_uc_read_valid_i(dcache_uc_read_valid),
+      .dcache_uc_read_i      (dcache_uc_read),
+      .dcache_uc_read_id_i   ('1),
+
+      .dcache_uc_read_resp_ready_i(dcache_uc_read_resp_ready),
+      .dcache_uc_read_resp_valid_o(dcache_uc_read_resp_valid),
+      .dcache_uc_read_resp_o      (dcache_uc_read_resp),
+
+      .dcache_uc_write_ready_o(dcache_uc_write_ready),
+      .dcache_uc_write_valid_i(dcache_uc_write_valid),
+      .dcache_uc_write_i      (dcache_uc_write),
+      .dcache_uc_write_id_i   ('1),
+
+      .dcache_uc_write_data_ready_o(dcache_uc_write_data_ready),
+      .dcache_uc_write_data_valid_i(dcache_uc_write_data_valid),
+      .dcache_uc_write_data_i      (dcache_uc_write_data),
+
+      .dcache_uc_write_resp_ready_i(dcache_uc_write_resp_ready),
+      .dcache_uc_write_resp_valid_o(dcache_uc_write_resp_valid),
+      .dcache_uc_write_resp_o      (dcache_uc_write_resp),
+
+      .axi_req_o (noc_req_o),
+      .axi_resp_i(noc_resp_i)
+  );
+  //  }}}
+
+  //  Assertions
+  //  {{{
+  //  pragma translate_off
+  initial
+    assert (hpdcache_pkg::HPDCACHE_REQ_SRC_ID_WIDTH >= $clog2(HPDCACHE_NREQUESTERS))
+    else $fatal(1, "HPDCACHE_REQ_SRC_ID_WIDTH is not wide enough");
+
+  a_invalid_instruction_fetch :
+  assert property (
+    @(posedge clk_i) disable iff (!rst_ni) icache_dreq_o.valid |-> (|icache_dreq_o.data) !== 1'hX)
+  else
+    $warning(
+        1,
+        "[l1 dcache] reading invalid instructions: vaddr=%08X, data=%08X",
+        icache_dreq_o.vaddr,
+        icache_dreq_o.data
+    );
+
+  a_invalid_write_data :
+  assert property (
+    @(posedge clk_i) disable iff (!rst_ni) dcache_req_ports_i[2].data_req |-> |dcache_req_ports_i[2].data_be |-> (|dcache_req_ports_i[2].data_wdata) !== 1'hX)
+  else
+    $warning(
+        1,
+        "[l1 dcache] writing invalid data: paddr=%016X, be=%02X, data=%016X",
+        {
+          dcache_req_ports_i[2].address_tag, dcache_req_ports_i[2].address_index
+        },
+        dcache_req_ports_i[2].data_be,
+        dcache_req_ports_i[2].data_wdata
+    );
+
+  for (genvar j = 0; j < 2; j++) begin : gen_assertion
+    a_invalid_read_data :
+    assert property (
+      @(posedge clk_i) disable iff (!rst_ni) dcache_req_ports_o[j].data_rvalid && ~dcache_req_ports_i[j].kill_req |-> (|dcache_req_ports_o[j].data_rdata) !== 1'hX)
+    else
+      $warning(
+          1,
+          "[l1 dcache] reading invalid data on port %01d: data=%016X",
+          j,
+          dcache_req_ports_o[j].data_rdata
+      );
+  end
+  //  pragma translate_on
+  //  }}}
+
+endmodule : cva6_hpdcache_subsystem

--- a/core/cache_subsystem/extended_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/extended_hpdcache_subsystem.sv
@@ -59,20 +59,50 @@ module extended_hpdcache_subsystem
 
     //  I$
     //  {{{
-    // Instruction cache enable - CSR_REGFILE
-    input logic icache_en_i,
-    // Flush the instruction cache - CONTROLLER
-    input logic icache_flush_i,
-    // instructino cache miss - PERF_COUNTERS
+    //    Cache management
+    // Data cache enable - CSR_REGFILE
+    input  logic icache_enable_i,
+    // Data cache flush - CONTROLLER
+    input  logic icache_flush_i,
+    // Flush acknowledge - CONTROLLER
+    output logic icache_flush_ack_o,
+    // Load or store miss - PERF_COUNTERS
     output logic icache_miss_o,
-    // Input address translation request - EX_STAGE
-    input icache_areq_t icache_areq_i,
-    // Output address translation request - EX_STAGE
-    output icache_arsp_t icache_areq_o,
-    // Input data translation request - FRONTEND
-    input icache_dreq_t icache_dreq_i,
-    // Output data translation request - FRONTEND
-    output icache_drsp_t icache_dreq_o,
+
+    // AMO request - EX_STAGE
+    input  ariane_pkg::amo_req_t                 icache_amo_req_i,
+    // AMO response - EX_STAGE
+    output ariane_pkg::amo_resp_t                icache_amo_resp_o,
+    // CMO interface request - TO_BE_COMPLETED
+    input  cmo_req_t                             icache_cmo_req_i,
+    // CMO interface response - TO_BE_COMPLETED
+    output cmo_rsp_t                             icache_cmo_resp_o,
+    // Data cache input request ports - EX_STAGE
+    input  icache_req_i_t         [NumPorts-1:0] icache_req_ports_i,
+    // Data cache output request ports - EX_STAGE
+    output icache_req_o_t         [NumPorts-1:0] icache_req_ports_o,
+
+    //  Hardware memory prefetcher configuration
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       icache_hwpf_base_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] icache_hwpf_base_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] icache_hwpf_base_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       icache_hwpf_param_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] icache_hwpf_param_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] icache_hwpf_param_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       icache_hwpf_throttle_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] icache_hwpf_throttle_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] icache_hwpf_throttle_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [               63:0]       icache_hwpf_status_o,
     //   }}}
 
     //  D$
@@ -131,84 +161,72 @@ module extended_hpdcache_subsystem
 
   //  I$ instantiation
   //  {{{
-  logic icache_miss_valid, icache_miss_ready;
-  icache_req_t icache_miss;
 
-  logic icache_miss_resp_valid;
-  icache_rtrn_t icache_miss_resp;
+  logic                                                         icache_miss_ready;
+  logic                                                         icache_miss_valid;
+  hpdcache_mem_req_t                                            icache_miss;
 
-  localparam int ICACHE_RDTXID = 1 << (CVA6Cfg.MEM_TID_WIDTH - 1);
+  logic                                                         icache_miss_resp_ready;
+  logic                                                         icache_miss_resp_valid;
+  hpdcache_mem_resp_r_t                                         icache_miss_resp;
 
-  cva6_icache #(
-      .CVA6Cfg(CVA6Cfg),
-      .icache_areq_t(icache_areq_t),
-      .icache_arsp_t(icache_arsp_t),
-      .icache_dreq_t(icache_dreq_t),
-      .icache_drsp_t(icache_drsp_t),
-      .icache_req_t(icache_req_t),
-      .icache_rtrn_t(icache_rtrn_t),
-      .RdTxId(ICACHE_RDTXID)
-  ) i_cva6_icache (
-      .clk_i         (clk_i),
-      .rst_ni        (rst_ni),
-      .flush_i       (icache_flush_i),
-      .en_i          (icache_en_i),
-      .miss_o        (icache_miss_o),
-      .areq_i        (icache_areq_i),
-      .areq_o        (icache_areq_o),
-      .dreq_i        (icache_dreq_i),
-      .dreq_o        (icache_dreq_o),
-      .mem_rtrn_vld_i(icache_miss_resp_valid),
-      .mem_rtrn_i    (icache_miss_resp),
-      .mem_data_req_o(icache_miss_valid),
-      .mem_data_ack_i(icache_miss_ready),
-      .mem_data_o    (icache_miss)
-  );
-  //  }}}
+  logic                                                         icache_uc_read_ready;
+  logic                                                         icache_uc_read_valid;
+  hpdcache_mem_req_t                                            icache_uc_read;
 
-  //  D$ instantiation
+  logic                                                         icache_uc_read_ready;
+  logic                                                         icache_uc_read_valid;
+  hpdcache_mem_req_t                                            icache_uc_read;
+
+  logic                                                         icache_uc_read_resp_ready;
+  logic                                                         icache_uc_read_resp_valid;
+  hpdcache_mem_resp_r_t                                         icache_uc_read_resp;
+
+
   //  {{{
-  `include "hpdcache_typedef.svh"
+  hpdcache_icache_with_adapter # (
+  ) i_hpdcache_dcache (
+      .icache_enable_i(icache_enable_i), //
+      .icache_flush_i(icache_flush_i), //
+      .icache_flush_ack_o(icache_flush_ack_o), //
+      .icache_miss_o(icache_miss_o), //
+      .icache_amo_req_i(icache_amo_req_i), //
+      .icache_amo_resp_o(icache_amo_resp_o), //
+      .icache_cmo_req_i(icache_cmo_req_i), //
+      .icache_cmo_resp_o(icache_cmo_resp_o), //
+      .icache_req_ports_i(icache_req_ports_i), //
+      .icache_req_ports_o(icache_req_ports_o), //
+      .wbuffer_empty_o(/**/),  //
+      .wbuffer_not_ni_o(/**/),//
+      .hwpf_base_set_i(icache_hwpf_base_set_i),//
+      .hwpf_base_i(icache_hwpf_base_i),//
+      .hwpf_base_o(icache_hwpf_base_o),//
+      .hwpf_param_set_i(icache_hwpf_param_set_i), //
+      .hwpf_param_i(icache_hwpf_param_i),//
+      .hwpf_param_o(icache_hwpf_param_o),//
+      .hwpf_throttle_set_i(icache_hwpf_throttle_set_i),//
+      .hwpf_throttle_i(icache_hwpf_throttle_i),//
+      .hwpf_throttle_o(icache_hwpf_throttle_o), //
+      .hwpf_status_o(icache_hwpf_status_o),//
 
-  //    0: Page-Table Walk (PTW)
-  //    1: Load unit
-  //    2: Accelerator load
-  //    3: Store/AMO
-  //    .
-  //    .
-  //    .
-  //    NumPorts: CMO
-  //    NumPorts + 1: Hardware Memory Prefetcher (hwpf)
-  localparam int HPDCACHE_NREQUESTERS = NumPorts + 2;
+      .icache_miss_ready_i(icache_miss_ready),
+      .icache_miss_valid_o(icache_miss_valid),
+      .icache_miss_lo(icache_miss),
 
-  typedef logic [CVA6Cfg.PLEN-1:0] hpdcache_mem_addr_t;
-  typedef logic [CVA6Cfg.MEM_TID_WIDTH-1:0] hpdcache_mem_id_t;
-  typedef logic [CVA6Cfg.AxiDataWidth-1:0] hpdcache_mem_data_t;
-  typedef logic [CVA6Cfg.AxiDataWidth/8-1:0] hpdcache_mem_be_t;
-  `HPDCACHE_TYPEDEF_MEM_REQ_T(hpdcache_mem_req_t, hpdcache_mem_addr_t, hpdcache_mem_id_t);
-  `HPDCACHE_TYPEDEF_MEM_RESP_R_T(hpdcache_mem_resp_r_t, hpdcache_mem_id_t, hpdcache_mem_data_t);
-  `HPDCACHE_TYPEDEF_MEM_REQ_W_T(hpdcache_mem_req_w_t, hpdcache_mem_data_t, hpdcache_mem_be_t);
-  `HPDCACHE_TYPEDEF_MEM_RESP_W_T(hpdcache_mem_resp_w_t, hpdcache_mem_id_t);
+      .icache_uc_read_ready_i(icache_uc_read_ready),
+      .icache_uc_read_valid_o(icache_uc_read_valid),
+      .icache_uc_read_o(icache_uc_read),
 
-  typedef logic [63:0] hwpf_stride_param_t;
+      .icache_uc_read_resp_ready_o(icache_uc_read_resp_ready),
+      .icache_uc_read_resp_valid_i(icache_uc_read_resp_valid),
+      .icache_uc_read_resp_i(icache_uc_read_resp),
 
-  logic                        dcache_req_valid[HPDCACHE_NREQUESTERS-1:0];
-  logic                        dcache_req_ready[HPDCACHE_NREQUESTERS-1:0];
-  hpdcache_pkg::hpdcache_req_t dcache_req      [HPDCACHE_NREQUESTERS-1:0];
-  logic                        dcache_req_abort[HPDCACHE_NREQUESTERS-1:0];
-  hpdcache_pkg::hpdcache_tag_t dcache_req_tag  [HPDCACHE_NREQUESTERS-1:0];
-  hpdcache_pkg::hpdcache_pma_t dcache_req_pma  [HPDCACHE_NREQUESTERS-1:0];
-  logic                        dcache_rsp_valid[HPDCACHE_NREQUESTERS-1:0];
-  hpdcache_pkg::hpdcache_rsp_t dcache_rsp      [HPDCACHE_NREQUESTERS-1:0];
-  logic dcache_read_miss, dcache_write_miss;
+      .icache_miss_resp_ready_o(icache_miss_resp_ready),
+      .icache_miss_resp_valid_i(icache_miss_resp_valid),
+      .icache_miss_resp_i(icache_miss_resp)
+  );
 
-  logic                                   [                2:0] snoop_valid;
-  logic                                   [                2:0] snoop_abort;
-  hpdcache_pkg::hpdcache_req_offset_t     [                2:0] snoop_addr_offset;
-  hpdcache_pkg::hpdcache_tag_t            [                2:0] snoop_addr_tag;
-  logic                                   [                2:0] snoop_phys_indexed;
-
-  logic                                                         dcache_cmo_req_is_prefetch;
+//   //  D$ instantiation
 
   logic                                                         dcache_miss_ready;
   logic                                                         dcache_miss_valid;
@@ -250,272 +268,74 @@ module extended_hpdcache_subsystem
   logic                                                         dcache_uc_write_resp_valid;
   hpdcache_mem_resp_w_t                                         dcache_uc_write_resp;
 
-  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_in;
-  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_out;
 
-  generate
-    dcache_req_i_t dcache_req_ports[HPDCACHE_NREQUESTERS-1:0];
+  //  {{{
+  hpdcache_dcache_with_adapter # () i_hpdcache_dcache (
+      .dcache_enable_i(dcache_enable_i),
+      .dcache_flush_i(dcache_flush_i),
+      .dcache_flush_ack_o(dcache_flush_ack_o),
+      .dcache_miss_o(dcache_miss_o),
+      .dcache_amo_req_i(dcache_amo_req_i),
+      .dcache_amo_resp_o(dcache_amo_resp_o),
+      .dcache_cmo_req_i(dcache_cmo_req_i),
+      .dcache_cmo_resp_o(dcache_cmo_resp_o),
+      .dcache_req_ports_i(dcache_req_ports_i),
+      .dcache_req_ports_o(dcache_req_ports_o),
+      .wbuffer_empty_o(wbuffer_empty_o),
+      .wbuffer_not_ni_o(wbuffer_not_ni_o),
+      .hwpf_base_set_i(hwpf_base_set_i),
+      .hwpf_base_i(hwpf_base_i),
+      .hwpf_base_o(hwpf_base_o),
+      .hwpf_param_set_i(hwpf_param_set_i),
+      .hwpf_param_i(hwpf_param_i),
+      .hwpf_param_o(hwpf_param_o),
+      .hwpf_throttle_set_i(hwpf_throttle_set_i),
+      .hwpf_throttle_i(hwpf_throttle_i),
+      .hwpf_throttle_o(hwpf_throttle_o),
+      .hwpf_status_o(hwpf_status_o),
 
-    for (genvar r = 0; r < (NumPorts - 1); r++) begin : cva6_hpdcache_load_if_adapter_gen
-      assign dcache_req_ports[r] = dcache_req_ports_i[r];
+      .dcache_miss_ready_i(dcache_miss_ready),
+      .dcache_miss_valid_o(dcache_miss_valid),
+      .dcache_miss_lo(dcache_miss),
 
-      cva6_hpdcache_if_adapter #(
-          .CVA6Cfg       (CVA6Cfg),
-          .dcache_req_i_t(dcache_req_i_t),
-          .dcache_req_o_t(dcache_req_o_t),
-          .is_load_port  (1'b1)
-      ) i_cva6_hpdcache_load_if_adapter (
-          .clk_i,
-          .rst_ni,
+      .dcache_wbuf_data_ready_i(dcache_wbuf_data_ready),
+      .dcache_wbuf_data_valid_o(dcache_wbuf_data_valid),
+      .dcache_wbuf_data_o(dcache_wbuf_data),
 
-          .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(r)),
+      .dcache_wbuf_resp_ready_o(dcache_wbuf_resp_ready),
+      .dcache_wbuf_resp_valid_i(dcache_wbuf_resp_valid),
+      .dcache_wbuf_resp_i(dcache_wbuf_resp),
 
-          .cva6_req_i     (dcache_req_ports[r]),
-          .cva6_req_o     (dcache_req_ports_o[r]),
-          .cva6_amo_req_i ('0),
-          .cva6_amo_resp_o(  /* unused */),
+      .dcache_uc_read_ready_i(dcache_uc_read_ready),
+      .dcache_uc_read_valid_o(dcache_uc_read_valid),
+      .dcache_uc_read_o(dcache_uc_read),
 
-          .hpdcache_req_valid_o(dcache_req_valid[r]),
-          .hpdcache_req_ready_i(dcache_req_ready[r]),
-          .hpdcache_req_o      (dcache_req[r]),
-          .hpdcache_req_abort_o(dcache_req_abort[r]),
-          .hpdcache_req_tag_o  (dcache_req_tag[r]),
-          .hpdcache_req_pma_o  (dcache_req_pma[r]),
+      .dcache_uc_read_resp_ready_o(dcache_uc_read_resp_ready),
+      .dcache_uc_read_resp_valid_i(dcache_uc_read_resp_valid),
+      .dcache_uc_read_resp_i(dcache_uc_read_resp),
 
-          .hpdcache_rsp_valid_i(dcache_rsp_valid[r]),
-          .hpdcache_rsp_i      (dcache_rsp[r])
-      );
-    end
+      .dcache_uc_write_ready_i(dcache_uc_write_ready),
+      .dcache_uc_write_valid_o(dcache_uc_write_valid),
+      .dcache_uc_write_o(dcache_uc_write),
 
-    cva6_hpdcache_if_adapter #(
-        .CVA6Cfg       (CVA6Cfg),
-        .dcache_req_i_t(dcache_req_i_t),
-        .dcache_req_o_t(dcache_req_o_t),
-        .is_load_port  (1'b0)
-    ) i_cva6_hpdcache_store_if_adapter (
-        .clk_i,
-        .rst_ni,
+      .dcache_uc_write_data_ready_i(dcache_uc_write_data_ready),
+      .dcache_uc_write_data_valid_o(dcache_uc_write_data_valid),
+      .dcache_uc_write_data_o(dcache_uc_write_data),
 
-        .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts - 1)),
+      .dcache_uc_write_resp_ready_o(dcache_uc_write_resp_ready),
+      .dcache_uc_write_resp_valid_i(dcache_uc_write_resp_valid),
+      .dcache_uc_write_resp_i(dcache_uc_write_resp),
 
-        .cva6_req_i     (dcache_req_ports_i[NumPorts-1]),
-        .cva6_req_o     (dcache_req_ports_o[NumPorts-1]),
-        .cva6_amo_req_i (dcache_amo_req_i),
-        .cva6_amo_resp_o(dcache_amo_resp_o),
+      .dcache_miss_resp_ready_o(dcache_miss_resp_ready),
+      .dcache_miss_resp_valid_i(dcache_miss_resp_valid),
+      .dcache_miss_resp_i(dcache_miss_resp),
 
-        .hpdcache_req_valid_o(dcache_req_valid[NumPorts-1]),
-        .hpdcache_req_ready_i(dcache_req_ready[NumPorts-1]),
-        .hpdcache_req_o      (dcache_req[NumPorts-1]),
-        .hpdcache_req_abort_o(dcache_req_abort[NumPorts-1]),
-        .hpdcache_req_tag_o  (dcache_req_tag[NumPorts-1]),
-        .hpdcache_req_pma_o  (dcache_req_pma[NumPorts-1]),
-
-        .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts-1]),
-        .hpdcache_rsp_i      (dcache_rsp[NumPorts-1])
-    );
-
-`ifdef HPDCACHE_ENABLE_CMO
-    cva6_hpdcache_cmo_if_adapter #(
-        .cmo_req_t(cmo_req_t),
-        .cmo_rsp_t(cmo_rsp_t)
-    ) i_cva6_hpdcache_cmo_if_adapter (
-        .clk_i,
-        .rst_ni,
-
-        .dcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts)),
-
-        .cva6_cmo_req_i (dcache_cmo_req_i),
-        .cva6_cmo_resp_o(dcache_cmo_resp_o),
-
-        .dcache_req_valid_o(dcache_req_valid[NumPorts]),
-        .dcache_req_ready_i(dcache_req_ready[NumPorts]),
-        .dcache_req_o      (dcache_req[NumPorts]),
-        .dcache_req_abort_o(dcache_req_abort[NumPorts]),
-        .dcache_req_tag_o  (dcache_req_tag[NumPorts]),
-        .dcache_req_pma_o  (dcache_req_pma[NumPorts]),
-
-        .dcache_rsp_valid_i(dcache_rsp_valid[NumPorts]),
-        .dcache_rsp_i      (dcache_rsp[NumPorts])
-    );
-`else
-    assign dcache_req_valid[NumPorts] = 1'b0,
-        dcache_req[NumPorts] = '0,
-        dcache_req_abort[NumPorts] = 1'b0,
-        dcache_req_tag[NumPorts] = '0,
-        dcache_req_pma[NumPorts] = '0;
-`endif
-  endgenerate
-
-  //  Snoop load port
-  assign snoop_valid[0] = dcache_req_valid[1] & dcache_req_ready[1],
-      snoop_abort[0] = dcache_req_abort[1],
-      snoop_addr_offset[0] = dcache_req[1].addr_offset,
-      snoop_addr_tag[0] = dcache_req_tag[1],
-      snoop_phys_indexed[0] = dcache_req[1].phys_indexed;
-
-  //  Snoop Store/AMO port
-  assign snoop_valid[1] = dcache_req_valid[NumPorts-1] & dcache_req_ready[NumPorts-1],
-      snoop_abort[1] = dcache_req_abort[NumPorts-1],
-      snoop_addr_offset[1] = dcache_req[NumPorts-1].addr_offset,
-      snoop_addr_tag[1] = dcache_req_tag[NumPorts-1],
-      snoop_phys_indexed[1] = dcache_req[NumPorts-1].phys_indexed;
-
-`ifdef HPDCACHE_ENABLE_CMO
-  //  Snoop CMO port (in case of read prefetch accesses)
-  assign dcache_cmo_req_is_prefetch = hpdcache_pkg::is_cmo_prefetch(
-      dcache_req[NumPorts].op, dcache_req[NumPorts].size
+      .dcache_wbuf_o(dcache_wbuf),
+      .dcache_wbuf_valid_o(dcache_wbuf_valid),
+      .dcache_wbuf_ready_i(dcache_wbuf_ready)
   );
-  assign snoop_valid[2]        = dcache_req_valid[NumPorts]
-                               & dcache_req_ready[NumPorts]
-                               & dcache_cmo_req_is_prefetch,
-      snoop_abort[2] = dcache_req_abort[NumPorts],
-      snoop_addr_offset[2] = dcache_req[NumPorts].addr_offset,
-      snoop_addr_tag[2] = dcache_req_tag[NumPorts],
-      snoop_phys_indexed[2] = dcache_req[NumPorts].phys_indexed;
-`else
-  assign snoop_valid[2] = 1'b0,
-      snoop_abort[2] = 1'b0,
-      snoop_addr_offset[2] = '0,
-      snoop_addr_tag[2] = '0,
-      snoop_phys_indexed[2] = 1'b0;
-`endif
-
-  generate
-    for (genvar h = 0; h < NrHwPrefetchers; h++) begin : hwpf_throttle_gen
-      assign hwpf_throttle_in[h] = hwpf_stride_pkg::hwpf_stride_throttle_t'(hwpf_throttle_i[h]),
-          hwpf_throttle_o[h] = hwpf_stride_pkg::hwpf_stride_param_t'(hwpf_throttle_out[h]);
-    end
-  endgenerate
-
-  hwpf_stride_wrapper #(
-      .NUM_HW_PREFETCH(NrHwPrefetchers),
-      .NUM_SNOOP_PORTS(3)
-  ) i_hwpf_stride_wrapper (
-      .clk_i,
-      .rst_ni,
-
-      .hwpf_stride_base_set_i    (hwpf_base_set_i),
-      .hwpf_stride_base_i        (hwpf_base_i),
-      .hwpf_stride_base_o        (hwpf_base_o),
-      .hwpf_stride_param_set_i   (hwpf_param_set_i),
-      .hwpf_stride_param_i       (hwpf_param_i),
-      .hwpf_stride_param_o       (hwpf_param_o),
-      .hwpf_stride_throttle_set_i(hwpf_throttle_set_i),
-      .hwpf_stride_throttle_i    (hwpf_throttle_in),
-      .hwpf_stride_throttle_o    (hwpf_throttle_out),
-      .hwpf_stride_status_o      (hwpf_status_o),
-
-      .snoop_valid_i       (snoop_valid),
-      .snoop_abort_i       (snoop_abort),
-      .snoop_addr_offset_i (snoop_addr_offset),
-      .snoop_addr_tag_i    (snoop_addr_tag),
-      .snoop_phys_indexed_i(snoop_phys_indexed),
-
-      .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts + 1)),
-
-      .hpdcache_req_valid_o(dcache_req_valid[NumPorts+1]),
-      .hpdcache_req_ready_i(dcache_req_ready[NumPorts+1]),
-      .hpdcache_req_o      (dcache_req[NumPorts+1]),
-      .hpdcache_req_abort_o(dcache_req_abort[NumPorts+1]),
-      .hpdcache_req_tag_o  (dcache_req_tag[NumPorts+1]),
-      .hpdcache_req_pma_o  (dcache_req_pma[NumPorts+1]),
-      .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts+1]),
-      .hpdcache_rsp_i      (dcache_rsp[NumPorts+1])
-  );
-
-  hpdcache #(
-      .NREQUESTERS         (HPDCACHE_NREQUESTERS),
-      .HPDcacheMemAddrWidth(CVA6Cfg.PLEN),
-      .HPDcacheMemIdWidth  (CVA6Cfg.MEM_TID_WIDTH),
-      .HPDcacheMemDataWidth(CVA6Cfg.AxiDataWidth)
-  ) i_hpdcache (
-      .clk_i,
-      .rst_ni,
-
-      .wbuf_flush_i(dcache_flush_i),
-
-      .core_req_valid_i(dcache_req_valid),
-      .core_req_ready_o(dcache_req_ready),
-      .core_req_i      (dcache_req),
-      .core_req_abort_i(dcache_req_abort),
-      .core_req_tag_i  (dcache_req_tag),
-      .core_req_pma_i  (dcache_req_pma),
-
-      .core_rsp_valid_o(dcache_rsp_valid),
-      .core_rsp_o      (dcache_rsp),
-
-      .mem_req_miss_read_ready_i(dcache_miss_ready),
-      .mem_req_miss_read_valid_o(dcache_miss_valid),
-      .mem_req_miss_read_o      (dcache_miss),
-
-      .mem_resp_miss_read_ready_o(dcache_miss_resp_ready),
-      .mem_resp_miss_read_valid_i(dcache_miss_resp_valid),
-      .mem_resp_miss_read_i      (dcache_miss_resp),
-
-      .mem_req_wbuf_write_ready_i(dcache_wbuf_ready),
-      .mem_req_wbuf_write_valid_o(dcache_wbuf_valid),
-      .mem_req_wbuf_write_o      (dcache_wbuf),
-
-      .mem_req_wbuf_write_data_ready_i(dcache_wbuf_data_ready),
-      .mem_req_wbuf_write_data_valid_o(dcache_wbuf_data_valid),
-      .mem_req_wbuf_write_data_o      (dcache_wbuf_data),
-
-      .mem_resp_wbuf_write_ready_o(dcache_wbuf_resp_ready),
-      .mem_resp_wbuf_write_valid_i(dcache_wbuf_resp_valid),
-      .mem_resp_wbuf_write_i      (dcache_wbuf_resp),
-
-      .mem_req_uc_read_ready_i(dcache_uc_read_ready),
-      .mem_req_uc_read_valid_o(dcache_uc_read_valid),
-      .mem_req_uc_read_o      (dcache_uc_read),
-
-      .mem_resp_uc_read_ready_o(dcache_uc_read_resp_ready),
-      .mem_resp_uc_read_valid_i(dcache_uc_read_resp_valid),
-      .mem_resp_uc_read_i      (dcache_uc_read_resp),
-
-      .mem_req_uc_write_ready_i(dcache_uc_write_ready),
-      .mem_req_uc_write_valid_o(dcache_uc_write_valid),
-      .mem_req_uc_write_o      (dcache_uc_write),
-
-      .mem_req_uc_write_data_ready_i(dcache_uc_write_data_ready),
-      .mem_req_uc_write_data_valid_o(dcache_uc_write_data_valid),
-      .mem_req_uc_write_data_o      (dcache_uc_write_data),
-
-      .mem_resp_uc_write_ready_o(dcache_uc_write_resp_ready),
-      .mem_resp_uc_write_valid_i(dcache_uc_write_resp_valid),
-      .mem_resp_uc_write_i      (dcache_uc_write_resp),
-
-      .evt_cache_write_miss_o(dcache_write_miss),
-      .evt_cache_read_miss_o (dcache_read_miss),
-      .evt_uncached_req_o    (  /* unused */),
-      .evt_cmo_req_o         (  /* unused */),
-      .evt_write_req_o       (  /* unused */),
-      .evt_read_req_o        (  /* unused */),
-      .evt_prefetch_req_o    (  /* unused */),
-      .evt_req_on_hold_o     (  /* unused */),
-      .evt_rtab_rollback_o   (  /* unused */),
-      .evt_stall_refill_o    (  /* unused */),
-      .evt_stall_o           (  /* unused */),
-
-      .wbuf_empty_o(wbuffer_empty_o),
-
-      .cfg_enable_i                       (dcache_enable_i),
-      .cfg_wbuf_threshold_i               (4'd2),
-      .cfg_wbuf_reset_timecnt_on_write_i  (1'b1),
-      .cfg_wbuf_sequential_waw_i          (1'b0),
-      .cfg_wbuf_inhibit_write_coalescing_i(1'b0),
-      .cfg_prefetch_updt_plru_i           (1'b1),
-      .cfg_error_on_cacheable_amo_i       (1'b0),
-      .cfg_rtab_single_entry_i            (1'b0)
-  );
-
-  assign dcache_miss_o = dcache_read_miss, wbuffer_not_ni_o = wbuffer_empty_o;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : dcache_flush_ff
-    if (!rst_ni) dcache_flush_ack_o <= 1'b0;
-    else dcache_flush_ack_o <= ~dcache_flush_ack_o & dcache_flush_i;
-  end
-
   //  }}}
+
 
   //  AXI arbiter instantiation
   //  {{{

--- a/core/cache_subsystem/extended_hpdcache_subsystem_axi_arbiter.sv
+++ b/core/cache_subsystem/extended_hpdcache_subsystem_axi_arbiter.sv
@@ -1,0 +1,572 @@
+// Copyright 2023 Commissariat a l'Energie Atomique et aux Energies
+//                Alternatives (CEA)
+//
+// Licensed under the Solderpad Hardware License, Version 2.1 (the “License”);
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Authors: Cesar Fuguet
+// Date: February, 2023
+// Description: AXI arbiter for the CVA6 cache subsystem integrating standard
+//              CVA6's instruction cache and the Core-V High-Performance
+//              L1 Dcache (CV-HPDcache).
+
+module extended_hpdcache_subsystem_axi_arbiter
+//  Parameters
+//  {{{
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type hpdcache_mem_req_t = logic,
+    parameter type hpdcache_mem_req_w_t = logic,
+    parameter type hpdcache_mem_resp_r_t = logic,
+    parameter type hpdcache_mem_resp_w_t = logic,
+    parameter type icache_req_t = logic,
+    parameter type icache_rtrn_t = logic,
+
+    parameter int unsigned AxiAddrWidth = 1,
+    parameter int unsigned AxiDataWidth = 1,
+    parameter int unsigned AxiIdWidth = 1,
+    parameter int unsigned AxiUserWidth = 1,
+    parameter type axi_ar_chan_t = logic,
+    parameter type axi_aw_chan_t = logic,
+    parameter type axi_w_chan_t = logic,
+    parameter type axi_b_chan_t = logic,
+    parameter type axi_r_chan_t = logic,
+    parameter type axi_req_t = logic,
+    parameter type axi_rsp_t = logic,
+
+    localparam type hpdcache_mem_id_t = logic [CVA6Cfg.MEM_TID_WIDTH-1:0]
+)
+//  }}}
+
+//  Ports
+//  {{{
+(
+    input logic clk_i,
+    input logic rst_ni,
+
+    //  Interfaces from/to I$
+    //  {{{
+    input  logic             icache_miss_valid_i,
+    output logic             icache_miss_ready_o,
+    input  icache_req_t      icache_miss_i,
+    input  hpdcache_mem_id_t icache_miss_id_i,
+
+    output logic         icache_miss_resp_valid_o,
+    output icache_rtrn_t icache_miss_resp_o,
+    //  }}}
+
+    //  Interfaces from/to D$
+    //  {{{
+    output logic              dcache_miss_ready_o,
+    input  logic              dcache_miss_valid_i,
+    input  hpdcache_mem_req_t dcache_miss_i,
+
+    input  logic                 dcache_miss_resp_ready_i,
+    output logic                 dcache_miss_resp_valid_o,
+    output hpdcache_mem_resp_r_t dcache_miss_resp_o,
+
+    //      Write-buffer write interface
+    output logic              dcache_wbuf_ready_o,
+    input  logic              dcache_wbuf_valid_i,
+    input  hpdcache_mem_req_t dcache_wbuf_i,
+
+    output logic                dcache_wbuf_data_ready_o,
+    input  logic                dcache_wbuf_data_valid_i,
+    input  hpdcache_mem_req_w_t dcache_wbuf_data_i,
+
+    input  logic                 dcache_wbuf_resp_ready_i,
+    output logic                 dcache_wbuf_resp_valid_o,
+    output hpdcache_mem_resp_w_t dcache_wbuf_resp_o,
+
+    //      Uncached read interface
+    output logic              dcache_uc_read_ready_o,
+    input  logic              dcache_uc_read_valid_i,
+    input  hpdcache_mem_req_t dcache_uc_read_i,
+    input  hpdcache_mem_id_t  dcache_uc_read_id_i,
+
+    input  logic                 dcache_uc_read_resp_ready_i,
+    output logic                 dcache_uc_read_resp_valid_o,
+    output hpdcache_mem_resp_r_t dcache_uc_read_resp_o,
+
+    //      Uncached write interface
+    output logic              dcache_uc_write_ready_o,
+    input  logic              dcache_uc_write_valid_i,
+    input  hpdcache_mem_req_t dcache_uc_write_i,
+    input  hpdcache_mem_id_t  dcache_uc_write_id_i,
+
+    output logic                dcache_uc_write_data_ready_o,
+    input  logic                dcache_uc_write_data_valid_i,
+    input  hpdcache_mem_req_w_t dcache_uc_write_data_i,
+
+    input  logic                 dcache_uc_write_resp_ready_i,
+    output logic                 dcache_uc_write_resp_valid_o,
+    output hpdcache_mem_resp_w_t dcache_uc_write_resp_o,
+    //  }}}
+
+    //  AXI port to upstream memory/peripherals
+    //  {{{
+    output axi_req_t axi_req_o,
+    input  axi_rsp_t axi_resp_i
+    //  }}}
+);
+  //  }}}
+
+  //  Internal type definitions
+  //  {{{
+
+  localparam int MEM_RESP_RT_DEPTH = (1 << CVA6Cfg.MEM_TID_WIDTH);
+  typedef hpdcache_mem_id_t [MEM_RESP_RT_DEPTH-1:0] mem_resp_rt_t;
+  typedef logic [CVA6Cfg.ICACHE_LINE_WIDTH-1:0] icache_resp_data_t;
+  //  }}}
+
+  //  Adapt the I$ interface to the HPDcache memory interface
+  //  {{{
+  localparam int ICACHE_CL_WORDS = CVA6Cfg.ICACHE_LINE_WIDTH / 64;
+  localparam int ICACHE_CL_WORD_INDEX = $clog2(ICACHE_CL_WORDS);
+  localparam int ICACHE_CL_SIZE = $clog2(CVA6Cfg.ICACHE_LINE_WIDTH / 8);
+  localparam int ICACHE_WORD_SIZE = 3;
+  localparam int ICACHE_MEM_REQ_CL_LEN =
+    (CVA6Cfg.ICACHE_LINE_WIDTH + CVA6Cfg.AxiDataWidth - 1)/CVA6Cfg.AxiDataWidth;
+  localparam int ICACHE_MEM_REQ_CL_SIZE =
+    (CVA6Cfg.AxiDataWidth <= CVA6Cfg.ICACHE_LINE_WIDTH) ?
+      $clog2(
+      CVA6Cfg.AxiDataWidth / 8
+  ) : ICACHE_CL_SIZE;
+
+  //    I$ request
+  hpdcache_mem_req_t icache_miss_req_wdata;
+  logic icache_miss_req_w, icache_miss_req_wok;
+
+  hpdcache_mem_req_t icache_miss_req_rdata;
+  logic icache_miss_req_r, icache_miss_req_rok;
+
+  logic icache_miss_pending_q;
+
+  //  This FIFO has two functionnalities:
+  //  -  Stabilize the ready-valid protocol. The ICACHE can abort a valid
+  //     transaction without receiving the corresponding ready signal. This
+  //     behavior is not supported by AXI.
+  //  -  Cut a possible long timing path.
+  hpdcache_fifo_reg #(
+      .FIFO_DEPTH (1),
+      .fifo_data_t(hpdcache_mem_req_t)
+  ) i_icache_miss_req_fifo (
+      .clk_i,
+      .rst_ni,
+
+      .w_i    (icache_miss_req_w),
+      .wok_o  (icache_miss_req_wok),
+      .wdata_i(icache_miss_req_wdata),
+
+      .r_i    (icache_miss_req_r),
+      .rok_o  (icache_miss_req_rok),
+      .rdata_o(icache_miss_req_rdata)
+  );
+
+  assign icache_miss_req_w = icache_miss_valid_i, icache_miss_ready_o = icache_miss_req_wok;
+
+  assign icache_miss_req_wdata.mem_req_addr = icache_miss_i.paddr,
+      icache_miss_req_wdata.mem_req_len = icache_miss_i.nc ? 0 : ICACHE_MEM_REQ_CL_LEN - 1,
+      icache_miss_req_wdata.mem_req_size      = icache_miss_i.nc ? ICACHE_WORD_SIZE : ICACHE_MEM_REQ_CL_SIZE,
+      icache_miss_req_wdata.mem_req_id = icache_miss_i.tid,
+      icache_miss_req_wdata.mem_req_command = hpdcache_pkg::HPDCACHE_MEM_READ,
+      icache_miss_req_wdata.mem_req_atomic = hpdcache_pkg::hpdcache_mem_atomic_e'(0),
+      icache_miss_req_wdata.mem_req_cacheable = ~icache_miss_i.nc;
+
+
+  //    I$ response
+  logic icache_miss_resp_w, icache_miss_resp_wok;
+  hpdcache_mem_resp_r_t icache_miss_resp_wdata;
+
+  logic icache_miss_resp_data_w, icache_miss_resp_data_wok;
+  logic icache_miss_resp_data_r, icache_miss_resp_data_rok;
+  icache_resp_data_t icache_miss_resp_data_rdata;
+
+  logic icache_miss_resp_meta_w, icache_miss_resp_meta_wok;
+  logic icache_miss_resp_meta_r, icache_miss_resp_meta_rok;
+  hpdcache_mem_id_t  icache_miss_resp_meta_id;
+
+  icache_resp_data_t icache_miss_rdata;
+
+  generate
+    if (CVA6Cfg.AxiDataWidth < CVA6Cfg.ICACHE_LINE_WIDTH) begin
+      hpdcache_fifo_reg #(
+          .FIFO_DEPTH (1),
+          .fifo_data_t(hpdcache_mem_id_t)
+      ) i_icache_refill_meta_fifo (
+          .clk_i,
+          .rst_ni,
+
+          .w_i    (icache_miss_resp_meta_w),
+          .wok_o  (icache_miss_resp_meta_wok),
+          .wdata_i(icache_miss_resp_wdata.mem_resp_r_id),
+
+          .r_i    (icache_miss_resp_meta_r),
+          .rok_o  (icache_miss_resp_meta_rok),
+          .rdata_o(icache_miss_resp_meta_id)
+      );
+
+      hpdcache_data_upsize #(
+          .WR_WIDTH(CVA6Cfg.AxiDataWidth),
+          .RD_WIDTH(CVA6Cfg.ICACHE_LINE_WIDTH),
+          .DEPTH   (1)
+      ) i_icache_hpdcache_data_upsize (
+          .clk_i,
+          .rst_ni,
+
+          .w_i    (icache_miss_resp_data_w),
+          .wlast_i(icache_miss_resp_wdata.mem_resp_r_last),
+          .wok_o  (icache_miss_resp_data_wok),
+          .wdata_i(icache_miss_resp_wdata.mem_resp_r_data),
+
+          .r_i    (icache_miss_resp_data_r),
+          .rok_o  (icache_miss_resp_data_rok),
+          .rdata_o(icache_miss_resp_data_rdata)
+      );
+
+      assign icache_miss_resp_meta_r = 1'b1, icache_miss_resp_data_r = 1'b1;
+
+      assign icache_miss_resp_meta_w = icache_miss_resp_w & icache_miss_resp_wdata.mem_resp_r_last;
+
+      assign icache_miss_resp_data_w = icache_miss_resp_w;
+
+      assign icache_miss_resp_wok = icache_miss_resp_data_wok & (
+               icache_miss_resp_meta_wok | ~icache_miss_resp_wdata.mem_resp_r_last);
+
+      assign icache_miss_rdata = icache_miss_resp_data_rdata;
+
+    end else begin
+      assign icache_miss_resp_data_rok = icache_miss_resp_w;
+      assign icache_miss_resp_meta_rok = icache_miss_resp_w;
+      assign icache_miss_resp_wok = 1'b1;
+      assign icache_miss_resp_meta_id = icache_miss_resp_wdata.mem_resp_r_id;
+      assign icache_miss_resp_data_rdata = icache_miss_resp_wdata.mem_resp_r_data;
+
+      //  In the case of uncacheable accesses, the Icache expects the data to be right-aligned
+      always_comb begin : icache_miss_resp_data_comb
+        if (!icache_miss_req_rdata.mem_req_cacheable) begin
+          automatic logic [ICACHE_CL_WORD_INDEX - 1:0] icache_miss_word_index;
+          automatic logic [63:0] icache_miss_word;
+          icache_miss_word_index = icache_miss_req_rdata.mem_req_addr[3+:ICACHE_CL_WORD_INDEX];
+          icache_miss_word = icache_miss_resp_data_rdata[icache_miss_word_index*64+:64];
+          icache_miss_rdata = {{CVA6Cfg.ICACHE_LINE_WIDTH - 64{1'b0}}, icache_miss_word};
+        end else begin
+          icache_miss_rdata = icache_miss_resp_data_rdata;
+        end
+      end
+    end
+  endgenerate
+
+  assign icache_miss_resp_valid_o = icache_miss_resp_meta_rok,
+      icache_miss_resp_o.rtype = wt_cache_pkg::ICACHE_IFILL_ACK,
+      icache_miss_resp_o.user = '0,
+      icache_miss_resp_o.inv = '0,
+      icache_miss_resp_o.tid = icache_miss_resp_meta_id,
+      icache_miss_resp_o.data = icache_miss_rdata;
+
+  //  consume the Icache miss on the arrival of the response. The request
+  //  metadata is decoded to forward the correct word in case of uncacheable
+  //  Icache access
+  assign icache_miss_req_r = icache_miss_resp_meta_rok;
+  //  }}}
+
+  //  Read request arbiter
+  //  {{{
+  logic              mem_req_read_ready     [2:0];
+  logic              mem_req_read_valid     [2:0];
+  hpdcache_mem_req_t mem_req_read           [2:0];
+
+  logic              mem_req_read_ready_arb;
+  logic              mem_req_read_valid_arb;
+  hpdcache_mem_req_t mem_req_read_arb;
+
+  assign mem_req_read_valid[0] = icache_miss_req_rok & ~icache_miss_pending_q,
+      mem_req_read[0] = icache_miss_req_rdata;
+
+  assign dcache_miss_ready_o = mem_req_read_ready[1],
+      mem_req_read_valid[1] = dcache_miss_valid_i,
+      mem_req_read[1] = dcache_miss_i;
+
+  assign dcache_uc_read_ready_o = mem_req_read_ready[2],
+      mem_req_read_valid[2] = dcache_uc_read_valid_i,
+      mem_req_read[2] = dcache_uc_read_i;
+
+  hpdcache_mem_req_read_arbiter #(
+      .N                 (3),
+      .hpdcache_mem_req_t(hpdcache_mem_req_t)
+  ) i_mem_req_read_arbiter (
+      .clk_i,
+      .rst_ni,
+
+      .mem_req_read_ready_o(mem_req_read_ready),
+      .mem_req_read_valid_i(mem_req_read_valid),
+      .mem_req_read_i      (mem_req_read),
+
+      .mem_req_read_ready_i(mem_req_read_ready_arb),
+      .mem_req_read_valid_o(mem_req_read_valid_arb),
+      .mem_req_read_o      (mem_req_read_arb)
+  );
+  //  }}}
+
+  //  Read response demultiplexor
+  //  {{{
+  logic                 mem_resp_read_ready;
+  logic                 mem_resp_read_valid;
+  hpdcache_mem_resp_r_t mem_resp_read;
+
+  logic                 mem_resp_read_ready_arb[2:0];
+  logic                 mem_resp_read_valid_arb[2:0];
+  hpdcache_mem_resp_r_t mem_resp_read_arb      [2:0];
+
+  mem_resp_rt_t         mem_resp_read_rt;
+
+  always_comb begin
+    for (int i = 0; i < MEM_RESP_RT_DEPTH; i++) begin
+      mem_resp_read_rt[i] = (i == int'(   icache_miss_id_i)) ? 0 :
+                            (i == int'(dcache_uc_read_id_i)) ? 2 : 1;
+    end
+  end
+
+  hpdcache_mem_resp_demux #(
+      .N        (3),
+      .resp_t   (hpdcache_mem_resp_r_t),
+      .resp_id_t(hpdcache_mem_id_t)
+  ) i_mem_resp_read_demux (
+      .clk_i,
+      .rst_ni,
+
+      .mem_resp_ready_o(mem_resp_read_ready),
+      .mem_resp_valid_i(mem_resp_read_valid),
+      .mem_resp_id_i   (mem_resp_read.mem_resp_r_id),
+      .mem_resp_i      (mem_resp_read),
+
+      .mem_resp_ready_i(mem_resp_read_ready_arb),
+      .mem_resp_valid_o(mem_resp_read_valid_arb),
+      .mem_resp_o      (mem_resp_read_arb),
+
+      .mem_resp_rt_i(mem_resp_read_rt)
+  );
+
+  assign icache_miss_resp_w = mem_resp_read_valid_arb[0],
+      icache_miss_resp_wdata = mem_resp_read_arb[0],
+      mem_resp_read_ready_arb[0] = icache_miss_resp_wok;
+
+  assign dcache_miss_resp_valid_o = mem_resp_read_valid_arb[1],
+      dcache_miss_resp_o = mem_resp_read_arb[1],
+      mem_resp_read_ready_arb[1] = dcache_miss_resp_ready_i;
+
+  assign dcache_uc_read_resp_valid_o = mem_resp_read_valid_arb[2],
+      dcache_uc_read_resp_o = mem_resp_read_arb[2],
+      mem_resp_read_ready_arb[2] = dcache_uc_read_resp_ready_i;
+  //  }}}
+
+  //  Write request arbiter
+  //  {{{
+  logic                mem_req_write_ready          [1:0];
+  logic                mem_req_write_valid          [1:0];
+  hpdcache_mem_req_t   mem_req_write                [1:0];
+
+  logic                mem_req_write_data_ready     [1:0];
+  logic                mem_req_write_data_valid     [1:0];
+  hpdcache_mem_req_w_t mem_req_write_data           [1:0];
+
+  logic                mem_req_write_ready_arb;
+  logic                mem_req_write_valid_arb;
+  hpdcache_mem_req_t   mem_req_write_arb;
+
+  logic                mem_req_write_data_ready_arb;
+  logic                mem_req_write_data_valid_arb;
+  hpdcache_mem_req_w_t mem_req_write_data_arb;
+
+  assign dcache_wbuf_ready_o = mem_req_write_ready[0],
+      mem_req_write_valid[0] = dcache_wbuf_valid_i,
+      mem_req_write[0] = dcache_wbuf_i;
+
+  assign dcache_wbuf_data_ready_o = mem_req_write_data_ready[0],
+      mem_req_write_data_valid[0] = dcache_wbuf_data_valid_i,
+      mem_req_write_data[0] = dcache_wbuf_data_i;
+
+  assign dcache_uc_write_ready_o = mem_req_write_ready[1],
+      mem_req_write_valid[1] = dcache_uc_write_valid_i,
+      mem_req_write[1] = dcache_uc_write_i;
+
+  assign dcache_uc_write_data_ready_o = mem_req_write_data_ready[1],
+      mem_req_write_data_valid[1] = dcache_uc_write_data_valid_i,
+      mem_req_write_data[1] = dcache_uc_write_data_i;
+
+  hpdcache_mem_req_write_arbiter #(
+      .N                   (2),
+      .hpdcache_mem_req_t  (hpdcache_mem_req_t),
+      .hpdcache_mem_req_w_t(hpdcache_mem_req_w_t)
+  ) i_mem_req_write_arbiter (
+      .clk_i,
+      .rst_ni,
+
+      .mem_req_write_ready_o(mem_req_write_ready),
+      .mem_req_write_valid_i(mem_req_write_valid),
+      .mem_req_write_i      (mem_req_write),
+
+      .mem_req_write_data_ready_o(mem_req_write_data_ready),
+      .mem_req_write_data_valid_i(mem_req_write_data_valid),
+      .mem_req_write_data_i      (mem_req_write_data),
+
+      .mem_req_write_ready_i(mem_req_write_ready_arb),
+      .mem_req_write_valid_o(mem_req_write_valid_arb),
+      .mem_req_write_o      (mem_req_write_arb),
+
+      .mem_req_write_data_ready_i(mem_req_write_data_ready_arb),
+      .mem_req_write_data_valid_o(mem_req_write_data_valid_arb),
+      .mem_req_write_data_o      (mem_req_write_data_arb)
+  );
+  //  }}}
+
+  //  Write response demultiplexor
+  //  {{{
+  logic                 mem_resp_write_ready;
+  logic                 mem_resp_write_valid;
+  hpdcache_mem_resp_w_t mem_resp_write;
+
+  logic                 mem_resp_write_ready_arb[1:0];
+  logic                 mem_resp_write_valid_arb[1:0];
+  hpdcache_mem_resp_w_t mem_resp_write_arb      [1:0];
+
+  mem_resp_rt_t         mem_resp_write_rt;
+
+  always_comb begin
+    for (int i = 0; i < MEM_RESP_RT_DEPTH; i++) begin
+      mem_resp_write_rt[i] = (i == int'(dcache_uc_write_id_i)) ? 1 : 0;
+    end
+  end
+
+  hpdcache_mem_resp_demux #(
+      .N        (2),
+      .resp_t   (hpdcache_mem_resp_w_t),
+      .resp_id_t(hpdcache_mem_id_t)
+  ) i_hpdcache_mem_resp_write_demux (
+      .clk_i,
+      .rst_ni,
+
+      .mem_resp_ready_o(mem_resp_write_ready),
+      .mem_resp_valid_i(mem_resp_write_valid),
+      .mem_resp_id_i   (mem_resp_write.mem_resp_w_id),
+      .mem_resp_i      (mem_resp_write),
+
+      .mem_resp_ready_i(mem_resp_write_ready_arb),
+      .mem_resp_valid_o(mem_resp_write_valid_arb),
+      .mem_resp_o      (mem_resp_write_arb),
+
+      .mem_resp_rt_i(mem_resp_write_rt)
+  );
+
+  assign dcache_wbuf_resp_valid_o = mem_resp_write_valid_arb[0],
+      dcache_wbuf_resp_o = mem_resp_write_arb[0],
+      mem_resp_write_ready_arb[0] = dcache_wbuf_resp_ready_i;
+
+  assign dcache_uc_write_resp_valid_o = mem_resp_write_valid_arb[1],
+      dcache_uc_write_resp_o = mem_resp_write_arb[1],
+      mem_resp_write_ready_arb[1] = dcache_uc_write_resp_ready_i;
+  //  }}}
+
+  //  I$ miss pending
+  //  {{{
+  always_ff @(posedge clk_i or negedge rst_ni) begin : icache_miss_pending_ff
+    if (!rst_ni) begin
+      icache_miss_pending_q <= 1'b0;
+    end else begin
+      icache_miss_pending_q <= ( (icache_miss_req_rok & mem_req_read_ready[0]) & ~icache_miss_pending_q) |
+                               (~(icache_miss_req_r   & icache_miss_req_rok)   &  icache_miss_pending_q);
+    end
+  end
+  // }}}
+
+  //  AXI adapters
+  //  {{{
+
+  hpdcache_mem_to_axi_write #(
+      .hpdcache_mem_req_t   (hpdcache_mem_req_t),
+      .hpdcache_mem_req_w_t (hpdcache_mem_req_w_t),
+      .hpdcache_mem_resp_w_t(hpdcache_mem_resp_w_t),
+      .aw_chan_t            (axi_aw_chan_t),
+      .w_chan_t             (axi_w_chan_t),
+      .b_chan_t             (axi_b_chan_t)
+  ) i_hpdcache_mem_to_axi_write (
+      .req_ready_o(mem_req_write_ready_arb),
+      .req_valid_i(mem_req_write_valid_arb),
+      .req_i      (mem_req_write_arb),
+
+      .req_data_ready_o(mem_req_write_data_ready_arb),
+      .req_data_valid_i(mem_req_write_data_valid_arb),
+      .req_data_i      (mem_req_write_data_arb),
+
+      .resp_ready_i(mem_resp_write_ready),
+      .resp_valid_o(mem_resp_write_valid),
+      .resp_o      (mem_resp_write),
+
+      .axi_aw_valid_o(axi_req_o.aw_valid),
+      .axi_aw_o      (axi_req_o.aw),
+      .axi_aw_ready_i(axi_resp_i.aw_ready),
+
+      .axi_w_valid_o(axi_req_o.w_valid),
+      .axi_w_o      (axi_req_o.w),
+      .axi_w_ready_i(axi_resp_i.w_ready),
+
+      .axi_b_valid_i(axi_resp_i.b_valid),
+      .axi_b_i      (axi_resp_i.b),
+      .axi_b_ready_o(axi_req_o.b_ready)
+  );
+
+  hpdcache_mem_to_axi_read #(
+      .hpdcache_mem_req_t   (hpdcache_mem_req_t),
+      .hpdcache_mem_resp_r_t(hpdcache_mem_resp_r_t),
+      .ar_chan_t            (axi_ar_chan_t),
+      .r_chan_t             (axi_r_chan_t)
+  ) i_hpdcache_mem_to_axi_read (
+      .req_ready_o(mem_req_read_ready_arb),
+      .req_valid_i(mem_req_read_valid_arb),
+      .req_i      (mem_req_read_arb),
+
+      .resp_ready_i(mem_resp_read_ready),
+      .resp_valid_o(mem_resp_read_valid),
+      .resp_o      (mem_resp_read),
+
+      .axi_ar_valid_o(axi_req_o.ar_valid),
+      .axi_ar_o      (axi_req_o.ar),
+      .axi_ar_ready_i(axi_resp_i.ar_ready),
+
+      .axi_r_valid_i(axi_resp_i.r_valid),
+      .axi_r_i      (axi_resp_i.r),
+      .axi_r_ready_o(axi_req_o.r_ready)
+  );
+
+  //  }}}
+
+  //  Assertions
+  //  {{{
+  //  pragma translate_off
+  initial
+    assert (CVA6Cfg.MEM_TID_WIDTH <= AxiIdWidth)
+    else $fatal("MEM_TID_WIDTH shall be less or equal to AxiIdWidth");
+  initial
+    assert (CVA6Cfg.MEM_TID_WIDTH >= (hpdcache_pkg::HPDCACHE_MSHR_SET_WIDTH + hpdcache_pkg::HPDCACHE_MSHR_WAY_WIDTH + 1))
+    else
+      $fatal(
+          "MEM_TID_WIDTH shall be wide enough to identify all pending HPDcache misses and Icache misses"
+      );
+  initial
+    assert (CVA6Cfg.MEM_TID_WIDTH >= (hpdcache_pkg::HPDCACHE_WBUF_DIR_PTR_WIDTH + 1))
+    else
+      $fatal(
+          "MEM_TID_WIDTH shall be wide enough to identify all pending HPDcache cacheable writes and uncacheable writes"
+      );
+  initial
+    assert (CVA6Cfg.AxiDataWidth <= CVA6Cfg.ICACHE_LINE_WIDTH)
+    else $fatal("AxiDataWidth shall be less or equal to the width of a Icache line");
+  initial
+    assert (CVA6Cfg.AxiDataWidth <= CVA6Cfg.DCACHE_LINE_WIDTH)
+    else $fatal("AxiDataWidth shall be less or equal to the width of a Dcache line");
+  //  pragma translate_on
+  //  }}}
+
+endmodule : cva6_hpdcache_subsystem_axi_arbiter

--- a/core/cache_subsystem/extended_hpdcache_subsystem_axi_arbiter.sv
+++ b/core/cache_subsystem/extended_hpdcache_subsystem_axi_arbiter.sv
@@ -48,13 +48,24 @@ module extended_hpdcache_subsystem_axi_arbiter
 
     //  Interfaces from/to I$
     //  {{{
-    input  logic             icache_miss_valid_i,
-    output logic             icache_miss_ready_o,
-    input  icache_req_t      icache_miss_i,
+    output logic              icache_miss_ready_o,
+    input  logic              icache_miss_valid_i,
+    input  hpdcache_mem_req_t icache_miss_i,
     input  hpdcache_mem_id_t icache_miss_id_i,
 
-    output logic         icache_miss_resp_valid_o,
-    output icache_rtrn_t icache_miss_resp_o,
+    input  logic                 icache_miss_resp_ready_i,
+    output logic                 icache_miss_resp_valid_o,
+    output hpdcache_mem_resp_r_t icache_miss_resp_o,
+
+    //      Uncached read interface
+    output logic              icache_uc_read_ready_o,
+    input  logic              icache_uc_read_valid_i,
+    input  hpdcache_mem_req_t icache_uc_read_i,
+    input  hpdcache_mem_id_t  icache_uc_read_id_i,
+
+    input  logic                 icache_uc_read_resp_ready_i,
+    output logic                 icache_uc_read_resp_valid_o,
+    output hpdcache_mem_resp_r_t icache_uc_read_resp_o,
     //  }}}
 
     //  Interfaces from/to D$
@@ -62,6 +73,7 @@ module extended_hpdcache_subsystem_axi_arbiter
     output logic              dcache_miss_ready_o,
     input  logic              dcache_miss_valid_i,
     input  hpdcache_mem_req_t dcache_miss_i,
+    input  hpdcache_mem_id_t  dcache_miss_id_i,
 
     input  logic                 dcache_miss_resp_ready_i,
     output logic                 dcache_miss_resp_valid_o,
@@ -144,100 +156,58 @@ module extended_hpdcache_subsystem_axi_arbiter
 
   logic icache_miss_pending_q;
 
-  //  This FIFO has two functionnalities:
-  //  -  Stabilize the ready-valid protocol. The ICACHE can abort a valid
-  //     transaction without receiving the corresponding ready signal. This
-  //     behavior is not supported by AXI.
-  //  -  Cut a possible long timing path.
-  hpdcache_fifo_reg #(
-      .FIFO_DEPTH (1),
-      .fifo_data_t(hpdcache_mem_req_t)
-  ) i_icache_miss_req_fifo (
-      .clk_i,
-      .rst_ni,
-
-      .w_i    (icache_miss_req_w),
-      .wok_o  (icache_miss_req_wok),
-      .wdata_i(icache_miss_req_wdata),
-
-      .r_i    (icache_miss_req_r),
-      .rok_o  (icache_miss_req_rok),
-      .rdata_o(icache_miss_req_rdata)
-  );
-
-  assign icache_miss_req_w = icache_miss_valid_i, icache_miss_ready_o = icache_miss_req_wok;
-
-  assign icache_miss_req_wdata.mem_req_addr = icache_miss_i.paddr,
-      icache_miss_req_wdata.mem_req_len = icache_miss_i.nc ? 0 : ICACHE_MEM_REQ_CL_LEN - 1,
-      icache_miss_req_wdata.mem_req_size      = icache_miss_i.nc ? ICACHE_WORD_SIZE : ICACHE_MEM_REQ_CL_SIZE,
-      icache_miss_req_wdata.mem_req_id = icache_miss_i.tid,
-      icache_miss_req_wdata.mem_req_command = hpdcache_pkg::HPDCACHE_MEM_READ,
-      icache_miss_req_wdata.mem_req_atomic = hpdcache_pkg::hpdcache_mem_atomic_e'(0),
-      icache_miss_req_wdata.mem_req_cacheable = ~icache_miss_i.nc;
-
 
   //    I$ response
-  logic icache_miss_resp_w, icache_miss_resp_wok;
-  hpdcache_mem_resp_r_t icache_miss_resp_wdata;
-
-  logic icache_miss_resp_data_w, icache_miss_resp_data_wok;
-  logic icache_miss_resp_data_r, icache_miss_resp_data_rok;
-  icache_resp_data_t icache_miss_resp_data_rdata;
-
-  logic icache_miss_resp_meta_w, icache_miss_resp_meta_wok;
-  logic icache_miss_resp_meta_r, icache_miss_resp_meta_rok;
-  hpdcache_mem_id_t  icache_miss_resp_meta_id;
-
-  icache_resp_data_t icache_miss_rdata;
 
   generate
-    if (CVA6Cfg.AxiDataWidth < CVA6Cfg.ICACHE_LINE_WIDTH) begin
-      hpdcache_fifo_reg #(
-          .FIFO_DEPTH (1),
-          .fifo_data_t(hpdcache_mem_id_t)
-      ) i_icache_refill_meta_fifo (
-          .clk_i,
-          .rst_ni,
+    // if (CVA6Cfg.AxiDataWidth < CVA6Cfg.ICACHE_LINE_WIDTH) begin
+    //   hpdcache_fifo_reg #(
+    //       .FIFO_DEPTH (1),
+    //       .fifo_data_t(hpdcache_mem_id_t)
+    //   ) i_icache_refill_meta_fifo (
+    //       .clk_i,
+    //       .rst_ni,
 
-          .w_i    (icache_miss_resp_meta_w),
-          .wok_o  (icache_miss_resp_meta_wok),
-          .wdata_i(icache_miss_resp_wdata.mem_resp_r_id),
+    //       .w_i    (icache_miss_resp_meta_w),
+    //       .wok_o  (icache_miss_resp_meta_wok),
+    //       .wdata_i(icache_miss_resp_wdata.mem_resp_r_id),
 
-          .r_i    (icache_miss_resp_meta_r),
-          .rok_o  (icache_miss_resp_meta_rok),
-          .rdata_o(icache_miss_resp_meta_id)
-      );
+    //       .r_i    (icache_miss_resp_meta_r),
+    //       .rok_o  (icache_miss_resp_meta_rok),
+    //       .rdata_o(icache_miss_resp_meta_id)
+    //   );
 
-      hpdcache_data_upsize #(
-          .WR_WIDTH(CVA6Cfg.AxiDataWidth),
-          .RD_WIDTH(CVA6Cfg.ICACHE_LINE_WIDTH),
-          .DEPTH   (1)
-      ) i_icache_hpdcache_data_upsize (
-          .clk_i,
-          .rst_ni,
+    //   hpdcache_data_upsize #(
+    //       .WR_WIDTH(CVA6Cfg.AxiDataWidth),
+    //       .RD_WIDTH(CVA6Cfg.ICACHE_LINE_WIDTH),
+    //       .DEPTH   (1)
+    //   ) i_icache_hpdcache_data_upsize (
+    //       .clk_i,
+    //       .rst_ni,
 
-          .w_i    (icache_miss_resp_data_w),
-          .wlast_i(icache_miss_resp_wdata.mem_resp_r_last),
-          .wok_o  (icache_miss_resp_data_wok),
-          .wdata_i(icache_miss_resp_wdata.mem_resp_r_data),
+    //       .w_i    (icache_miss_resp_data_w),
+    //       .wlast_i(icache_miss_resp_wdata.mem_resp_r_last),
+    //       .wok_o  (icache_miss_resp_data_wok),
+    //       .wdata_i(icache_miss_resp_wdata.mem_resp_r_data),
 
-          .r_i    (icache_miss_resp_data_r),
-          .rok_o  (icache_miss_resp_data_rok),
-          .rdata_o(icache_miss_resp_data_rdata)
-      );
+    //       .r_i    (icache_miss_resp_data_r),
+    //       .rok_o  (icache_miss_resp_data_rok),
+    //       .rdata_o(icache_miss_resp_data_rdata)
+    //   );
 
-      assign icache_miss_resp_meta_r = 1'b1, icache_miss_resp_data_r = 1'b1;
+    //   assign icache_miss_resp_meta_r = 1'b1, icache_miss_resp_data_r = 1'b1;
 
-      assign icache_miss_resp_meta_w = icache_miss_resp_w & icache_miss_resp_wdata.mem_resp_r_last;
+    //   assign icache_miss_resp_meta_w = icache_miss_resp_w & icache_miss_resp_wdata.mem_resp_r_last;
 
-      assign icache_miss_resp_data_w = icache_miss_resp_w;
+    //   assign icache_miss_resp_data_w = icache_miss_resp_w;
 
-      assign icache_miss_resp_wok = icache_miss_resp_data_wok & (
-               icache_miss_resp_meta_wok | ~icache_miss_resp_wdata.mem_resp_r_last);
+    //   assign icache_miss_resp_wok = icache_miss_resp_data_wok & (
+    //            icache_miss_resp_meta_wok | ~icache_miss_resp_wdata.mem_resp_r_last);
 
-      assign icache_miss_rdata = icache_miss_resp_data_rdata;
+    //   assign icache_miss_rdata = icache_miss_resp_data_rdata;
 
-    end else begin
+    // end else begin
+    begin
       assign icache_miss_resp_data_rok = icache_miss_resp_w;
       assign icache_miss_resp_meta_rok = icache_miss_resp_w;
       assign icache_miss_resp_wok = 1'b1;
@@ -246,25 +216,20 @@ module extended_hpdcache_subsystem_axi_arbiter
 
       //  In the case of uncacheable accesses, the Icache expects the data to be right-aligned
       always_comb begin : icache_miss_resp_data_comb
-        if (!icache_miss_req_rdata.mem_req_cacheable) begin
-          automatic logic [ICACHE_CL_WORD_INDEX - 1:0] icache_miss_word_index;
-          automatic logic [63:0] icache_miss_word;
-          icache_miss_word_index = icache_miss_req_rdata.mem_req_addr[3+:ICACHE_CL_WORD_INDEX];
-          icache_miss_word = icache_miss_resp_data_rdata[icache_miss_word_index*64+:64];
-          icache_miss_rdata = {{CVA6Cfg.ICACHE_LINE_WIDTH - 64{1'b0}}, icache_miss_word};
-        end else begin
-          icache_miss_rdata = icache_miss_resp_data_rdata;
-        end
+        // if (!icache_miss_req_rdata.mem_req_cacheable) begin
+        //   automatic logic [ICACHE_CL_WORD_INDEX - 1:0] icache_miss_word_index;
+        //   automatic logic [63:0] icache_miss_word;
+        //   icache_miss_word_index = icache_miss_req_rdata.mem_req_addr[3+:ICACHE_CL_WORD_INDEX];
+        //   icache_miss_word = icache_miss_resp_data_rdata[icache_miss_word_index*64+:64];
+        //   icache_miss_rdata = {{CVA6Cfg.ICACHE_LINE_WIDTH - 64{1'b0}}, icache_miss_word};
+        // end else begin
+        // begin
+        //   icache_miss_rdata = icache_miss_resp_data_rdata;
+        // end
       end
     end
   endgenerate
 
-  assign icache_miss_resp_valid_o = icache_miss_resp_meta_rok,
-      icache_miss_resp_o.rtype = wt_cache_pkg::ICACHE_IFILL_ACK,
-      icache_miss_resp_o.user = '0,
-      icache_miss_resp_o.inv = '0,
-      icache_miss_resp_o.tid = icache_miss_resp_meta_id,
-      icache_miss_resp_o.data = icache_miss_rdata;
 
   //  consume the Icache miss on the arrival of the response. The request
   //  metadata is decoded to forward the correct word in case of uncacheable
@@ -274,24 +239,29 @@ module extended_hpdcache_subsystem_axi_arbiter
 
   //  Read request arbiter
   //  {{{
-  logic              mem_req_read_ready     [2:0];
-  logic              mem_req_read_valid     [2:0];
-  hpdcache_mem_req_t mem_req_read           [2:0];
+  logic              mem_req_read_ready     [3:0];
+  logic              mem_req_read_valid     [3:0];
+  hpdcache_mem_req_t mem_req_read           [3:0];
 
   logic              mem_req_read_ready_arb;
   logic              mem_req_read_valid_arb;
   hpdcache_mem_req_t mem_req_read_arb;
 
-  assign mem_req_read_valid[0] = icache_miss_req_rok & ~icache_miss_pending_q,
-      mem_req_read[0] = icache_miss_req_rdata;
+  assign icache_miss_ready_o = mem_req_read_ready[0],
+      mem_req_read_valid[0] = icache_miss_valid_i,
+      mem_req_read[0] = icache_miss_i;
 
-  assign dcache_miss_ready_o = mem_req_read_ready[1],
-      mem_req_read_valid[1] = dcache_miss_valid_i,
-      mem_req_read[1] = dcache_miss_i;
+  assign icache_uc_read_ready_o = mem_req_read_ready[1],
+      mem_req_read_valid[1] = icache_uc_read_valid_i,
+      mem_req_read[1] = icache_uc_read_i;
 
-  assign dcache_uc_read_ready_o = mem_req_read_ready[2],
-      mem_req_read_valid[2] = dcache_uc_read_valid_i,
-      mem_req_read[2] = dcache_uc_read_i;
+  assign dcache_miss_ready_o = mem_req_read_ready[2],
+      mem_req_read_valid[2] = dcache_miss_valid_i,
+      mem_req_read[2] = dcache_miss_i;
+
+  assign dcache_uc_read_ready_o = mem_req_read_ready[3],
+      mem_req_read_valid[3] = dcache_uc_read_valid_i,
+      mem_req_read[3] = dcache_uc_read_i;
 
   hpdcache_mem_req_read_arbiter #(
       .N                 (3),
@@ -316,16 +286,18 @@ module extended_hpdcache_subsystem_axi_arbiter
   logic                 mem_resp_read_valid;
   hpdcache_mem_resp_r_t mem_resp_read;
 
-  logic                 mem_resp_read_ready_arb[2:0];
-  logic                 mem_resp_read_valid_arb[2:0];
-  hpdcache_mem_resp_r_t mem_resp_read_arb      [2:0];
+  logic                 mem_resp_read_ready_arb[3:0];
+  logic                 mem_resp_read_valid_arb[3:0];
+  hpdcache_mem_resp_r_t mem_resp_read_arb      [3:0];
 
   mem_resp_rt_t         mem_resp_read_rt;
 
   always_comb begin
     for (int i = 0; i < MEM_RESP_RT_DEPTH; i++) begin
       mem_resp_read_rt[i] = (i == int'(   icache_miss_id_i)) ? 0 :
-                            (i == int'(dcache_uc_read_id_i)) ? 2 : 1;
+                            (i == int'(icache_uc_read_id_i)) ? 1 :
+                            (i == int'(   dcache_miss_id_i)) ? 2 :
+                            (i == int'(dcache_uc_read_id_i)) ? 3 : 2;
     end
   end
 
@@ -349,17 +321,21 @@ module extended_hpdcache_subsystem_axi_arbiter
       .mem_resp_rt_i(mem_resp_read_rt)
   );
 
-  assign icache_miss_resp_w = mem_resp_read_valid_arb[0],
-      icache_miss_resp_wdata = mem_resp_read_arb[0],
-      mem_resp_read_ready_arb[0] = icache_miss_resp_wok;
+  assign icache_miss_resp_valid_o = mem_resp_read_valid_arb[0],
+      icache_miss_resp_o = mem_resp_read_arb[0],
+      mem_resp_read_ready_arb[0] = icache_miss_resp_ready_i;
 
-  assign dcache_miss_resp_valid_o = mem_resp_read_valid_arb[1],
-      dcache_miss_resp_o = mem_resp_read_arb[1],
-      mem_resp_read_ready_arb[1] = dcache_miss_resp_ready_i;
+  assign icache_uc_read_resp_valid_o = mem_resp_read_valid_arb[1],
+      icache_uc_read_resp_o = mem_resp_read_arb[1],
+      mem_resp_read_ready_arb[1] = icache_uc_read_resp_ready_i;
 
-  assign dcache_uc_read_resp_valid_o = mem_resp_read_valid_arb[2],
-      dcache_uc_read_resp_o = mem_resp_read_arb[2],
-      mem_resp_read_ready_arb[2] = dcache_uc_read_resp_ready_i;
+  assign dcache_miss_resp_valid_o = mem_resp_read_valid_arb[2],
+      dcache_miss_resp_o = mem_resp_read_arb[2],
+      mem_resp_read_ready_arb[2] = dcache_miss_resp_ready_i;
+
+  assign dcache_uc_read_resp_valid_o = mem_resp_read_valid_arb[3],
+      dcache_uc_read_resp_o = mem_resp_read_arb[3],
+      mem_resp_read_ready_arb[3] = dcache_uc_read_resp_ready_i;
   //  }}}
 
   //  Write request arbiter
@@ -469,17 +445,6 @@ module extended_hpdcache_subsystem_axi_arbiter
       mem_resp_write_ready_arb[1] = dcache_uc_write_resp_ready_i;
   //  }}}
 
-  //  I$ miss pending
-  //  {{{
-  always_ff @(posedge clk_i or negedge rst_ni) begin : icache_miss_pending_ff
-    if (!rst_ni) begin
-      icache_miss_pending_q <= 1'b0;
-    end else begin
-      icache_miss_pending_q <= ( (icache_miss_req_rok & mem_req_read_ready[0]) & ~icache_miss_pending_q) |
-                               (~(icache_miss_req_r   & icache_miss_req_rok)   &  icache_miss_pending_q);
-    end
-  end
-  // }}}
 
   //  AXI adapters
   //  {{{

--- a/core/cache_subsystem/extended_hpdcache_subsystem_axi_arbiter.sv
+++ b/core/cache_subsystem/extended_hpdcache_subsystem_axi_arbiter.sv
@@ -51,7 +51,7 @@ module extended_hpdcache_subsystem_axi_arbiter
     output logic              icache_miss_ready_o,
     input  logic              icache_miss_valid_i,
     input  hpdcache_mem_req_t icache_miss_i,
-    input  hpdcache_mem_id_t icache_miss_id_i,
+    input  hpdcache_mem_id_t  icache_miss_id_i,
 
     input  logic                 icache_miss_resp_ready_i,
     output logic                 icache_miss_resp_valid_o,

--- a/core/cache_subsystem/hpdcache_dcache_with_adapter.sv
+++ b/core/cache_subsystem/hpdcache_dcache_with_adapter.sv
@@ -1,0 +1,412 @@
+`include "hpdcache_typedef.svh"
+
+module hpdcache_dcache_with_adapter
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type dcache_req_i_t = logic,
+    parameter type dcache_req_o_t = logic,
+    parameter int NumPorts = 4,
+    parameter int NrHwPrefetchers = 4,
+    parameter type cmo_req_t = logic,
+    parameter type cmo_rsp_t = logic
+)
+(
+    //    Cache management
+    // Data cache enable - CSR_REGFILE
+    input  logic dcache_enable_i,
+    // Data cache flush - CONTROLLER
+    input  logic dcache_flush_i,
+    // Flush acknowledge - CONTROLLER
+    output logic dcache_flush_ack_o,
+    // Load or store miss - PERF_COUNTERS
+    output logic dcache_miss_o,
+    input logic dcache_miss_ready,
+    output logic dcache_miss_valid,
+    output hpdcache_mem_req_t  dcache_miss,
+
+    output logic dcache_miss_resp_ready_o,
+    input logic dcache_miss_resp_valid_i,
+    input hpdcache_mem_resp_r_t dcache_miss_resp_i,
+
+    // AMO request - EX_STAGE
+    input  ariane_pkg::amo_req_t                 dcache_amo_req_i,
+    // AMO response - EX_STAGE
+    output ariane_pkg::amo_resp_t                dcache_amo_resp_o,
+    // CMO interface request - TO_BE_COMPLETED
+    input  cmo_req_t                             dcache_cmo_req_i,
+    // CMO interface response - TO_BE_COMPLETED
+    output cmo_rsp_t                             dcache_cmo_resp_o,
+    // Data cache input request ports - EX_STAGE
+    input  dcache_req_i_t         [NumPorts-1:0] dcache_req_ports_i,
+    // Data cache output request ports - EX_STAGE
+    output dcache_req_o_t         [NumPorts-1:0] dcache_req_ports_o,
+
+    output hpdcache_mem_req_t     dcache_wbuf_o,
+    output logic dcache_wbuf_valid_o,
+    input logic dcache_wbuf_ready_i,
+
+    // Write buffer status to know if empty - EX_STAGE
+    output logic                                 wbuffer_empty_o,
+    // Write buffer status to know if not non idempotent - EX_STAGE
+    output logic                                 wbuffer_not_ni_o,
+
+    //  Hardware memory prefetcher configuration
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_base_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_base_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_base_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_param_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_param_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_param_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_throttle_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_throttle_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_throttle_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [               63:0]       hwpf_status_o,
+    //  }}}
+
+    input logic dcache_wbuf_data_ready_i,
+    output logic dcache_wbuf_data_valid_o,
+    output hpdcache_mem_req_w_t dcache_wbuf_data_o,
+
+    output logic dcache_wbuf_resp_ready_o,
+    input logic dcache_wbuf_resp_valid_i,
+    input hpdcache_mem_resp_w_t dcache_wbuf_resp_i,
+
+    input logic dcache_uc_read_ready_i,
+    output logic dcache_uc_read_valid_o,
+    output hpdcache_mem_req_t dcache_uc_read_o,
+
+    output logic dcache_uc_read_resp_ready_o,
+    input logic dcache_uc_read_resp_valid_i,
+    input hpdcache_mem_resp_r_t dcache_uc_read_resp_i,
+
+    input logic dcache_uc_write_ready_i,
+    output logic dcache_uc_write_valid_o,
+    output hpdcache_mem_req_t dcache_uc_write_o,
+
+    input logic dcache_uc_write_data_ready_i,
+    output logic dcache_uc_write_data_valid_o,
+    output hpdcache_mem_req_w_t dcache_uc_write_data_o,
+
+    output logic dcache_uc_write_resp_ready_o,
+    input logic dcache_uc_write_resp_valid_i,
+    input hpdcache_mem_resp_w_t dcache_uc_write_resp_i
+);
+  //  }}}
+
+  //    0: Page-Table Walk (PTW)
+  //    1: Load unit
+  //    2: Accelerator load
+  //    3: Store/AMO
+  //    .
+  //    .
+  //    .
+  //    NumPorts: CMO
+  //    NumPorts + 1: Hardware Memory Prefetcher (hwpf)
+  localparam int HPDCACHE_NREQUESTERS = NumPorts + 2;
+
+  typedef logic [CVA6Cfg.PLEN-1:0] hpdcache_mem_addr_t;
+  typedef logic [CVA6Cfg.MEM_TID_WIDTH-1:0] hpdcache_mem_id_t;
+  typedef logic [CVA6Cfg.AxiDataWidth-1:0] hpdcache_mem_data_t;
+  typedef logic [CVA6Cfg.AxiDataWidth/8-1:0] hpdcache_mem_be_t;
+  `HPDCACHE_TYPEDEF_MEM_REQ_T(hpdcache_mem_req_t, hpdcache_mem_addr_t, hpdcache_mem_id_t);
+  `HPDCACHE_TYPEDEF_MEM_RESP_R_T(hpdcache_mem_resp_r_t, hpdcache_mem_id_t, hpdcache_mem_data_t);
+  `HPDCACHE_TYPEDEF_MEM_REQ_W_T(hpdcache_mem_req_w_t, hpdcache_mem_data_t, hpdcache_mem_be_t);
+  `HPDCACHE_TYPEDEF_MEM_RESP_W_T(hpdcache_mem_resp_w_t, hpdcache_mem_id_t);
+
+  typedef logic [63:0] hwpf_stride_param_t;
+
+  logic                        dcache_req_valid[HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_req_ready[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_req_t dcache_req      [HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_req_abort[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_tag_t dcache_req_tag  [HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_pma_t dcache_req_pma  [HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_rsp_valid[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_rsp_t dcache_rsp      [HPDCACHE_NREQUESTERS-1:0];
+  logic dcache_read_miss, dcache_write_miss;
+
+  logic                                   [                2:0] snoop_valid;
+  logic                                   [                2:0] snoop_abort;
+  hpdcache_pkg::hpdcache_req_offset_t     [                2:0] snoop_addr_offset;
+  hpdcache_pkg::hpdcache_tag_t            [                2:0] snoop_addr_tag;
+  logic                                   [                2:0] snoop_phys_indexed;
+
+  logic                                                         dcache_cmo_req_is_prefetch;
+
+  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_in;
+  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_out;
+
+  generate
+    dcache_req_i_t dcache_req_ports[HPDCACHE_NREQUESTERS-1:0];
+
+    for (genvar r = 0; r < (NumPorts - 1); r++) begin : cva6_hpdcache_load_if_adapter_gen
+      assign dcache_req_ports[r] = dcache_req_ports_i[r];
+
+      cva6_hpdcache_if_adapter #(
+          .CVA6Cfg       (CVA6Cfg),
+          .dcache_req_i_t(dcache_req_i_t),
+          .dcache_req_o_t(dcache_req_o_t),
+          .is_load_port  (1'b1)
+      ) i_cva6_hpdcache_load_if_adapter (
+          .clk_i,
+          .rst_ni,
+
+          .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(r)),
+
+          .cva6_req_i     (dcache_req_ports[r]),
+          .cva6_req_o     (dcache_req_ports_o[r]),
+          .cva6_amo_req_i ('0),
+          .cva6_amo_resp_o(  /* unused */),
+
+          .hpdcache_req_valid_o(dcache_req_valid[r]),
+          .hpdcache_req_ready_i(dcache_req_ready[r]),
+          .hpdcache_req_o      (dcache_req[r]),
+          .hpdcache_req_abort_o(dcache_req_abort[r]),
+          .hpdcache_req_tag_o  (dcache_req_tag[r]),
+          .hpdcache_req_pma_o  (dcache_req_pma[r]),
+
+          .hpdcache_rsp_valid_i(dcache_rsp_valid[r]),
+          .hpdcache_rsp_i      (dcache_rsp[r])
+      );
+    end
+
+    cva6_hpdcache_if_adapter #(
+        .CVA6Cfg       (CVA6Cfg),
+        .dcache_req_i_t(dcache_req_i_t),
+        .dcache_req_o_t(dcache_req_o_t),
+        .is_load_port  (1'b0)
+    ) i_cva6_hpdcache_store_if_adapter (
+        .clk_i,
+        .rst_ni,
+
+        .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts - 1)),
+
+        .cva6_req_i     (dcache_req_ports_i[NumPorts-1]),
+        .cva6_req_o     (dcache_req_ports_o[NumPorts-1]),
+        .cva6_amo_req_i (dcache_amo_req_i),
+        .cva6_amo_resp_o(dcache_amo_resp_o),
+
+        .hpdcache_req_valid_o(dcache_req_valid[NumPorts-1]),
+        .hpdcache_req_ready_i(dcache_req_ready[NumPorts-1]),
+        .hpdcache_req_o      (dcache_req[NumPorts-1]),
+        .hpdcache_req_abort_o(dcache_req_abort[NumPorts-1]),
+        .hpdcache_req_tag_o  (dcache_req_tag[NumPorts-1]),
+        .hpdcache_req_pma_o  (dcache_req_pma[NumPorts-1]),
+
+        .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts-1]),
+        .hpdcache_rsp_i      (dcache_rsp[NumPorts-1])
+    );
+
+`ifdef HPDCACHE_ENABLE_CMO
+    cva6_hpdcache_cmo_if_adapter #(
+        .cmo_req_t(cmo_req_t),
+        .cmo_rsp_t(cmo_rsp_t)
+    ) i_cva6_hpdcache_cmo_if_adapter (
+        .clk_i,
+        .rst_ni,
+
+        .dcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts)),
+
+        .cva6_cmo_req_i (dcache_cmo_req_i),
+        .cva6_cmo_resp_o(dcache_cmo_resp_o),
+
+        .dcache_req_valid_o(dcache_req_valid[NumPorts]),
+        .dcache_req_ready_i(dcache_req_ready[NumPorts]),
+        .dcache_req_o      (dcache_req[NumPorts]),
+        .dcache_req_abort_o(dcache_req_abort[NumPorts]),
+        .dcache_req_tag_o  (dcache_req_tag[NumPorts]),
+        .dcache_req_pma_o  (dcache_req_pma[NumPorts]),
+
+        .dcache_rsp_valid_i(dcache_rsp_valid[NumPorts]),
+        .dcache_rsp_i      (dcache_rsp[NumPorts])
+    );
+`else
+    assign dcache_req_valid[NumPorts] = 1'b0,
+        dcache_req[NumPorts] = '0,
+        dcache_req_abort[NumPorts] = 1'b0,
+        dcache_req_tag[NumPorts] = '0,
+        dcache_req_pma[NumPorts] = '0;
+`endif
+  endgenerate
+
+  //  Snoop load port
+  assign snoop_valid[0] = dcache_req_valid[1] & dcache_req_ready[1],
+      snoop_abort[0] = dcache_req_abort[1],
+      snoop_addr_offset[0] = dcache_req[1].addr_offset,
+      snoop_addr_tag[0] = dcache_req_tag[1],
+      snoop_phys_indexed[0] = dcache_req[1].phys_indexed;
+
+  //  Snoop Store/AMO port
+  assign snoop_valid[1] = dcache_req_valid[NumPorts-1] & dcache_req_ready[NumPorts-1],
+      snoop_abort[1] = dcache_req_abort[NumPorts-1],
+      snoop_addr_offset[1] = dcache_req[NumPorts-1].addr_offset,
+      snoop_addr_tag[1] = dcache_req_tag[NumPorts-1],
+      snoop_phys_indexed[1] = dcache_req[NumPorts-1].phys_indexed;
+
+`ifdef HPDCACHE_ENABLE_CMO
+  //  Snoop CMO port (in case of read prefetch accesses)
+  assign dcache_cmo_req_is_prefetch = hpdcache_pkg::is_cmo_prefetch(
+      dcache_req[NumPorts].op, dcache_req[NumPorts].size
+  );
+  assign snoop_valid[2]        = dcache_req_valid[NumPorts]
+                               & dcache_req_ready[NumPorts]
+                               & dcache_cmo_req_is_prefetch,
+      snoop_abort[2] = dcache_req_abort[NumPorts],
+      snoop_addr_offset[2] = dcache_req[NumPorts].addr_offset,
+      snoop_addr_tag[2] = dcache_req_tag[NumPorts],
+      snoop_phys_indexed[2] = dcache_req[NumPorts].phys_indexed;
+`else
+  assign snoop_valid[2] = 1'b0,
+      snoop_abort[2] = 1'b0,
+      snoop_addr_offset[2] = '0,
+      snoop_addr_tag[2] = '0,
+      snoop_phys_indexed[2] = 1'b0;
+`endif
+
+  generate
+    for (genvar h = 0; h < NrHwPrefetchers; h++) begin : hwpf_throttle_gen
+      assign hwpf_throttle_in[h] = hwpf_stride_pkg::hwpf_stride_throttle_t'(hwpf_throttle_i[h]),
+          hwpf_throttle_o[h] = hwpf_stride_pkg::hwpf_stride_param_t'(hwpf_throttle_out[h]);
+    end
+  endgenerate
+
+  hwpf_stride_wrapper #(
+      .NUM_HW_PREFETCH(NrHwPrefetchers),
+      .NUM_SNOOP_PORTS(3)
+  ) i_hwpf_stride_wrapper (
+      .clk_i,
+      .rst_ni,
+
+      .hwpf_stride_base_set_i    (hwpf_base_set_i),
+      .hwpf_stride_base_i        (hwpf_base_i),
+      .hwpf_stride_base_o        (hwpf_base_o),
+      .hwpf_stride_param_set_i   (hwpf_param_set_i),
+      .hwpf_stride_param_i       (hwpf_param_i),
+      .hwpf_stride_param_o       (hwpf_param_o),
+      .hwpf_stride_throttle_set_i(hwpf_throttle_set_i),
+      .hwpf_stride_throttle_i    (hwpf_throttle_in),
+      .hwpf_stride_throttle_o    (hwpf_throttle_out),
+      .hwpf_stride_status_o      (hwpf_status_o),
+
+      .snoop_valid_i       (snoop_valid),
+      .snoop_abort_i       (snoop_abort),
+      .snoop_addr_offset_i (snoop_addr_offset),
+      .snoop_addr_tag_i    (snoop_addr_tag),
+      .snoop_phys_indexed_i(snoop_phys_indexed),
+
+      .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts + 1)),
+
+      .hpdcache_req_valid_o(dcache_req_valid[NumPorts+1]),
+      .hpdcache_req_ready_i(dcache_req_ready[NumPorts+1]),
+      .hpdcache_req_o      (dcache_req[NumPorts+1]),
+      .hpdcache_req_abort_o(dcache_req_abort[NumPorts+1]),
+      .hpdcache_req_tag_o  (dcache_req_tag[NumPorts+1]),
+      .hpdcache_req_pma_o  (dcache_req_pma[NumPorts+1]),
+      .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts+1]),
+      .hpdcache_rsp_i      (dcache_rsp[NumPorts+1])
+  );
+
+  hpdcache #(
+      .NREQUESTERS         (HPDCACHE_NREQUESTERS),
+      .HPDcacheMemAddrWidth(CVA6Cfg.PLEN),
+      .HPDcacheMemIdWidth  (CVA6Cfg.MEM_TID_WIDTH),
+      .HPDcacheMemDataWidth(CVA6Cfg.AxiDataWidth)
+  ) i_hpdcache (
+      .clk_i,
+      .rst_ni,
+
+      .wbuf_flush_i(dcache_flush_i),
+
+      .core_req_valid_i(dcache_req_valid),
+      .core_req_ready_o(dcache_req_ready),
+      .core_req_i      (dcache_req),
+      .core_req_abort_i(dcache_req_abort),
+      .core_req_tag_i  (dcache_req_tag),
+      .core_req_pma_i  (dcache_req_pma),
+
+      .core_rsp_valid_o(dcache_rsp_valid),
+      .core_rsp_o      (dcache_rsp),
+
+      .mem_req_miss_read_ready_i(dcache_miss_ready),
+      .mem_req_miss_read_valid_o(dcache_miss_valid),
+      .mem_req_miss_read_o      (dcache_miss),
+
+      .mem_resp_miss_read_ready_o(dcache_miss_resp_ready_o),
+      .mem_resp_miss_read_valid_i(dcache_miss_resp_valid_i),
+      .mem_resp_miss_read_i      (dcache_miss_resp_i),
+
+      .mem_req_wbuf_write_ready_i(dcache_wbuf_ready_i),
+      .mem_req_wbuf_write_valid_o(dcache_wbuf_valid_o),
+      .mem_req_wbuf_write_o      (dcache_wbuf_o),
+
+      .mem_req_wbuf_write_data_ready_i(dcache_wbuf_data_ready_i),
+      .mem_req_wbuf_write_data_valid_o(dcache_wbuf_data_valid_o),
+      .mem_req_wbuf_write_data_o      (dcache_wbuf_data_o),
+
+      .mem_resp_wbuf_write_ready_o(dcache_wbuf_resp_ready_o),
+      .mem_resp_wbuf_write_valid_i(dcache_wbuf_resp_valid_i),
+      .mem_resp_wbuf_write_i      (dcache_wbuf_resp_i),
+
+      .mem_req_uc_read_ready_i(dcache_uc_read_ready_i),
+      .mem_req_uc_read_valid_o(dcache_uc_read_valid_o),
+      .mem_req_uc_read_o      (dcache_uc_read_o),
+
+      .mem_resp_uc_read_ready_o(dcache_uc_read_resp_ready_o),
+      .mem_resp_uc_read_valid_i(dcache_uc_read_resp_valid_i),
+      .mem_resp_uc_read_i      (dcache_uc_read_resp_i),
+
+      .mem_req_uc_write_ready_i(dcache_uc_write_ready_i),
+      .mem_req_uc_write_valid_o(dcache_uc_write_valid_o),
+      .mem_req_uc_write_o      (dcache_uc_write_o),
+
+      .mem_req_uc_write_data_ready_i(dcache_uc_write_data_ready_i),
+      .mem_req_uc_write_data_valid_o(dcache_uc_write_data_valid_o),
+      .mem_req_uc_write_data_o      (dcache_uc_write_data_o),
+
+      .mem_resp_uc_write_ready_o(dcache_uc_write_resp_ready_o),
+      .mem_resp_uc_write_valid_i(dcache_uc_write_resp_valid_i),
+      .mem_resp_uc_write_i      (dcache_uc_write_resp_i),
+
+      .evt_cache_write_miss_o(dcache_write_miss),
+      .evt_cache_read_miss_o (dcache_read_miss),
+      .evt_uncached_req_o    (  /* unused */),
+      .evt_cmo_req_o         (  /* unused */),
+      .evt_write_req_o       (  /* unused */),
+      .evt_read_req_o        (  /* unused */),
+      .evt_prefetch_req_o    (  /* unused */),
+      .evt_req_on_hold_o     (  /* unused */),
+      .evt_rtab_rollback_o   (  /* unused */),
+      .evt_stall_refill_o    (  /* unused */),
+      .evt_stall_o           (  /* unused */),
+
+      .wbuf_empty_o(wbuffer_empty_o),
+
+      .cfg_enable_i                       (dcache_enable_i),
+      .cfg_wbuf_threshold_i               (4'd2),
+      .cfg_wbuf_reset_timecnt_on_write_i  (1'b1),
+      .cfg_wbuf_sequential_waw_i          (1'b0),
+      .cfg_wbuf_inhibit_write_coalescing_i(1'b0),
+      .cfg_prefetch_updt_plru_i           (1'b1),
+      .cfg_error_on_cacheable_amo_i       (1'b0),
+      .cfg_rtab_single_entry_i            (1'b0)
+  );
+
+  assign dcache_miss_o = dcache_read_miss, wbuffer_not_ni_o = wbuffer_empty_o;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : dcache_flush_ff
+    if (!rst_ni) dcache_flush_ack_o <= 1'b0;
+    else dcache_flush_ack_o <= ~dcache_flush_ack_o & dcache_flush_i;
+  end
+
+  //  }}}
+endmodule

--- a/core/cache_subsystem/hpdcache_dcache_with_adapter.sv
+++ b/core/cache_subsystem/hpdcache_dcache_with_adapter.sv
@@ -20,9 +20,10 @@ module hpdcache_dcache_with_adapter
     output logic dcache_flush_ack_o,
     // Load or store miss - PERF_COUNTERS
     output logic dcache_miss_o,
-    input logic dcache_miss_ready,
-    output logic dcache_miss_valid,
-    output hpdcache_mem_req_t  dcache_miss,
+
+    input logic dcache_miss_ready_i,
+    output logic dcache_miss_valid_o,
+    output hpdcache_mem_req_t  dcache_miss_lo,
 
     output logic dcache_miss_resp_ready_o,
     input logic dcache_miss_resp_valid_i,
@@ -337,9 +338,9 @@ module hpdcache_dcache_with_adapter
       .core_rsp_valid_o(dcache_rsp_valid),
       .core_rsp_o      (dcache_rsp),
 
-      .mem_req_miss_read_ready_i(dcache_miss_ready),
-      .mem_req_miss_read_valid_o(dcache_miss_valid),
-      .mem_req_miss_read_o      (dcache_miss),
+      .mem_req_miss_read_ready_i(dcache_miss_ready_i),
+      .mem_req_miss_read_valid_o(dcache_miss_valid_o),
+      .mem_req_miss_read_o      (dcache_miss_lo),
 
       .mem_resp_miss_read_ready_o(dcache_miss_resp_ready_o),
       .mem_resp_miss_read_valid_i(dcache_miss_resp_valid_i),

--- a/core/cache_subsystem/hpdcache_dcache_with_adapter.sv
+++ b/core/cache_subsystem/hpdcache_dcache_with_adapter.sv
@@ -1,7 +1,6 @@
 `include "hpdcache_typedef.svh"
 
-module hpdcache_dcache_with_adapter
-#(
+module hpdcache_dcache_with_adapter #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter type dcache_req_i_t = logic,
     parameter type dcache_req_o_t = logic,
@@ -9,8 +8,7 @@ module hpdcache_dcache_with_adapter
     parameter int NrHwPrefetchers = 4,
     parameter type cmo_req_t = logic,
     parameter type cmo_rsp_t = logic
-)
-(
+) (
     //    Cache management
     // Data cache enable - CSR_REGFILE
     input  logic dcache_enable_i,
@@ -23,7 +21,7 @@ module hpdcache_dcache_with_adapter
 
     input logic dcache_miss_ready_i,
     output logic dcache_miss_valid_o,
-    output hpdcache_mem_req_t  dcache_miss_lo,
+    output hpdcache_mem_req_t dcache_miss_lo,
 
     output logic dcache_miss_resp_ready_o,
     input logic dcache_miss_resp_valid_i,
@@ -42,14 +40,14 @@ module hpdcache_dcache_with_adapter
     // Data cache output request ports - EX_STAGE
     output dcache_req_o_t         [NumPorts-1:0] dcache_req_ports_o,
 
-    output hpdcache_mem_req_t     dcache_wbuf_o,
-    output logic dcache_wbuf_valid_o,
-    input logic dcache_wbuf_ready_i,
+    output hpdcache_mem_req_t dcache_wbuf_o,
+    output logic              dcache_wbuf_valid_o,
+    input  logic              dcache_wbuf_ready_i,
 
     // Write buffer status to know if empty - EX_STAGE
-    output logic                                 wbuffer_empty_o,
+    output logic wbuffer_empty_o,
     // Write buffer status to know if not non idempotent - EX_STAGE
-    output logic                                 wbuffer_not_ni_o,
+    output logic wbuffer_not_ni_o,
 
     //  Hardware memory prefetcher configuration
     // TO_BE_COMPLETED - TO_BE_COMPLETED

--- a/core/cache_subsystem/hpdcache_icache_with_adapter.sv
+++ b/core/cache_subsystem/hpdcache_icache_with_adapter.sv
@@ -1,0 +1,412 @@
+`include "hpdcache_typedef.svh"
+
+module hpdcache_icache_with_adapter
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type dcache_req_i_t = logic,
+    parameter type dcache_req_o_t = logic,
+    parameter int NumPorts = 4,
+    parameter int NrHwPrefetchers = 4,
+    parameter type cmo_req_t = logic,
+    parameter type cmo_rsp_t = logic
+)
+(
+    //    Cache management
+    // Data cache enable - CSR_REGFILE
+    input  logic dcache_enable_i,
+    // Data cache flush - CONTROLLER
+    input  logic dcache_flush_i,
+    // Flush acknowledge - CONTROLLER
+    output logic dcache_flush_ack_o,
+    // Load or store miss - PERF_COUNTERS
+    output logic dcache_miss_o,
+    input logic dcache_miss_ready,
+    output logic dcache_miss_valid,
+    output hpdcache_mem_req_t  dcache_miss,
+
+    output logic dcache_miss_resp_ready_o,
+    input logic dcache_miss_resp_valid_i,
+    input hpdcache_mem_resp_r_t dcache_miss_resp_i,
+
+    // AMO request - EX_STAGE
+    input  ariane_pkg::amo_req_t                 dcache_amo_req_i,
+    // AMO response - EX_STAGE
+    output ariane_pkg::amo_resp_t                dcache_amo_resp_o,
+    // CMO interface request - TO_BE_COMPLETED
+    input  cmo_req_t                             dcache_cmo_req_i,
+    // CMO interface response - TO_BE_COMPLETED
+    output cmo_rsp_t                             dcache_cmo_resp_o,
+    // Data cache input request ports - EX_STAGE
+    input  dcache_req_i_t         [NumPorts-1:0] dcache_req_ports_i,
+    // Data cache output request ports - EX_STAGE
+    output dcache_req_o_t         [NumPorts-1:0] dcache_req_ports_o,
+
+    output hpdcache_mem_req_t     dcache_wbuf_o,
+    output logic dcache_wbuf_valid_o,
+    input logic dcache_wbuf_ready_i,
+
+    // Write buffer status to know if empty - EX_STAGE
+    output logic                                 wbuffer_empty_o,
+    // Write buffer status to know if not non idempotent - EX_STAGE
+    output logic                                 wbuffer_not_ni_o,
+
+    //  Hardware memory prefetcher configuration
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_base_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_base_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_base_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_param_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_param_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_param_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0]       hwpf_throttle_set_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    input  logic [NrHwPrefetchers-1:0][63:0] hwpf_throttle_i,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [NrHwPrefetchers-1:0][63:0] hwpf_throttle_o,
+    // TO_BE_COMPLETED - TO_BE_COMPLETED
+    output logic [               63:0]       hwpf_status_o,
+    //  }}}
+
+    input logic dcache_wbuf_data_ready_i,
+    output logic dcache_wbuf_data_valid_o,
+    output hpdcache_mem_req_w_t dcache_wbuf_data_o,
+
+    output logic dcache_wbuf_resp_ready_o,
+    input logic dcache_wbuf_resp_valid_i,
+    input hpdcache_mem_resp_w_t dcache_wbuf_resp_i,
+
+    input logic dcache_uc_read_ready_i,
+    output logic dcache_uc_read_valid_o,
+    output hpdcache_mem_req_t dcache_uc_read_o,
+
+    output logic dcache_uc_read_resp_ready_o,
+    input logic dcache_uc_read_resp_valid_i,
+    input hpdcache_mem_resp_r_t dcache_uc_read_resp_i,
+
+    input logic dcache_uc_write_ready_i,
+    output logic dcache_uc_write_valid_o,
+    output hpdcache_mem_req_t dcache_uc_write_o,
+
+    input logic dcache_uc_write_data_ready_i,
+    output logic dcache_uc_write_data_valid_o,
+    output hpdcache_mem_req_w_t dcache_uc_write_data_o,
+
+    output logic dcache_uc_write_resp_ready_o,
+    input logic dcache_uc_write_resp_valid_i,
+    input hpdcache_mem_resp_w_t dcache_uc_write_resp_i
+);
+  //  }}}
+
+  //    0: Page-Table Walk (PTW)
+  //    1: Load unit
+  //    2: Accelerator load
+  //    3: Store/AMO
+  //    .
+  //    .
+  //    .
+  //    NumPorts: CMO
+  //    NumPorts + 1: Hardware Memory Prefetcher (hwpf)
+  localparam int HPDCACHE_NREQUESTERS = NumPorts + 2;
+
+  typedef logic [CVA6Cfg.PLEN-1:0] hpdcache_mem_addr_t;
+  typedef logic [CVA6Cfg.MEM_TID_WIDTH-1:0] hpdcache_mem_id_t;
+  typedef logic [CVA6Cfg.AxiDataWidth-1:0] hpdcache_mem_data_t;
+  typedef logic [CVA6Cfg.AxiDataWidth/8-1:0] hpdcache_mem_be_t;
+  `HPDCACHE_TYPEDEF_MEM_REQ_T(hpdcache_mem_req_t, hpdcache_mem_addr_t, hpdcache_mem_id_t);
+  `HPDCACHE_TYPEDEF_MEM_RESP_R_T(hpdcache_mem_resp_r_t, hpdcache_mem_id_t, hpdcache_mem_data_t);
+  `HPDCACHE_TYPEDEF_MEM_REQ_W_T(hpdcache_mem_req_w_t, hpdcache_mem_data_t, hpdcache_mem_be_t);
+  `HPDCACHE_TYPEDEF_MEM_RESP_W_T(hpdcache_mem_resp_w_t, hpdcache_mem_id_t);
+
+  typedef logic [63:0] hwpf_stride_param_t;
+
+  logic                        dcache_req_valid[HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_req_ready[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_req_t dcache_req      [HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_req_abort[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_tag_t dcache_req_tag  [HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_pma_t dcache_req_pma  [HPDCACHE_NREQUESTERS-1:0];
+  logic                        dcache_rsp_valid[HPDCACHE_NREQUESTERS-1:0];
+  hpdcache_pkg::hpdcache_rsp_t dcache_rsp      [HPDCACHE_NREQUESTERS-1:0];
+  logic dcache_read_miss, dcache_write_miss;
+
+  logic                                   [                2:0] snoop_valid;
+  logic                                   [                2:0] snoop_abort;
+  hpdcache_pkg::hpdcache_req_offset_t     [                2:0] snoop_addr_offset;
+  hpdcache_pkg::hpdcache_tag_t            [                2:0] snoop_addr_tag;
+  logic                                   [                2:0] snoop_phys_indexed;
+
+  logic                                                         dcache_cmo_req_is_prefetch;
+
+  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_in;
+  hwpf_stride_pkg::hwpf_stride_throttle_t [NrHwPrefetchers-1:0] hwpf_throttle_out;
+
+  generate
+    dcache_req_i_t dcache_req_ports[HPDCACHE_NREQUESTERS-1:0];
+
+    for (genvar r = 0; r < (NumPorts - 1); r++) begin : cva6_hpdcache_load_if_adapter_gen
+      assign dcache_req_ports[r] = dcache_req_ports_i[r];
+
+      cva6_hpdcache_if_adapter #(
+          .CVA6Cfg       (CVA6Cfg),
+          .dcache_req_i_t(dcache_req_i_t),
+          .dcache_req_o_t(dcache_req_o_t),
+          .is_load_port  (1'b1)
+      ) i_cva6_hpdcache_load_if_adapter (
+          .clk_i,
+          .rst_ni,
+
+          .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(r)),
+
+          .cva6_req_i     (dcache_req_ports[r]),
+          .cva6_req_o     (dcache_req_ports_o[r]),
+          .cva6_amo_req_i ('0),
+          .cva6_amo_resp_o(  /* unused */),
+
+          .hpdcache_req_valid_o(dcache_req_valid[r]),
+          .hpdcache_req_ready_i(dcache_req_ready[r]),
+          .hpdcache_req_o      (dcache_req[r]),
+          .hpdcache_req_abort_o(dcache_req_abort[r]),
+          .hpdcache_req_tag_o  (dcache_req_tag[r]),
+          .hpdcache_req_pma_o  (dcache_req_pma[r]),
+
+          .hpdcache_rsp_valid_i(dcache_rsp_valid[r]),
+          .hpdcache_rsp_i      (dcache_rsp[r])
+      );
+    end
+
+    cva6_hpdcache_if_adapter #(
+        .CVA6Cfg       (CVA6Cfg),
+        .dcache_req_i_t(dcache_req_i_t),
+        .dcache_req_o_t(dcache_req_o_t),
+        .is_load_port  (1'b0)
+    ) i_cva6_hpdcache_store_if_adapter (
+        .clk_i,
+        .rst_ni,
+
+        .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts - 1)),
+
+        .cva6_req_i     (dcache_req_ports_i[NumPorts-1]),
+        .cva6_req_o     (dcache_req_ports_o[NumPorts-1]),
+        .cva6_amo_req_i (dcache_amo_req_i),
+        .cva6_amo_resp_o(dcache_amo_resp_o),
+
+        .hpdcache_req_valid_o(dcache_req_valid[NumPorts-1]),
+        .hpdcache_req_ready_i(dcache_req_ready[NumPorts-1]),
+        .hpdcache_req_o      (dcache_req[NumPorts-1]),
+        .hpdcache_req_abort_o(dcache_req_abort[NumPorts-1]),
+        .hpdcache_req_tag_o  (dcache_req_tag[NumPorts-1]),
+        .hpdcache_req_pma_o  (dcache_req_pma[NumPorts-1]),
+
+        .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts-1]),
+        .hpdcache_rsp_i      (dcache_rsp[NumPorts-1])
+    );
+
+`ifdef HPDCACHE_ENABLE_CMO
+    cva6_hpdcache_cmo_if_adapter #(
+        .cmo_req_t(cmo_req_t),
+        .cmo_rsp_t(cmo_rsp_t)
+    ) i_cva6_hpdcache_cmo_if_adapter (
+        .clk_i,
+        .rst_ni,
+
+        .dcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts)),
+
+        .cva6_cmo_req_i (dcache_cmo_req_i),
+        .cva6_cmo_resp_o(dcache_cmo_resp_o),
+
+        .dcache_req_valid_o(dcache_req_valid[NumPorts]),
+        .dcache_req_ready_i(dcache_req_ready[NumPorts]),
+        .dcache_req_o      (dcache_req[NumPorts]),
+        .dcache_req_abort_o(dcache_req_abort[NumPorts]),
+        .dcache_req_tag_o  (dcache_req_tag[NumPorts]),
+        .dcache_req_pma_o  (dcache_req_pma[NumPorts]),
+
+        .dcache_rsp_valid_i(dcache_rsp_valid[NumPorts]),
+        .dcache_rsp_i      (dcache_rsp[NumPorts])
+    );
+`else
+    assign dcache_req_valid[NumPorts] = 1'b0,
+        dcache_req[NumPorts] = '0,
+        dcache_req_abort[NumPorts] = 1'b0,
+        dcache_req_tag[NumPorts] = '0,
+        dcache_req_pma[NumPorts] = '0;
+`endif
+  endgenerate
+
+  //  Snoop load port
+  assign snoop_valid[0] = dcache_req_valid[1] & dcache_req_ready[1],
+      snoop_abort[0] = dcache_req_abort[1],
+      snoop_addr_offset[0] = dcache_req[1].addr_offset,
+      snoop_addr_tag[0] = dcache_req_tag[1],
+      snoop_phys_indexed[0] = dcache_req[1].phys_indexed;
+
+  //  Snoop Store/AMO port
+  assign snoop_valid[1] = dcache_req_valid[NumPorts-1] & dcache_req_ready[NumPorts-1],
+      snoop_abort[1] = dcache_req_abort[NumPorts-1],
+      snoop_addr_offset[1] = dcache_req[NumPorts-1].addr_offset,
+      snoop_addr_tag[1] = dcache_req_tag[NumPorts-1],
+      snoop_phys_indexed[1] = dcache_req[NumPorts-1].phys_indexed;
+
+`ifdef HPDCACHE_ENABLE_CMO
+  //  Snoop CMO port (in case of read prefetch accesses)
+  assign dcache_cmo_req_is_prefetch = hpdcache_pkg::is_cmo_prefetch(
+      dcache_req[NumPorts].op, dcache_req[NumPorts].size
+  );
+  assign snoop_valid[2]        = dcache_req_valid[NumPorts]
+                               & dcache_req_ready[NumPorts]
+                               & dcache_cmo_req_is_prefetch,
+      snoop_abort[2] = dcache_req_abort[NumPorts],
+      snoop_addr_offset[2] = dcache_req[NumPorts].addr_offset,
+      snoop_addr_tag[2] = dcache_req_tag[NumPorts],
+      snoop_phys_indexed[2] = dcache_req[NumPorts].phys_indexed;
+`else
+  assign snoop_valid[2] = 1'b0,
+      snoop_abort[2] = 1'b0,
+      snoop_addr_offset[2] = '0,
+      snoop_addr_tag[2] = '0,
+      snoop_phys_indexed[2] = 1'b0;
+`endif
+
+  generate
+    for (genvar h = 0; h < NrHwPrefetchers; h++) begin : hwpf_throttle_gen
+      assign hwpf_throttle_in[h] = hwpf_stride_pkg::hwpf_stride_throttle_t'(hwpf_throttle_i[h]),
+          hwpf_throttle_o[h] = hwpf_stride_pkg::hwpf_stride_param_t'(hwpf_throttle_out[h]);
+    end
+  endgenerate
+
+  hwpf_stride_wrapper #(
+      .NUM_HW_PREFETCH(NrHwPrefetchers),
+      .NUM_SNOOP_PORTS(3)
+  ) i_hwpf_stride_wrapper (
+      .clk_i,
+      .rst_ni,
+
+      .hwpf_stride_base_set_i    (hwpf_base_set_i),
+      .hwpf_stride_base_i        (hwpf_base_i),
+      .hwpf_stride_base_o        (hwpf_base_o),
+      .hwpf_stride_param_set_i   (hwpf_param_set_i),
+      .hwpf_stride_param_i       (hwpf_param_i),
+      .hwpf_stride_param_o       (hwpf_param_o),
+      .hwpf_stride_throttle_set_i(hwpf_throttle_set_i),
+      .hwpf_stride_throttle_i    (hwpf_throttle_in),
+      .hwpf_stride_throttle_o    (hwpf_throttle_out),
+      .hwpf_stride_status_o      (hwpf_status_o),
+
+      .snoop_valid_i       (snoop_valid),
+      .snoop_abort_i       (snoop_abort),
+      .snoop_addr_offset_i (snoop_addr_offset),
+      .snoop_addr_tag_i    (snoop_addr_tag),
+      .snoop_phys_indexed_i(snoop_phys_indexed),
+
+      .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts + 1)),
+
+      .hpdcache_req_valid_o(dcache_req_valid[NumPorts+1]),
+      .hpdcache_req_ready_i(dcache_req_ready[NumPorts+1]),
+      .hpdcache_req_o      (dcache_req[NumPorts+1]),
+      .hpdcache_req_abort_o(dcache_req_abort[NumPorts+1]),
+      .hpdcache_req_tag_o  (dcache_req_tag[NumPorts+1]),
+      .hpdcache_req_pma_o  (dcache_req_pma[NumPorts+1]),
+      .hpdcache_rsp_valid_i(dcache_rsp_valid[NumPorts+1]),
+      .hpdcache_rsp_i      (dcache_rsp[NumPorts+1])
+  );
+
+  hpdcache #(
+      .NREQUESTERS         (HPDCACHE_NREQUESTERS),
+      .HPDcacheMemAddrWidth(CVA6Cfg.PLEN),
+      .HPDcacheMemIdWidth  (CVA6Cfg.MEM_TID_WIDTH),
+      .HPDcacheMemDataWidth(CVA6Cfg.AxiDataWidth)
+  ) i_hpdcache (
+      .clk_i,
+      .rst_ni,
+
+      .wbuf_flush_i(dcache_flush_i),
+
+      .core_req_valid_i(dcache_req_valid),
+      .core_req_ready_o(dcache_req_ready),
+      .core_req_i      (dcache_req),
+      .core_req_abort_i(dcache_req_abort),
+      .core_req_tag_i  (dcache_req_tag),
+      .core_req_pma_i  (dcache_req_pma),
+
+      .core_rsp_valid_o(dcache_rsp_valid),
+      .core_rsp_o      (dcache_rsp),
+
+      .mem_req_miss_read_ready_i(dcache_miss_ready),
+      .mem_req_miss_read_valid_o(dcache_miss_valid),
+      .mem_req_miss_read_o      (dcache_miss),
+
+      .mem_resp_miss_read_ready_o(dcache_miss_resp_ready_o),
+      .mem_resp_miss_read_valid_i(dcache_miss_resp_valid_i),
+      .mem_resp_miss_read_i      (dcache_miss_resp_i),
+
+      .mem_req_wbuf_write_ready_i(dcache_wbuf_ready_i),
+      .mem_req_wbuf_write_valid_o(dcache_wbuf_valid_o),
+      .mem_req_wbuf_write_o      (dcache_wbuf_o),
+
+      .mem_req_wbuf_write_data_ready_i(dcache_wbuf_data_ready_i),
+      .mem_req_wbuf_write_data_valid_o(dcache_wbuf_data_valid_o),
+      .mem_req_wbuf_write_data_o      (dcache_wbuf_data_o),
+
+      .mem_resp_wbuf_write_ready_o(dcache_wbuf_resp_ready_o),
+      .mem_resp_wbuf_write_valid_i(dcache_wbuf_resp_valid_i),
+      .mem_resp_wbuf_write_i      (dcache_wbuf_resp_i),
+
+      .mem_req_uc_read_ready_i(dcache_uc_read_ready_i),
+      .mem_req_uc_read_valid_o(dcache_uc_read_valid_o),
+      .mem_req_uc_read_o      (dcache_uc_read_o),
+
+      .mem_resp_uc_read_ready_o(dcache_uc_read_resp_ready_o),
+      .mem_resp_uc_read_valid_i(dcache_uc_read_resp_valid_i),
+      .mem_resp_uc_read_i      (dcache_uc_read_resp_i),
+
+      .mem_req_uc_write_ready_i(dcache_uc_write_ready_i),
+      .mem_req_uc_write_valid_o(dcache_uc_write_valid_o),
+      .mem_req_uc_write_o      (dcache_uc_write_o),
+
+      .mem_req_uc_write_data_ready_i(dcache_uc_write_data_ready_i),
+      .mem_req_uc_write_data_valid_o(dcache_uc_write_data_valid_o),
+      .mem_req_uc_write_data_o      (dcache_uc_write_data_o),
+
+      .mem_resp_uc_write_ready_o(dcache_uc_write_resp_ready_o),
+      .mem_resp_uc_write_valid_i(dcache_uc_write_resp_valid_i),
+      .mem_resp_uc_write_i      (dcache_uc_write_resp_i),
+
+      .evt_cache_write_miss_o(dcache_write_miss),
+      .evt_cache_read_miss_o (dcache_read_miss),
+      .evt_uncached_req_o    (  /* unused */),
+      .evt_cmo_req_o         (  /* unused */),
+      .evt_write_req_o       (  /* unused */),
+      .evt_read_req_o        (  /* unused */),
+      .evt_prefetch_req_o    (  /* unused */),
+      .evt_req_on_hold_o     (  /* unused */),
+      .evt_rtab_rollback_o   (  /* unused */),
+      .evt_stall_refill_o    (  /* unused */),
+      .evt_stall_o           (  /* unused */),
+
+      .wbuf_empty_o(wbuffer_empty_o),
+
+      .cfg_enable_i                       (dcache_enable_i),
+      .cfg_wbuf_threshold_i               (4'd2),
+      .cfg_wbuf_reset_timecnt_on_write_i  (1'b1),
+      .cfg_wbuf_sequential_waw_i          (1'b0),
+      .cfg_wbuf_inhibit_write_coalescing_i(1'b0),
+      .cfg_prefetch_updt_plru_i           (1'b1),
+      .cfg_error_on_cacheable_amo_i       (1'b0),
+      .cfg_rtab_single_entry_i            (1'b0)
+  );
+
+  assign dcache_miss_o = dcache_read_miss, wbuffer_not_ni_o = wbuffer_empty_o;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : dcache_flush_ff
+    if (!rst_ni) dcache_flush_ack_o <= 1'b0;
+    else dcache_flush_ack_o <= ~dcache_flush_ack_o & dcache_flush_i;
+  end
+
+  //  }}}
+endmodule

--- a/core/cache_subsystem/hpdcache_icache_with_adapter.sv
+++ b/core/cache_subsystem/hpdcache_icache_with_adapter.sv
@@ -1,7 +1,6 @@
 `include "hpdcache_typedef.svh"
 
-module hpdcache_icache_with_adapter
-#(
+module hpdcache_icache_with_adapter #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter type dcache_req_i_t = logic,
     parameter type dcache_req_o_t = logic,
@@ -9,8 +8,7 @@ module hpdcache_icache_with_adapter
     parameter int NrHwPrefetchers = 4,
     parameter type cmo_req_t = logic,
     parameter type cmo_rsp_t = logic
-)
-(
+) (
     //    Cache management
     // Data cache enable - CSR_REGFILE
     input  logic icache_enable_i,
@@ -23,7 +21,7 @@ module hpdcache_icache_with_adapter
 
     input logic icache_miss_ready_i,
     output logic icache_miss_valid_o,
-    output hpdcache_mem_req_t  icache_miss_lo,
+    output hpdcache_mem_req_t icache_miss_lo,
 
     output logic icache_miss_resp_ready_o,
     input logic icache_miss_resp_valid_i,
@@ -43,9 +41,9 @@ module hpdcache_icache_with_adapter
     output dcache_req_o_t         [NumPorts-1:0] icache_req_ports_o,
 
     // Write buffer status to know if empty - EX_STAGE
-    output logic                                 wbuffer_empty_o,
+    output logic wbuffer_empty_o,
     // Write buffer status to know if not non idempotent - EX_STAGE
-    output logic                                 wbuffer_not_ni_o,
+    output logic wbuffer_not_ni_o,
 
     //  Hardware memory prefetcher configuration
     // TO_BE_COMPLETED - TO_BE_COMPLETED

--- a/core/cache_subsystem/hpdcache_icache_with_adapter.sv
+++ b/core/cache_subsystem/hpdcache_icache_with_adapter.sv
@@ -20,9 +20,10 @@ module hpdcache_icache_with_adapter
     output logic icache_flush_ack_o,
     // Load or store miss - PERF_COUNTERS
     output logic icache_miss_o,
-    input logic icache_miss_ready,
-    output logic icache_miss_valid,
-    output hpdcache_mem_req_t  icache_miss,
+
+    input logic icache_miss_ready_i,
+    output logic icache_miss_valid_o,
+    output hpdcache_mem_req_t  icache_miss_lo,
 
     output logic icache_miss_resp_ready_o,
     input logic icache_miss_resp_valid_i,
@@ -313,9 +314,9 @@ module hpdcache_icache_with_adapter
       .core_rsp_valid_o(dcache_rsp_valid),
       .core_rsp_o      (dcache_rsp),
 
-      .mem_req_miss_read_ready_i(icache_miss_ready),
-      .mem_req_miss_read_valid_o(icache_miss_valid),
-      .mem_req_miss_read_o      (icache_miss),
+      .mem_req_miss_read_ready_i(icache_miss_ready_i),
+      .mem_req_miss_read_valid_o(icache_miss_valid_o),
+      .mem_req_miss_read_o      (icache_miss_lo),
 
       .mem_resp_miss_read_ready_o(icache_miss_resp_ready_o),
       .mem_resp_miss_read_valid_i(icache_miss_resp_valid_i),

--- a/core/cache_subsystem/hpdcache_icache_with_adapter.sv
+++ b/core/cache_subsystem/hpdcache_icache_with_adapter.sv
@@ -13,37 +13,33 @@ module hpdcache_icache_with_adapter
 (
     //    Cache management
     // Data cache enable - CSR_REGFILE
-    input  logic dcache_enable_i,
+    input  logic icache_enable_i,
     // Data cache flush - CONTROLLER
-    input  logic dcache_flush_i,
+    input  logic icache_flush_i,
     // Flush acknowledge - CONTROLLER
-    output logic dcache_flush_ack_o,
+    output logic icache_flush_ack_o,
     // Load or store miss - PERF_COUNTERS
-    output logic dcache_miss_o,
-    input logic dcache_miss_ready,
-    output logic dcache_miss_valid,
-    output hpdcache_mem_req_t  dcache_miss,
+    output logic icache_miss_o,
+    input logic icache_miss_ready,
+    output logic icache_miss_valid,
+    output hpdcache_mem_req_t  icache_miss,
 
-    output logic dcache_miss_resp_ready_o,
-    input logic dcache_miss_resp_valid_i,
-    input hpdcache_mem_resp_r_t dcache_miss_resp_i,
+    output logic icache_miss_resp_ready_o,
+    input logic icache_miss_resp_valid_i,
+    input hpdcache_mem_resp_r_t icache_miss_resp_i,
 
     // AMO request - EX_STAGE
-    input  ariane_pkg::amo_req_t                 dcache_amo_req_i,
+    input  ariane_pkg::amo_req_t                 icache_amo_req_i,
     // AMO response - EX_STAGE
-    output ariane_pkg::amo_resp_t                dcache_amo_resp_o,
+    output ariane_pkg::amo_resp_t                icache_amo_resp_o,
     // CMO interface request - TO_BE_COMPLETED
-    input  cmo_req_t                             dcache_cmo_req_i,
+    input  cmo_req_t                             icache_cmo_req_i,
     // CMO interface response - TO_BE_COMPLETED
-    output cmo_rsp_t                             dcache_cmo_resp_o,
+    output cmo_rsp_t                             icache_cmo_resp_o,
     // Data cache input request ports - EX_STAGE
-    input  dcache_req_i_t         [NumPorts-1:0] dcache_req_ports_i,
+    input  dcache_req_i_t         [NumPorts-1:0] icache_req_ports_i,
     // Data cache output request ports - EX_STAGE
-    output dcache_req_o_t         [NumPorts-1:0] dcache_req_ports_o,
-
-    output hpdcache_mem_req_t     dcache_wbuf_o,
-    output logic dcache_wbuf_valid_o,
-    input logic dcache_wbuf_ready_i,
+    output dcache_req_o_t         [NumPorts-1:0] icache_req_ports_o,
 
     // Write buffer status to know if empty - EX_STAGE
     output logic                                 wbuffer_empty_o,
@@ -73,33 +69,13 @@ module hpdcache_icache_with_adapter
     output logic [               63:0]       hwpf_status_o,
     //  }}}
 
-    input logic dcache_wbuf_data_ready_i,
-    output logic dcache_wbuf_data_valid_o,
-    output hpdcache_mem_req_w_t dcache_wbuf_data_o,
+    input logic icache_uc_read_ready_i,
+    output logic icache_uc_read_valid_o,
+    output hpdcache_mem_req_t icache_uc_read_o,
 
-    output logic dcache_wbuf_resp_ready_o,
-    input logic dcache_wbuf_resp_valid_i,
-    input hpdcache_mem_resp_w_t dcache_wbuf_resp_i,
-
-    input logic dcache_uc_read_ready_i,
-    output logic dcache_uc_read_valid_o,
-    output hpdcache_mem_req_t dcache_uc_read_o,
-
-    output logic dcache_uc_read_resp_ready_o,
-    input logic dcache_uc_read_resp_valid_i,
-    input hpdcache_mem_resp_r_t dcache_uc_read_resp_i,
-
-    input logic dcache_uc_write_ready_i,
-    output logic dcache_uc_write_valid_o,
-    output hpdcache_mem_req_t dcache_uc_write_o,
-
-    input logic dcache_uc_write_data_ready_i,
-    output logic dcache_uc_write_data_valid_o,
-    output hpdcache_mem_req_w_t dcache_uc_write_data_o,
-
-    output logic dcache_uc_write_resp_ready_o,
-    input logic dcache_uc_write_resp_valid_i,
-    input hpdcache_mem_resp_w_t dcache_uc_write_resp_i
+    output logic icache_uc_read_resp_ready_o,
+    input logic icache_uc_read_resp_valid_i,
+    input hpdcache_mem_resp_r_t icache_uc_read_resp_i
 );
   //  }}}
 
@@ -150,7 +126,7 @@ module hpdcache_icache_with_adapter
     dcache_req_i_t dcache_req_ports[HPDCACHE_NREQUESTERS-1:0];
 
     for (genvar r = 0; r < (NumPorts - 1); r++) begin : cva6_hpdcache_load_if_adapter_gen
-      assign dcache_req_ports[r] = dcache_req_ports_i[r];
+      assign dcache_req_ports[r] = icache_req_ports_i[r];
 
       cva6_hpdcache_if_adapter #(
           .CVA6Cfg       (CVA6Cfg),
@@ -164,7 +140,7 @@ module hpdcache_icache_with_adapter
           .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(r)),
 
           .cva6_req_i     (dcache_req_ports[r]),
-          .cva6_req_o     (dcache_req_ports_o[r]),
+          .cva6_req_o     (icache_req_ports_o[r]),
           .cva6_amo_req_i ('0),
           .cva6_amo_resp_o(  /* unused */),
 
@@ -191,10 +167,10 @@ module hpdcache_icache_with_adapter
 
         .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts - 1)),
 
-        .cva6_req_i     (dcache_req_ports_i[NumPorts-1]),
-        .cva6_req_o     (dcache_req_ports_o[NumPorts-1]),
-        .cva6_amo_req_i (dcache_amo_req_i),
-        .cva6_amo_resp_o(dcache_amo_resp_o),
+        .cva6_req_i     (icache_req_ports_i[NumPorts-1]),
+        .cva6_req_o     (icache_req_ports_o[NumPorts-1]),
+        .cva6_amo_req_i (icache_amo_req_i),
+        .cva6_amo_resp_o(icache_amo_resp_o),
 
         .hpdcache_req_valid_o(dcache_req_valid[NumPorts-1]),
         .hpdcache_req_ready_i(dcache_req_ready[NumPorts-1]),
@@ -217,8 +193,8 @@ module hpdcache_icache_with_adapter
 
         .dcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts)),
 
-        .cva6_cmo_req_i (dcache_cmo_req_i),
-        .cva6_cmo_resp_o(dcache_cmo_resp_o),
+        .cva6_cmo_req_i (icache_cmo_req_i),
+        .cva6_cmo_resp_o(icache_cmo_resp_o),
 
         .dcache_req_valid_o(dcache_req_valid[NumPorts]),
         .dcache_req_ready_i(dcache_req_ready[NumPorts]),
@@ -316,7 +292,7 @@ module hpdcache_icache_with_adapter
       .hpdcache_rsp_i      (dcache_rsp[NumPorts+1])
   );
 
-  hpdcache #(
+  hpdcache_icache #(
       .NREQUESTERS         (HPDCACHE_NREQUESTERS),
       .HPDcacheMemAddrWidth(CVA6Cfg.PLEN),
       .HPDcacheMemIdWidth  (CVA6Cfg.MEM_TID_WIDTH),
@@ -325,7 +301,7 @@ module hpdcache_icache_with_adapter
       .clk_i,
       .rst_ni,
 
-      .wbuf_flush_i(dcache_flush_i),
+      .wbuf_flush_i(icache_flush_i),
 
       .core_req_valid_i(dcache_req_valid),
       .core_req_ready_o(dcache_req_ready),
@@ -337,45 +313,21 @@ module hpdcache_icache_with_adapter
       .core_rsp_valid_o(dcache_rsp_valid),
       .core_rsp_o      (dcache_rsp),
 
-      .mem_req_miss_read_ready_i(dcache_miss_ready),
-      .mem_req_miss_read_valid_o(dcache_miss_valid),
-      .mem_req_miss_read_o      (dcache_miss),
+      .mem_req_miss_read_ready_i(icache_miss_ready),
+      .mem_req_miss_read_valid_o(icache_miss_valid),
+      .mem_req_miss_read_o      (icache_miss),
 
-      .mem_resp_miss_read_ready_o(dcache_miss_resp_ready_o),
-      .mem_resp_miss_read_valid_i(dcache_miss_resp_valid_i),
-      .mem_resp_miss_read_i      (dcache_miss_resp_i),
+      .mem_resp_miss_read_ready_o(icache_miss_resp_ready_o),
+      .mem_resp_miss_read_valid_i(icache_miss_resp_valid_i),
+      .mem_resp_miss_read_i      (icache_miss_resp_i),
 
-      .mem_req_wbuf_write_ready_i(dcache_wbuf_ready_i),
-      .mem_req_wbuf_write_valid_o(dcache_wbuf_valid_o),
-      .mem_req_wbuf_write_o      (dcache_wbuf_o),
+      .mem_req_uc_read_ready_i(icache_uc_read_ready_i),
+      .mem_req_uc_read_valid_o(icache_uc_read_valid_o),
+      .mem_req_uc_read_o      (icache_uc_read_o),
 
-      .mem_req_wbuf_write_data_ready_i(dcache_wbuf_data_ready_i),
-      .mem_req_wbuf_write_data_valid_o(dcache_wbuf_data_valid_o),
-      .mem_req_wbuf_write_data_o      (dcache_wbuf_data_o),
-
-      .mem_resp_wbuf_write_ready_o(dcache_wbuf_resp_ready_o),
-      .mem_resp_wbuf_write_valid_i(dcache_wbuf_resp_valid_i),
-      .mem_resp_wbuf_write_i      (dcache_wbuf_resp_i),
-
-      .mem_req_uc_read_ready_i(dcache_uc_read_ready_i),
-      .mem_req_uc_read_valid_o(dcache_uc_read_valid_o),
-      .mem_req_uc_read_o      (dcache_uc_read_o),
-
-      .mem_resp_uc_read_ready_o(dcache_uc_read_resp_ready_o),
-      .mem_resp_uc_read_valid_i(dcache_uc_read_resp_valid_i),
-      .mem_resp_uc_read_i      (dcache_uc_read_resp_i),
-
-      .mem_req_uc_write_ready_i(dcache_uc_write_ready_i),
-      .mem_req_uc_write_valid_o(dcache_uc_write_valid_o),
-      .mem_req_uc_write_o      (dcache_uc_write_o),
-
-      .mem_req_uc_write_data_ready_i(dcache_uc_write_data_ready_i),
-      .mem_req_uc_write_data_valid_o(dcache_uc_write_data_valid_o),
-      .mem_req_uc_write_data_o      (dcache_uc_write_data_o),
-
-      .mem_resp_uc_write_ready_o(dcache_uc_write_resp_ready_o),
-      .mem_resp_uc_write_valid_i(dcache_uc_write_resp_valid_i),
-      .mem_resp_uc_write_i      (dcache_uc_write_resp_i),
+      .mem_resp_uc_read_ready_o(icache_uc_read_resp_ready_o),
+      .mem_resp_uc_read_valid_i(icache_uc_read_resp_valid_i),
+      .mem_resp_uc_read_i      (icache_uc_read_resp_i),
 
       .evt_cache_write_miss_o(dcache_write_miss),
       .evt_cache_read_miss_o (dcache_read_miss),
@@ -391,7 +343,7 @@ module hpdcache_icache_with_adapter
 
       .wbuf_empty_o(wbuffer_empty_o),
 
-      .cfg_enable_i                       (dcache_enable_i),
+      .cfg_enable_i                       (icache_enable_i),
       .cfg_wbuf_threshold_i               (4'd2),
       .cfg_wbuf_reset_timecnt_on_write_i  (1'b1),
       .cfg_wbuf_sequential_waw_i          (1'b0),
@@ -401,11 +353,11 @@ module hpdcache_icache_with_adapter
       .cfg_rtab_single_entry_i            (1'b0)
   );
 
-  assign dcache_miss_o = dcache_read_miss, wbuffer_not_ni_o = wbuffer_empty_o;
+  assign icache_miss_o = dcache_read_miss, wbuffer_not_ni_o = wbuffer_empty_o;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : dcache_flush_ff
-    if (!rst_ni) dcache_flush_ack_o <= 1'b0;
-    else dcache_flush_ack_o <= ~dcache_flush_ack_o & dcache_flush_i;
+    if (!rst_ni) icache_flush_ack_o <= 1'b0;
+    else icache_flush_ack_o <= ~icache_flush_ack_o & icache_flush_i;
   end
 
   //  }}}

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1240,8 +1240,73 @@ module cva6
         .inval_valid_i     (inval_valid),
         .inval_ready_o     (inval_ready)
     );
+  // end else if (DCACHE_TYPE == int'(config_pkg::HPDCACHE)) begin : gen_cache_hpd
+  //   cva6_hpdcache_subsystem #(
+  //       .CVA6Cfg   (CVA6Cfg),
+  //       .icache_areq_t(icache_areq_t),
+  //       .icache_arsp_t(icache_arsp_t),
+  //       .icache_dreq_t(icache_dreq_t),
+  //       .icache_drsp_t(icache_drsp_t),
+  //       .icache_req_t(icache_req_t),
+  //       .icache_rtrn_t(icache_rtrn_t),
+  //       .dcache_req_i_t(dcache_req_i_t),
+  //       .dcache_req_o_t(dcache_req_o_t),
+  //       .NumPorts  (NumPorts),
+  //       .axi_ar_chan_t(axi_ar_chan_t),
+  //       .axi_aw_chan_t(axi_aw_chan_t),
+  //       .axi_w_chan_t (axi_w_chan_t),
+  //       .axi_b_chan_t (b_chan_t),
+  //       .axi_r_chan_t (r_chan_t),
+  //       .noc_req_t (noc_req_t),
+  //       .noc_resp_t(noc_resp_t),
+  //       .cmo_req_t (logic  /*FIXME*/),
+  //       .cmo_rsp_t (logic  /*FIXME*/)
+  //   ) i_cache_subsystem (
+  //       .clk_i (clk_i),
+  //       .rst_ni(rst_ni),
+
+  //       .icache_en_i   (icache_en_csr),
+  //       .icache_flush_i(icache_flush_ctrl_cache),
+  //       .icache_miss_o (icache_miss_cache_perf),
+  //       .icache_areq_i (icache_areq_ex_cache),
+  //       .icache_areq_o (icache_areq_cache_ex),
+  //       .icache_dreq_i (icache_dreq_if_cache),
+  //       .icache_dreq_o (icache_dreq_cache_if),
+
+  //       .dcache_enable_i   (dcache_en_csr_nbdcache),
+  //       .dcache_flush_i    (dcache_flush_ctrl_cache),
+  //       .dcache_flush_ack_o(dcache_flush_ack_cache_ctrl),
+  //       .dcache_miss_o     (dcache_miss_cache_perf),
+
+  //       .dcache_amo_req_i (amo_req),
+  //       .dcache_amo_resp_o(amo_resp),
+
+  //       .dcache_cmo_req_i ('0  /*FIXME*/),
+  //       .dcache_cmo_resp_o(  /*FIXME*/),
+
+  //       .dcache_req_ports_i(dcache_req_to_cache),
+  //       .dcache_req_ports_o(dcache_req_from_cache),
+
+  //       .wbuffer_empty_o (dcache_commit_wbuffer_empty),
+  //       .wbuffer_not_ni_o(dcache_commit_wbuffer_not_ni),
+
+  //       .hwpf_base_set_i    ('0  /*FIXME*/),
+  //       .hwpf_base_i        ('0  /*FIXME*/),
+  //       .hwpf_base_o        (  /*FIXME*/),
+  //       .hwpf_param_set_i   ('0  /*FIXME*/),
+  //       .hwpf_param_i       ('0  /*FIXME*/),
+  //       .hwpf_param_o       (  /*FIXME*/),
+  //       .hwpf_throttle_set_i('0  /*FIXME*/),
+  //       .hwpf_throttle_i    ('0  /*FIXME*/),
+  //       .hwpf_throttle_o    (  /*FIXME*/),
+  //       .hwpf_status_o      (  /*FIXME*/),
+
+  //       .noc_req_o (noc_req_o),
+  //       .noc_resp_i(noc_resp_i)
+  //   );
+  //   assign inval_ready = 1'b1;
   end else if (DCACHE_TYPE == int'(config_pkg::HPDCACHE)) begin : gen_cache_hpd
-    cva6_hpdcache_subsystem #(
+    extended_hpdcache_subsystem #(
         .CVA6Cfg   (CVA6Cfg),
         .icache_areq_t(icache_areq_t),
         .icache_arsp_t(icache_arsp_t),
@@ -1289,6 +1354,17 @@ module cva6
 
         .wbuffer_empty_o (dcache_commit_wbuffer_empty),
         .wbuffer_not_ni_o(dcache_commit_wbuffer_not_ni),
+
+        .icache_hwpf_base_set_i    ('0  /*FIXME*/),
+        .icache_hwpf_base_i        ('0  /*FIXME*/),
+        .icache_hwpf_base_o        (  /*FIXME*/),
+        .icache_hwpf_param_set_i   ('0  /*FIXME*/),
+        .icache_hwpf_param_i       ('0  /*FIXME*/),
+        .icache_hwpf_param_o       (  /*FIXME*/),
+        .icache_hwpf_throttle_set_i('0  /*FIXME*/),
+        .icache_hwpf_throttle_i    ('0  /*FIXME*/),
+        .icache_hwpf_throttle_o    (  /*FIXME*/),
+        .icache_hwpf_status_o      (  /*FIXME*/),
 
         .hwpf_base_set_i    ('0  /*FIXME*/),
         .hwpf_base_i        ('0  /*FIXME*/),


### PR DESCRIPTION
## WHAT
- gsoc 2024 project: [Transforming the OpenHW High Performance Data Cache into a High Performance Instruction Cache](https://fossi-foundation.org/gsoc/gsoc24-ideas#transforming-the-openhw-high-performance-data-cache-into-a-high-performance-instruction-cache)
- extend hpdcache (high performance data cache) so that it can also serve as an instruction cache
- cf. https://github.com/openhwgroup/cv-hpdcache/pull/16

### detail
- `axi arbiter` for extended hpdc 

### HOW to extend hpdcache

- High Performance Instruction Cache:
  - instruction cache with 3-stage pipeline, Replay Table and MSHR
  - based on the original hpdcache code, remove the module for the write buffer part and the signals that control it, plus the module for the uncacheable write part and the signals that control it
   - the depth of Replay Table and MSHR will be decided through performance evaluation (reason: The utilization of the instruction cache is dependent on the capability of instruction fetch.) 
-  replace [current](https://github.com/takeshiho0531/cva6/tree/8d6c1f709f05638f7e02dd3576111bbc4dccc9b3) [cva6_icache](https://github.com/takeshiho0531/cva6/blob/8d6c1f709f05638f7e02dd3576111bbc4dccc9b3/core/cache_subsystem/cva6_hpdcache_subsystem.sv#L142) in `cva6_hpdcache_subsystem.sv` by High Performance Instruction Cache
    - arrange [cva6_hpdcache_subsystem_axi_arbiter](https://github.com/takeshiho0531/cva6/blob/8d6c1f709f05638f7e02dd3576111bbc4dccc9b3/core/cache_subsystem/cva6_hpdcache_subsystem.sv#L522) so that the interface will be appropriate
