### PR TITLE
Update PMA description for CV32A65X

### DIFF
--- a/docs/06_cv32a65x_riscv/priv-isa-cv32a65x.html
+++ b/docs/06_cv32a65x_riscv/priv-isa-cv32a65x.html
@@ -3356,9 +3356,12 @@ and UPP are read-only 0.</p>
 <div class="sect4">
 <h5 id="_memory_privilege_in_mstatus_register">3.1.6.3. Memory Privilege in <code>mstatus</code> Register</h5>
 <div class="paragraph">
-<p>[CV32A65X] As the U-Mode is not implemented, MPRV is read-only 0.
+<p>[CV32A65X] As U-Mode is not implemented, MPRV is read-only 0.
 Loads and stores behave as normal, using the translation and protection
 mechanisms of the current privilege mode.</p>
+</div>
+<div class="paragraph">
+<p>[CV32A65X] As S-mode is not implemented, MXR and SUM are read-only 0.</p>
 </div>
 </div>
 <div class="sect4">
@@ -3506,7 +3509,8 @@ machine mode cause the <code>pc</code> to be set to the address in the BASE fiel
 mode.</p>
 </div>
 <div class="paragraph">
-<p>[CV32A65X] As S-mode is not implemented, the <code>medeleg</code> and <code>mideleg</code> registers do not exist.</p>
+<p>[CV32A65X] As S-mode is not implemented, the <code>medeleg</code> and <code>mideleg</code> registers do not exist.
+The SPP, SPIE, SIE fields of <code>mstatus</code> are read-only zero.</p>
 </div>
 </div>
 <div class="sect3">
@@ -4246,29 +4250,17 @@ systems implement and check PMAs.</p>
 some memory regions are fixed at chip design time.</p>
 </div>
 <div class="paragraph">
-<p>[CV32A65X] Most systems will require that at least some PMAs are dynamically
+<p>[CV32A65X] Some PMAs are dynamically
 checked in hardware later in the execution pipeline after the physical
 address is known, as some operations will not be supported at all
 physical memory addresses, and some operations require knowing the
-current setting of a configurable PMA attribute. While many other
-architectures specify some PMAs in the virtual memory page tables and
-use the TLB to inform the pipeline of these properties, this approach
-injects platform-specific information into a virtualized layer and can
-cause system errors unless attributes are correctly initialized in each
-page-table entry for each physical memory region. In addition, the
-available page sizes might not be optimal for specifying attributes in
-the physical memory space, leading to address-space fragmentation and
-inefficient use of expensive TLB entries.</p>
+setting of a PMA attribute.</p>
 </div>
 <div class="paragraph">
 <p>[CV32A65X] For RISC-V, we separate out specification and checking of PMAs into a
-separate hardware structure, the <em>PMA checker</em>. In many cases, the
+separate hardware structure, the <em>PMA checker</em>. In CV32A65X, the
 attributes are known at system design time for each physical address
-region, and can be hardwired into the PMA checker. Where the attributes
-are run-time configurable, platform-specific memory-mapped control
-registers can be provided to specify these attributes at a granularity
-appropriate to each region on the platform (e.g., for an on-chip SRAM
-that can be flexibly divided between cacheable and uncacheable uses).
+region, and are hardwired into the PMA checker.
 PMAs are checked for any access to physical memory, including accesses
 that have undergone virtual to physical memory translation. To aid in
 system debugging, we strongly recommend that, where possible, RISC-V
@@ -4281,17 +4273,7 @@ of the discovery mechanism. In this case, error responses from
 peripheral devices will be reported as imprecise bus-error interrupts.</p>
 </div>
 <div class="paragraph">
