### PR TITLE
[UVM TB] Initialize information about DRAM presence, address and size.

### DIFF
--- a/verif/tb/core/uvma_cva6pkg_utils.sv
+++ b/verif/tb/core/uvma_cva6pkg_utils.sv
@@ -37,6 +37,12 @@ function st_core_cntrl_cfg cva6pkg_to_core_cntrl_cfg(st_core_cntrl_cfg base);
     base.pmp_regions = CVA6Cfg.NrPMPEntries;
     base.debug_supported = CVA6Cfg.DebugEn;
 
+    // FIXME TODO: Temporary solution. We need explicit info on memory map.
+    // FORNOW The solution below relies on specific region ordering.
+    base.dram_base = CVA6Cfg.ExecuteRegionAddrBase[2];
+    base.dram_size = CVA6Cfg.ExecuteRegionLength[2];
+    base.dram_valid = 1;
+
     base.disable_all_csr_checks = 0;
 
     base.unsupported_csr_mask['h643] = 1; // HTVAL


### PR DESCRIPTION
Fxx issue openhwgroup/core-v-verif#2444: Fill the 'dram', 'dram_base' and 'dram_size' fields of the st_core_cntrl_cfg structure with reliable values.

The corresponding fields in the (virtual) base class of st_core_cntrl_cfg are declared with 'rand' modifier.  In particular, the 'dram' field could occasionally take value 1'b1, causing the Spike tandem interface to pass the random values of DRAM base address and DRAM size to Spike.  When DRAM size is not a strictly positive multiple of PAGE_SIZE, Spike throws a runtime exception causing issue openhwgroup/core-v-verif#2444.

NOTE: The comment added in the code is there purposely as a reminder that we need an overhaul of memory layout management.