### PR TITLE
Address translation request moved from icache to frontend

### DIFF
--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -17,8 +17,6 @@ module cva6_hpdcache_subsystem
 //  {{{
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter type icache_areq_t = logic,
-    parameter type icache_arsp_t = logic,
     parameter type icache_dreq_t = logic,
     parameter type icache_drsp_t = logic,
     parameter type icache_req_t = logic,
@@ -65,13 +63,9 @@ module cva6_hpdcache_subsystem
     input logic icache_flush_i,
     // instructino cache miss - PERF_COUNTERS
     output logic icache_miss_o,
-    // Input address translation request - EX_STAGE
-    input icache_areq_t icache_areq_i,
-    // Output address translation request - EX_STAGE
-    output icache_arsp_t icache_areq_o,
-    // Input data translation request - FRONTEND
+    // Access request - FRONTEND
     input icache_dreq_t icache_dreq_i,
-    // Output data translation request - FRONTEND
+    // Output Access request - FRONTEND
     output icache_drsp_t icache_dreq_o,
     //   }}}
 
@@ -141,8 +135,6 @@ module cva6_hpdcache_subsystem
 
   cva6_icache #(
       .CVA6Cfg(CVA6Cfg),
-      .icache_areq_t(icache_areq_t),
-      .icache_arsp_t(icache_arsp_t),
       .icache_dreq_t(icache_dreq_t),
       .icache_drsp_t(icache_drsp_t),
       .icache_req_t(icache_req_t),
@@ -154,8 +146,6 @@ module cva6_hpdcache_subsystem
       .flush_i       (icache_flush_i),
       .en_i          (icache_en_i),
       .miss_o        (icache_miss_o),
-      .areq_i        (icache_areq_i),
-      .areq_o        (icache_areq_o),
       .dreq_i        (icache_dreq_i),
       .dreq_o        (icache_dreq_o),
       .mem_rtrn_vld_i(icache_miss_resp_valid),
@@ -612,7 +602,7 @@ module cva6_hpdcache_subsystem
     $warning(
         1,
         "[l1 dcache] reading invalid instructions: vaddr=%08X, data=%08X",
-        icache_dreq_o.vaddr,
+        icache_dreq_i.vaddr,
         icache_dreq_o.data
     );
 

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -260,8 +260,8 @@ module cva6_icache
           if (flush_d) begin
             state_d = IDLE;
             // we have a hit or an exception output valid result
-          end else if (((|cl_hit && cache_en_q) || dreq_i.kill_req) && !inv_q) begin
-            dreq_o.valid = ~dreq_i.kill_s2;  // just don't output in this case
+          end else if ((|cl_hit && cache_en_q) && !inv_q) begin
+            dreq_o.valid = ~dreq_i.kill_req;  // just don't output in this case
             state_d      = IDLE;
 
             // we can accept another request
@@ -279,7 +279,7 @@ module cva6_icache
               state_d = IDLE;
             end
             // we have a miss / NC transaction
-          end else if (dreq_i.kill_s2) begin
+          end else if (dreq_i.kill_req) begin
             state_d = IDLE;
           end else if (!inv_q) begin
             cmp_en_d = 1'b0;
@@ -293,7 +293,7 @@ module cva6_icache
             end
           end
           // bail out if this request is being killed (and we missed on the TLB)
-        end else if (dreq_i.kill_s2 || flush_d) begin
+        end else if (dreq_i.kill_req || flush_d) begin
           state_d = KILL_ATRANS;
         end
       end
@@ -307,13 +307,13 @@ module cva6_icache
         if (mem_rtrn_vld_i && mem_rtrn_i.rtype == ICACHE_IFILL_ACK) begin
           state_d = IDLE;
           // only return data if request is not being killed
-          if (!(dreq_i.kill_s2 || flush_d)) begin
+          if (!(dreq_i.kill_req || flush_d)) begin
             dreq_o.valid = 1'b1;
             // only write to cache if this address is cacheable
             cache_wren   = ~paddr_is_nc;
           end
           // bail out if this request is being killed
