### PR TITLE
Add in Github's CI a 64-bit configuration of the CVA6 using the HPDcache and restore WB cache test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,20 @@ jobs:
           ci/setup.sh
 
 
-  execute-riscv-tests:
-    name: execute-riscv-tests
+  execute-riscv64-tests:
+    name: execute-riscv64-tests
     runs-on: ubuntu-latest
     env:
       SPIKE_TANDEM: 1
     strategy:
       matrix:
-        testcase: [ dv-riscv-arch-test , smoke-tests ]
-        target:   [ veri-testharness ]
+        testcase:  [ cv64a6_imafdc_tests ]
+        config:    [ cv64a6_imafdc_sv39_hpdcache, cv64a6_imafdc_sv39_wb, cv64a6_imafdc_sv39 ]
+        simulator: [ veri-testharness ]
+        include:
+          - testcase: dv-riscv-arch-test
+            config: cv64a6_imafdc_sv39_hpdcache
+            simulator: veri-testharness
     needs:
       build-riscv-tests
     steps:
@@ -98,11 +103,71 @@ jobs:
           export RISCV=$(pwd)/tools/riscv-toolchain/
           source ci/install-prereq.sh
           source verif/sim/setup-env.sh
-          DV_SIMULATORS=${{matrix.target}} bash verif/regress/${{matrix.testcase}}.sh
+          DV_SIMULATORS=${{matrix.simulator}},spike DV_TARGET=${{matrix.config}} bash verif/regress/${{matrix.testcase}}.sh
 
     - name: Upload Lint Report to Github
       uses: actions/upload-artifact@v4
       with:
-        name: ${{matrix.target}}.${{matrix.testcase}}
+        name: ${{matrix.simulator}}.${{matrix.testcase}}.${{matrix.config}}
+        path: 'verif/sim/out*'
+        retention-days: 10
+
+
+  execute-riscv32-tests:
+    name: execute-riscv32-tests
+    runs-on: ubuntu-latest
+    env:
+      SPIKE_TANDEM: 1
+    strategy:
+      matrix:
+        testcase:  [ dv-riscv-arch-test, cv32a6_tests ]
+        config:    [ cv32a65x ]
+        simulator: [ veri-testharness ]
+    needs:
+      build-riscv-tests
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Cache toolchain
+      id: cache-toolchain
+      uses: actions/cache@v3
+      env:
+          cache-name: cache-toolchain
+      with:
+          path: tools/riscv-toolchain/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('ci/install-toolchain.sh') }}
+
+    - name: Cache verilator
+      id: cache-verilator
+      uses: actions/cache@v3
+      env:
+          cache-name: cache-verilator
+      with:
+          path: tools/verilator/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('verif/regress/install-verilator.sh') }}
+
+    - name: Cache Spike
+      id: cache-spike
+      uses: actions/cache@v3
+      env:
+          cache-name: cache-spike
+      with:
+          path: tools/spike/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('verif/regress/install-spike.sh', 'verif/core-v-verif/vendor/riscv/riscv-isa-sim/') }}
+
+    - name: Run Tests
+      run: |
+          set -x
+          export RISCV=$(pwd)/tools/riscv-toolchain/
+          source ci/install-prereq.sh
+          source verif/sim/setup-env.sh
+          DV_SIMULATORS=${{matrix.simulator}},spike DV_TARGET=${{matrix.config}} bash verif/regress/${{matrix.testcase}}.sh
+
+    - name: Upload Lint Report to Github
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{matrix.simulator}}.${{matrix.testcase}}.${{matrix.config}}
         path: 'verif/sim/out*'
         retention-days: 10

--- a/verif/regress/cv32a6_tests.sh
+++ b/verif/regress/cv32a6_tests.sh
@@ -48,11 +48,17 @@ cd verif/sim/
 errors=0
 
 # 32-bit configurations without MMU
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-${DV_TARGET}-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
-[[ $? > 0 ]] && ((errors++))
-
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-${DV_TARGET}-p.yaml --test rv32ui-p-lw --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
-[[ $? > 0 ]] && ((errors++))
+riscv_tests_list=(
+  rv32ui-p-add
+  rv32ui-p-lw
+  rv32ui-p-sw
+  rv32ui-p-beq
+  rv32ui-p-jal
+)
+for t in ${riscv_tests_list[@]} ; do
+  python3 cva6.py --testlist=../tests/testlist_riscv-tests-${DV_TARGET}-p.yaml --test $t --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+  [[ $? > 0 ]] && ((errors++))
+done
 
 python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c --linker=../tests/custom/common/test.ld\
   --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common" $DV_OPTS

