### PR TITLE
Move `DCacheType` to config struct

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -14,154 +14,93 @@ dependencies:
   tech_cells_generic:
     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13 }
 
-frozen: true
+export_include_dirs:
+  - core/include
 
 sources:
   - include_dirs:
       - core/include
     files:
       - core/include/config_pkg.sv
-      - core/include/build_config_pkg.sv
+      # Pick the right configuration by passing the right bender flag.
       - target: cv64a6_imafdcv_sv39
         files:
           - core/include/cv64a6_imafdcv_sv39_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
-          - core/mmu_sv39/tlb.sv
-          - core/mmu_sv39/mmu.sv
-          - core/mmu_sv39/ptw.sv
-          - corev_apu/tb/common/mock_uart.sv
 
       - target: cv64a6_imafdc_sv39
         files:
           - core/include/cv64a6_imafdc_sv39_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
-          - core/mmu_sv39/tlb.sv
-          - core/mmu_sv39/mmu.sv
-          - core/mmu_sv39/ptw.sv
-          - core/cva6_accel_first_pass_decoder_stub.sv
 
       - target: cv64a6_imafdc_sv39_wb
         files:
           - core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
-          - core/mmu_sv39/tlb.sv
-          - core/mmu_sv39/mmu.sv
-          - core/mmu_sv39/ptw.sv
-          - core/cva6_accel_first_pass_decoder_stub.sv
 
       - target: cv64a6_imafdch_sv39
         files:
           - core/include/cv64a6_imafdch_sv39_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
-          - core/mmu_sv39x4/cva6_tlb_sv39x4.sv
-          - core/mmu_sv39x4/cva6_mmu_sv39x4.sv
-          - core/mmu_sv39x4/cva6_ptw_sv39x4.sv
-          - core/cva6_accel_first_pass_decoder_stub.sv
 
       - target: cv64a6_imafdch_sv39_wb
         files:
           - core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
-          - core/mmu_sv39x4/cva6_tlb_sv39x4.sv
-          - core/mmu_sv39x4/cva6_mmu_sv39x4.sv
-          - core/mmu_sv39x4/cva6_ptw_sv39x4.sv
-          - core/cva6_accel_first_pass_decoder_stub.sv
 
       - target: cv32a6_imac_sv0
         files:
           - core/include/cv32a6_imac_sv0_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
-          - core/mmu_sv32/cva6_tlb_sv32.sv
-          - core/mmu_sv32/cva6_mmu_sv32.sv
-          - core/mmu_sv32/cva6_ptw_sv32.sv
-          - core/cva6_accel_first_pass_decoder_stub.sv
 
       - target: cv32a6_imac_sv32
         files:
           - core/include/cv32a6_imac_sv32_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
-          - core/mmu_sv32/cva6_tlb_sv32.sv
-          - core/mmu_sv32/cva6_mmu_sv32.sv
-          - core/mmu_sv32/cva6_ptw_sv32.sv
-          - core/cva6_accel_first_pass_decoder_stub.sv
 
       - target: cv32a6_imafc_sv32
         files:
           - core/include/cv32a6_imafc_sv32_config_pkg.sv
-          - core/include/riscv_pkg.sv
-          - core/include/ariane_pkg.sv
+
+      # General config infrastructure
+      - core/include/riscv_pkg.sv
+      - core/include/ariane_pkg.sv
+      - core/include/build_config_pkg.sv
+
+      - target: not(exclude_first_pass_decoder)
+        files:
+          - core/cva6_accel_first_pass_decoder_stub.sv
+
+      # MMU
+      - target: any(cv64a6_imafdcv_sv39, cv64a6_imafdc_sv39, cv64a6_imafdc_sv39_wb)
+        files:
+          - core/mmu_sv39/tlb.sv
+          - core/mmu_sv39/mmu.sv
+          - core/mmu_sv39/ptw.sv
+
+      - target: any(cv64a6_imafdch_sv39, cv64a6_imafdch_sv39_wb)
+        files:
+          - core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+          - core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+          - core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+
+      - target: any(cv32a6_imac_sv0, cv32a6_imac_sv32, cv32a6_imafc_sv32)
+        files:
           - core/mmu_sv32/cva6_tlb_sv32.sv
           - core/mmu_sv32/cva6_mmu_sv32.sv
           - core/mmu_sv32/cva6_ptw_sv32.sv
