### PR TITLE
Logfile naming fix up and dashboard improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,6 +132,7 @@ smoke:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Basic"
     SPIKE_TANDEM: 1
+    COLLECT_SIMU_LOGS: 1
   parallel:
     matrix:
       - DV_SIMULATORS:
@@ -151,6 +152,7 @@ gen_smoke:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Basic"
     DV_SIMULATORS: "vcs-uvm,spike"
+    COLLECT_SIMU_LOGS: 1
   script:
     - bash verif/regress/smoke-gen_tests.sh
     - !reference [.simu_after_script]
@@ -242,9 +244,7 @@ fpga-build:
     - source $VIVADO_SETUP
     - source ./verif/sim/setup-env.sh
     - mkdir -p artifacts/logs
-    - make fpga target=$TARGET &> artifacts/logs/logfile.log
-    - tail -20 artifacts/logs/logfile.log > artifacts/logs/logfile.log.tail
-    - rm -f artifacts/logs/logfile.log
+    - make fpga target=$TARGET |& tail -20 > artifacts/logs/logfile.log.tail
     - mkdir -p artifacts/reports
     - mv corev_apu/fpga/work-fpga/ariane_xilinx.bit artifacts/ariane_xilinx_$TARGET.bit
     - python3 .gitlab-ci/scripts/report_fpga.py corev_apu/fpga/reports/ariane.utilization.rpt artifacts/logs/logfile.log.tail
@@ -280,6 +280,7 @@ riscv_arch_test:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
+    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-arch-test.sh
   after_script: *simu_after_script
 
@@ -292,6 +293,7 @@ compliance:
     DASHBOARD_SORT_INDEX: 2
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
+    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-compliance.sh
   after_script: *simu_after_script
 
@@ -306,6 +308,7 @@ riscv-tests-v:
     DV_SIMULATORS: "veri-testharness,spike"
     DV_TARGET: cv64a6_imafdc_sv39
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
+    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script
 
@@ -319,6 +322,7 @@ riscv-tests-p:
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-p.yaml"
+    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script
 

--- a/.gitlab-ci/scripts/report_simu.py
+++ b/.gitlab-ci/scripts/report_simu.py
@@ -15,8 +15,10 @@ import os
 with open(str(sys.argv[1]), 'r') as f:
     log = f.read()
 
+with_logs = os.environ.get("COLLECT_SIMU_LOGS") != None
+
 pattern = re.compile(
-    r'(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} INFO     )Compiling (.*): .*(tests\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} INFO     )Found matching ISS: (\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} INFO     )Target: (\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2}(?: INFO     ))ISA (\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (?:(?:INFO     )\[(\w*)\]: (\d*) matched(?:, (\d*) mismatch)?)|(?:^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2})(?: ERROR    )(\D{5})(?:.*)$))',
+    r'(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} INFO     )(?:Processing regression test list : (?:.*)/testlist_(.*-.*)(?:.yaml), test: (\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} INFO     )Compiling (.*):.*$|Compiling (.*): .*(tests\S*))$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} INFO     )Found matching ISS: (\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} INFO     )Target: (\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2}(?: INFO     ))ISA (\S*)$[\s\S]*?^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} (?:(?:INFO     )\[(\w*)\]: (\d*) matched(?:, (\d*) mismatch)?)|(?:^(?:\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2})(?: ERROR    )(\D{5})(?:.*)$))',
     re.MULTILINE)
 list_of_tests = pattern.findall(log)
 
@@ -24,32 +26,36 @@ metric = rb.TableStatusMetric('')
 
 metric.add_column("TARGET", "text")
 metric.add_column("ISA", "text")
-metric.add_column("TEST_TYPE", "text")
 metric.add_column("TEST", "text")
-metric.add_column("OUTPUT", "log")
-metric.add_column("TB_LOGS", "log")
-metric.add_column("DISASSEMBLY", "log")
+metric.add_column("TEST LIST", "text")
+
+if with_logs:
+    metric.add_column("OUTPUT", "log")
+    metric.add_column("TB LOGS", "log")
+    metric.add_column("DISASSEMBLY", "log")
 
 job_test_pass = 0
 job_test_total = 0
 
-logsPath = "logs/" + os.environ.get("CI_JOB_ID") + "/artifacts/logs/"
-
 for i in list_of_tests:
     job_test_total += 1
 
