### PR TITLE
[DVplans] Fix broken paths to VPTOOL.

### DIFF
--- a/verif/docs/VerifPlans/AXI/runme.sh
+++ b/verif/docs/VerifPlans/AXI/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*
+sh $ROOTDIR/../../../../verif/core-v-verif/tools/vptool/vptool.sh $*

--- a/verif/docs/VerifPlans/CVXIF/runme.sh
+++ b/verif/docs/VerifPlans/CVXIF/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*
+sh $ROOTDIR/../../../../verif/core-v-verif/tools/vptool/vptool.sh $*

--- a/verif/docs/VerifPlans/FENCEI/runme.sh
+++ b/verif/docs/VerifPlans/FENCEI/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*
+sh $ROOTDIR/../../../../verif/core-v-verif/tools/vptool/vptool.sh $*

--- a/verif/docs/VerifPlans/FRONTEND/runme.sh
+++ b/verif/docs/VerifPlans/FRONTEND/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*
+sh $ROOTDIR/../../../../verif/core-v-verif/tools/vptool/vptool.sh $*

--- a/verif/docs/VerifPlans/MMU_SV32/runme.sh
+++ b/verif/docs/VerifPlans/MMU_SV32/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-python3 $ROOTDIR/../../../../tools/vptool/vptool/vp.py $*
+sh $ROOTDIR/../../../../verif/core-v-verif/tools/vptool/vptool.sh $*

--- a/verif/docs/VerifPlans/csr_access/runme.sh
+++ b/verif/docs/VerifPlans/csr_access/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*
+sh $ROOTDIR/../../../../verif/core-v-verif/tools/vptool/vptool.sh $*


### PR DESCRIPTION
Fix incorrect paths to VPTOOL that prevented correct operation of `runme.sh` scripts in:
- verif/docs/VerifPlans/AXI
- verif/docs/VerifPlans/CVXIF
- verif/docs/VerifPlans/FENCEI
- verif/docs/VerifPlans/FRONTEND
- verif/docs/VerifPlans/MMU_SV32
- verif/docs/VerifPlans/csr_access