-          - core/cva6_accel_first_pass_decoder_stub.sv
-
-      # included via target core/include/${TARGET_CFG}_config_pkg.sv
-      # ariane_axi_pkg is dependent on this.
-      # - vendor/pulp-platform/axi/src/axi_pkg.sv
 
       # Packages
       - core/include/wt_cache_pkg.sv
       - core/include/std_cache_pkg.sv
 
-      # for all the below files use Flist.cva6 as baseline and also look at Makefile pd/synth
-      # CVXIF
-      - core/include/instr_tracer_pkg.sv
+      # Extension Interface
       - core/include/cvxif_pkg.sv
       - core/cvxif_example/include/cvxif_instr_pkg.sv
       - core/cvxif_fu.sv
       - core/cvxif_example/cvxif_example_coprocessor.sv
       - core/cvxif_example/instr_decoder.sv
 
+      # Tracing
       - core/cva6_rvfi_probes.sv
       - core/cva6_fifo_v3.sv
-      # vendored deps
-      # - include_dirs: [vendor/pulp-platform/common_cells/include/, vendor/pulp-platform/common_cells/src/]
-      #   files:
-      #     - vendor/pulp-platform/common_cells/src/cf_math_pkg.sv
-      #     - vendor/pulp-platform/common_cells/src/lfsr.sv
-      #     - vendor/pulp-platform/common_cells/src/lzc.sv
-      #     - vendor/pulp-platform/common_cells/src/rr_arb_tree.sv
-      #     - vendor/pulp-platform/common_cells/src/shift_reg.sv
-      #     - vendor/pulp-platform/common_cells/src/unread.sv
-      #     - vendor/pulp-platform/common_cells/src/popcount.sv
-      #     - vendor/pulp-platform/common_cells/src/exp_backoff.sv
-      #     # Common Cells for example coprocessor
-      #     - vendor/pulp-platform/common_cells/src/counter.sv
-      #     - vendor/pulp-platform/common_cells/src/delta_counter.sv
-
-      # Floating point unit
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_pkg.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_cast_multi.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_classifier.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_divsqrt_multi.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_fma_multi.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_fma.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_noncomp.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_opgroup_block.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_opgroup_fmt_slice.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_opgroup_multifmt_slice.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_rounding.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpnew_top.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv
-      #     - vendor/openhwgroup/cvfpu/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv
-
       # Top-level source files (not necessarily instantiated at the top of the cva6).
       - core/cva6.sv
       - core/alu.sv
-      # Note: depends on fpnew_pkg, above
-      - core/fpu_wrap.sv
+      - core/fpu_wrap.sv # depends on fpnew_pkg, above
       - core/branch_unit.sv
       - core/compressed_decoder.sv
       - core/controller.sv
@@ -182,7 +121,6 @@ sources:
       - core/perf_counters.sv
       - core/ariane_regfile_ff.sv
       - core/ariane_regfile_fpga.sv
-      # NOTE: scoreboard.sv modified for DSIM (unchanged for other simulators)
       - core/scoreboard.sv
       - core/store_buffer.sv
       - core/amo_buffer.sv
@@ -190,23 +128,22 @@ sources:
       - core/commit_stage.sv
       - core/axi_shim.sv
 
-      # What is "frontend"?
+      # Frontend (i.e., fetch, decode, dispatch)
       - core/frontend/btb.sv
       - core/frontend/bht.sv
       - core/frontend/ras.sv
       - core/frontend/instr_scan.sv
       - core/frontend/instr_queue.sv
       - core/frontend/frontend.sv
-
-      # Cache subsystem
+      # Cache subsystem(s)
       - core/cache_subsystem/wt_dcache_ctrl.sv
       - core/cache_subsystem/wt_dcache_mem.sv
       - core/cache_subsystem/wt_dcache_missunit.sv
       - core/cache_subsystem/wt_dcache_wbuffer.sv
       - core/cache_subsystem/wt_dcache.sv
-      - core/cache_subsystem/cva6_icache.sv
       - core/cache_subsystem/wt_cache_subsystem.sv
       - core/cache_subsystem/wt_axi_adapter.sv
+      - core/cache_subsystem/cva6_icache.sv
       - core/cache_subsystem/tag_cmp.sv
       - core/cache_subsystem/cva6_icache_axi_wrapper.sv
       - core/cache_subsystem/axi_adapter.sv
@@ -216,7 +153,6 @@ sources:
       - core/cache_subsystem/std_cache_subsystem.sv
 
       # Physical Memory Protection
