### PR TITLE
Rename ZiCondExtEn and FPGA_EN parameters

### DIFF
--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -169,7 +169,7 @@ module acc_dispatcher
       .DEPTH       (InstructionQueueDepth),
       .FALL_THROUGH(1'b1),
       .dtype       (fu_data_t),
-      .FpgaEn      (CVA6Cfg.FpgaEn)
+      .FPGA_EN     (CVA6Cfg.FpgaEn)
   ) i_acc_insn_queue (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -169,7 +169,7 @@ module acc_dispatcher
       .DEPTH       (InstructionQueueDepth),
       .FALL_THROUGH(1'b1),
       .dtype       (fu_data_t),
-      .FPGAEn     (CVA6Cfg.FPGAEn)
+      .FpgaEn      (CVA6Cfg.FpgaEn)
   ) i_acc_insn_queue (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -169,7 +169,7 @@ module acc_dispatcher
       .DEPTH       (InstructionQueueDepth),
       .FALL_THROUGH(1'b1),
       .dtype       (fu_data_t),
-      .FPGA_EN     (CVA6Cfg.FPGA_EN)
+      .FPGAEn     (CVA6Cfg.FPGAEn)
   ) i_acc_insn_queue (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/alu.sv
+++ b/core/alu.sv
@@ -353,7 +353,7 @@ module alu
           result_o = {{CVA6Cfg.XLEN-32{1'b0}}, fu_data_i.operand_a[31:0]} << fu_data_i.operand_b[5:0];  // Left Shift 32 bit unsigned
       endcase
     end
-    if (CVA6Cfg.ZiCondExtEn) begin
+    if (CVA6Cfg.RVZiCond) begin
       unique case (fu_data_i.operation)
         CZERO_EQZ:
         result_o = (|fu_data_i.operand_b) ? fu_data_i.operand_a : '0;  // move zero to rd if rs2 is equal to zero else rs1

--- a/core/amo_buffer.sv
+++ b/core/amo_buffer.sv
@@ -63,9 +63,9 @@ module amo_buffer #(
   assign flush_amo_buffer = flush_i & !amo_valid_commit_i;
 
   fifo_v3 #(
-      .DEPTH (1),
-      .dtype (amo_op_t),
-      .FpgaEn(CVA6Cfg.FpgaEn)
+      .DEPTH  (1),
+      .dtype  (amo_op_t),
+      .FPGA_EN(CVA6Cfg.FpgaEn)
   ) i_amo_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/amo_buffer.sv
+++ b/core/amo_buffer.sv
@@ -65,7 +65,7 @@ module amo_buffer #(
   fifo_v3 #(
       .DEPTH  (1),
       .dtype  (amo_op_t),
-      .FPGA_EN(CVA6Cfg.FPGA_EN)
+      .FPGAEn(CVA6Cfg.FPGAEn)
   ) i_amo_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/amo_buffer.sv
+++ b/core/amo_buffer.sv
@@ -63,9 +63,9 @@ module amo_buffer #(
   assign flush_amo_buffer = flush_i & !amo_valid_commit_i;
 
   fifo_v3 #(
-      .DEPTH  (1),
-      .dtype  (amo_op_t),
-      .FPGAEn(CVA6Cfg.FPGAEn)
+      .DEPTH (1),
+      .dtype (amo_op_t),
+      .FpgaEn(CVA6Cfg.FpgaEn)
   ) i_amo_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/std_cache_subsystem.sv
+++ b/core/cache_subsystem/std_cache_subsystem.sv
@@ -184,7 +184,7 @@ module std_cache_subsystem
       // we can have a maximum of 4 oustanding transactions as each port is blocking
       .DEPTH       (4),
       .FALL_THROUGH(1'b1),
-      .FPGAEn     (CVA6Cfg.FPGAEn)
+      .FpgaEn      (CVA6Cfg.FpgaEn)
   ) i_fifo_w_channel (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/std_cache_subsystem.sv
+++ b/core/cache_subsystem/std_cache_subsystem.sv
@@ -184,7 +184,7 @@ module std_cache_subsystem
       // we can have a maximum of 4 oustanding transactions as each port is blocking
       .DEPTH       (4),
       .FALL_THROUGH(1'b1),
-      .FPGA_EN     (CVA6Cfg.FPGA_EN)
+      .FPGAEn     (CVA6Cfg.FPGAEn)
   ) i_fifo_w_channel (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/std_cache_subsystem.sv
+++ b/core/cache_subsystem/std_cache_subsystem.sv
@@ -184,7 +184,7 @@ module std_cache_subsystem
       // we can have a maximum of 4 oustanding transactions as each port is blocking
       .DEPTH       (4),
       .FALL_THROUGH(1'b1),
-      .FpgaEn      (CVA6Cfg.FpgaEn)
+      .FPGA_EN     (CVA6Cfg.FpgaEn)
   ) i_fifo_w_channel (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -311,9 +311,9 @@ module wt_axi_adapter
   end
 
   fifo_v3 #(
-      .dtype (icache_req_t),
-      .DEPTH (ReqFifoDepth),
-      .FpgaEn(CVA6Cfg.FpgaEn)
+      .dtype  (icache_req_t),
+      .DEPTH  (ReqFifoDepth),
+      .FPGA_EN(CVA6Cfg.FpgaEn)
   ) i_icache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -329,9 +329,9 @@ module wt_axi_adapter
   );
 
   fifo_v3 #(
-      .dtype (dcache_req_t),
-      .DEPTH (ReqFifoDepth),
-      .FpgaEn(CVA6Cfg.FpgaEn)
+      .dtype  (dcache_req_t),
+      .DEPTH  (ReqFifoDepth),
+      .FPGA_EN(CVA6Cfg.FpgaEn)
   ) i_dcache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -356,7 +356,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FpgaEn    (CVA6Cfg.FpgaEn)
+      .FPGA_EN   (CVA6Cfg.FpgaEn)
   ) i_rd_icache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -374,7 +374,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FpgaEn    (CVA6Cfg.FpgaEn)
+      .FPGA_EN   (CVA6Cfg.FpgaEn)
   ) i_rd_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -392,7 +392,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FpgaEn    (CVA6Cfg.FpgaEn)
+      .FPGA_EN   (CVA6Cfg.FpgaEn)
   ) i_wr_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -423,7 +423,7 @@ module wt_axi_adapter
       .DATA_WIDTH  (CVA6Cfg.AxiIdWidth + 1),
       .DEPTH       (MetaFifoDepth),
       .FALL_THROUGH(1'b1),
-      .FpgaEn      (CVA6Cfg.FpgaEn)
+      .FPGA_EN     (CVA6Cfg.FpgaEn)
   ) i_b_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -311,9 +311,9 @@ module wt_axi_adapter
   end
 
   fifo_v3 #(
