### PR TITLE
Disable warnings in Code coverage Job

### DIFF
--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -368,7 +368,7 @@ questa-uvm:
 
 
 generate_cov_dash:
-	urg -hvp_proj cva6_embedded -format both -group instcov_for_score -hvp_attributes weight+description+Comment -dir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -tgl portsonly
+	urg -warn none -hvp_proj cva6_embedded -format both -group instcov_for_score -hvp_attributes weight+description+Comment -dir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -tgl portsonly
 
 vcs_clean_all:
 	@echo "[VCS] Cleanup (entire vcs_work dir)"


### PR DESCRIPTION
This is a temporary workaround, we have a lot of warning in the CC Job,so until investigating the cause of the warnings i'll disable them for now !!