-      # NOTE: pmp.sv modified for DSIM (unchanged for other simulators)
       - core/pmp/src/pmp.sv
       - core/pmp/src/pmp_entry.sv
 
@@ -230,7 +166,6 @@ sources:
           - common/local/util
         files:
           - common/local/util/tc_sram_wrapper.sv
-          # - vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
 
       - target: all(fpga, xilinx)
         include_dirs:
@@ -246,49 +181,3 @@ sources:
           # Tracer (behavioral code, not RTL)
           - core/include/instr_tracer_pkg.sv
           - common/local/util/instr_tracer.sv
-
-    # TODO target define FPGA target + verification etc
-    #   - target: test
-    #     files:
-    #       - corev_apu/riscv-dbg/src/dm_pkg.sv
-    #       - corev_apu/tb/ariane_soc_pkg.sv
-    #       - corev_apu/tb/ariane_axi_soc_pkg.sv
-    #       - corev_apu/tb/ariane_testharness.sv
-    #       - corev_apu/tb/ariane_peripherals.sv
-    #       - corev_apu/tb/common/uart.sv
-    #       - corev_apu/tb/common/SimDTM.sv
-    #       - corev_apu/tb/common/SimJTAG.sv
-
-    # - target: all(fpga, xilinx)
-    #   files:
-    #   - corev_apu/fpga/src/ariane_peripherals_xilinx.sv
-    #   - corev_apu/fpga/src/ariane_xilinx.sv
-    #   - corev_apu/fpga/src/fan_ctrl.sv
-    #   - corev_apu/fpga/src/bootrom/bootrom.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/ssio_ddr_in.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_soc.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/axis_gmii_rx.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/oddr.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/axis_gmii_tx.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/dualmem_widen8.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_phy_if.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/dualmem_widen.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_lfsr.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_core.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g_rgmii.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g_rgmii_fifo.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/iddr.sv
-    #   - corev_apu/fpga/src/ariane-ethernet/framing_top.sv
-    #   - corev_apu/fpga/src/apb_uart/src/apb_uart.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/uart_transmitter.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/uart_interrupt.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/slib_mv_filter.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/slib_input_filter.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/slib_counter.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/uart_receiver.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/slib_input_sync.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/slib_edge_detect.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/slib_clock_div.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/slib_fifo.vhd
-    #   - corev_apu/fpga/src/apb_uart/src/uart_baudgen.vhd

--- a/core/cache_subsystem/wt_cache_subsystem.sv
+++ b/core/cache_subsystem/wt_cache_subsystem.sv
@@ -14,7 +14,7 @@
 //              coherent memory system.
 //
 //              Define PITON_ARIANE if you want to use this cache.
-//              Define DCACHE_TYPE if you want to use this cache
+//              Define CVA6Cfg.DCacheType if you want to use this cache
 //              with a standard 64 bit AXI interface instead of the OpenPiton
 //              L1.5 interface.
 

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -246,7 +246,7 @@ module commit_stage
       // from interrupt service routine
       // Fence synchronizes data and instruction streams. That means that we need to flush the private icache
       // and the private dcache. This is the most expensive instruction.