-<p>[CV32A65X] PMAs must also be readable by software to correctly access certain
-devices or to correctly configure other hardware components that access
-memory, such as DMA engines. As PMAs are tightly tied to a given
-physical platform’s organization, many details are inherently
-platform-specific, as is the means by which software can learn the PMA
-values for a platform. Some devices, particularly legacy buses, do not
-support discovery of PMAs and so will give error responses or time out
-if an unsupported access is attempted. Typically, platform-specific
-machine-mode code will extract PMAs and ultimately present this
-information to higher-level less-privileged software using some standard
-representation.</p>
+<p>[CV32A65X] PMAs are not readable by software.</p>
 </div>
 <div class="sect3">
 <h4 id="_main_memory_versus_io_versus_vacant_regions">3.6.1. Main Memory versus I/O versus Vacant Regions</h4>
@@ -4355,53 +4337,8 @@ page-table writes are supported.</p>
 <div class="sect3">
 <h4 id="_memory_ordering_pmas">3.6.5. Memory-Ordering PMAs</h4>
 <div class="paragraph">
-<p>Regions of the address space are classified as either <em>main memory</em> or
-<em>I/O</em> for the purposes of ordering by the FENCE instruction and
-atomic-instruction ordering bits.</p>
-</div>
-<div class="paragraph">
-<p>Accesses by one hart to main memory regions are observable not only by
-other harts but also by other devices with the capability to initiate
-requests in the main memory system (e.g., DMA engines). Coherent main
-memory regions always have either the RVWMO or RVTSO memory model.
-Incoherent main memory regions have an implementation-defined memory
-model.</p>
-</div>
-<div class="paragraph">
-<p>Accesses by one hart to an I/O region are observable not only by other
-harts and bus mastering devices but also by the targeted I/O devices,
-and I/O regions may be accessed with either <em>relaxed</em> or <em>strong</em>
-ordering. Accesses to an I/O region with relaxed ordering are generally
-observed by other harts and bus mastering devices in a manner similar to
-the ordering of accesses to an RVWMO memory region, as discussed in
-Section A.4.2 in Volume I of this specification. By contrast, accesses
-to an I/O region with strong ordering are generally observed by other
-harts and bus mastering devices in program order.</p>
-</div>
-<div class="paragraph">
-<p>Each strongly ordered I/O region specifies a numbered ordering channel,
-which is a mechanism by which ordering guarantees can be provided
-between different I/O regions. Channel 0 is used to indicate
-point-to-point strong ordering only, where only accesses by the hart to
-the single associated I/O region are strongly ordered.</p>
-</div>
-<div class="paragraph">
-<p>Channel 1 is used to provide global strong ordering across all I/O
-regions. Any accesses by a hart to any I/O region associated with
-channel 1 can only be observed to have occurred in program order by all
-other harts and I/O devices, including relative to accesses made by that
-hart to relaxed I/O regions or strongly ordered I/O regions with
-different channel numbers. In other words, any access to a region in
-channel 1 is equivalent to executing a <code>fence io,io</code> instruction before
-and after the instruction.</p>
-</div>
-<div class="paragraph">
-<p>Other larger channel numbers provide program ordering to accesses by
-that hart across any regions with the same channel number.</p>
-</div>
-<div class="paragraph">
-<p>Systems might support dynamic configuration of ordering properties on
-each memory region.</p>
+<p>[CV32A65X] As CV32A65X is dedicated to a one hart
+platform without any DMA, no memory-ordering mechanism is implemented.</p>
 </div>
 </div>
 <div class="sect3">
@@ -4433,7 +4370,7 @@ effect.</p>
 <div class="paragraph">
 <p>For non-idempotent regions, implicit reads and writes must not be
 performed early or speculatively, with the following exceptions. When a
-non-speculative implicit read is performed, an implementation (TODO) is
+non-speculative implicit read is performed, an implementation is
 permitted to additionally read any of the bytes within a naturally
 aligned power-of-2 region containing the address of the non-speculative
 implicit read. Furthermore, when a non-speculative instruction fetch is

--- a/docs/06_cv32a65x_riscv/src/machine.adoc
+++ b/docs/06_cv32a65x_riscv/src/machine.adoc
@@ -3115,28 +3115,16 @@ ifeval::[{ohg-config} == CV32A65X]
 [{ohg-config}] PMAs are inherent properties of the underlying hardware. The PMAs of
 some memory regions are fixed at chip design time.
 
