### PR TITLE
32 bits WB cache

### DIFF
--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -322,8 +322,8 @@ module cache_ctrl
           data_o.data[cl_offset+:CVA6Cfg.XLEN]    = mem_req_q.wdata;
           data_o.tag                              = mem_req_d.tag;
           // ~> change the state
-          data_o.dirty               = 1'b1;
-          data_o.valid               = 1'b1;
+          data_o.dirty                            = 1'b1;
+          data_o.valid                            = 1'b1;
 
           // got a grant ~> this is finished now
           if (gnt_i) begin

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -315,7 +315,7 @@ module cache_ctrl
           addr_o                     = mem_req_q.index;
           we_o                       = 1'b1;
 
-          be_o.vldrty                = hit_way_q;
+          be_o.vldrty                             = hit_way_q;
 
           // set the correct byte enable
           be_o.data[cl_offset>>3+:CVA6Cfg.XLEN/8] = mem_req_q.be;

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -319,8 +319,8 @@ module cache_ctrl
 
           // set the correct byte enable
           be_o.data[cl_offset>>3+:CVA6Cfg.XLEN/8] = mem_req_q.be;
-          data_o.data[cl_offset+:CVA6Cfg.XLEN] = mem_req_q.wdata;
-          data_o.tag                 = mem_req_d.tag;
+          data_o.data[cl_offset+:CVA6Cfg.XLEN]    = mem_req_q.wdata;
+          data_o.tag                              = mem_req_d.tag;
           // ~> change the state
           data_o.dirty               = 1'b1;
           data_o.valid               = 1'b1;

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -139,7 +139,8 @@ module cache_ctrl
     mem_req_d.killed |= req_port_i.kill_req;
 
     if (CVA6Cfg.XLEN == 32) begin
-      axi_offset = mem_req_q.index[$clog2(CVA6Cfg.AxiDataWidth/8)-1:$clog2(CVA6Cfg.XLEN/8)] << $clog2(CVA6Cfg.XLEN);
+      axi_offset = mem_req_q.index[$clog2(CVA6Cfg.AxiDataWidth/8)-1:$clog2(CVA6Cfg.XLEN/8)] <<
+          $clog2(CVA6Cfg.XLEN);
     end
 
     case (state_q)

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -115,7 +115,8 @@ module cache_ctrl
     automatic logic [$clog2(CVA6Cfg.AxiDataWidth)-1:0] axi_offset;
     // incoming cache-line -> this is needed as synthesis is not supporting +: indexing in a multi-dimensional array
     // cache-line offset -> multiple of XLEN
-    cl_offset = mem_req_q.index[CVA6Cfg.DCACHE_OFFSET_WIDTH-1:$clog2(CVA6Cfg.XLEN/8)] << $clog2(CVA6Cfg.XLEN);  // shift by log2(XLEN) to the left
+    cl_offset = mem_req_q.index[CVA6Cfg.DCACHE_OFFSET_WIDTH-1:$clog2(CVA6Cfg.XLEN/8)] <<
+        $clog2(CVA6Cfg.XLEN);  // shift by log2(XLEN) to the left
     axi_offset = '0;
     // default assignments
     state_d = state_q;

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -82,10 +82,10 @@ module cache_ctrl
     logic [CVA6Cfg.DCACHE_INDEX_WIDTH-1:0] index;
     logic [CVA6Cfg.DCACHE_TAG_WIDTH-1:0]   tag;
     logic [CVA6Cfg.DcacheIdWidth-1:0]      id;
-    logic [7:0]                            be;
+    logic [(CVA6Cfg.XLEN/8)-1:0]           be;
     logic [1:0]                            size;
     logic                                  we;
-    logic [63:0]                           wdata;
+    logic [CVA6Cfg.XLEN-1:0]               wdata;
     logic                                  bypass;
     logic                                  killed;
   } mem_req_t;
@@ -112,9 +112,11 @@ module cache_ctrl
   // --------------
   always_comb begin : cache_ctrl_fsm
     automatic logic [$clog2(CVA6Cfg.DCACHE_LINE_WIDTH)-1:0] cl_offset;
+    automatic logic [$clog2(CVA6Cfg.AxiDataWidth)-1:0] axi_offset;
     // incoming cache-line -> this is needed as synthesis is not supporting +: indexing in a multi-dimensional array
-    // cache-line offset -> multiple of 64
-    cl_offset = mem_req_q.index[CVA6Cfg.DCACHE_OFFSET_WIDTH-1:3] << 6;  // shift by 6 to the left
+    // cache-line offset -> multiple of XLEN
+    cl_offset = mem_req_q.index[CVA6Cfg.DCACHE_OFFSET_WIDTH-1:$clog2(CVA6Cfg.XLEN/8)] << $clog2(CVA6Cfg.XLEN);  // shift by log2(XLEN) to the left
+    axi_offset = '0;
     // default assignments
     state_d = state_q;
     mem_req_d = mem_req_q;
