### PR TITLE
[HOTFIX] Add missing 'build' directory belonging in vendorized ISA docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Bender.lock
 /tools/
 /util/gcc-toolchain-builder/src/
 /util/gcc-toolchain-builder/build/
+# Both following lines are needed to list contents of ISA manual build dir.
+!/vendor/riscv/riscv-isa-manual/build/
+!/vendor/riscv/riscv-isa-manual/build/*

--- a/vendor/riscv/riscv-isa-manual/build/.gitignore
+++ b/vendor/riscv/riscv-isa-manual/build/.gitignore
@@ -1,0 +1,11 @@
+*.aux
+*.bbl
+*.blg
+*.html
+*.log
+*.out
+*.pdf
+*.pdf.tmp
+*.toc
+images
+.asciidoctor

--- a/vendor/riscv/riscv-isa-manual/build/Makefile
+++ b/vendor/riscv/riscv-isa-manual/build/Makefile
@@ -1,0 +1,119 @@
+# Makefile for RISC-V ISA Manuals
+#
+# This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
+# International License. To view a copy of this license, visit
+# http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+# Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+#
+# Description:
+# 
+# This Makefile is designed to automate the process of building and packaging 
+# the documentation for RISC-V ISA Manuals. It supports multiple build targets 
+# for generating documentation in various formats (PDF, HTML).
+
+# Build Targets
+TARGETS := priv unpriv priv-html unpriv-html priv-latex
+
+# Declare phony targets
+.PHONY: all $(TARGETS) clean
+
+# Default target builds all
+all: $(TARGETS)
+
+# Build with preinstalled docker container; first install it with:
+#   docker pull riscvintl/riscv-docs-base-container-image:latest
+docker:
+	cd .. && docker run -it -v .:/build riscvintl/riscv-docs-base-container-image:latest /bin/sh -c 'cd ./build; make'
+
+# Asciidoctor options
+ASCIIDOCTOR_OPTS := -a compress \
+                    --attribute=mathematical-format=svg \
+                    --failure-level=ERROR \
+                    --require=asciidoctor-bibtex \
+                    --require=asciidoctor-diagram \
+                    --require=asciidoctor-mathematical \
+                    --trace
+
+# Source directory
+SRCDIR := ../src
+
+# LaTeX source and related files
+SRCS := $(wildcard $(SRCDIR)/latex/*.tex)
+FIGS := $(wildcard $(SRCDIR)/latex/figs/*)
+BIBS := $(SRCDIR)/latex/riscv-spec.bib
+
+# LaTeX build tools
+PDFLATEX := TEXINPUTS=$(SRCDIR)/latex: pdflatex -interaction=nonstopmode -halt-on-error
+BIBTEX := BIBINPUTS=$(SRCDIR)/latex: bibtex
+
+# Temporary files to clean up for LaTeX build
+JUNK := *.pdf *.aux *.log *.bbl *.blg *.toc *.out *.fdb_latexmk *.fls *.synctex.gz
+
+# Privileged ISA build
+priv: priv-isa-asciidoc.pdf
+
+priv-isa-asciidoc.pdf: $(SRCDIR)/riscv-privileged.adoc $(SRCDIR)/*.adoc
+	@echo "Building Privileged ISA"
+	rm -f $@.tmp
+	asciidoctor-pdf $(ASCIIDOCTOR_OPTS) --out-file=$@.tmp $<
+	mv $@.tmp $@
+
+# Unprivileged ISA build
+unpriv: unpriv-isa-asciidoc.pdf
+
+unpriv-isa-asciidoc.pdf: $(SRCDIR)/riscv-unprivileged.adoc $(SRCDIR)/*.adoc
+	@echo "Building Unprivileged ISA"
+	rm -f $@.tmp
+	asciidoctor-pdf $(ASCIIDOCTOR_OPTS) --out-file=$@.tmp $<
+	mv $@.tmp $@
+
+# Privileged ISA HTML build
+priv-html: priv-isa-asciidoc.html
+
+priv-isa-asciidoc.html: $(SRCDIR)/riscv-privileged.adoc
+	@echo "Building Privileged ISA HTML"
+	asciidoctor $(ASCIIDOCTOR_OPTS) --out-file=$@ $<
+
+# Unprivileged ISA HTML build
+unpriv-html: unpriv-isa-asciidoc.html
+
+unpriv-isa-asciidoc.html: $(SRCDIR)/riscv-unprivileged.adoc
+	@echo "Building Unprivileged ISA HTML"
+	asciidoctor $(ASCIIDOCTOR_OPTS) --out-file=$@ $<
+
+# LaTeX build for Privileged ISA
+priv-latex: riscv-privileged.pdf
+
+riscv-privileged.pdf: $(SRCDIR)/latex/riscv-privileged.tex $(SRCS) $(FIGS) $(BIBS)
+	$(PDFLATEX) riscv-privileged
+	$(BIBTEX) riscv-privileged
+	$(PDFLATEX) riscv-privileged
+	$(PDFLATEX) riscv-privileged
+
+clean:
+	@if [ -f priv-isa-asciidoc.pdf ]; then \
+		echo "Removing priv-isa-asciidoc.pdf"; \
+		rm -f priv-isa-asciidoc.pdf; \
+	fi
+	@if [ -f unpriv-isa-asciidoc.pdf ]; then \
+		echo "Removing unpriv-isa-asciidoc.pdf"; \
+		rm -f unpriv-isa-asciidoc.pdf; \
+	fi
+	@if [ -f priv-isa-asciidoc.html ]; then \
+		echo "Removing priv-isa-asciidoc.html"; \
+		rm -f priv-isa-asciidoc.html; \
+	fi
+	@if [ -f unpriv-isa-asciidoc.html ]; then \
+		echo "Removing unpriv-isa-asciidoc.html"; \
+		rm -f unpriv-isa-asciidoc.html; \
+	fi
+	@echo "Cleaning up files from LaTeX build"
+	@cd $(SRCDIR)/latex; \
+	for file in $(JUNK); do \
+		if [ -f "$$file" ]; then \
+			echo "Removing $$file"; \
+			rm -f "$$file"; \
+		fi; \
+	done


### PR DESCRIPTION
- `.gitignore`: Enable Git visibility of the `build` subdir in vendorized ISA docs
- `vendor/riscv/riscv-isa-manual`: Add contents of the directory (contains a.o. a Makefile.)