### PR TITLE
decoder.sv: fix ZEXT.H instruction (fix #1758, #1975, #2010)

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -78,7 +78,7 @@ module decoder
     input logic vtw_i,
     // Trap sret - CSR_REGFILE
     input logic tsr_i,
-    // Hypervisor user mode - CSR_REGFILE 
+    // Hypervisor user mode - CSR_REGFILE
     input logic hu_i,
     // Instruction to be added to scoreboard entry - ISSUE_STAGE
     output scoreboard_entry_t instruction_o,
@@ -776,8 +776,14 @@ module decoder
                 // Bitwise Shifting
                 {7'b011_0000, 3'b001} : instruction_o.op = ariane_pkg::ROL;  // rol
                 {7'b011_0000, 3'b101} : instruction_o.op = ariane_pkg::ROR;  // ror
-                // Zero Extend Op
-                {7'b000_0100, 3'b100} : instruction_o.op = ariane_pkg::ZEXTH;
+                // Zero Extend Op RV32 encoding
+                {
+                  7'b000_0100, 3'b100
+                } : begin
+                  if (!CVA6Cfg.IS_XLEN64 && instr.instr[24:20] == 5'b00000)
+                    instruction_o.op = ariane_pkg::ZEXTH;
+                  else illegal_instr_bm = 1'b1;
+                end
                 default: begin
                   illegal_instr_bm = 1'b1;
                 end
@@ -845,6 +851,14 @@ module decoder
                 // Bitwise Shifting
                 {7'b011_0000, 3'b001}: instruction_o.op = ariane_pkg::ROLW;     // rolw
                 {7'b011_0000, 3'b101}: instruction_o.op = ariane_pkg::RORW;     // rorw
+                // Zero Extend Op RV64 encoding
+                {7'b000_0100, 3'b100}:
+                begin
+                  if (instr.instr[24:20] == 5'b00000)
+                    instruction_o.op = ariane_pkg::ZEXTH;
+                  else
+                    illegal_instr_bm = 1'b1;
+                end
                 default: illegal_instr_bm = 1'b1;
               endcase
               illegal_instr = illegal_instr_non_bm & illegal_instr_bm;


### PR DESCRIPTION
- add missing ZEXT.H for RV64
- fix ZEXT.H for RV32: bit[24:20] shall be 0