### PR TITLE
Fix bug when killing WB cache request

### DIFF
--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -440,7 +440,7 @@ module cache_ctrl
 
     if (req_port_i.kill_req) begin
       req_port_o.data_rvalid = 1'b1;
-      if (!(state_q inside {WAIT_REFILL_GNT, WAIT_CRITICAL_WORD})) begin
+      if (!(state_q inside {WAIT_REFILL_GNT, WAIT_REFILL_VALID, WAIT_CRITICAL_WORD})) begin
         state_d = IDLE;
       end
     end


### PR DESCRIPTION
This PR fixes a bug that could happen when a WB cache request gets killed while the _cache_ctrl_ is in the **WAIT_REFILL_VALID** state. When receiving the kill request, the _cache_ctrl_ went immediately back to the **IDLE** state. However,  the AXI request was already issued and could be associated to the following cache request, effectively sending back the wrong data to the CPU. By not going immediately back to **IDLE**, the cache waits for the AXI response to arrive before going back to **IDLE**. Since this case is quite rare, the bottleneck introduced by not going immediately back to **IDLE** is minimal. The bug was found while running the WB TB. In this screenshot, the first request for addresss 0x10D1C gets killed and the cache_ctrl starts working on the next requets. 
![image](https://github.com/openhwgroup/cva6/assets/46382251/c968159a-eb9c-4566-a1ab-bcfcb5131f62)
Later, the request for address 0x1D72 receives an AXI bypass response which is not the one it was supposed to receive but associates it with the current cache request:
![image](https://github.com/openhwgroup/cva6/assets/46382251/62a41669-b453-416d-959a-b2591c960bd3)
Which causes the bug:
![image](https://github.com/openhwgroup/cva6/assets/46382251/e752e3fb-9c02-43b6-ac07-0fc18aa5e016)