-        end else if (dreq_i.kill_s2 || flush_d) begin
+        end else if (dreq_i.kill_req || flush_d) begin
           state_d = KILL_MISS;
         end
       end

--- a/core/cache_subsystem/cva6_icache_axi_wrapper.sv
+++ b/core/cache_subsystem/cva6_icache_axi_wrapper.sv
@@ -18,8 +18,6 @@ module cva6_icache_axi_wrapper
   import wt_cache_pkg::*;
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter type icache_areq_t = logic,
-    parameter type icache_arsp_t = logic,
     parameter type icache_dreq_t = logic,
     parameter type icache_drsp_t = logic,
     parameter type icache_req_t = logic,
@@ -34,9 +32,6 @@ module cva6_icache_axi_wrapper
     input logic flush_i,  // flush the icache, flush and kill have to be asserted together
     input logic en_i,  // enable icache
     output logic miss_o,  // to performance counter
-    // address translation requests
-    input icache_areq_t areq_i,
-    output icache_arsp_t areq_o,
     // data requests
     input icache_dreq_t dreq_i,
     output icache_drsp_t dreq_o,
@@ -108,8 +103,6 @@ module cva6_icache_axi_wrapper
   cva6_icache #(
       // use ID 0 for icache reads
       .CVA6Cfg(CVA6Cfg),
-      .icache_areq_t(icache_areq_t),
-      .icache_arsp_t(icache_arsp_t),
       .icache_dreq_t(icache_dreq_t),
       .icache_drsp_t(icache_drsp_t),
       .icache_req_t(icache_req_t),
@@ -121,8 +114,6 @@ module cva6_icache_axi_wrapper
       .flush_i       (flush_i),
       .en_i          (en_i),
       .miss_o        (miss_o),
-      .areq_i        (areq_i),
-      .areq_o        (areq_o),
       .dreq_i        (dreq_i),
       .dreq_o        (dreq_o),
       .mem_rtrn_vld_i(icache_mem_rtrn_vld),

--- a/core/cache_subsystem/std_cache_subsystem.sv
+++ b/core/cache_subsystem/std_cache_subsystem.sv
@@ -20,8 +20,6 @@ module std_cache_subsystem
   import std_cache_pkg::*;
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter type icache_areq_t = logic,
-    parameter type icache_arsp_t = logic,
     parameter type icache_dreq_t = logic,
     parameter type icache_drsp_t = logic,
     parameter type icache_req_t = logic,
@@ -42,9 +40,6 @@ module std_cache_subsystem
     input logic icache_en_i,  // enable icache (or bypass e.g: in debug mode)
     input logic icache_flush_i,  // flush the icache, flush and kill have to be asserted together
     output logic icache_miss_o,  // to performance counter
-    // address translation requests
-    input icache_areq_t icache_areq_i,  // to/from frontend
-    output icache_arsp_t icache_areq_o,
     // data requests
     input icache_dreq_t icache_dreq_i,  // to/from frontend
     output icache_drsp_t icache_dreq_o,
@@ -77,8 +72,6 @@ module std_cache_subsystem
 
   cva6_icache_axi_wrapper #(
       .CVA6Cfg(CVA6Cfg),
-      .icache_areq_t(icache_areq_t),
-      .icache_arsp_t(icache_arsp_t),
       .icache_dreq_t(icache_dreq_t),
       .icache_drsp_t(icache_drsp_t),
       .icache_req_t(icache_req_t),
@@ -92,8 +85,6 @@ module std_cache_subsystem
       .flush_i   (icache_flush_i),
       .en_i      (icache_en_i),
       .miss_o    (icache_miss_o),
-      .areq_i    (icache_areq_i),
-      .areq_o    (icache_areq_o),
       .dreq_i    (icache_dreq_i),
       .dreq_o    (icache_dreq_o),
       .axi_req_o (axi_req_icache),
@@ -295,7 +286,7 @@ module std_cache_subsystem
     $warning(
         1,
         "[l1 dcache] reading invalid instructions: vaddr=%08X, data=%08X",
-        icache_dreq_o.vaddr,
+        icache_dreq_i.vaddr,
         icache_dreq_o.data
     );
 

