### PR TITLE
fix util/user_config.py for DCacheType

### DIFF
--- a/util/user_config.py
+++ b/util/user_config.py
@@ -116,7 +116,7 @@ def replace_param(lines, i_params, name, new_value):
 # Statement parsers
 
 param_re = re.compile(
-    r"^(\s*localparam\s+)(?P<name>\w+)(\s*=\s*)(?P<value>[^;]+)(;.*)$"
+    r"^(\s*localparam\b.*?\b)(?P<name>\w+)(\s*=\s*)(?P<value>[^;]+)(;.*)$"
 )
 
 
@@ -253,9 +253,15 @@ def write_file(path, lines):
 # Command line interface
 
 if __name__ == "__main__":
-    base, changes = parse_derive_args(sys.argv[1:])
+    if len(sys.argv) == 2:
+        target = sys.argv[1]
+        config = get_config(f"core/include/{target}_config_pkg.sv")
+        for k, v in config.items():
+            print(f"{k} = {v}")
+    elif len(sys.argv) > 1:
+        base, changes = parse_derive_args(sys.argv[1:])
 
-    input_file = f"core/include/{base}_config_pkg.sv"
-    output_file = "core/include/gen_config_pkg.sv"
+        input_file = f"core/include/{base}_config_pkg.sv"
+        output_file = "core/include/gen_config_pkg.sv"
 
-    derive_config(input_file, output_file, changes)
+        derive_config(input_file, output_file, changes)


### PR DESCRIPTION
https://github.com/openhwgroup/cva6/pull/2025 introduces a new case which was not tested yet.
This modifications makes the script able to handle this case.

By the way, for debugging purpose, the script can now be run with a single argument (the configuration) to print the configuration interpreted as Python variables.