-      if (commit_instr_i[0].op == FENCE_I || (flush_dcache_i && DCACHE_TYPE == int'(config_pkg::WB) && commit_instr_i[0].fu != STORE)) begin
+      if (commit_instr_i[0].op == FENCE_I || (flush_dcache_i && CVA6Cfg.DCacheType == config_pkg::WB && commit_instr_i[0].fu != STORE)) begin
         commit_ack_o[0] = no_st_pending_i;
         // tell the controller to flush the I$
         fence_i_o = no_st_pending_i;

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -120,7 +120,7 @@ module controller
       flush_ex_o             = 1'b1;
       // this is not needed in the case since we
       // have a write-through cache in this case
-      if (DCACHE_TYPE == int'(config_pkg::WB)) begin
+      if (CVA6Cfg.DCacheType == config_pkg::WB) begin
         flush_dcache   = 1'b1;
         fence_active_d = 1'b1;
       end
@@ -138,7 +138,7 @@ module controller
       flush_icache_o         = 1'b1;
       // this is not needed in the case since we
       // have a write-through cache in this case
-      if (DCACHE_TYPE == int'(config_pkg::WB)) begin
+      if (CVA6Cfg.DCacheType == config_pkg::WB) begin
         flush_dcache   = 1'b1;
         fence_active_d = 1'b1;
       end
@@ -146,7 +146,7 @@ module controller
 
     // this is not needed in the case since we
     // have a write-through cache in this case
-    if (DCACHE_TYPE == int'(config_pkg::WB)) begin
+    if (CVA6Cfg.DCacheType == config_pkg::WB) begin
       // wait for the acknowledge here
       if (flush_dcache_ack_i && fence_active_q) begin
         fence_active_d = 1'b0;
@@ -238,7 +238,7 @@ module controller
   // ----------------------
   always_comb begin
     // halt the core if the fence is active
-    halt_o = halt_csr_i || halt_acc_i || (DCACHE_TYPE == int'(config_pkg::WB) && fence_active_q);
+    halt_o = halt_csr_i || halt_acc_i || (CVA6Cfg.DCacheType == config_pkg::WB && fence_active_q);
   end
 
   // ----------------------

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1191,7 +1191,7 @@ module cva6
     dcache_req_ports_cache_acc[1].data_gnt &= !dcache_req_ports_ex_cache[2].data_req;
   end
 
-  if (DCACHE_TYPE == int'(config_pkg::WT)) begin : gen_cache_wt
+  if (CVA6Cfg.DCacheType == config_pkg::WT) begin : gen_cache_wt
     // this is a cache subsystem that is compatible with OpenPiton
     wt_cache_subsystem #(
         .CVA6Cfg   (CVA6Cfg),
@@ -1240,7 +1240,7 @@ module cva6
         .inval_valid_i     (inval_valid),
         .inval_ready_o     (inval_ready)
     );
-  end else if (DCACHE_TYPE == int'(config_pkg::HPDCACHE)) begin : gen_cache_hpd
+  end else if (CVA6Cfg.DCacheType == config_pkg::HPDCACHE) begin : gen_cache_hpd
     cva6_hpdcache_subsystem #(
         .CVA6Cfg   (CVA6Cfg),
         .icache_areq_t(icache_areq_t),

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -36,12 +36,11 @@ package ariane_pkg;
   // depth of store-buffers, this needs to be a power of two
   localparam logic [2:0] DEPTH_SPEC = 'd4;
 
-  localparam int unsigned DCACHE_TYPE = int'(cva6_config_pkg::CVA6ConfigDcacheType);
-  // if DCACHE_TYPE = cva6_config_pkg::WT
+  // if CVA6Cfg.DCacheType = cva6_config_pkg::WT
   // we can use a small commit queue since we have a write buffer in the dcache
   // we could in principle do without the commit queue in this case, but the timing degrades if we do that due
   // to longer paths into the commit stage
-  // if DCACHE_TYPE = cva6_config_pkg::WB
+  // if CVA6Cfg.DCacheType = cva6_config_pkg::WB
   // allocate more space for the commit buffer to be on the save side, this needs to be a power of two
   localparam logic [2:0] DEPTH_COMMIT = 'd4;
 
@@ -772,7 +771,7 @@ package ariane_pkg;
   function automatic logic is_trans_2M(input logic s_st_enbl, input logic g_st_enbl,
                                        input logic is_s_1G, input logic is_s_2M,
                                        input logic is_g_1G, input logic is_g_2M);
-    return  (s_st_enbl && g_st_enbl) ? 
+    return  (s_st_enbl && g_st_enbl) ?
                 ((is_s_2M && (is_g_1G || is_g_2M)) || (is_g_2M && (is_s_1G || is_s_2M))) :
                 ((is_s_2M && s_st_enbl) || (is_g_2M && g_st_enbl));
   endfunction : is_trans_2M

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -111,6 +111,7 @@ package build_config_pkg;
     cfg.ICACHE_TAG_WIDTH = cfg.PLEN - ICACHE_INDEX_WIDTH;
     cfg.ICACHE_LINE_WIDTH = CVA6Cfg.IcacheLineWidth;
     cfg.ICACHE_USER_LINE_WIDTH = (CVA6Cfg.AxiUserWidth == 1) ? 4 : CVA6Cfg.IcacheLineWidth;
+    cfg.DCacheType = CVA6Cfg.DCacheType;
     cfg.DCACHE_SET_ASSOC = CVA6Cfg.DcacheSetAssoc;
     cfg.DCACHE_SET_ASSOC_WIDTH = $clog2(CVA6Cfg.DcacheSetAssoc);
     cfg.DCACHE_INDEX_WIDTH = DCACHE_INDEX_WIDTH;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -257,7 +257,7 @@ package config_pkg;
     int unsigned ICACHE_TAG_WIDTH;
     int unsigned ICACHE_LINE_WIDTH;
     int unsigned ICACHE_USER_LINE_WIDTH;
-    cache_type_t                 DCacheType;
+    cache_type_t DCacheType;
     int unsigned DCACHE_SET_ASSOC;
     int unsigned DCACHE_SET_ASSOC_WIDTH;
     int unsigned DCACHE_INDEX_WIDTH;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -136,6 +136,8 @@ package config_pkg;
     int unsigned                 IcacheSetAssoc;
     // Instruction cache line width
     int unsigned                 IcacheLineWidth;
+    // Cache Type
+    cache_type_t                 DCacheType;
     // Data cache size (in bytes)
     int unsigned                 DcacheByteSize;
     // Data cache associativity (number of ways)
@@ -255,6 +257,7 @@ package config_pkg;
     int unsigned ICACHE_TAG_WIDTH;
     int unsigned ICACHE_LINE_WIDTH;
     int unsigned ICACHE_USER_LINE_WIDTH;
+    cache_type_t                 DCacheType;
     int unsigned DCACHE_SET_ASSOC;
     int unsigned DCACHE_SET_ASSOC_WIDTH;
     int unsigned DCACHE_INDEX_WIDTH;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -70,8 +70,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 0;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -130,6 +128,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -70,6 +70,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 0;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -128,7 +130,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -70,8 +70,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 0;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -130,6 +128,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -70,6 +70,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 0;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -128,7 +130,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WB;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -134,6 +132,7 @@ package cva6_config_pkg;
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),
+      DCacheType: config_pkg::WB,
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
       FetchUserEn: unsigned'(CVA6ConfigFetchUserEn)

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WB;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -132,7 +134,7 @@ package cva6_config_pkg;
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),
-      DCacheType: config_pkg::WB,
+      DCacheType: CVA6ConfigDcacheType,
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
       FetchUserEn: unsigned'(CVA6ConfigFetchUserEn)

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -78,8 +78,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::HPDCACHE;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -138,6 +136,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::HPDCACHE,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -78,6 +78,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::HPDCACHE;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -136,7 +138,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::HPDCACHE,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WT,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WT,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WB;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -129,7 +131,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
-      DCacheType: config_pkg::WB,
+      DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WB;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -131,6 +129,7 @@ package cva6_config_pkg;
       IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
       IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
       IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      DCacheType: config_pkg::WB,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -123,7 +125,7 @@ package cva6_config_pkg;
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
       AxiBurstWriteEn: bit'(0),
-      DCacheType: config_pkg::WT
+      DCacheType: CVA6ConfigDcacheType
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -124,7 +122,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      AxiBurstWriteEn: bit'(0)
+      AxiBurstWriteEn: bit'(0),
+      DCacheType: config_pkg::WT
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WB;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -124,7 +122,8 @@ package cva6_config_pkg;
       CachedRegionLength: 1024'({64'h40000000}),
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
-      AxiBurstWriteEn: bit'(0)
+      AxiBurstWriteEn: bit'(0),
+      DCacheType: config_pkg::WB
   };
 
 endpackage

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WB;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -123,7 +125,7 @@ package cva6_config_pkg;
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(1),
       AxiBurstWriteEn: bit'(0),
-      DCacheType: config_pkg::WB
+      DCacheType: CVA6ConfigDcacheType
   };
 
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -71,6 +71,8 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -135,6 +137,6 @@ package cva6_config_pkg;
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
       FetchUserEn: unsigned'(CVA6ConfigFetchUserEn),
-      DCacheType: config_pkg::WT
+      DCacheType: CVA6ConfigDcacheType
   };
 endpackage

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -71,8 +71,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigPerfCounterEn = 1;
 
-  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
-
   localparam CVA6ConfigMmuPresent = 1;
 
   localparam CVA6ConfigRvfiTrace = 1;
@@ -136,6 +134,7 @@ package cva6_config_pkg;
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),
       DataUserEn: unsigned'(CVA6ConfigDataUserEn),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
-      FetchUserEn: unsigned'(CVA6ConfigFetchUserEn)
+      FetchUserEn: unsigned'(CVA6ConfigFetchUserEn),
+      DCacheType: config_pkg::WT
   };
 endpackage


### PR DESCRIPTION
As discussed on Mattermost, this moves the DCacheType into the new parameterization. I am also sneaking in some other Bender changes that should not make troubles for other users.

A general note: We are maintaining quite a lot of different configurations, wondering whether that makes sense.

/cc @domenicw 