--- a/verif/regress/cv32a6_tests.sh
+++ b/verif/regress/cv32a6_tests.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2021 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Jean-Roch COULON - Thales
+
+# where are the tools
+if ! [ -n "$RISCV" ]; then
+  echo "Error: RISCV variable undefined"
+  return
+fi
+
+
+# install the required tools
+source ./verif/regress/install-verilator.sh
+source ./verif/regress/install-spike.sh
+
+# install the required test suites
+source ./verif/regress/install-riscv-compliance.sh
+source ./verif/regress/install-riscv-tests.sh
+source ./verif/regress/install-riscv-arch-test.sh
+
+# setup sim env
+source ./verif/sim/setup-env.sh
+
+echo "$SPIKE_INSTALL_DIR$"
+
+if ! [ -n "$DV_SIMULATORS" ]; then
+  DV_SIMULATORS=vcs-testharness,spike
+fi
+
+if ! [ -n "$DV_TARGET" ]; then
+  DV_TARGET=cv32a65x
+fi
+
+if ! [ -n "$UVM_VERBOSITY" ]; then
+  export UVM_VERBOSITY=UVM_NONE
+fi
+
+export DV_OPTS="$DV_OPTS --issrun_opts=+debug_disable=1+UVM_VERBOSITY=$UVM_VERBOSITY"
+
+cd verif/sim/
+
+errors=0
+
+# 32-bit configurations without MMU
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-${DV_TARGET}-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+[[ $? > 0 ]] && ((errors++))
+
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-${DV_TARGET}-p.yaml --test rv32ui-p-lw --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+[[ $? > 0 ]] && ((errors++))
+
+python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c --linker=../tests/custom/common/test.ld\
+  --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common" $DV_OPTS
+[[ $? > 0 ]] && ((errors++))
+
+make -C ../.. clean
+make clean_all
+
+[[ $errors > 0 ]] && exit 1 ;
+exit 0 ;

--- a/verif/regress/cv64a6_imafdc_tests.sh
+++ b/verif/regress/cv64a6_imafdc_tests.sh
@@ -7,6 +7,9 @@
 # You may obtain a copy of the License at https://solderpad.org/licenses/
 #
 # Original Author: Jean-Roch COULON - Thales
+#
+# Contributor: Cesar Fuguet, CEA List
+# RISC-V tests for 64-bit configurations implementing MMU
 
 # where are the tools
 if ! [ -n "$RISCV" ]; then
@@ -48,11 +51,17 @@ cd verif/sim/
 errors=0
 
 # 64-bit configurations implementing MMU
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-add --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
-[[ $? > 0 ]] && ((errors++))
-
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-ld  --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
-[[ $? > 0 ]] && ((errors++))
+riscv_tests_list=(
+  rv64ui-v-add
+  rv64ui-v-ld
+  rv64ui-v-sd
+  rv64ui-v-beq
+  rv64ui-v-jal
+)
+for t in ${riscv_tests_list[@]} ; do
+  python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test $t --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+  [[ $? > 0 ]] && ((errors++))
+done
 
 python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c \
   --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld" $DV_OPTS