-      .dtype  (icache_req_t),
-      .DEPTH  (ReqFifoDepth),
-      .FPGAEn(CVA6Cfg.FPGAEn)
+      .dtype (icache_req_t),
+      .DEPTH (ReqFifoDepth),
+      .FpgaEn(CVA6Cfg.FpgaEn)
   ) i_icache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -329,9 +329,9 @@ module wt_axi_adapter
   );
 
   fifo_v3 #(
-      .dtype  (dcache_req_t),
-      .DEPTH  (ReqFifoDepth),
-      .FPGAEn(CVA6Cfg.FPGAEn)
+      .dtype (dcache_req_t),
+      .DEPTH (ReqFifoDepth),
+      .FpgaEn(CVA6Cfg.FpgaEn)
   ) i_dcache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -356,7 +356,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FPGAEn   (CVA6Cfg.FPGAEn)
+      .FpgaEn    (CVA6Cfg.FpgaEn)
   ) i_rd_icache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -374,7 +374,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FPGAEn   (CVA6Cfg.FPGAEn)
+      .FpgaEn    (CVA6Cfg.FpgaEn)
   ) i_rd_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -392,7 +392,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FPGAEn   (CVA6Cfg.FPGAEn)
+      .FpgaEn    (CVA6Cfg.FpgaEn)
   ) i_wr_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -423,7 +423,7 @@ module wt_axi_adapter
       .DATA_WIDTH  (CVA6Cfg.AxiIdWidth + 1),
       .DEPTH       (MetaFifoDepth),
       .FALL_THROUGH(1'b1),
-      .FPGAEn     (CVA6Cfg.FPGAEn)
+      .FpgaEn      (CVA6Cfg.FpgaEn)
   ) i_b_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -313,7 +313,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .dtype  (icache_req_t),
       .DEPTH  (ReqFifoDepth),
-      .FPGA_EN(CVA6Cfg.FPGA_EN)
+      .FPGAEn(CVA6Cfg.FPGAEn)
   ) i_icache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -331,7 +331,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .dtype  (dcache_req_t),
       .DEPTH  (ReqFifoDepth),
-      .FPGA_EN(CVA6Cfg.FPGA_EN)
+      .FPGAEn(CVA6Cfg.FPGAEn)
   ) i_dcache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -356,7 +356,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FPGA_EN   (CVA6Cfg.FPGA_EN)
+      .FPGAEn   (CVA6Cfg.FPGAEn)
   ) i_rd_icache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -374,7 +374,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FPGA_EN   (CVA6Cfg.FPGA_EN)
+      .FPGAEn   (CVA6Cfg.FPGAEn)
   ) i_rd_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -392,7 +392,7 @@ module wt_axi_adapter
   fifo_v3 #(
       .DATA_WIDTH(CVA6Cfg.MEM_TID_WIDTH),
       .DEPTH     (MetaFifoDepth),
-      .FPGA_EN   (CVA6Cfg.FPGA_EN)
+      .FPGAEn   (CVA6Cfg.FPGAEn)
   ) i_wr_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
