### PR TITLE
ci/hyp: Fix reference to riscv-hyp-tests

### DIFF
--- a/ci/build-hyp-riscv-tests.sh
+++ b/ci/build-hyp-riscv-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-VERSION="920c1379cf6ca2374c6c5207dca425a933d8c7fd"
+VERSION="9ace7ffdb384ed84075dbe6219d9c0c9431f278b"
 
 cd $ROOT/tmp
 


### PR DESCRIPTION
The previous ref `920c137` does not seem to exist anymore. Update to the latest commit hash of `cva6-dev` (@ninolomata) 