### PR TITLE
[CI] Fix spike version checks on the CVA6

### DIFF
--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1064,7 +1064,7 @@ def check_gcc_version():
 
 def check_spike_version():
   # Get Spike hash from core-v-verif submodule
-  spike_hash = subprocess.run('git log -1 --pretty=tformat:%h -- $SPIKE_SRC_DIR/', capture_output=True, text=True, shell=True, cwd=os.environ.get("SPIKE_SRC_DIR"))
+  spike_hash = subprocess.run('git log -1 --pretty=tformat:%h', capture_output=True, text=True, shell=True, cwd=os.environ.get("SPIKE_SRC_DIR"))
   spike_version = "1.1.1-dev " + spike_hash.stdout.strip()
 
   # Get Spike User version


### PR DESCRIPTION
Correctly determine CVV hash when checking the expected checksum in verif/sim/cva6.py.

Calling "git log -1 -- PATH" will return the most recent commit that affected files in PATH.  In particular, "cd PATH ; git log" and "cd PATH ; git log -- ." may produce two distinct values if current commit is a merge point.

To avoid ambiguities, this change forces the use of project-level hashes on the CVA6 side, matching the behavior of core-v-verif PR #2442 (merged as commit 6af3cc55d).