### PR TITLE
fix exit code

### DIFF
--- a/verif/tests/custom/common/crt.S
+++ b/verif/tests/custom/common/crt.S
@@ -245,8 +245,7 @@ exit:
   // Minimal low-level exit function.
   .global  _exit
 _exit:
-  sll  a0, a0, 1      # Set up exit code: shift a0 left by 1
-  add  a0, a0, 1      # and set bit 0.
+  li   a0, 0x1        # and set bit 0.
   sw   a0, tohost, t5 # Store bits [31:0] of a0 into variable tohost
   nop                 # Leave one cycle of slack before entering endless loop
 1:


### PR DESCRIPTION
To fix #2012

The previous code would fail to exit normally under certain circumstances. 

For example, before exiting, `a0=0b01` (which becomes `0b10` after left shifting), so it is necessary to clear the value of `a0` before exiting.