### PR TITLE
Clean-up 65x config_pkg.sv file by removing the localparams

### DIFF
--- a/core/cva6_rvfi_probes.sv
+++ b/core/cva6_rvfi_probes.sv
@@ -93,7 +93,7 @@ module cva6_rvfi_probes
 
     instr.commit_pointer = commit_pointer_i;
 
-    for (int i = 0; i < cva6_config_pkg::CVA6ConfigNrCommitPorts; i++) begin
+    for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
       instr.commit_instr_pc[i] = commit_instr_i[i].pc;
       instr.commit_instr_op[i] = commit_instr_i[i].op;
       instr.commit_instr_rs1[i] = commit_instr_i[i].rs1;

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -11,7 +11,6 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigXlen = 32;
 
-  localparam CVA6ConfigFpuEn = 0;
   localparam CVA6ConfigF16En = 0;
   localparam CVA6ConfigF16AltEn = 0;
   localparam CVA6ConfigF8En = 0;
@@ -86,7 +85,7 @@ package cva6_config_pkg;
       AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
       MemTidWidth: unsigned'(CVA6ConfigMemTidWidth),
       NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
-      FpuEn: bit'(CVA6ConfigFpuEn),
+      FpuEn: bit'(0),
       XF16: bit'(CVA6ConfigF16En),
       XF16ALT: bit'(CVA6ConfigF16AltEn),
       XF8: bit'(CVA6ConfigF8En),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -11,38 +11,20 @@ package cva6_config_pkg;
 
   localparam CVA6ConfigXlen = 32;
 
-  localparam CVA6ConfigF16En = 0;
-  localparam CVA6ConfigF16AltEn = 0;
-  localparam CVA6ConfigF8En = 0;
-  localparam CVA6ConfigFVecEn = 0;
-
   localparam CVA6ConfigCvxifEn = 1;
   localparam CVA6ConfigCExtEn = 1;
-  localparam CVA6ConfigZcbExtEn = 1;
-  localparam CVA6ConfigZcmpExtEn = 0;
-  localparam CVA6ConfigAExtEn = 0;
-  localparam CVA6ConfigHExtEn = 0;
   localparam CVA6ConfigBExtEn = 1;
   localparam CVA6ConfigVExtEn = 0;
-  localparam CVA6ConfigRVZiCond = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
   localparam CVA6ConfigAxiDataWidth = 64;
-  localparam CVA6ConfigFetchUserEn = 0;
-  localparam CVA6ConfigFetchUserWidth = 32;
-  localparam CVA6ConfigDataUserEn = 0;
   localparam CVA6ConfigDataUserWidth = 32;
 
-  localparam CVA6ConfigIcacheByteSize = 2048;
-  localparam CVA6ConfigIcacheSetAssoc = 2;
-  localparam CVA6ConfigIcacheLineWidth = 128;
+  localparam CVA6ConfigDcacheIdWidth = 1;
   localparam CVA6ConfigDcacheByteSize = 32768;
   localparam CVA6ConfigDcacheSetAssoc = 8;
   localparam CVA6ConfigDcacheLineWidth = 128;
-
-  localparam CVA6ConfigDcacheIdWidth = 1;
-  localparam CVA6ConfigMemTidWidth = 2;
 
   localparam CVA6ConfigWtDcacheWbufDepth = 2;
 
@@ -50,22 +32,12 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrCommitPorts = 1;
   localparam CVA6ConfigNrScoreboardEntries = 4;
 
-  localparam CVA6ConfigFpgaEn = 0;
-
   localparam CVA6ConfigNrLoadPipeRegs = 0;
   localparam CVA6ConfigNrStorePipeRegs = 0;
   localparam CVA6ConfigNrLoadBufEntries = 1;
 
   localparam CVA6ConfigInstrTlbEntries = 2;
   localparam CVA6ConfigDataTlbEntries = 2;
