### PR TITLE
Disable MISA WE in Reference Model

### DIFF
--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -194,14 +194,11 @@ COMMON_PLUS_ARGS = \
 	+tohost_addr=$(shell $$RISCV/bin/$(CV_SW_PREFIX)nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
 	+signature=$(elf).signature_output +UVM_TESTNAME=uvmt_cva6_firmware_test_c \
 	$(spike-yaml-plusarg) \
+	+report_file=$(log).yaml +core_name=$(target)
 
 ifneq ($(UVM_VERBOSITY),)
 COMMON_PLUS_ARGS += +UVM_VERBOSITY=$(UVM_VERBOSITY)
 endif
-
-COMMON_RUN_UVM_FLAGS = \
-	 +UVM_TESTNAME=uvmt_cva6_firmware_test_c \
-	+report_file=$(log).yaml +core_name=$(target)
 
 COMMON_RUN_ARGS = \
 	$(COMMON_PLUS_ARGS) $(issrun_opts) \

--- a/verif/tb/core/uvma_cva6pkg_utils.sv
+++ b/verif/tb/core/uvma_cva6pkg_utils.sv
@@ -75,6 +75,8 @@ function st_core_cntrl_cfg cva6pkg_to_core_cntrl_cfg(st_core_cntrl_cfg cfg);
     void'(spike_set_param_bool(base, "status_xs_field_we", 1'b0));
     void'(spike_set_param_uint64_t(base, "misa_override_value", get_misa(cfg)));
     void'(spike_set_param_uint64_t(base, "misa_override_mask", 64'h0FFF_FFFF));
+    void'(spike_set_param_bool    (base, "misa_we_enable", 1'b1));
+    void'(spike_set_param_bool    (base, "misa_we", 1'b0));
 
     return cfg;
 


### PR DESCRIPTION
- Disabling MISA WE as cva6 does not allow writes
- Add YAML report for all the tests