### PR TITLE
TRAP VERIF : Add checking pc after a trap and remove unnecessary coverage

### DIFF
--- a/verif/env/uvme/cov/uvme_exception_covg.sv
+++ b/verif/env/uvme/cov/uvme_exception_covg.sv
@@ -22,6 +22,7 @@ covergroup cg_exception(
     string name,
     bit pmp_supported,
     bit unaligned_access_supported,
+    bit ext_c_supported,
     bit mode_u_supported,
     bit mode_s_supported,
     bit debug_supported,
@@ -37,54 +38,40 @@ covergroup cg_exception(
     bins NO_EXCEPTION = {0} iff (!instr.trap);
 
     bins BREAKPOINT = {3} iff (instr.trap);
-    bins BREAKPOINT_EXC_RAISED = (NO_EXCEPTION => BREAKPOINT => NO_EXCEPTION);
 
     bins ILLEGAL_INSTR = {2} iff (instr.trap);
-    bins ILLEGAL_INSTR_EXC_RAISED = (NO_EXCEPTION => ILLEGAL_INSTR => NO_EXCEPTION);
 
     ignore_bins IGN_ADDR_MISALIGNED_EXC = {0, 4, 6} iff (unaligned_access_supported);
+    ignore_bins IGN_INSTR_ADDR_MISALIGNED_EXC = {0} iff (ext_c_supported);
     bins INSTR_ADDR_MISALIGNED = {0} iff (instr.trap);
-    bins INSTR_ADDR_MISALIGNED_EXC_RAISED = (NO_EXCEPTION => INSTR_ADDR_MISALIGNED => NO_EXCEPTION);
 
     bins LD_ADDR_MISALIGNED    = {4} iff (instr.trap);
-    bins LD_ADDR_MISALIGNED_EXC_RAISED = (NO_EXCEPTION => LD_ADDR_MISALIGNED => NO_EXCEPTION);
 
     bins ST_ADDR_MISALIGNED    = {6} iff (instr.trap);
-    bins ST_ADDR_MISALIGNED_EXC_RAISED = (NO_EXCEPTION => ST_ADDR_MISALIGNED => NO_EXCEPTION);
 
     ignore_bins IGN_ACCESS_FAULT_EXC = {1,5,7} iff (!pmp_supported);
     bins INSTR_ACCESS_FAULT = {1} iff (instr.trap);
-    bins INSTR_ACCESS_FAULT_EXC_RAISED = (NO_EXCEPTION => INSTR_ACCESS_FAULT => NO_EXCEPTION);
 
     bins LD_ACCESS_FAULT    = {5} iff (instr.trap);
-    bins LD_ACCESS_FAULT_EXC_RAISED = (NO_EXCEPTION => LD_ACCESS_FAULT => NO_EXCEPTION);
 
     bins ST_ACCESS_FAULT    = {7} iff (instr.trap);
-    bins ST_ACCESS_FAULT_EXC_RAISED = (NO_EXCEPTION => ST_ACCESS_FAULT => NO_EXCEPTION);
 
     ignore_bins IGN_ENV_CALL_UMODE = {8} iff (!mode_u_supported);
     bins ENV_CALL_UMODE = {8} iff (instr.trap);
-    bins ENV_CALL_UMODE_EXC_RAISED = (NO_EXCEPTION => ENV_CALL_UMODE => NO_EXCEPTION);
 
     ignore_bins IGN_ENV_CALL_SMODE = {9} iff (!mode_s_supported);
     bins ENV_CALL_SMODE = {9} iff (instr.trap);
-    bins ENV_CALL_SMODE_EXC_RAISED = (NO_EXCEPTION => ENV_CALL_SMODE => NO_EXCEPTION);
 
     bins ENV_CALL_MMODE = {11} iff (instr.trap);
-    bins ENV_CALL_MMODE_EXC_RAISED = (NO_EXCEPTION => ENV_CALL_MMODE => NO_EXCEPTION);
 
     bins INSTR_PAGE_FAULT = {12} iff (instr.trap);
-    bins INSTR_PAGE_FAULT_EXC_RAISED = (NO_EXCEPTION => INSTR_PAGE_FAULT => NO_EXCEPTION);
 
     bins LOAD_PAGE_FAULT  = {13} iff (instr.trap);
-    bins LOAD_PAGE_FAULT_EXC_RAISED = (NO_EXCEPTION => LOAD_PAGE_FAULT => NO_EXCEPTION);
 
     bins STORE_PAGE_FAULT = {15} iff (instr.trap);
-    bins STORE_PAGE_FAULT_EXC_RAISED = (NO_EXCEPTION => STORE_PAGE_FAULT => NO_EXCEPTION);
 
     ignore_bins IGN_DEBUG_REQUEST = {24} iff (!debug_supported);
     bins DEBUG_REQUEST = {24} iff (instr.trap);
-    bins DEBUG_REQUEST_EXC_RAISED = (NO_EXCEPTION => DEBUG_REQUEST => NO_EXCEPTION);
 
   }
 
@@ -143,11 +130,11 @@ covergroup cg_exception(
     ignore_bins IGN = !binsof(cp_exception) intersect{2};
   }
 
-  cross_illegal_csr : cross cp_exception, cp_illegal_csr,  cp_is_csr {
+  cross_illegal_csr : cross cp_exception, cp_illegal_csr, cp_is_csr {
     ignore_bins IGN = !binsof(cp_exception) intersect{2};
   }
 
-  cross_illegal_write_csr : cross cp_exception, cp_ro_csr,  cp_is_write_csr {
+  cross_illegal_write_csr : cross cp_exception, cp_ro_csr, cp_is_write_csr {
     ignore_bins IGN = !binsof(cp_exception) intersect{2};
   }
 
@@ -207,6 +194,7 @@ function void uvme_exception_cov_model_c::build_phase(uvm_phase phase);
    exception_cg = new("exception_cg",
                       .pmp_supported(cfg.pmp_supported),
                       .unaligned_access_supported(cfg.unaligned_access_supported),
+                      .ext_c_supported(cfg.ext_c_supported),
                       .mode_u_supported(cfg.mode_u_supported),
                       .mode_s_supported(cfg.mode_s_supported),
                       .debug_supported(cfg.debug_supported),

--- a/verif/env/uvme/uvme_cva6_cfg.sv
+++ b/verif/env/uvme/uvme_cva6_cfg.sv
@@ -32,6 +32,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
    rand bit                      enabled;
 
    rand bit                      scoreboard_enabled;
+   rand bit                      spike_tandem_enabled;
    rand bit                      cov_model_enabled;
    rand bit                      cov_cvxif_model_enabled;
    rand bit                      cov_isa_model_enabled;
@@ -59,6 +60,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
       `uvm_field_int (                         enabled                     , UVM_DEFAULT          )
       `uvm_field_enum(uvm_active_passive_enum, is_active                   , UVM_DEFAULT          )
       `uvm_field_int (                         scoreboard_enabled          , UVM_DEFAULT          )
+      `uvm_field_int (                         spike_tandem_enabled        , UVM_DEFAULT          )
       `uvm_field_int (                         cov_model_enabled           , UVM_DEFAULT          )
       `uvm_field_int (                         trn_log_enabled             , UVM_DEFAULT          )
       `uvm_field_int (                         ext_zicond_supported        , UVM_DEFAULT          )

--- a/verif/env/uvme/uvme_cva6_sb.sv
+++ b/verif/env/uvme/uvme_cva6_sb.sv
@@ -37,7 +37,30 @@ class uvme_cva6_sb_c extends uvm_scoreboard;
    //          uvme_cva6_sb_simplex_c  ingress_sb;
    uvmc_rvfi_scoreboard_c#(ILEN,XLEN) m_rvfi_scoreboard;
 
+   // TLM
+   uvm_tlm_analysis_fifo#(uvma_isacov_mon_trn_c)  instr_trn_fifo;
 
+   uvma_isacov_mon_trn_c instr_trn;
+
+   // Store previous instruction
+   uvma_isacov_instr_c instr_prev;
+
+   // Store MTVEC value
+   bit [XLEN-1:0]  mtvec_value = 'h0;
+
+   // Store MEPC value
+   bit [XLEN-1:0]  mepc_value;
+
+   // Store trap pc value
+   bit [XLEN-1:0]  trap_pc;
+
+   // Flag to see if mtvec/mepc has been changed
+   bit  mtvec_change = 'h0;
+   bit  mepc_change = 'h0;
+   static bit  has_trap = 0;
+
+   // Flag for compressed instruction
+   bit trap_is_compressed;
 
    `uvm_component_utils_begin(uvme_cva6_sb_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -77,6 +100,21 @@ class uvme_cva6_sb_c extends uvm_scoreboard;
     */
    extern virtual function void create_sbs();
 
+   /**
+    * Check after a trap the CVA6 jump to the value in mtvec
+    */
+   extern virtual function void check_pc_trap(uvma_isacov_instr_c instr, uvma_isacov_instr_c instr_prev);
+
+   /**
+    * Check after a trap mepc has the pc trap
+    */
+   extern virtual function void check_mepc(uvma_isacov_instr_c instr);
+
+   /**
+    * Creates sub-scoreboard components.
+    */
+   extern task run_phase(uvm_phase phase);
+
 endclass : uvme_cva6_sb_c
 
 
@@ -100,6 +138,8 @@ function void uvme_cva6_sb_c::build_phase(uvm_phase phase);
    if (!cntxt) begin
       `uvm_fatal("CNTXT", "Context handle is null")
    end
+
+   instr_trn_fifo   = new("instr_trn_fifo" , this);
 
    assign_cfg  ();
    assign_cntxt();
@@ -135,5 +175,111 @@ function void uvme_cva6_sb_c::create_sbs();
 
 endfunction : create_sbs
 
+function void uvme_cva6_sb_c::check_pc_trap(uvma_isacov_instr_c instr,
+                                            uvma_isacov_instr_c instr_prev);
+
+  if (instr.group == uvma_isacov_pkg::CSR_GROUP && instr.is_csr_write() && instr.csr_val == 12'h305) begin
+     if (instr.name inside {uvma_isacov_pkg::CSRRWI, uvma_isacov_pkg::CSRRSI, uvma_isacov_pkg::CSRRCI}) begin
+        mtvec_value = instr.rs1;
+        mtvec_change = 1'h1;
+        `uvm_info(get_type_name(), $sformatf("Write into MTVEC the value = 0x%h", mtvec_value), UVM_NONE)
+     end
+     else begin
+        mtvec_value = instr.rs1_value;
+        mtvec_change = 1'h1;
+        `uvm_info(get_type_name(), $sformatf("Write into MTVEC the value = 0x%h", mtvec_value), UVM_NONE)
+     end
+  end
+
+  if (instr_prev != null) begin
+     if (instr_prev.trap) begin
+        if (mtvec_change) begin
+           if (instr.rvfi.pc_rdata[31:2] == mtvec_value[31:2]) begin
+              //we only support MTVEC Direct mode
+              `uvm_info(get_type_name(), $sformatf("After a trap, PC matches MTVEC value"), UVM_NONE)
+           end
+           else begin
+              `uvm_fatal(get_type_name(), "ERROR -> Doesn't jump to MTVEC")
+           end
+        end
+        else begin
+             // TODO : need more checking on mtvec value
+             `uvm_warning(get_type_name(), "BE CAREFUL -> MTVEC still has the reset value")
+             return;
+        end
+     end
+  end
+
+endfunction : check_pc_trap
+
+function void uvme_cva6_sb_c::check_mepc(uvma_isacov_instr_c instr);
+
+  if (instr.trap) begin
+     trap_pc = instr.rvfi.pc_rdata[31:0];
+     `uvm_info(get_type_name(), $sformatf("Trap PC : 0x%h ", trap_pc), UVM_NONE)
+     if (instr.rvfi.insn[1:0] == 2'h3) begin
+        trap_is_compressed = 1'h0;
+     end
+     else begin
+        trap_is_compressed = 1'h1;
+     end
+     if (trap_pc == instr.rvfi.name_csrs["mepc"].wdata) begin
+         `uvm_info(get_type_name(), $sformatf("Trap PC has been written successfully "), UVM_NONE)
+     end
+     else begin
+         `uvm_error(get_type_name(), "ERROR -> Trap PC != MEPC")
+     end
+     has_trap = 1'h1;
+  end
+
+  if (has_trap) begin
+     if (instr.group == uvma_isacov_pkg::CSR_GROUP && instr.is_csr_write() && instr.csr_val == 12'h341) begin
+        if (instr.name inside {uvma_isacov_pkg::CSRRWI, uvma_isacov_pkg::CSRRSI, uvma_isacov_pkg::CSRRCI}) begin
+           mepc_value = instr.rs1;
+           mepc_change = 1'h1;
+           `uvm_info(get_type_name(), $sformatf("Write into MEPC the value = 0x%h", mepc_value), UVM_NONE)
+        end
+        else begin
+           mepc_value = instr.rs1_value;
+           mepc_change = 1'h1;
+           `uvm_info(get_type_name(), $sformatf("Write into MEPC the value = 0x%h", mepc_value), UVM_NONE)
+        end
+     end
+
+     if (instr.name == uvma_isacov_pkg::MRET) begin
+         if (mepc_change) begin
+            `uvm_info(get_type_name(), $sformatf("Trap is compressed ? : %h ", trap_is_compressed), UVM_NONE)
+            if (trap_is_compressed) begin
+               if (mepc_value != trap_pc + 'h2) begin
+                  `uvm_warning(get_type_name(), $sformatf("BE CAREFUL -> MEPC hasn't the next instruction's PC 2"))
+               end
+            end
+            else begin
+               if (mepc_value != trap_pc + 'h4) begin
+                  `uvm_warning(get_type_name(), $sformatf("BE CAREFUL -> MEPC hasn't the next instruction's PC 4"))
+               end
+            end
+         end
+         else begin
+            `uvm_warning(get_type_name(), $sformatf("BE CAREFUL -> MEPC still has the trap pc, this could create an infinite loop "))
+         end
+     end
+  end
+
+endfunction : check_mepc
+
+task uvme_cva6_sb_c::run_phase(uvm_phase phase);
+
+  super.run_phase(phase);
+
+  forever begin
+     instr_trn_fifo.get(instr_trn);
+     check_pc_trap(instr_trn.instr, instr_prev);
+     check_mepc(instr_trn.instr);
+    // Move instructions down the pipeline
+     instr_prev = instr_trn.instr;
+  end
+
+endtask : run_phase
 
 `endif // __UVME_CVA6_SB_SV__

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -287,9 +287,9 @@ ifneq ($(DEBUG),)               # If RTL DEBUG support requested
 endif
 
 ifneq ($(SPIKE_TANDEM),)
-COMMON_RUN_UVM_FLAGS += +scoreboard_enabled=1
+COMMON_RUN_UVM_FLAGS += +spike_tandem_enabled=1
 else
-COMMON_RUN_UVM_FLAGS += +scoreboard_enabled=0
+COMMON_RUN_UVM_FLAGS += +spike_tandem_enabled=0
 endif
 
 vcs_uvm_comp:


### PR DESCRIPTION
This MR add the first scoreboard check in our UVM env, by checking the mtvec and mepc behaver after an exception or an interruption, this MR gonna complete the verification on the exceptions