### PR TITLE
Invalid pte reserved

### DIFF
--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -104,6 +104,7 @@ module cva6_mmu
 
   // memory management, pte for cva6
   localparam type pte_cva6_t = struct packed {
+    logic [9:0] reserved;
     logic [CVA6Cfg.PPNW-1:0] ppn;  // PPN length for
     logic [1:0] rsw;
     logic d;

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -404,9 +404,8 @@ module cva6_ptw
           // -------------
           // Invalid PTE
           // -------------
-          // If pte.v = 0, or if pte.r = 0 and pte.w = 1, stop and raise a page-fault exception.
-          if (!pte.v || (!pte.r && pte.w))  // || (|pte.reserved))
-            state_d = PROPAGATE_ERROR;
+          // If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if pte.reserved !=0, stop and raise a page-fault exception.
+          if (!pte.v || (!pte.r && pte.w) || (|pte.reserved)) state_d = PROPAGATE_ERROR;
           // -----------
           // Valid PTE
           // -----------

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -98,7 +98,7 @@ module cva6_ptw
   pte_cva6_t pte;
   // register to perform context switch between stages
   pte_cva6_t gpte_q, gpte_d;
-  assign pte = pte_cva6_t'(data_rdata_q[CVA6Cfg.PPNW+9:0]);
+  assign pte = pte_cva6_t'(data_rdata_q);
 
   enum logic [2:0] {
     IDLE,
@@ -404,8 +404,8 @@ module cva6_ptw
           // -------------
           // Invalid PTE
           // -------------
-          // If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if pte.reserved !=0, stop and raise a page-fault exception.
-          if (!pte.v || (!pte.r && pte.w) || (|pte.reserved)) state_d = PROPAGATE_ERROR;
+          // If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if pte.reserved !=0 in sv39 and sv39x4, stop and raise a page-fault exception.
+          if (!pte.v || (!pte.r && pte.w) || (|pte.reserved && CVA6Cfg.XLEN == 64)) state_d = PROPAGATE_ERROR;
           // -----------
           // Valid PTE
           // -----------

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -405,7 +405,8 @@ module cva6_ptw
           // Invalid PTE
           // -------------
           // If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if pte.reserved !=0 in sv39 and sv39x4, stop and raise a page-fault exception.
-          if (!pte.v || (!pte.r && pte.w) || (|pte.reserved && CVA6Cfg.XLEN == 64)) state_d = PROPAGATE_ERROR;
+          if (!pte.v || (!pte.r && pte.w) || (|pte.reserved && CVA6Cfg.XLEN == 64))
+            state_d = PROPAGATE_ERROR;
           // -----------
           // Valid PTE
           // -----------

--- a/core/cva6_mmu/cva6_shared_tlb.sv
+++ b/core/cva6_mmu/cva6_shared_tlb.sv
@@ -112,11 +112,11 @@ module cva6_shared_tlb #(
 
   logic [               SHARED_TLB_WAYS-1:0] pte_wr_en;
   logic [$clog2(CVA6Cfg.SharedTlbDepth)-1:0] pte_wr_addr;
-  logic [             $bits(pte_cva6_t)-1:0] pte_wr_data      [                1:0];
+  logic [                  CVA6Cfg.XLEN-1:0] pte_wr_data      [                1:0];
 
   logic [               SHARED_TLB_WAYS-1:0] pte_rd_en;
   logic [$clog2(CVA6Cfg.SharedTlbDepth)-1:0] pte_rd_addr;
-  logic [             $bits(pte_cva6_t)-1:0] pte_rd_data      [SHARED_TLB_WAYS-1:0] [HYP_EXT:0];
+  logic [                  CVA6Cfg.XLEN-1:0] pte_rd_data      [SHARED_TLB_WAYS-1:0] [HYP_EXT:0];
 
   logic [               SHARED_TLB_WAYS-1:0] pte_req;
   logic [               SHARED_TLB_WAYS-1:0] pte_we;
@@ -413,8 +413,8 @@ module cva6_shared_tlb #(
 
   assign pte_wr_addr = shared_tlb_update_i.vpn[$clog2(CVA6Cfg.SharedTlbDepth)-1:0];
 
-  assign pte_wr_data[0] = shared_tlb_update_i.content;
-  assign pte_wr_data[1] = shared_tlb_update_i.g_content;
+  assign pte_wr_data[0] = shared_tlb_update_i.content[CVA6Cfg.XLEN-1:0];
+  assign pte_wr_data[1] = shared_tlb_update_i.g_content[CVA6Cfg.XLEN-1:0];
 
 
 
@@ -479,7 +479,7 @@ module cva6_shared_tlb #(
       for (genvar a = 0; a < HYP_EXT + 1; a++) begin : g_content_sram
         // PTE RAM
         sram #(
-            .DATA_WIDTH($bits(pte_cva6_t)),
+            .DATA_WIDTH(CVA6Cfg.XLEN),
             .NUM_WORDS (CVA6Cfg.SharedTlbDepth)
         ) pte_sram (
             .clk_i  (clk_i),


### PR DESCRIPTION
Add reserved bits to PTE structure be used in sv39 and sv39x4 only

Check that they are 0, otherwise the PTE is considered invalid