### PR TITLE
Configure AXI assertion and coverage model for easy utilization of WT and HPDcache

### DIFF
--- a/verif/env/uvme/uvme_cva6_cfg.sv
+++ b/verif/env/uvme/uvme_cva6_cfg.sv
@@ -47,6 +47,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
 
    // Zicond extension
    rand bit                      ext_zicond_supported;
+   rand bit                      HPDCache_supported;
 
    //pmp entries
    rand int                      nr_pmp_entries;
@@ -58,6 +59,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
       `uvm_field_int (                         cov_model_enabled           , UVM_DEFAULT          )
       `uvm_field_int (                         trn_log_enabled             , UVM_DEFAULT          )
       `uvm_field_int (                         ext_zicond_supported        , UVM_DEFAULT          )
+      `uvm_field_int (                         HPDCache_supported          , UVM_DEFAULT          )
       `uvm_field_int (                         nr_pmp_entries              , UVM_DEFAULT          )
       `uvm_field_int (                         sys_clk_period            , UVM_DEFAULT + UVM_DEC)
 
@@ -138,6 +140,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
       dm_halt_addr_valid      == 1;
       dm_exception_addr_valid == 1;
       nmi_addr_valid          == 1;
+      HPDCache_supported      == 1;
    }
 
    constraint ext_const {

--- a/verif/tb/uvmt/uvmt_axi_assert.sv
+++ b/verif/tb/uvmt/uvmt_axi_assert.sv
@@ -7,7 +7,8 @@
 //
 // Original Author: Alae Eddine EZ ZEJJARI (alae-eddine.ez-zejjari@external.thalesgroup.com) – sub-contractor MU-Electronics for Thales group
 
-module  uvmt_axi_assert (uvma_axi_intf axi_assert_if);
+module  uvmt_axi_assert#(int HPDCache=2)
+  (uvma_axi_intf axi_assert_if);
 
    import uvm_pkg::*;
 
@@ -25,7 +26,7 @@ module  uvmt_axi_assert (uvma_axi_intf axi_assert_if);
 
    uvma_axi_amo_assert        axi_amo_assert(.axi_assert(axi_assert_if));
 
-   uvmt_cva6_axi_assert       cva6_axi_assert(.axi_assert_if(axi_assert_if));
+   uvmt_cva6_axi_assert#(HPDCache)       cva6_axi_assert(.axi_assert_if(axi_assert_if));
 
 
 endmodule : uvmt_axi_assert

--- a/verif/tb/uvmt/uvmt_cva6_axi_assert.sv
+++ b/verif/tb/uvmt/uvmt_cva6_axi_assert.sv
@@ -11,19 +11,19 @@
 
 `include "uvm_macros.svh"
 
-module  uvmt_cva6_axi_assert (uvma_axi_intf axi_assert_if);
+module  uvmt_cva6_axi_assert#(int HPDCache=2)
+        (uvma_axi_intf axi_assert_if);
 
    import uvm_pkg::*;
 
-
    //check if the CVA6 identify read transaction with an ID equal to 0 or 1
    property AXI4_CVA6_ARID;
-      @(posedge axi_assert_if.clk) disable iff (!axi_assert_if.rst_n) axi_assert_if.ar_valid |-> axi_assert_if.ar_id == 0 || axi_assert_if.ar_id == 1 || (axi_assert_if.ar_id == 3 && axi_assert_if.ar_lock == 1);
+      @(posedge axi_assert_if.clk && (HPDCache != 2)) disable iff (!axi_assert_if.rst_n) axi_assert_if.ar_valid |-> axi_assert_if.ar_id == 0 || axi_assert_if.ar_id == 1 || (axi_assert_if.ar_id == 3 && axi_assert_if.ar_lock == 1);
    endproperty
 
    //check if the CVA6 identify write transaction with an ID equal to 0 or 1
    property AXI4_CVA6_AWID;
-      @(posedge axi_assert_if.clk) disable iff (!axi_assert_if.rst_n) axi_assert_if.aw_valid |-> axi_assert_if.aw_id == 1 || (axi_assert_if.aw_id == 3 && axi_assert_if.aw_atop != 0) || (axi_assert_if.aw_id == 3 && axi_assert_if.aw_lock == 1);
+      @(posedge axi_assert_if.clk && (HPDCache != 2)) disable iff (!axi_assert_if.rst_n) axi_assert_if.aw_valid |-> axi_assert_if.aw_id == 1 || (axi_assert_if.aw_id == 3 && axi_assert_if.aw_atop != 0) || (axi_assert_if.aw_id == 3 && axi_assert_if.aw_lock == 1);
    endproperty
 
    //Check if user-defined extension for read address channel is equal to 0b00
@@ -58,12 +58,12 @@ module  uvmt_cva6_axi_assert (uvma_axi_intf axi_assert_if);
 
    //Check if AWCACHE is always equal to 0b0000
    property AXI4_CVA6_AWCACHE;
-      @(posedge axi_assert_if.clk) disable iff (!axi_assert_if.rst_n) axi_assert_if.aw_valid |-> axi_assert_if.aw_cache == 2;
+      @(posedge axi_assert_if.clk && (HPDCache != 2)) disable iff (!axi_assert_if.rst_n) axi_assert_if.aw_valid |-> axi_assert_if.aw_cache == 2;
    endproperty
 
    //Check if ARCACHE is always equal to 0b0000
    property AXI4_CVA6_ARCACHE;
-      @(posedge axi_assert_if.clk) disable iff (!axi_assert_if.rst_n) axi_assert_if.ar_valid |-> axi_assert_if.ar_cache == 2;
+      @(posedge axi_assert_if.clk && (HPDCache != 2)) disable iff (!axi_assert_if.rst_n) axi_assert_if.ar_valid |-> axi_assert_if.ar_cache == 2;
    endproperty
 
    //Check if Protection attributes for write transaction always take the 0b000
@@ -103,14 +103,11 @@ module  uvmt_cva6_axi_assert (uvma_axi_intf axi_assert_if);
 
 /********************************************** Assert Property ******************************************************/
 
-   // TODO: commented when integrating HPDCache
-   if (0) begin
    cva6_arid                : assert property (AXI4_CVA6_ARID)
                          else `uvm_error (" AXI4 protocol checks assertion ", "Violation of AXI4_CVA6_ARID");
 
    cva6_awid                : assert property (AXI4_CVA6_AWID)
                          else `uvm_error (" AXI4 protocol checks assertion ", "Violation of AXI4_CVA6_AWID");
-   end
 
    cva6_aruser              : assert property (AXI4_CVA6_ARUSER)
                          else `uvm_error (" AXI4 protocol checks assertion ", "Violation of AXI4_CVA6_ARUSER");
@@ -130,14 +127,11 @@ module  uvmt_cva6_axi_assert (uvma_axi_intf axi_assert_if);
    cva6_awregion            : assert property (AXI4_CVA6_AWREGION)
                          else `uvm_error (" AXI4 protocol checks assertion ", "Violation of AXI4_CVA6_AWREGION");
 
-   // TODO: commented when integrating HPDCache
-   if (0) begin
    cva6_arcache             : assert property (AXI4_CVA6_ARCACHE)
                          else `uvm_error (" AXI4 protocol checks assertion ", "Violation of AXI4_CVA6_ARCAHCE");
 
    cva6_awcache             : assert property (AXI4_CVA6_AWCACHE)
                          else `uvm_error (" AXI4 protocol checks assertion ", "Violation of AXI4_CVA6_AWCAHCE");
-   end
 
    cva6_arprot              : assert property (AXI4_CVA6_ARPROT)
                          else `uvm_error (" AXI4 protocol checks assertion ", "Violation of AXI4_CVA6_ARPROT");
@@ -199,5 +193,3 @@ module  uvmt_cva6_axi_assert (uvma_axi_intf axi_assert_if);
 
 
 endmodule : uvmt_cva6_axi_assert
-
-

--- a/verif/tb/uvmt/uvmt_cva6_tb.sv
+++ b/verif/tb/uvmt/uvmt_cva6_tb.sv
@@ -86,7 +86,7 @@ module uvmt_cva6_tb;
                                              );
    //bind assertion module for axi interface
    bind uvmt_cva6_dut_wrap
-      uvmt_axi_assert            axi_assert(.axi_assert_if(axi_if));
+      uvmt_axi_assert #(CVA6Cfg.DCacheType)           axi_assert(.axi_assert_if(axi_if));
 
    // DUT Wrapper Interfaces
    uvmt_rvfi_if #(


### PR DESCRIPTION
Parametrize AXI assertion module to disable invalid assertions with HPDCache.
Implementation of the HPDCache parameter in env_cfg to configure the AXI coverage model.