@@ -423,7 +423,7 @@ module wt_axi_adapter
       .DATA_WIDTH  (CVA6Cfg.AxiIdWidth + 1),
       .DEPTH       (MetaFifoDepth),
       .FALL_THROUGH(1'b1),
-      .FPGA_EN     (CVA6Cfg.FPGA_EN)
+      .FPGAEn     (CVA6Cfg.FPGAEn)
   ) i_b_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -303,7 +303,7 @@ module wt_dcache_wbuffer
       .FALL_THROUGH(1'b0),
       .DATA_WIDTH  ($clog2(CVA6Cfg.DCACHE_MAX_TX)),
       .DEPTH       (CVA6Cfg.DCACHE_MAX_TX),
-      .FPGA_EN     (CVA6Cfg.FPGA_EN)
+      .FPGAEn     (CVA6Cfg.FPGAEn)
   ) i_rtrn_id_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -303,7 +303,7 @@ module wt_dcache_wbuffer
       .FALL_THROUGH(1'b0),
       .DATA_WIDTH  ($clog2(CVA6Cfg.DCACHE_MAX_TX)),
       .DEPTH       (CVA6Cfg.DCACHE_MAX_TX),
-      .FpgaEn      (CVA6Cfg.FpgaEn)
+      .FPGA_EN     (CVA6Cfg.FpgaEn)
   ) i_rtrn_id_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -303,7 +303,7 @@ module wt_dcache_wbuffer
       .FALL_THROUGH(1'b0),
       .DATA_WIDTH  ($clog2(CVA6Cfg.DCACHE_MAX_TX)),
       .DEPTH       (CVA6Cfg.DCACHE_MAX_TX),
-      .FPGAEn     (CVA6Cfg.FPGAEn)
+      .FpgaEn      (CVA6Cfg.FpgaEn)
   ) i_rtrn_id_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1468,7 +1468,7 @@ module cva6
     fifo_v3 #(
         .DATA_WIDTH(64),
         .DEPTH(PC_QUEUE_DEPTH),