--- a/core/cache_subsystem/wt_cache_subsystem.sv
+++ b/core/cache_subsystem/wt_cache_subsystem.sv
@@ -24,8 +24,6 @@ module wt_cache_subsystem
   import wt_cache_pkg::*;
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg        = config_pkg::cva6_cfg_empty,
-    parameter type                   icache_areq_t  = logic,
-    parameter type                   icache_arsp_t  = logic,
     parameter type                   icache_dreq_t  = logic,
     parameter type                   icache_drsp_t  = logic,
     parameter type                   dcache_req_i_t = logic,
@@ -42,9 +40,6 @@ module wt_cache_subsystem
     input logic icache_en_i,  // enable icache (or bypass e.g: in debug mode)
     input logic icache_flush_i,  // flush the icache, flush and kill have to be asserted together
     output logic icache_miss_o,  // to performance counter
-    // address translation requests
-    input icache_areq_t icache_areq_i,  // to/from frontend
-    output icache_arsp_t icache_areq_o,
     // data requests
     input icache_dreq_t icache_dreq_i,  // to/from frontend
     output icache_drsp_t icache_dreq_o,
@@ -115,8 +110,6 @@ module wt_cache_subsystem
   cva6_icache #(
       // use ID 0 for icache reads
       .CVA6Cfg(CVA6Cfg),
-      .icache_areq_t(icache_areq_t),
-      .icache_arsp_t(icache_arsp_t),
       .icache_dreq_t(icache_dreq_t),
       .icache_drsp_t(icache_drsp_t),
       .icache_req_t(icache_req_t),
@@ -128,8 +121,6 @@ module wt_cache_subsystem
       .flush_i       (icache_flush_i),
       .en_i          (icache_en_i),
       .miss_o        (icache_miss_o),
-      .areq_i        (icache_areq_i),
-      .areq_o        (icache_areq_o),
       .dreq_i        (icache_dreq_i),
       .dreq_o        (icache_dreq_o),
       .mem_rtrn_vld_i(adapter_icache_rtrn_vld),
