### PR TITLE
fix gcc-14 compile error on dhrystone: implicit-function-declaration, implicit-int

### DIFF
--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -45,6 +45,8 @@ cflags=(
         -nostartfiles
         -lgcc
         -O3 --no-inline
+        -Wno-implicit-function-declaration
+        -Wno-implicit-int
         -I../tests/custom/env
         -I../tests/custom/common
         -I../tests/riscv-tests/benchmarks/dhrystone/


### PR DESCRIPTION
When compiling dhrystone with gcc-14, there is below errors

```
Tue, 28 May 2024 11:55:02 INFO     GCC Version: 14.0.1

Tue, 28 May 2024 11:55:02 INFO     ../tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: In function 'main':
../tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:120:7: error: implicit declaration of function 'Proc_5' [-Wimplicit-function-declaration]
  120 |       Proc_5();
      |       ^~~~~~

../tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c: At top level:
../tests/riscv-tests/benchmarks/dhrystone/dhrystone_main.c:242:1: error: return type defaults to 'int' [-Wimplicit-int]
  242 | Proc_1 (Ptr_Val_Par)
      | ^~~~~~
```

As [Porting to GCC 14](https://gcc.gnu.org/gcc-14/porting_to.html) says, 
> For backwards compatibility, GCC 13 and earlier diagnosed use of these features as warnings only. Although these warnings have been enabled by default for many releases, experience shows that these warnings are easily ignored, resulting in difficult to diagnose bugs. In GCC 14, these issues are now reported as errors, and no output file is created, providing clearer feedback to programmers that something is wrong.

So, turn off these here.