@@ -134,6 +136,10 @@ module cache_ctrl
     we_o = '0;
 
     mem_req_d.killed |= req_port_i.kill_req;
+
+    if (CVA6Cfg.XLEN == 32) begin
+      axi_offset = mem_req_q.index[$clog2(CVA6Cfg.AxiDataWidth/8)-1:$clog2(CVA6Cfg.XLEN/8)] << $clog2(CVA6Cfg.XLEN);
+    end
 
     case (state_q)
 
@@ -211,7 +217,7 @@ module cache_ctrl
             end
 
             // this is timing critical
-            req_port_o.data_rdata = cl_i[cl_offset+:64];
+            req_port_o.data_rdata = cl_i[cl_offset+:CVA6Cfg.XLEN];
 
             // report data for a read
             if (!mem_req_q.we) begin
@@ -310,8 +316,9 @@ module cache_ctrl
           be_o.vldrty                = hit_way_q;
 
           // set the correct byte enable
-          be_o.data[cl_offset>>3+:8] = mem_req_q.be;
-          data_o.data[cl_offset+:64] = mem_req_q.wdata;
+          be_o.data[cl_offset>>3+:CVA6Cfg.XLEN/8] = mem_req_q.be;
+          data_o.data[cl_offset+:CVA6Cfg.XLEN] = mem_req_q.wdata;
+          data_o.tag                 = mem_req_d.tag;
           // ~> change the state
           data_o.dirty               = 1'b1;
           data_o.valid               = 1'b1;
@@ -357,10 +364,10 @@ module cache_ctrl
         miss_req_o.valid = 1'b1;
         miss_req_o.bypass = mem_req_q.bypass;
         miss_req_o.addr = {mem_req_q.tag, mem_req_q.index};
-        miss_req_o.be = mem_req_q.be;
+        miss_req_o.be[axi_offset>>3+:CVA6Cfg.XLEN/8] = mem_req_q.be;
         miss_req_o.size = mem_req_q.size;
         miss_req_o.we = mem_req_q.we;
-        miss_req_o.wdata = mem_req_q.wdata;
+        miss_req_o.wdata[axi_offset+:CVA6Cfg.XLEN] = mem_req_q.wdata;
 
         // got a grant so go to valid
         if (bypass_gnt_i) begin
@@ -399,7 +406,7 @@ module cache_ctrl
 
         if (critical_word_valid_i) begin
           req_port_o.data_rvalid = ~mem_req_q.killed;
-          req_port_o.data_rdata  = critical_word_i;
+          req_port_o.data_rdata  = critical_word_i[axi_offset+:CVA6Cfg.XLEN];
           // we can make another request
           if (req_port_i.data_req && !flush_i) begin
             // save index, be and we
@@ -428,7 +435,7 @@ module cache_ctrl
       WAIT_REFILL_VALID: begin
         // got a valid answer
         if (bypass_valid_i) begin
-          req_port_o.data_rdata = bypass_data_i;
+          req_port_o.data_rdata = bypass_data_i[axi_offset+:CVA6Cfg.XLEN];
           req_port_o.data_rvalid = ~mem_req_q.killed;
           state_d = IDLE;
         end

--- a/corev_apu/tb/tb_wb_dcache/hdl/cv32a6_config_pkg.sv
+++ b/corev_apu/tb/tb_wb_dcache/hdl/cv32a6_config_pkg.sv
@@ -58,9 +58,6 @@ package cva6_config_pkg;
   localparam CVA6ConfigNrStorePipeRegs = 0;
   localparam CVA6ConfigNrLoadBufEntries = 2;
 
-  localparam CVA6ConfigInstrTlbEntries = 2;
-  localparam CVA6ConfigDataTlbEntries = 2;
-
   localparam CVA6ConfigRASDepth = 2;
   localparam CVA6ConfigBTBEntries = 32;
   localparam CVA6ConfigBHTEntries = 128;
@@ -149,8 +146,10 @@ package cva6_config_pkg;
       WtDcacheWbufDepth: int'(CVA6ConfigWtDcacheWbufDepth),
       FetchUserWidth: unsigned'(CVA6ConfigFetchUserWidth),
       FetchUserEn: unsigned'(CVA6ConfigFetchUserEn),
-      InstrTlbEntries: int'(CVA6ConfigInstrTlbEntries),
-      DataTlbEntries: int'(CVA6ConfigDataTlbEntries),
+      InstrTlbEntries: int'(2),
+      DataTlbEntries: int'(2),
+      UseSharedTlb: bit'(1),
+      SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),
       DcacheIdWidth: int'(CVA6ConfigDcacheIdWidth)


### PR DESCRIPTION
This PR adapts the WB cache so that it works with the 32 bits versions of CVA6. It was tested using the updated TB from PR #2151 and should also solve the issue #2006. It works by aligning the data to and from the AXI bus on the 64 bits of the bus (lower or upper 32 bits depending on the address).