### PR TITLE
ci: perform synthesis on cv32a6_embedded only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,11 +211,7 @@ asic-synthesis:
     INPUT_DELAY: "0.46"
     OUTPUT_DELAY: "0.11"
     PERIOD: "0.85"
-  parallel:
-    matrix:
-      - DV_TARGET:
-        - "cv32a6_embedded"
-        - "cv32a65x"
+    DV_TARGET: "cv32a6_embedded"
   script:
     - echo $SYNTH_PERIOD
     - echo $INPUT_DELAY


### PR DESCRIPTION
Synthesis of cv32a65x is not interesting *yet* and uses synthesis licenses.