### PR TITLE
[riscv-config] Fix issues in CV32A65X input spec and regenerate output.

### DIFF
--- a/config/riscv-config/cv32a65x/generated/custom_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/custom_gen.yaml
@@ -61,12 +61,18 @@ hart0:
                 shadow_type:
                 msb: 0
                 lsb: 0
+            reserved_0:
+                implemented: true
+                description: reserved for future use
+                type:
+                    ro_constant: 0x0
+                shadow:
+                shadow_type:
+                msb: 31
+                lsb: 1
             fields:
               - dcache
-              -
-                  -
-                      - 1
-                      - 31
+              - reserved_0
         description: the register controls the operation of the d-cache unit.
         address: 0x7c1
         priv_mode: M

--- a/config/riscv-config/cv32a65x/generated/isa_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/isa_gen.yaml
@@ -16,7 +16,7 @@
 
 hart_ids: [0]
 hart0:
-    ISA: RV32IMCZicsr_Zicntr_Zifencei
+    ISA: RV32IMCZicsr_Zicntr_Zifencei_Zba_Zbb_Zbc_Zbs
     User_Spec_Version: '2.3'
     supported_xlen:
       - 32
@@ -69,11 +69,11 @@ hart0:
         rv64:
             accessible: false
     mvendorid:
-        reset-val: 0xdeadbeef
+        reset-val: 0x00000602
         rv32:
             accessible: true
             type:
-                ro_constant: 0xdeadbeef
+                ro_constant: 0x00000602
             fields: []
             shadow:
             shadow_type: rw
@@ -146,7 +146,7 @@ hart0:
         address: 0x200
         priv_mode: S
     mstatus:
-        reset-val: 0x0
+        reset-val: 0x00001800
         rv32:
             accessible: true
             uie:
@@ -213,7 +213,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - mpp[1:0] in [0x0, 0x3]
+                          - mpp[1:0] in [0x3]
                         wr_illegal:
                           - Unchanged
                 description: Stores the previous priority mode for machine.
@@ -690,7 +690,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                ro_constant: 0x0
+                ro_constant: 0x00000003
             fields: []
             shadow:
             shadow_type: rw
@@ -698,7 +698,7 @@ hart0:
             lsb: 0
         rv64:
             accessible: false
-        reset-val: 0x0
+        reset-val: 0x00000003
         description: MXLEN-bit read-only register encoding the base microarchitecture
             of the hart.
         address: 3858

--- a/config/riscv-config/cv32a65x/spec/custom_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/custom_spec.yaml
@@ -58,6 +58,15 @@ hart0:
           shadow_type:
           msb: 0
           lsb: 0
+        reserved_0:
+          implemented: true
+          description: reserved for future use
+          type:
+            ro_constant: 0x0
+          shadow:
+          shadow_type:
+          msb: 31
+          lsb: 1
       description: the register controls the operation of the d-cache unit.
       address: 0x7c1
       priv_mode: M

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -155,9 +155,7 @@ hart0: &hart0
      fs:
       implemented: false
      xs:
-      implemented: true
-      type:
-        ro_variable: true
+      implemented: false
      mprv:
       implemented: false
      sum:

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -70,7 +70,7 @@ hart0: &hart0
          warl:
            dependency_fields: []
            legal:
-             - mode[1:0] in [0x0,0x1]
+             - mode[1:0] in [0x0]
            wr_illegal:
              - Unchanged
   sstatus:

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -16,13 +16,13 @@
 
 hart_ids: [0]
 hart0: &hart0
-  ISA: RV32IMCZicsr_Zicntr_Zifencei
+  ISA: RV32IMCZicsr_Zicntr_Zifencei_Zba_Zbb_Zbc_Zbs
   User_Spec_Version: '2.3'
   supported_xlen: [32]
   physical_addr_sz: 32
   pmp_granularity: 5
   misa:
-   reset-val: 0x40001104 # C: bit 2, I = bit 8, M = bit 12, Z = bit 25
+   reset-val: 0x40001104 # B: bit 1, C: bit 2, I = bit 8, M = bit 12, Z = bit 25
    rv32:
      accessible: true
      mxl:
@@ -44,11 +44,11 @@ hart0: &hart0
               wr_illegal:
                 - unchanged
   mvendorid:
-   reset-val: 0xdeadbeef
+   reset-val: 0x00000602
    rv32:
      accessible: true
      type:
-       ro_constant: 0xdeadbeef
+       ro_constant: 0x00000602
    rv64:
      accessible: false
   mtvec:
@@ -61,18 +61,18 @@ hart0: &hart0
          warl:
            dependency_fields: []
            legal:
-             - "base[29:0] bitmask [0x3FFFFFFF, 0x00000000]"
+             - base[29:0] bitmask [0x3FFFFFFF, 0x00000000]
            wr_illegal:
-             - "Unchanged"
+             - Unchanged
      mode:
        implemented: true
        type:                            
          warl:
            dependency_fields: []
            legal:
-             - "mode[1:0] in [0x0,0x1]"
+             - mode[1:0] in [0x0,0x1]
            wr_illegal:
-             - "Unchanged"
+             - Unchanged
   sstatus:
    reset-val: 0x0
    rv32:
@@ -126,36 +126,30 @@ hart0: &hart0
    rv64:
      accessible: false
   mstatus:
-   reset-val: 0x0
+   reset-val: 0x00001800 # .mpp = 0x3
    rv32:
      accessible: true
      uie:
       implemented: false
      sie:
       implemented: false
-      type:
-        wlrl: [0:1]
      mie:
       implemented: true
      upie:
       implemented: false
      spie:
       implemented: false
-      type:
-        wlrl: [0:1]
      mpie:
       implemented: true
      spp:
       implemented: false
-      type:
-        wlrl: [0:1]
      mpp:
       implemented: true
       type:
         warl:
           dependency_fields: []
           legal: 
-            - mpp[1:0] in [0x0, 0x3]
+            - mpp[1:0] in [0x3]
           wr_illegal: 
             - Unchanged
      fs:
@@ -166,30 +160,18 @@ hart0: &hart0
         ro_variable: true
      mprv:
       implemented: false
-      type:
-        wlrl: [0:1]
      sum:
       implemented: false
-      type:
-        wlrl: [0:1]
      mxr:
       implemented: false
-      type:
-        wlrl: [0:1]
      tvm:
       implemented: false
-      type:
-        wlrl: [0:1]
      tw:
       implemented: false
      tsr:
       implemented: false
-      type:
-        wlrl: [0:1]
      sd:
       implemented: false
-      type:
-        ro_variable: true
    rv64:
      accessible: false
 
@@ -212,7 +194,7 @@ hart0: &hart0
      mtip:
       implemented: true
       type:
-        ro_variable: [0x01]
+        ro_variable: true
      ueip:
       implemented: false
      seip:
@@ -306,10 +288,10 @@ hart0: &hart0
    rv32:
      accessible: true
      type:
-       ro_constant: 0x0
+       ro_constant: 0x00000003
    rv64:
      accessible: false
-   reset-val: 0x0
+   reset-val: 0x00000003
   mhartid:
     rv32:
       accessible: true


### PR DESCRIPTION
- Add Zba, Zbb, Zbc and Zbs extensions (FIXME: implied B not handled yet)
- Update MVENDORID
- Update MARCHID
- Fix MSTATUS legal values and MSTATUS reset value
- Remove over-specification of unimp fields of MSTATUS
- Define the reserved bits of DCACHE as read-only 0.
- Remove unnecessary quotes.
- Regenerate files under cv32a65x/generated.