-    target = i[3]
-    isa = i[4]
-    testsuite = i[0]
-    test = i[1].split("/")[-1].split(".")[0]
+    target = i[6]
+    isa = i[7]
+    test = i[1] or i[4].split("/")[-1].split(".")[0]
+    testsuite = i[0] or "custom test"
+    test_type = i[2] or i[4]
 
-    output_log = logsPath + 'logfile.log.head'
-    tb_log = logsPath + test + "." + target + '.log.iss.head'
-    disassembly = logsPath + test + "." + target + '.csv.head'
+    if with_logs:
+        logsPath = "logs/" + os.environ.get("CI_JOB_ID") + "/artifacts/logs/"
+        output_log = logsPath + 'logfile.log.head'
+        tb_log = logsPath + test + "." + target + '.log.iss.head'
+        disassembly = logsPath + test + "." + target + '.csv.head'
+        col = [target, isa, test, testsuite, output_log, tb_log, disassembly]
+    else:
+        col = [target, isa, test, testsuite]
 
-    col = [target, isa, testsuite, test, output_log, tb_log, disassembly]
-
-    if i[5] == "PASSED":
+    if i[8] == "PASSED":
         metric.add_pass(*col)
         job_test_pass += 1
     else:

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -411,7 +411,7 @@ def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd, linker):
 
 
 def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
-                 setting_dir, debug_cmd, linker, priv, spike_params):
+                 setting_dir, debug_cmd, linker, priv, spike_params, test_name = None):
   """Run a directed assembly test with ISS
 
   Args:
@@ -455,12 +455,13 @@ def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, outp
   elf2bin(elf, binary, debug_cmd)
   log_list = []
   # ISS simulation
+  test_log_name = test_name or asm
   for iss in iss_list:
     run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
     if log_format == 1:
-      log = ("%s/%s_sim/%s_%d.%s.log" % (output_dir, iss, asm, test_iteration, target))
+      log = ("%s/%s_sim/%s_%d.%s.log" % (output_dir, iss, test_log_name, test_iteration, target))
     else:
-      log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, asm, target))
+      log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, test_log_name, target))
     log_list.append(log)
     base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spike_params)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
@@ -550,7 +551,7 @@ def run_elf(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
 
 
 def run_c(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
-          setting_dir, debug_cmd, linker, priv, spike_params):
+          setting_dir, debug_cmd, linker, priv, spike_params, test_name = None):
   """Run a directed c test with ISS
 
   Args:
@@ -592,12 +593,13 @@ def run_c(c_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, output_dir,
   elf2bin(elf, binary, debug_cmd)
   log_list = []
   # ISS simulation
+  test_log_name = test_name or c
   for iss in iss_list:
     run_cmd("mkdir -p %s/%s_sim" % (output_dir, iss))
     if log_format == 1:
-      log = ("%s/%s_sim/%s_%d.%s.log" % (output_dir, iss, c, test_iteration, target))
+      log = ("%s/%s_sim/%s_%d.%s.log" % (output_dir, iss, test_log_name, test_iteration, target))
     else:
-      log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, c, target))
+      log = ("%s/%s_sim/%s.%s.log" % (output_dir, iss, test_log_name, target))
     log_list.append(log)
     base_cmd = parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spike_params)
     cmd = get_iss_cmd(base_cmd, elf, target, log)
@@ -1284,7 +1286,7 @@ def main():
               elif os.path.isfile(path_asm_test):
                 run_assembly(path_asm_test, args.iss_yaml, args.isa, args.target, args.mabi, gcc_opts,
                              args.iss, output_dir, args.core_setting_dir, args.debug, args.linker,
-                             args.priv, args.spike_params)
+                             args.priv, args.spike_params, test_entry['test'])
               else:
                 if not args.debug:
                   logging.error('%s does not exist' % path_asm_test)
@@ -1314,7 +1316,7 @@ def main():
               elif os.path.isfile(path_c_test):
                 run_c(path_c_test, args.iss_yaml, args.isa, args.target, args.mabi, gcc_opts,
                       args.iss, output_dir, args.core_setting_dir, args.debug, args.linker,
-                      args.priv, args.spike_params)
+                      args.priv, args.spike_params, test_entry['test'])
               else:
                 if not args.debug:
                   logging.error('%s does not exist' % path_c_test)


### PR DESCRIPTION
* Adds more information on simulation job report
* Fixes issue https://github.com/openhwgroup/cva6/issues/1964 by using test name instead of source file name
* Avoid displaying the whole fpga synthesis on Gitlab job stdout