@@ -247,7 +238,7 @@ module wt_cache_subsystem
     $warning(
         1,
         "[l1 dcache] reading invalid instructions: vaddr=%08X, data=%08X",
-        icache_dreq_o.vaddr,
+        icache_dreq_i.vaddr,
         icache_dreq_o.data
     );
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -64,7 +64,6 @@ module cva6
     localparam type icache_dreq_t = struct packed {
       logic                    req;                // we request a new word
       logic                    kill_s1;            // kill the current request
-      logic                    kill_s2;            // kill the last request
       logic                    kill_req;           // kill the last request
       logic                    spec;               // request is speculative
       logic [CVA6Cfg.VLEN-1:0] vaddr;              // 1st cycle: 12 bit index is taken for lookup

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -24,8 +24,8 @@ module ex_stage
     parameter type dcache_req_o_t = logic,
     parameter type exception_t = logic,
     parameter type fu_data_t = logic,
-    parameter type icache_areq_t = logic,
-    parameter type icache_arsp_t = logic,
+    parameter type fetch_areq_t = logic,
+    parameter type fetch_arsp_t = logic,
     parameter type icache_dreq_t = logic,
     parameter type icache_drsp_t = logic,
     parameter type lsu_ctrl_t = logic
@@ -194,10 +194,10 @@ module ex_stage
     input logic [CVA6Cfg.PPNW-1:0] hgatp_ppn_i,
     // TO_BE_COMPLETED - CSR_REGFILE
     input logic [CVA6Cfg.VMID_WIDTH-1:0] vmid_i,
-    // icache translation response - CACHE
-    input icache_arsp_t icache_areq_i,
-    // icache translation request - CACHE
-    output icache_areq_t icache_areq_o,
+    // fetch translation request - FETCH
+    input fetch_areq_t fetch_areq_i,
+    // fetch translation response - FETCH
+    output fetch_arsp_t fetch_arsp_o,
     // Data cache request ouput - CACHE
     input dcache_req_o_t [2:0] dcache_req_ports_i,
     // Data cache request input - CACHE
@@ -417,8 +417,8 @@ module ex_stage
       .dcache_req_o_t(dcache_req_o_t),
       .exception_t(exception_t),
       .fu_data_t (fu_data_t),
-      .icache_areq_t(icache_areq_t),
-      .icache_arsp_t(icache_arsp_t),
+      .fetch_areq_t(fetch_areq_t),
+      .fetch_arsp_t(fetch_arsp_t),
       .icache_dreq_t(icache_dreq_t),
       .icache_drsp_t(icache_drsp_t),
       .lsu_ctrl_t(lsu_ctrl_t)
@@ -446,8 +446,8 @@ module ex_stage
       .enable_g_translation_i,
       .en_ld_st_translation_i,
       .en_ld_st_g_translation_i,
-      .icache_areq_i,
-      .icache_areq_o,
+      .fetch_areq_i,
+      .fetch_arsp_o,
       .priv_lvl_i,
       .v_i,
       .ld_st_priv_lvl_i,

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -21,8 +21,8 @@ module load_store_unit
     parameter type dcache_req_o_t = logic,
     parameter type exception_t = logic,
     parameter type fu_data_t = logic,
-    parameter type icache_areq_t = logic,
-    parameter type icache_arsp_t = logic,
+    parameter type fetch_areq_t = logic,
+    parameter type fetch_arsp_t = logic,
     parameter type icache_dreq_t = logic,
     parameter type icache_drsp_t = logic,
     parameter type lsu_ctrl_t = logic
@@ -82,10 +82,10 @@ module load_store_unit
     // Enable G-Stage memory translation for load/stores - TO_BE_COMPLETED
     input logic en_ld_st_g_translation_i,
 
-    // Instruction cache input request - CACHES
-    input  icache_arsp_t icache_areq_i,
-    // Instruction cache output request - CACHES
-    output icache_areq_t icache_areq_o,
+    // Instruction cache input request - FETCH
+    input  fetch_areq_t fetch_areq_i,
+    // Instruction cache output response - FETCH
+    output fetch_arsp_t fetch_arsp_o,
 
     // Current privilege mode - CSR_REGFILE
     input  riscv::priv_lvl_t                          priv_lvl_i,
@@ -235,8 +235,8 @@ module load_store_unit
     cva6_mmu_sv39x4 #(
         .CVA6Cfg          (CVA6Cfg),
         .exception_t      (exception_t),
-        .icache_areq_t    (icache_areq_t),
-        .icache_arsp_t    (icache_arsp_t),
+        .fetch_areq_t     (fetch_areq_t),
+        .fetch_arsp_t     (fetch_arsp_t),
         .icache_dreq_t    (icache_dreq_t),
         .icache_drsp_t    (icache_drsp_t),
         .dcache_req_i_t   (dcache_req_i_t),
@@ -258,13 +258,13 @@ module load_store_unit
         // connecting PTW to D$ IF
         .req_port_i     (dcache_req_ports_i[0]),
         .req_port_o     (dcache_req_ports_o[0]),
-        // icache address translation requests
-        .icache_areq_i  (icache_areq_i),
+        // fetch address translation requests
+        .fetch_areq_i   (fetch_areq_i),
         .asid_to_be_flushed_i,
         .vmid_to_be_flushed_i,
         .vaddr_to_be_flushed_i,
         .gpaddr_to_be_flushed_i,
-        .icache_areq_o  (icache_areq_o),
+        .fetch_arsp_o   (fetch_arsp_o),
         .pmpcfg_i,
         .pmpaddr_i,
         // Hypervisor load/store signals
@@ -276,8 +276,8 @@ module load_store_unit
     mmu #(
         .CVA6Cfg          (CVA6Cfg),
         .exception_t      (exception_t),
-        .icache_areq_t    (icache_areq_t),
-        .icache_arsp_t    (icache_arsp_t),
+        .fetch_areq_t     (fetch_areq_t),
+        .fetch_arsp_t     (fetch_arsp_t),
         .icache_dreq_t    (icache_dreq_t),
         .icache_drsp_t    (icache_drsp_t),
         .dcache_req_i_t   (dcache_req_i_t),
@@ -299,10 +299,10 @@ module load_store_unit
         .req_port_i     (dcache_req_ports_i[0]),
         .req_port_o     (dcache_req_ports_o[0]),
         // icache address translation requests
-        .icache_areq_i  (icache_areq_i),
+        .fetch_areq_i   (fetch_areq_i),
         .asid_to_be_flushed_i,
         .vaddr_to_be_flushed_i,
-        .icache_areq_o  (icache_areq_o),
+        .fetch_arsp_o   (fetch_arsp_o),
         .pmpcfg_i,
         .pmpaddr_i,
         .*
@@ -311,8 +311,8 @@ module load_store_unit
     cva6_mmu_sv32 #(
         .CVA6Cfg          (CVA6Cfg),
         .exception_t      (exception_t),
-        .icache_areq_t    (icache_areq_t),
-        .icache_arsp_t    (icache_arsp_t),
+        .fetch_areq_t     (fetch_areq_t),
+        .fetch_arsp_t     (fetch_arsp_t),
         .icache_dreq_t    (icache_dreq_t),
         .icache_drsp_t    (icache_drsp_t),
         .dcache_req_i_t   (dcache_req_i_t),
@@ -334,10 +334,10 @@ module load_store_unit
         .req_port_i     (dcache_req_ports_i[0]),
         .req_port_o     (dcache_req_ports_o[0]),
         // icache address translation requests
-        .icache_areq_i  (icache_areq_i),
+        .fetch_areq_i   (fetch_areq_i),
         .asid_to_be_flushed_i,
         .vaddr_to_be_flushed_i,
-        .icache_areq_o  (icache_areq_o),
+        .fetch_arsp_o   (fetch_arsp_o),
         .pmpcfg_i,
         .pmpaddr_i,
         .*
@@ -346,15 +346,15 @@ module load_store_unit
 
     if (CVA6Cfg.VLEN > CVA6Cfg.PLEN) begin
       assign mmu_vaddr_plen   = mmu_vaddr[CVA6Cfg.PLEN-1:0];
-      assign fetch_vaddr_plen = icache_areq_i.fetch_vaddr[CVA6Cfg.PLEN-1:0];
+      assign fetch_vaddr_plen = fetch_areq_i.fetch_vaddr[CVA6Cfg.PLEN-1:0];
     end else begin
-      assign mmu_vaddr_plen = {{{CVA6Cfg.PLEN - CVA6Cfg.VLEN} {1'b0}}, mmu_vaddr};
-      assign fetch_vaddr_plen = {{{CVA6Cfg.PLEN - CVA6Cfg.VLEN} {1'b0}}, icache_areq_i.fetch_vaddr};
+      assign mmu_vaddr_plen   = {{{CVA6Cfg.PLEN - CVA6Cfg.VLEN} {1'b0}}, mmu_vaddr};
+      assign fetch_vaddr_plen = {{{CVA6Cfg.PLEN - CVA6Cfg.VLEN} {1'b0}}, fetch_areq_i.fetch_vaddr};
     end
 
-    assign icache_areq_o.fetch_valid           = icache_areq_i.fetch_req;
-    assign icache_areq_o.fetch_paddr           = fetch_vaddr_plen;
-    assign icache_areq_o.fetch_exception       = '0;
+    assign fetch_arsp_o.fetch_valid            = fetch_areq_i.fetch_req;
+    assign fetch_arsp_o.fetch_paddr            = fetch_vaddr_plen;
+    assign fetch_arsp_o.fetch_exception        = '0;
 
     assign dcache_req_ports_o[0].address_index = '0;
     assign dcache_req_ports_o[0].address_tag   = '0;

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -31,8 +31,8 @@ module cva6_mmu_sv32
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg           = config_pkg::cva6_cfg_empty,
     parameter type                   exception_t       = logic,
-    parameter type                   icache_areq_t     = logic,
-    parameter type                   icache_arsp_t     = logic,
+    parameter type                   fetch_arsp_t      = logic,
+    parameter type                   fetch_areq_t      = logic,
     parameter type                   icache_dreq_t     = logic,
     parameter type                   icache_drsp_t     = logic,
     parameter type                   dcache_req_i_t    = logic,
@@ -46,8 +46,8 @@ module cva6_mmu_sv32
     input logic enable_translation_i,
     input logic en_ld_st_translation_i,  // enable virtual memory translation for load/stores
     // IF interface
-    input icache_arsp_t icache_areq_i,
-    output icache_areq_t icache_areq_o,
+    input fetch_areq_t fetch_areq_i,
+    output fetch_arsp_t fetch_arsp_o,
     // LSU interface
     // this is a more minimalistic interface because the actual addressing logic is handled
     // in the LSU as we distinguish load and stores, what we do here is simple address translation
@@ -114,7 +114,7 @@ module cva6_mmu_sv32
 
 
   // Assignments
-  assign itlb_lu_access = icache_areq_i.fetch_req;
+  assign itlb_lu_access = fetch_areq_i.fetch_req;
   assign dtlb_lu_access = lsu_req_i;
 
 
@@ -132,7 +132,7 @@ module cva6_mmu_sv32
       .lu_asid_i            (asid_i),
       .asid_to_be_flushed_i (asid_to_be_flushed_i),
       .vaddr_to_be_flushed_i(vaddr_to_be_flushed_i),
-      .lu_vaddr_i           (icache_areq_i.fetch_vaddr),
+      .lu_vaddr_i           (fetch_areq_i.fetch_vaddr),
       .lu_content_o         (itlb_content),
 
       .lu_is_4M_o(itlb_is_4M),
@@ -177,7 +177,7 @@ module cva6_mmu_sv32
       // did we miss?
       .itlb_access_i(itlb_lu_access),
       .itlb_hit_i   (itlb_lu_hit),
-      .itlb_vaddr_i (icache_areq_i.fetch_vaddr),
+      .itlb_vaddr_i (fetch_areq_i.fetch_vaddr),
 
       .dtlb_access_i(dtlb_lu_access),
       .dtlb_hit_i   (dtlb_lu_hit),
@@ -263,7 +263,7 @@ module cva6_mmu_sv32
   //     .probe10(lsu_vaddr_i), // input wire [0:0]  probe10
   //     .probe11(dtlb_lu_hit), // input wire [0:0]  probe11
   //     .probe12(itlb_lu_access), // input wire [0:0]  probe12
-  //     .probe13(icache_areq_i.fetch_vaddr), // input wire [0:0]  probe13
+  //     .probe13(fetch_areq_i.fetch_vaddr), // input wire [0:0]  probe13
   //     .probe14(itlb_lu_hit) // input wire [0:0]  probe13
   // );
 
@@ -276,21 +276,21 @@ module cva6_mmu_sv32
   // The instruction interface is a simple request response interface
   always_comb begin : instr_interface
     // MMU disabled: just pass through
-    icache_areq_o.fetch_valid = icache_areq_i.fetch_req;
+    fetch_arsp_o.fetch_valid = fetch_areq_i.fetch_req;
     if (CVA6Cfg.PLEN > CVA6Cfg.VLEN)
-      icache_areq_o.fetch_paddr = {
-        {CVA6Cfg.PLEN - CVA6Cfg.VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+      fetch_arsp_o.fetch_paddr = {
+        {CVA6Cfg.PLEN - CVA6Cfg.VLEN{1'b0}}, fetch_areq_i.fetch_vaddr
       };  // play through in case we disabled address translation
     else
-      icache_areq_o.fetch_paddr = {
-        2'b00, icache_areq_i.fetch_vaddr[CVA6Cfg.VLEN-1:0]
+      fetch_arsp_o.fetch_paddr = {
+        2'b00, fetch_areq_i.fetch_vaddr[CVA6Cfg.VLEN-1:0]
       };  // play through in case we disabled address translation
     // two potential exception sources:
     // 1. HPTW threw an exception -> signal with a page fault exception
     // 2. We got an access error because of insufficient permissions -> throw an access exception
-    icache_areq_o.fetch_exception = '0;
+    fetch_arsp_o.fetch_exception = '0;
     // Check whether we are allowed to access this memory region from a fetch perspective
-    iaccess_err   = icache_areq_i.fetch_req && (((priv_lvl_i == riscv::PRIV_LVL_U) && ~itlb_content.u)
+    iaccess_err   = fetch_areq_i.fetch_req && (((priv_lvl_i == riscv::PRIV_LVL_U) && ~itlb_content.u)
                                                  || ((priv_lvl_i == riscv::PRIV_LVL_S) && itlb_content.u));
 
     // MMU enabled: address from TLB, request delayed until hit. Error when TLB
@@ -299,22 +299,22 @@ module cva6_mmu_sv32
     // an error.
     if (enable_translation_i) begin
       // we work with SV32, so if VM is enabled, check that all bits [CVA6Cfg.VLEN-1:CVA6Cfg.SV-1] are equal
-      if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[CVA6Cfg.VLEN-1:CVA6Cfg.SV-1]) == 1'b1 || (|icache_areq_i.fetch_vaddr[CVA6Cfg.VLEN-1:CVA6Cfg.SV-1]) == 1'b0)) begin
-        icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
-        icache_areq_o.fetch_exception.valid = 1'b1;
+      if (fetch_areq_i.fetch_req && !((&fetch_areq_i.fetch_vaddr[CVA6Cfg.VLEN-1:CVA6Cfg.SV-1]) == 1'b1 || (|fetch_areq_i.fetch_vaddr[CVA6Cfg.VLEN-1:CVA6Cfg.SV-1]) == 1'b0)) begin
+        fetch_arsp_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+        fetch_arsp_o.fetch_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          icache_areq_o.fetch_exception.tval = {
-            {CVA6Cfg.XLEN - CVA6Cfg.VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+          fetch_arsp_o.fetch_exception.tval = {
+            {CVA6Cfg.XLEN - CVA6Cfg.VLEN{1'b0}}, fetch_areq_i.fetch_vaddr
           };
       end
 
-      icache_areq_o.fetch_valid = 1'b0;
+      fetch_arsp_o.fetch_valid = 1'b0;
 
       // 4K page
-      icache_areq_o.fetch_paddr = {itlb_content.ppn, icache_areq_i.fetch_vaddr[11:0]};
+      fetch_arsp_o.fetch_paddr = {itlb_content.ppn, fetch_areq_i.fetch_vaddr[11:0]};
       // Mega page
       if (itlb_is_4M) begin
-        icache_areq_o.fetch_paddr[21:12] = icache_areq_i.fetch_vaddr[21:12];
+        fetch_arsp_o.fetch_paddr[21:12] = fetch_areq_i.fetch_vaddr[21:12];
       end
 
 
@@ -323,21 +323,21 @@ module cva6_mmu_sv32
       // --------
       // if we hit the ITLB output the request signal immediately
       if (itlb_lu_hit) begin
-        icache_areq_o.fetch_valid = icache_areq_i.fetch_req;
+        fetch_arsp_o.fetch_valid = fetch_areq_i.fetch_req;
         // we got an access error
         if (iaccess_err) begin
           // throw a page fault
-          icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
-          icache_areq_o.fetch_exception.valid = 1'b1;
+          fetch_arsp_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
+          fetch_arsp_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval = {
-              {CVA6Cfg.XLEN - CVA6Cfg.VLEN{1'b0}}, icache_areq_i.fetch_vaddr
+            fetch_arsp_o.fetch_exception.tval = {
+              {CVA6Cfg.XLEN - CVA6Cfg.VLEN{1'b0}}, fetch_areq_i.fetch_vaddr
             };
           //to check on wave --> not connected
         end else if (!pmp_instr_allow) begin
-          icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
-          icache_areq_o.fetch_exception.valid = 1'b1;
-          if (CVA6Cfg.TvalEn) icache_areq_o.fetch_exception.tval = icache_areq_i.fetch_vaddr;
+          fetch_arsp_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+          fetch_arsp_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn) fetch_arsp_o.fetch_exception.tval = fetch_areq_i.fetch_vaddr;
           //to check on wave --> not connected
         end
       end else
@@ -346,37 +346,35 @@ module cva6_mmu_sv32
       // ---------
       // watch out for exceptions happening during walking the page table
       if (ptw_active && walking_instr) begin
-        icache_areq_o.fetch_valid = ptw_error | ptw_access_exception;
+        fetch_arsp_o.fetch_valid = ptw_error | ptw_access_exception;
         if (ptw_error) begin
-          icache_areq_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
-          icache_areq_o.fetch_exception.valid = 1'b1;
+          fetch_arsp_o.fetch_exception.cause = riscv::INSTR_PAGE_FAULT;
+          fetch_arsp_o.fetch_exception.valid = 1'b1;
           if (CVA6Cfg.TvalEn)
-            icache_areq_o.fetch_exception.tval = {
-              {CVA6Cfg.XLEN - CVA6Cfg.VLEN{1'b0}}, update_vaddr
-            };
+            fetch_arsp_o.fetch_exception.tval = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{1'b0}}, update_vaddr};
         end  //to check on wave
         // TODO(moschn,zarubaf): What should the value of tval be in this case?
         else begin
-          icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
-          icache_areq_o.fetch_exception.valid = 1'b1;
-          if (CVA6Cfg.TvalEn) icache_areq_o.fetch_exception.tval = ptw_bad_paddr[CVA6Cfg.PLEN-1:2];
+          fetch_arsp_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+          fetch_arsp_o.fetch_exception.valid = 1'b1;
+          if (CVA6Cfg.TvalEn) fetch_arsp_o.fetch_exception.tval = ptw_bad_paddr[CVA6Cfg.PLEN-1:2];
         end
       end
     end
     // if it didn't match any execute region throw an `Instruction Access Fault`
     // or: if we are not translating, check PMPs immediately on the paddr
     if (!match_any_execute_region || (!enable_translation_i && !pmp_instr_allow)) begin
-      icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
-      icache_areq_o.fetch_exception.valid = 1'b1;
+      fetch_arsp_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
+      fetch_arsp_o.fetch_exception.valid = 1'b1;
       if (CVA6Cfg.TvalEn)
-        icache_areq_o.fetch_exception.tval = icache_areq_o.fetch_paddr[CVA6Cfg.PLEN-1:2];
+        fetch_arsp_o.fetch_exception.tval = fetch_arsp_o.fetch_paddr[CVA6Cfg.PLEN-1:2];
       //to check on wave --> not connected
     end
   end
 
   // check for execute flag on memory
   assign match_any_execute_region = config_pkg::is_inside_execute_regions(
-      CVA6Cfg, {{64 - CVA6Cfg.PLEN{1'b0}}, icache_areq_o.fetch_paddr}
+      CVA6Cfg, {{64 - CVA6Cfg.PLEN{1'b0}}, fetch_arsp_o.fetch_paddr}
   );
 
   // Instruction fetch
@@ -385,7 +383,7 @@ module cva6_mmu_sv32
       .PMP_LEN   (CVA6Cfg.PLEN - 2),
       .NR_ENTRIES(CVA6Cfg.NrPMPEntries)
   ) i_pmp_if (
-      .addr_i       (icache_areq_o.fetch_paddr),
+      .addr_i       (fetch_arsp_o.fetch_paddr),
       .priv_lvl_i,
       // we will always execute on the instruction fetch port
       .access_type_i(riscv::ACCESS_EXEC),


### PR DESCRIPTION
In order to aligned the ways address translation is managed between FETCH and DATA the address translation request is moved from the icache to the frontend.

The change is supposed to be transparent, no functional impact, same perf, same critical path...