### PR TITLE
Allow to pass custom location for the Boost library for Spike

### DIFF
--- a/verif/regress/install-spike.sh
+++ b/verif/regress/install-spike.sh
@@ -41,8 +41,12 @@ if ! [ -f "$SPIKE_INSTALL_DIR/bin/spike" ]; then
   # Build and install Spike (including extensions).
   mkdir -p build
   cd build
+  WITH_BOOST=""
+  if [[ ! -z "$BOOST_INSTALL_DIR" ]]; then
+      WITH_BOOST="--with-boost=${BOOST_INSTALL_DIR}"
+  fi
   if [[ ! -f config.log ]]; then
-      ../configure --prefix="$SPIKE_INSTALL_DIR"
+      ../configure --prefix="$SPIKE_INSTALL_DIR" ${WITH_BOOST}
   fi
   make -j${NUM_JOBS}
   echo "Installing Spike in '$SPIKE_INSTALL_DIR'..."


### PR DESCRIPTION
This allows to pass a custom location for the Boost library when compiling Spike.

In some cases, it is not possible to install libraries in standard locations using package managers (apt, yum, etc). For example, when you do not have administrator rights on the host machine.