--- a/verif/regress/cv64a6_imafdc_tests.sh
+++ b/verif/regress/cv64a6_imafdc_tests.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2021 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Jean-Roch COULON - Thales
+
+# where are the tools
+if ! [ -n "$RISCV" ]; then
+  echo "Error: RISCV variable undefined"
+  return
+fi
+
+
+# install the required tools
+source ./verif/regress/install-verilator.sh
+source ./verif/regress/install-spike.sh
+
+# install the required test suites
+source ./verif/regress/install-riscv-compliance.sh
+source ./verif/regress/install-riscv-tests.sh
+source ./verif/regress/install-riscv-arch-test.sh
+
+# setup sim env
+source ./verif/sim/setup-env.sh
+
+echo "$SPIKE_INSTALL_DIR$"
+
+if ! [ -n "$DV_SIMULATORS" ]; then
+  DV_SIMULATORS=vcs-testharness,spike
+fi
+
+if ! [ -n "$DV_TARGET" ]; then
+  DV_TARGET=cv64a6_imafdc_sv39_hpdcache
+fi
+
+if ! [ -n "$UVM_VERBOSITY" ]; then
+  export UVM_VERBOSITY=UVM_NONE
+fi
+
+export DV_OPTS="$DV_OPTS --issrun_opts=+debug_disable=1+UVM_VERBOSITY=$UVM_VERBOSITY"
+
+cd verif/sim/
+
+errors=0
+
+# 64-bit configurations implementing MMU
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-add --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+[[ $? > 0 ]] && ((errors++))
+
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-ld  --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
+[[ $? > 0 ]] && ((errors++))
+
+python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c \
+  --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld" $DV_OPTS
+[[ $? > 0 ]] && ((errors++))
+
+make -C ../.. clean
+make clean_all
+
+[[ $errors > 0 ]] && exit 1 ;
+exit 0 ;

--- a/verif/regress/dv-riscv-arch-test.sh
+++ b/verif/regress/dv-riscv-arch-test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2021 Thales DIS design services SAS
 #
 # Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
@@ -28,6 +29,11 @@ if ! [ -n "$DV_SIMULATORS" ]; then
   DV_SIMULATORS=veri-testharness,spike
 fi
 
+if [[ "$DV_TARGET" =~ cv64a6_imafdc* ]] ; then
+  TESTLIST=../tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml
+else
+  TESTLIST=../tests/testlist_riscv-arch-test-$DV_TARGET.yaml
+fi
+
 cd verif/sim
-python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
-cd -
+python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -965,7 +965,7 @@ def load_config(args, cwd):
   if not args.custom_target:
     if not args.testlist:
       args.testlist = cwd + "/target/"+ args.target +"/testlist.yaml"
-    if args.target == "cv64a6_imafdc_sv39":
+    if args.target in ("cv64a6_imafdc_sv39", "cv64a6_imafdc_sv39_hpdcache", "cv64a6_imafdc_sv39_wb"):
       args.mabi = "lp64d"
       args.isa  = "rv64gc_zba_zbb_zbs_zbc"
     elif args.target == "cv32a60x": # step1 configuration


### PR DESCRIPTION
This PR adds to the Github's CI a tests with the cv64a6_imafdc_sv39_hpdcache configuration.

This configuration uses 64-bit variant of the CVA6 with "deep" structures related to the data cache:
- Up to 8 inflight loads to the cache (and thus up to 8 miss requests to the memory)
- Up to 8 inflight write requests to the memory

It also restores the testing of the WB cache into the CI.

FIXME: In addition, this PR comments out some coverpoints in the AXI agent because of illegal bins that are not compatible with the HPDcache. These coverpoints expect that the cache uses a very small subset of IDs in AXI transactions, however the HPDcache is able to use a larger subset as it can issue multiple inflight requests to the memory (both reads and writes).

I pushed a first proposal for the Github's CI. It runs the following configurations:

    cv64a6_imafdc_sv39_hpdcache
    cv64a6_imafdc_sv39_wb
    cv64a6_imafdc_sv39
    cv32a65x

However, the number of tests is limited. The selected tests allow to test arithmetic, memory and branch/jump instructions and a complete but very simple application (hello_world). In addition, the riscv-arch-test suite is executed with the cv64a6_imafdc_sv39_hpdcache and cv32a65x configurations. In the case of 64 bits configurations, I selected the unitary tests that enable the MMU.

The tests for a given configuration are run sequentially but all configurations are run in parallel to reduce the overall latency.

For 64 bits configurations:

    riscv-arch-test (only in the cv64a6_imafdc_sv39_hpdcache configuration)
    rv64ui-v-add
    rv64ui-v-ld
    rv64ui-v-sd
    rv64ui-v-beq
    rv64ui-v-jal
    hello_world.c

For 32 bits configurations:

    riscv-arch-test
    rv32ui-p-add
    rv32ui-p-lw
    rv32ui-p-sw
    rv32ui-p-beq
    rv32ui-p-jal
    hello_world.c