-
-  localparam CVA6ConfigRASDepth = 2;
-  localparam CVA6ConfigBTBEntries = 0;
-  localparam CVA6ConfigBHTEntries = 32;
-
-  localparam CVA6ConfigTvalEn = 0;
-
-  localparam CVA6ConfigNrPMPEntries = 8;
 
   localparam CVA6ConfigPerfCounterEn = 0;
 
@@ -77,39 +49,39 @@ package cva6_config_pkg;
 
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
-      FpgaEn: bit'(CVA6ConfigFpgaEn),
+      FpgaEn: bit'(0),
       NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
       AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
       AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
       AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
-      MemTidWidth: unsigned'(CVA6ConfigMemTidWidth),
-      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      MemTidWidth: unsigned'(2),
+      NrLoadBufEntries: unsigned'(1),
       FpuEn: bit'(0),
-      XF16: bit'(CVA6ConfigF16En),
-      XF16ALT: bit'(CVA6ConfigF16AltEn),
-      XF8: bit'(CVA6ConfigF8En),
-      RVA: bit'(CVA6ConfigAExtEn),
+      XF16: bit'(0),
+      XF16ALT: bit'(0),
+      XF8: bit'(0),
+      RVA: bit'(0),
       RVB: bit'(CVA6ConfigBExtEn),
       RVV: bit'(CVA6ConfigVExtEn),
       RVC: bit'(CVA6ConfigCExtEn),
-      RVH: bit'(CVA6ConfigHExtEn),
-      RVZCB: bit'(CVA6ConfigZcbExtEn),
-      RVZCMP: bit'(CVA6ConfigZcmpExtEn),
-      XFVec: bit'(CVA6ConfigFVecEn),
+      RVH: bit'(0),
+      RVZCB: bit'(1),
+      RVZCMP: bit'(0),
+      XFVec: bit'(0),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      RVZiCond: bit'(CVA6ConfigRVZiCond),
+      RVZiCond: bit'(0),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       RVS: bit'(0),
       RVU: bit'(0),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
-      RASDepth: unsigned'(CVA6ConfigRASDepth),
-      BTBEntries: unsigned'(CVA6ConfigBTBEntries),
-      BHTEntries: unsigned'(CVA6ConfigBHTEntries),
+      RASDepth: unsigned'(2),
+      BTBEntries: unsigned'(0),
+      BHTEntries: unsigned'(32),
       DmBaseAddress: 64'h0,
-      TvalEn: bit'(CVA6ConfigTvalEn),
-      NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
+      TvalEn: bit'(0),
+      NrPMPEntries: unsigned'(8),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},
       PMPEntryReadOnly: 16'd0,
@@ -126,16 +98,16 @@ package cva6_config_pkg;
       MaxOutstandingStores: unsigned'(7),
       DebugEn: bit'(0),
       AxiBurstWriteEn: bit'(0),
-      IcacheByteSize: unsigned'(CVA6ConfigIcacheByteSize),
-      IcacheSetAssoc: unsigned'(CVA6ConfigIcacheSetAssoc),
-      IcacheLineWidth: unsigned'(CVA6ConfigIcacheLineWidth),
+      IcacheByteSize: unsigned'(2048),
+      IcacheSetAssoc: unsigned'(2),
+      IcacheLineWidth: unsigned'(128),
       DCacheType: CVA6ConfigDcacheType,
       DcacheByteSize: unsigned'(CVA6ConfigDcacheByteSize),
       DcacheSetAssoc: unsigned'(CVA6ConfigDcacheSetAssoc),
       DcacheLineWidth: unsigned'(CVA6ConfigDcacheLineWidth),
-      DataUserEn: unsigned'(CVA6ConfigDataUserEn),
-      FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
-      FetchUserEn: unsigned'(CVA6ConfigFetchUserEn)
+      DataUserEn: unsigned'(0),
+      FetchUserWidth: unsigned'(32),
+      FetchUserEn: unsigned'(0)
   };
 
 endpackage


### PR DESCRIPTION
The goal is to remove all the localparams of config_pkg.sv. The work is not finished, to be continued