### PR TITLE
[UVM] Few LRM compliance fixes

### DIFF
--- a/verif/env/corev-dv/cva6_illegal_instr.sv
+++ b/verif/env/corev-dv/cva6_illegal_instr.sv
@@ -63,7 +63,7 @@ class cva6_illegal_instr_c extends riscv_illegal_instr;
 
   // Invalid SYSTEM instructions
   constraint system_instr_c {
-    if (!(SUPERVISOR_MODE inside supported_privileged_mode)) {
+    if (!(SUPERVISOR_MODE inside {supported_privileged_mode})) {
        if (exception == kIllegalSystemInstr) {
          opcode == 7'b1110011;
          func3 == 3'b000;

--- a/verif/env/corev-dv/cva6_instr_test_pkg.sv
+++ b/verif/env/corev-dv/cva6_instr_test_pkg.sv
@@ -37,4 +37,4 @@ package cva6_instr_test_pkg;
    `include "rv32zcmp_instr.sv"
    `include "rv64zcb_instr.sv"
    
-endpackage : cva6_instr_test_pkg;
+endpackage : cva6_instr_test_pkg


### PR DESCRIPTION
Those fixes are suggested in the context of supporting Cadence Xcelium simulator for cva6 verification.

The usage of keyword `inside` should be used as followed: **_variable_ inside {_values or range_}**. The `{}` brackets are mandatory.
See https://www.chipverify.com/systemverilog/systemverilog-constraint-inside

Concerning packages, the keyword **endpackage** should not be followed by `;`.

This has been check with VCS 2021.09.