-        .FpgaEn(CVA6Cfg.FpgaEn)
+        .FPGA_EN(CVA6Cfg.FpgaEn)
     ) i_pc_fifo (
         .clk_i     (clk_i),
         .rst_ni    (rst_ni),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1468,7 +1468,7 @@ module cva6
     fifo_v3 #(
         .DATA_WIDTH(64),
         .DEPTH(PC_QUEUE_DEPTH),
-        .FPGA_EN(CVA6Cfg.FPGA_EN)
+        .FPGAEn(CVA6Cfg.FPGAEn)
     ) i_pc_fifo (
         .clk_i     (clk_i),
         .rst_ni    (rst_ni),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1468,7 +1468,7 @@ module cva6
     fifo_v3 #(
         .DATA_WIDTH(64),
         .DEPTH(PC_QUEUE_DEPTH),
-        .FPGAEn(CVA6Cfg.FPGAEn)
+        .FpgaEn(CVA6Cfg.FpgaEn)
     ) i_pc_fifo (
         .clk_i     (clk_i),
         .rst_ni    (rst_ni),

--- a/core/cvxif_example/cvxif_example_coprocessor.sv
+++ b/core/cvxif_example/cvxif_example_coprocessor.sv
@@ -115,7 +115,7 @@ module cvxif_example_coprocessor
       .DATA_WIDTH  (64),
       .DEPTH       (8),
       .dtype       (x_issue_t),
-      .FpgaEn      (CVA6Cfg.FpgaEn)
+      .FPGA_EN     (CVA6Cfg.FpgaEn)
   ) fifo_commit_i (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cvxif_example/cvxif_example_coprocessor.sv
+++ b/core/cvxif_example/cvxif_example_coprocessor.sv
@@ -111,11 +111,11 @@ module cvxif_example_coprocessor
   end
 
   fifo_v3 #(
-      .FALL_THROUGH(1),               //data_o ready and pop in the same cycle
+      .FALL_THROUGH(1),              //data_o ready and pop in the same cycle
       .DATA_WIDTH  (64),
       .DEPTH       (8),
       .dtype       (x_issue_t),
-      .FPGAEn     (CVA6Cfg.FPGAEn)
+      .FpgaEn      (CVA6Cfg.FpgaEn)
   ) fifo_commit_i (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/cvxif_example/cvxif_example_coprocessor.sv
+++ b/core/cvxif_example/cvxif_example_coprocessor.sv
@@ -115,7 +115,7 @@ module cvxif_example_coprocessor
       .DATA_WIDTH  (64),
       .DEPTH       (8),
       .dtype       (x_issue_t),
-      .FPGA_EN     (CVA6Cfg.FPGA_EN)
+      .FPGAEn     (CVA6Cfg.FPGAEn)
   ) fifo_commit_i (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -783,7 +783,7 @@ module decoder
                 end
               endcase
             end
-            if (CVA6Cfg.ZiCondExtEn) begin
+            if (CVA6Cfg.RVZiCond) begin
               unique case ({
                 instr.rtype.funct7, instr.rtype.funct3
               })
@@ -797,7 +797,7 @@ module decoder
             end
             //VCS coverage on
             unique case ({
-              CVA6Cfg.RVB, CVA6Cfg.ZiCondExtEn
+              CVA6Cfg.RVB, CVA6Cfg.RVZiCond
             })
               2'b00: illegal_instr = illegal_instr_non_bm;
               2'b01: illegal_instr = illegal_instr_non_bm & illegal_instr_zic;

--- a/core/frontend/bht.sv
+++ b/core/frontend/bht.sv
@@ -68,7 +68,7 @@ module bht #(
     assign update_row_index = '0;
   end
 
-  if (!CVA6Cfg.FPGA_EN) begin : gen_asic_bht  // ASIC TARGET
+  if (!CVA6Cfg.FPGAEn) begin : gen_asic_bht  // ASIC TARGET
 
     logic [1:0] saturation_counter;
     // prediction assignment

--- a/core/frontend/bht.sv
+++ b/core/frontend/bht.sv
@@ -68,7 +68,7 @@ module bht #(
     assign update_row_index = '0;
   end
 
-  if (!CVA6Cfg.FPGAEn) begin : gen_asic_bht  // ASIC TARGET
+  if (!CVA6Cfg.FpgaEn) begin : gen_asic_bht  // ASIC TARGET
 
     logic [1:0] saturation_counter;
     // prediction assignment

--- a/core/frontend/btb.sv
+++ b/core/frontend/btb.sv
@@ -74,7 +74,7 @@ module btb #(
     assign update_row_index = '0;
   end
 
-  if (CVA6Cfg.FPGA_EN) begin : gen_fpga_btb  //FPGA TARGETS
+  if (CVA6Cfg.FPGAEn) begin : gen_fpga_btb  //FPGA TARGETS
     logic [                CVA6Cfg.INSTR_PER_FETCH-1:0] btb_ram_csel_prediction;
     logic [                CVA6Cfg.INSTR_PER_FETCH-1:0] btb_ram_we_prediction;
     logic [CVA6Cfg.INSTR_PER_FETCH*$clog2(NR_ROWS)-1:0] btb_ram_addr_prediction;

--- a/core/frontend/btb.sv
+++ b/core/frontend/btb.sv
@@ -74,7 +74,7 @@ module btb #(
     assign update_row_index = '0;
   end
 
-  if (CVA6Cfg.FPGAEn) begin : gen_fpga_btb  //FPGA TARGETS
+  if (CVA6Cfg.FpgaEn) begin : gen_fpga_btb  //FPGA TARGETS
     logic [                CVA6Cfg.INSTR_PER_FETCH-1:0] btb_ram_csel_prediction;
     logic [                CVA6Cfg.INSTR_PER_FETCH-1:0] btb_ram_we_prediction;
     logic [CVA6Cfg.INSTR_PER_FETCH*$clog2(NR_ROWS)-1:0] btb_ram_addr_prediction;

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -482,7 +482,7 @@ module frontend
   //For FPGA, BTB is implemented in read synchronous BRAM
   //while for ASIC, BTB is implemented in D flip-flop
   //and can be read at the same cycle.
-  assign vpc_btb = (CVA6Cfg.FPGA_EN) ? icache_dreq_i.vaddr : icache_vaddr_q;
+  assign vpc_btb = (CVA6Cfg.FPGAEn) ? icache_dreq_i.vaddr : icache_vaddr_q;
 
   if (CVA6Cfg.BTBEntries == 0) begin
     assign btb_prediction = '0;

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -482,7 +482,7 @@ module frontend
   //For FPGA, BTB is implemented in read synchronous BRAM
   //while for ASIC, BTB is implemented in D flip-flop
   //and can be read at the same cycle.
-  assign vpc_btb = (CVA6Cfg.FPGAEn) ? icache_dreq_i.vaddr : icache_vaddr_q;
+  assign vpc_btb = (CVA6Cfg.FpgaEn) ? icache_dreq_i.vaddr : icache_vaddr_q;
 
   if (CVA6Cfg.BTBEntries == 0) begin
     assign btb_prediction = '0;

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -414,7 +414,7 @@ ariane_pkg::FETCH_FIFO_DEPTH
     fifo_v3 #(
         .DEPTH  (ariane_pkg::FETCH_FIFO_DEPTH),
         .dtype  (instr_data_t),
-        .FPGA_EN(CVA6Cfg.FPGA_EN)
+        .FPGAEn(CVA6Cfg.FPGAEn)
     ) i_fifo_instr_data (
         .clk_i     (clk_i),
         .rst_ni    (rst_ni),
@@ -442,7 +442,7 @@ ariane_pkg::FETCH_FIFO_DEPTH
   fifo_v3 #(
       .DEPTH     (ariane_pkg::FETCH_FIFO_DEPTH),  // TODO(zarubaf): Fork out to separate param
       .DATA_WIDTH(CVA6Cfg.VLEN),
-      .FPGA_EN   (CVA6Cfg.FPGA_EN)
+      .FPGAEn   (CVA6Cfg.FPGAEn)
   ) i_fifo_address (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -412,9 +412,9 @@ ariane_pkg::FETCH_FIFO_DEPTH
     // Make sure we don't save any instructions if we couldn't save the address
     assign push_instr_fifo[i] = push_instr[i] & ~address_overflow;
     fifo_v3 #(
-        .DEPTH (ariane_pkg::FETCH_FIFO_DEPTH),
-        .dtype (instr_data_t),
-        .FpgaEn(CVA6Cfg.FpgaEn)
+        .DEPTH  (ariane_pkg::FETCH_FIFO_DEPTH),
+        .dtype  (instr_data_t),
+        .FPGA_EN(CVA6Cfg.FpgaEn)
     ) i_fifo_instr_data (
         .clk_i     (clk_i),
         .rst_ni    (rst_ni),
@@ -442,7 +442,7 @@ ariane_pkg::FETCH_FIFO_DEPTH
   fifo_v3 #(
       .DEPTH     (ariane_pkg::FETCH_FIFO_DEPTH),  // TODO(zarubaf): Fork out to separate param
       .DATA_WIDTH(CVA6Cfg.VLEN),
-      .FpgaEn    (CVA6Cfg.FpgaEn)
+      .FPGA_EN   (CVA6Cfg.FpgaEn)
   ) i_fifo_address (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -412,9 +412,9 @@ ariane_pkg::FETCH_FIFO_DEPTH
     // Make sure we don't save any instructions if we couldn't save the address
     assign push_instr_fifo[i] = push_instr[i] & ~address_overflow;
     fifo_v3 #(
-        .DEPTH  (ariane_pkg::FETCH_FIFO_DEPTH),
-        .dtype  (instr_data_t),
-        .FPGAEn(CVA6Cfg.FPGAEn)
+        .DEPTH (ariane_pkg::FETCH_FIFO_DEPTH),
+        .dtype (instr_data_t),
+        .FpgaEn(CVA6Cfg.FpgaEn)
     ) i_fifo_instr_data (
         .clk_i     (clk_i),
         .rst_ni    (rst_ni),
@@ -442,7 +442,7 @@ ariane_pkg::FETCH_FIFO_DEPTH
   fifo_v3 #(
       .DEPTH     (ariane_pkg::FETCH_FIFO_DEPTH),  // TODO(zarubaf): Fork out to separate param
       .DATA_WIDTH(CVA6Cfg.VLEN),
-      .FPGAEn   (CVA6Cfg.FPGAEn)
+      .FpgaEn    (CVA6Cfg.FpgaEn)
   ) i_fifo_address (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -39,7 +39,7 @@ package build_config_pkg;
     cfg.ASID_WIDTH = (CVA6Cfg.XLEN == 64) ? 16 : 1;
     cfg.VMID_WIDTH = (CVA6Cfg.XLEN == 64) ? 14 : 1;
 
-    cfg.FPGA_EN = CVA6Cfg.FPGA_EN;
+    cfg.FPGAEn = CVA6Cfg.FPGAEn;
     cfg.NrCommitPorts = CVA6Cfg.NrCommitPorts;
     cfg.AxiAddrWidth = CVA6Cfg.AxiAddrWidth;
     cfg.AxiDataWidth = CVA6Cfg.AxiDataWidth;

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -39,7 +39,7 @@ package build_config_pkg;
     cfg.ASID_WIDTH = (CVA6Cfg.XLEN == 64) ? 16 : 1;
     cfg.VMID_WIDTH = (CVA6Cfg.XLEN == 64) ? 14 : 1;
 
-    cfg.FPGAEn = CVA6Cfg.FPGAEn;
+    cfg.FpgaEn = CVA6Cfg.FpgaEn;
     cfg.NrCommitPorts = CVA6Cfg.NrCommitPorts;
     cfg.AxiAddrWidth = CVA6Cfg.AxiAddrWidth;
     cfg.AxiDataWidth = CVA6Cfg.AxiDataWidth;

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -60,7 +60,7 @@ package build_config_pkg;
     cfg.RVZCMP = CVA6Cfg.RVZCMP;
     cfg.XFVec = CVA6Cfg.XFVec;
     cfg.CvxifEn = CVA6Cfg.CvxifEn;
-    cfg.ZiCondExtEn = CVA6Cfg.ZiCondExtEn;
+    cfg.RVZiCond = CVA6Cfg.RVZiCond;
     cfg.NR_SB_ENTRIES = CVA6Cfg.NrScoreboardEntries;
     cfg.TRANS_ID_BITS = $clog2(CVA6Cfg.NrScoreboardEntries);
 

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -63,7 +63,7 @@ package config_pkg;
     // Zcmp RISC-V extension
     bit                          RVZCMP;
     // Zicond RISC-V extension
-    bit                          ZiCondExtEn;
+    bit                          RVZiCond;
     // Floating Point
     bit                          FpuEn;
     // Non standard 16bits Floating Point extension
@@ -203,7 +203,7 @@ package config_pkg;
     bit          RVZCMP;
     bit          XFVec;
     bit          CvxifEn;
-    bit          ZiCondExtEn;
+    bit          RVZiCond;
 
     int unsigned NR_SB_ENTRIES;
     int unsigned TRANS_ID_BITS;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -149,7 +149,7 @@ package config_pkg;
     // Width of fetch user field
     int unsigned                 FetchUserWidth;
     // Is FPGA optimization of CV32A6
-    bit                          FPGAEn;
+    bit                          FpgaEn;
     // Number of commit ports
     int unsigned                 NrCommitPorts;
     // Scoreboard length
@@ -177,7 +177,7 @@ package config_pkg;
     int unsigned ASID_WIDTH;
     int unsigned VMID_WIDTH;
 
-    bit          FPGAEn;
+    bit          FpgaEn;
     /// Number of commit ports, i.e., maximum number of instructions that the
     /// core can retire per cycle. It can be beneficial to have more commit
     /// ports than issue ports, for the scoreboard to empty out in case one

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -149,7 +149,7 @@ package config_pkg;
     // Width of fetch user field
     int unsigned                 FetchUserWidth;
     // Is FPGA optimization of CV32A6
-    bit                          FPGA_EN;
+    bit                          FPGAEn;
     // Number of commit ports
     int unsigned                 NrCommitPorts;
     // Scoreboard length
@@ -177,7 +177,7 @@ package config_pkg;
     int unsigned ASID_WIDTH;
     int unsigned VMID_WIDTH;
 
-    bit          FPGA_EN;
+    bit          FPGAEn;
     /// Number of commit ports, i.e., maximum number of instructions that the
     /// core can retire per cycle. It can be beneficial to have more commit
     /// ports than issue ports, for the scoreboard to empty out in case one

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 1;
+  localparam CVA6ConfigRVZiCond = 1;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 1;
   localparam CVA6ConfigNrScoreboardEntries = 4;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -98,7 +98,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(0),
       RVU: bit'(0),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -77,7 +77,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -50,7 +50,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 1;
   localparam CVA6ConfigNrScoreboardEntries = 4;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 0;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -77,7 +77,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -25,7 +25,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -98,7 +98,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(0),
       RVU: bit'(0),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -77,7 +77,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -50,7 +50,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 1;
   localparam CVA6ConfigNrScoreboardEntries = 4;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 0;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -77,7 +77,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 0;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 1;
   localparam CVA6ConfigNrScoreboardEntries = 4;
 
-  localparam CVA6ConfigFPGAEn = 1;
+  localparam CVA6ConfigFpgaEn = 1;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -52,7 +52,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrScoreboardEntries = 8;
   localparam CVA6ConfigNrLoadBufEntries = 2;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 0;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 0;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 0;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigBExtEn = 0;
   localparam CVA6ConfigHExtEn = 0;
   localparam CVA6ConfigVExtEn = 1;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 1;
+  localparam CVA6ConfigRVZiCond = 1;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -33,7 +33,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigHExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 1;
+  localparam CVA6ConfigRVZiCond = 1;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -106,7 +106,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -85,7 +85,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -58,7 +58,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -85,7 +85,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;  // always disabled
   localparam CVA6ConfigBExtEn = 0;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigHExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 1;
+  localparam CVA6ConfigRVZiCond = 1;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 1;
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigZiCondExtEn = 1;
+  localparam CVA6ConfigRVZiCond = 1;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -97,7 +97,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 2;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigHExtEn = 1;
-  localparam CVA6ConfigZiCondExtEn = 1;
+  localparam CVA6ConfigRVZiCond = 1;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -97,7 +97,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVS: bit'(1),
       RVU: bit'(1),
       HaltAddress: 64'h800,

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -26,7 +26,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigBExtEn = 0;
   localparam CVA6ConfigHExtEn = 0;
   localparam CVA6ConfigVExtEn = 1;
-  localparam CVA6ConfigZiCondExtEn = 0;
+  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      RVZiCond: bit'(CVA6ConfigRVZiCond),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(1),
       RVU: bit'(1),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGA_EN: bit'(CVA6ConfigFPGAEn),
+      FPGAEn: bit'(CVA6ConfigFPGAEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -51,7 +51,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 1;
   localparam CVA6ConfigNrScoreboardEntries = 8;
 
-  localparam CVA6ConfigFPGAEn = 0;
+  localparam CVA6ConfigFpgaEn = 0;
 
   localparam CVA6ConfigNrLoadPipeRegs = 1;
   localparam CVA6ConfigNrStorePipeRegs = 0;
@@ -78,7 +78,7 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FPGAEn: bit'(CVA6ConfigFPGAEn),
+      FpgaEn: bit'(CVA6ConfigFpgaEn),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -490,7 +490,7 @@ module issue_read_operands
     assign wdata_pack[i] = wdata_i[i];
     assign we_pack[i]    = we_gpr_i[i];
   end
-  if (CVA6Cfg.FPGAEn) begin : gen_fpga_regfile
+  if (CVA6Cfg.FpgaEn) begin : gen_fpga_regfile
     ariane_regfile_fpga #(
         .CVA6Cfg      (CVA6Cfg),
         .DATA_WIDTH   (CVA6Cfg.XLEN),
@@ -539,7 +539,7 @@ module issue_read_operands
       for (genvar i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin : gen_fp_wdata_pack
         assign fp_wdata_pack[i] = {wdata_i[i][CVA6Cfg.FLen-1:0]};
       end
-      if (CVA6Cfg.FPGAEn) begin : gen_fpga_fp_regfile
+      if (CVA6Cfg.FpgaEn) begin : gen_fpga_fp_regfile
         ariane_regfile_fpga #(
             .CVA6Cfg      (CVA6Cfg),
             .DATA_WIDTH   (CVA6Cfg.FLen),

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -490,7 +490,7 @@ module issue_read_operands
     assign wdata_pack[i] = wdata_i[i];
     assign we_pack[i]    = we_gpr_i[i];
   end
-  if (CVA6Cfg.FPGA_EN) begin : gen_fpga_regfile
+  if (CVA6Cfg.FPGAEn) begin : gen_fpga_regfile
     ariane_regfile_fpga #(
         .CVA6Cfg      (CVA6Cfg),
         .DATA_WIDTH   (CVA6Cfg.XLEN),
@@ -539,7 +539,7 @@ module issue_read_operands
       for (genvar i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin : gen_fp_wdata_pack
         assign fp_wdata_pack[i] = {wdata_i[i][CVA6Cfg.FLen-1:0]};
       end
-      if (CVA6Cfg.FPGA_EN) begin : gen_fpga_fp_regfile
+      if (CVA6Cfg.FPGAEn) begin : gen_fpga_fp_regfile
         ariane_regfile_fpga #(
             .CVA6Cfg      (CVA6Cfg),
             .DATA_WIDTH   (CVA6Cfg.FLen),

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -157,7 +157,7 @@ module ariane_xilinx (
 // CVA6 Xilinx configuration
 function automatic config_pkg::cva6_cfg_t build_fpga_config(config_pkg::cva6_user_cfg_t CVA6UserCfg);
   config_pkg::cva6_user_cfg_t cfg = CVA6UserCfg;
-  cfg.ZiCondExtEn = bit'(0);
+  cfg.RVZiCond = bit'(0);
   cfg.NrNonIdempotentRules = unsigned'(1);
   cfg.NonIdempotentAddrBase = 1024'({64'b0});
   cfg.NonIdempotentLength = 1024'({ariane_soc::DRAMBase});

--- a/docs/01_cva6_user/Parameters_Configuration.rst
+++ b/docs/01_cva6_user/Parameters_Configuration.rst
@@ -78,7 +78,7 @@ Parameters
    "``RenameEn``",                  "Pipeline",         "Register renaming feature enable"
    "``NrCommitPorts``",             "Pipeline",         "Commit port number"
    "``NrScoreboardEntries``",       "Pipeline",         "Scoreboard entry number"
-   "``FPGAEn``",                    "Technology",       "FPGA optimization enable"
+   "``FpgaEn``",                    "Technology",       "FPGA optimization enable"
 
 
 Configurations
@@ -136,4 +136,4 @@ A configuration is a fixed set of parameters.
    "``RenameEn``",                  "0"
    "``NrCommitPorts``",             "1"
    "``NrScoreboardEntries``",       "4"
-   "``FPGAEn``",                    "0"
+   "``FpgaEn``",                    "0"

--- a/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
+++ b/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
@@ -220,7 +220,7 @@
      - Width of fetch user field
      - 32
 
-   * - FPGA_EN
+   * - FPGAEn
      - Is FPGA optimization of CV32A6
      - 0
 

--- a/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
+++ b/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
@@ -48,7 +48,7 @@
      - Zcmp RISC-V extension
      - 0
 
-   * - ZiCondExtEn
+   * - RVZiCond
      - Zicond RISC-V extension
      - 0
 

--- a/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
+++ b/docs/04_cv32a65x_design/source/parameters_cv32a65x.rst
@@ -220,7 +220,7 @@
      - Width of fetch user field
      - 32
 
-   * - FPGAEn
+   * - FpgaEn
      - Is FPGA optimization of CV32A6
      - 0
 

--- a/util/config_pkg_generator.py
+++ b/util/config_pkg_generator.py
@@ -79,7 +79,7 @@ def setup_parser_config_generator():
                       help="Number of commit ports")
   parser.add_argument("--NrScoreboardEntries", type=int, default=None,
                       help="Number of scoreboard entries")
-  parser.add_argument("--FPGAEn", type=int, default=None, choices=[0,1],
+  parser.add_argument("--FpgaEn", type=int, default=None, choices=[0,1],
                       help="Use FPGA-specific hardware")
   parser.add_argument("--NrLoadPipeRegs", type=int, default=None,
                       help="Load latency")
@@ -148,7 +148,7 @@ MapArgsToParameter={
   "WtDcacheWbufDepth": "CVA6ConfigWtDcacheWbufDepth",
   "NrCommitPorts" : "CVA6ConfigNrCommitPorts",
   "NrScoreboardEntries" : "CVA6ConfigNrScoreboardEntries",
-  "FPGAEn" : "CVA6ConfigFPGAEn",
+  "FpgaEn" : "CVA6ConfigFpgaEn",
   "NrLoadPipeRegs" : "CVA6ConfigNrLoadPipeRegs",
   "NrStorePipeRegs" : "CVA6ConfigNrStorePipeRegs",
   "NrLoadBufEntries" : "CVA6ConfigNrLoadBufEntries",

--- a/vendor/pulp-platform/common_cells/src/fifo_v3.sv
+++ b/vendor/pulp-platform/common_cells/src/fifo_v3.sv
@@ -15,7 +15,7 @@ module fifo_v3 #(
     parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
     parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
     parameter type dtype                = logic [DATA_WIDTH-1:0],
-    parameter bit          FPGAEn      = 1'b0,
+    parameter bit          FpgaEn      = 1'b0,
     // DO NOT OVERWRITE THIS PARAMETER
     parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
 )(
@@ -71,7 +71,7 @@ module fifo_v3 #(
         read_pointer_n  = read_pointer_q;
         write_pointer_n = write_pointer_q;
         status_cnt_n    = status_cnt_q;
-        if (FPGAEn) begin
+        if (FpgaEn) begin
              fifo_ram_we             = '0;
              fifo_ram_read_address   = read_pointer_q;
              fifo_ram_write_address  = '0;
@@ -85,7 +85,7 @@ module fifo_v3 #(
 
         // push a new element to the queue
         if (push_i && ~full_o) begin
-            if (FPGAEn) begin
+            if (FpgaEn) begin
                 fifo_ram_we = 1'b1;
                 fifo_ram_write_address = write_pointer_q;
                 fifo_ram_wdata = data_i;
@@ -150,7 +150,7 @@ module fifo_v3 #(
         end
     end
 
-    if (FPGAEn) begin : gen_fpga_queue
+    if (FpgaEn) begin : gen_fpga_queue
         AsyncDpRam #(
             .ADDR_WIDTH (ADDR_DEPTH),
             .DATA_DEPTH (DEPTH),

--- a/vendor/pulp-platform/common_cells/src/fifo_v3.sv
+++ b/vendor/pulp-platform/common_cells/src/fifo_v3.sv
@@ -15,7 +15,7 @@ module fifo_v3 #(
     parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
     parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
     parameter type dtype                = logic [DATA_WIDTH-1:0],
-    parameter bit          FpgaEn      = 1'b0,
+    parameter bit          FPGA_EN      = 1'b0,
     // DO NOT OVERWRITE THIS PARAMETER
     parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
 )(
@@ -71,7 +71,7 @@ module fifo_v3 #(
         read_pointer_n  = read_pointer_q;
         write_pointer_n = write_pointer_q;
         status_cnt_n    = status_cnt_q;
-        if (FpgaEn) begin
+        if (FPGA_EN) begin
              fifo_ram_we             = '0;
              fifo_ram_read_address   = read_pointer_q;
              fifo_ram_write_address  = '0;
@@ -85,7 +85,7 @@ module fifo_v3 #(
 
         // push a new element to the queue
         if (push_i && ~full_o) begin
-            if (FpgaEn) begin
+            if (FPGA_EN) begin
                 fifo_ram_we = 1'b1;
                 fifo_ram_write_address = write_pointer_q;
                 fifo_ram_wdata = data_i;
@@ -150,7 +150,7 @@ module fifo_v3 #(
         end
     end
 
-    if (FpgaEn) begin : gen_fpga_queue
+    if (FPGA_EN) begin : gen_fpga_queue
         AsyncDpRam #(
             .ADDR_WIDTH (ADDR_DEPTH),
             .DATA_DEPTH (DEPTH),

--- a/vendor/pulp-platform/common_cells/src/fifo_v3.sv
+++ b/vendor/pulp-platform/common_cells/src/fifo_v3.sv
@@ -15,7 +15,7 @@ module fifo_v3 #(
     parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
     parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
     parameter type dtype                = logic [DATA_WIDTH-1:0],
-    parameter bit          FPGA_EN      = 1'b0,
+    parameter bit          FPGAEn      = 1'b0,
     // DO NOT OVERWRITE THIS PARAMETER
     parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
 )(
@@ -71,7 +71,7 @@ module fifo_v3 #(
         read_pointer_n  = read_pointer_q;
         write_pointer_n = write_pointer_q;
         status_cnt_n    = status_cnt_q;
-        if (FPGA_EN) begin
+        if (FPGAEn) begin
              fifo_ram_we             = '0;
              fifo_ram_read_address   = read_pointer_q;
              fifo_ram_write_address  = '0;
@@ -85,7 +85,7 @@ module fifo_v3 #(
 
         // push a new element to the queue
         if (push_i && ~full_o) begin
-            if (FPGA_EN) begin
+            if (FPGAEn) begin
                 fifo_ram_we = 1'b1;
                 fifo_ram_write_address = write_pointer_q;
                 fifo_ram_wdata = data_i;
@@ -150,7 +150,7 @@ module fifo_v3 #(
         end
     end
 
-    if (FPGA_EN) begin : gen_fpga_queue
+    if (FPGAEn) begin : gen_fpga_queue
         AsyncDpRam #(
             .ADDR_WIDTH (ADDR_DEPTH),
             .DATA_DEPTH (DEPTH),

--- a/verif/env/uvme/cov/uvme_cva6_config_covg.sv
+++ b/verif/env/uvme/cov/uvme_cva6_config_covg.sv
@@ -54,8 +54,8 @@ covergroup cg_cva6_config(string name) with function sample();
    cp_VExtEn : coverpoint cva6_config_pkg::CVA6ConfigVExtEn {
       bins VExtEn ={0};
    }
-   cp_ZiCondExtEn : coverpoint cva6_config_pkg::CVA6ConfigZiCondExtEn {
-      bins ZiCondExtEn ={0};
+   cp_RVZiCond : coverpoint cva6_config_pkg::CVA6ConfigRVZiCond {
+      bins RVZiCond ={0};
    }
    cp_AxiIdWidth : coverpoint cva6_config_pkg::CVA6ConfigAxiIdWidth {
       bins AxiIdWidth ={4};

--- a/verif/env/uvme/cov/uvme_cva6_config_covg.sv
+++ b/verif/env/uvme/cov/uvme_cva6_config_covg.sv
@@ -111,8 +111,8 @@ covergroup cg_cva6_config(string name) with function sample();
    cp_NrScoreboardEntries : coverpoint cva6_config_pkg::CVA6ConfigNrScoreboardEntries {
       bins NrScoreboardEntries ={4};
    }
-   cp_FPGAEn : coverpoint cva6_config_pkg::CVA6ConfigFPGAEn {
-      bins FPGAEn ={0};
+   cp_FpgaEn : coverpoint cva6_config_pkg::CVA6ConfigFpgaEn {
+      bins FpgaEn ={0};
    }
    cp_NrLoadPipeRegs : coverpoint cva6_config_pkg::CVA6ConfigNrLoadPipeRegs {
       bins NrLoadPipeRegs ={0};

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -1633,8 +1633,8 @@ plan "CVA6 Verification Master Plan";
             measure Group FLen;
                 source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FLen";
             endmeasure
-            measure Group FPGAEn;
-                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FPGAEn";
+            measure Group FpgaEn;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FpgaEn";
             endmeasure
             measure Group FVecEn;
                 source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_FVecEn";

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -1735,8 +1735,8 @@ plan "CVA6 Verification Master Plan";
             measure Group Xlen;
                 source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_Xlen";
             endmeasure
-            measure Group ZiCondExtEn;
-                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_ZiCondExtEn";
+            measure Group RVZiCond;
+                source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.config_cg.cp_RVZiCond";
             endmeasure
         endfeature
         feature "Hard Reset";


### PR DESCRIPTION
It is better to follow the good nomenclature for parameter naming: "RV+extension" and camel notation