-[{ohg-config}] Most systems will require that at least some PMAs are dynamically
+[{ohg-config}] Some PMAs are dynamically
 checked in hardware later in the execution pipeline after the physical
 address is known, as some operations will not be supported at all
 physical memory addresses, and some operations require knowing the
-current setting of a configurable PMA attribute. While many other
-architectures specify some PMAs in the virtual memory page tables and
-use the TLB to inform the pipeline of these properties, this approach
-injects platform-specific information into a virtualized layer and can
-cause system errors unless attributes are correctly initialized in each
-page-table entry for each physical memory region. In addition, the
-available page sizes might not be optimal for specifying attributes in
-the physical memory space, leading to address-space fragmentation and
-inefficient use of expensive TLB entries.
+setting of a PMA attribute.
 
 [{ohg-config}] For RISC-V, we separate out specification and checking of PMAs into a
-separate hardware structure, the _PMA checker_. In many cases, the
+separate hardware structure, the _PMA checker_. In {ohg-config}, the
 attributes are known at system design time for each physical address
-region, and can be hardwired into the PMA checker. Where the attributes
-are run-time configurable, platform-specific memory-mapped control
-registers can be provided to specify these attributes at a granularity
-appropriate to each region on the platform (e.g., for an on-chip SRAM
-that can be flexibly divided between cacheable and uncacheable uses).
+region, and are hardwired into the PMA checker.
 PMAs are checked for any access to physical memory, including accesses
 that have undergone virtual to physical memory translation. To aid in
 system debugging, we strongly recommend that, where possible, RISC-V
@@ -3148,17 +3136,7 @@ when probing a legacy bus architecture that uses access failures as part
 of the discovery mechanism. In this case, error responses from
 peripheral devices will be reported as imprecise bus-error interrupts.
 
-[{ohg-config}] PMAs must also be readable by software to correctly access certain
-devices or to correctly configure other hardware components that access
-memory, such as DMA engines. As PMAs are tightly tied to a given
-physical platform’s organization, many details are inherently
-platform-specific, as is the means by which software can learn the PMA
-values for a platform. Some devices, particularly legacy buses, do not
-support discovery of PMAs and so will give error responses or time out
-if an unsupported access is attempted. Typically, platform-specific
-machine-mode code will extract PMAs and ultimately present this
-information to higher-level less-privileged software using some standard
-representation.
+[{ohg-config}] PMAs are not readable by software.
 endif::[]
 
 ==== Main Memory versus I/O versus Vacant Regions
@@ -3355,6 +3333,7 @@ endif::[]
 
 ==== Memory-Ordering PMAs
 
+ifeval::[{ohg-config} != CV32A65X]
 Regions of the address space are classified as either _main memory_ or
 _I/O_ for the purposes of ordering by the FENCE instruction and
 atomic-instruction ordering bits.
@@ -3396,6 +3375,12 @@ that hart across any regions with the same channel number.
 
 Systems might support dynamic configuration of ordering properties on
 each memory region.
+endif::[]
+
+ifeval::[{ohg-config} == CV32A65X]
+[{ohg-config}] As {ohg-config} is dedicated to a one hart
+platform without any DMA, no memory-ordering mechanism is implemented.
+endif::[]
 
 ifeval::[{note} == true]
 [NOTE]
@@ -3533,7 +3518,7 @@ endif::[]
 
 For non-idempotent regions, implicit reads and writes must not be
 performed early or speculatively, with the following exceptions. When a
-non-speculative implicit read is performed, an implementation (TODO) is
+non-speculative implicit read is performed, an implementation is
 permitted to additionally read any of the bytes within a naturally
 aligned power-of-2 region containing the address of the non-speculative
 implicit read. Furthermore, when a non-speculative instruction fetch is


### PR DESCRIPTION
As PMA are static and memory model not needed for CV32A65X, update doc