### PR TITLE
Update riscv-config infra to better match expressivity needs of CV32A65X.

### DIFF
--- a/config/riscv-config/Makefile
+++ b/config/riscv-config/Makefile
@@ -42,5 +42,8 @@ $(RVCONFIG_OUTPUTS): $(RVCONFIG_INPUTS) Makefile
 	  -cspec $(SPEC_DIR)/custom_spec.yaml \
 	  -pspec $(SPEC_DIR)/platform_spec.yaml
 
-clean:
-	$(RM) $(OUTPUT_FILES) $(RVCONFIG_OUTPUTS)
+clean: distclean
+	$(RM) $(OUTPUT_FILES)
+
+distclean:
+	$(RM) run.log $(RVCONFIG_OUTPUTS)

--- a/vendor/patches/riscv/riscv-config/0001-enable-implied-B-ext.patch
+++ b/vendor/patches/riscv/riscv-config/0001-enable-implied-B-ext.patch
@@ -1,0 +1,18 @@
+diff --git a/vendor/riscv/riscv-config/riscv_config/isa_validator.py b/vendor/riscv/riscv-config/riscv_config/isa_validator.py
+index 94f7412ae..9655258b3 100644
+--- a/vendor/riscv/riscv-config/riscv_config/isa_validator.py
++++ b/vendor/riscv/riscv-config/riscv_config/isa_validator.py
+@@ -60,7 +60,12 @@ def get_extension_list(isa):
+         elif a1 == a2 and a3 > a4:
+             err = True
+             err_list.append( f"Within the Z{a1.lower()} category extension {zext_list[i]} must occur after {zext_list[i+1]}")
+-        
++    if 'B' not in extension_list and (set(['Zba', 'Zbb', 'Zbs']) & set(extension_list) == set(['Zba', 'Zbb', 'Zbs'])):
++        # Insert 'B' at correct location: after any of its predecessors in canonical ordering.
++        # At least 'I' or 'E' must be present by definition.
++        B_preds = canonical_ordering[:canonical_ordering.find('B')]
++        lastpred_B_idx = max([pos for pos, char in enumerate(standard_isa) if char in list(B_preds)])
++        extension_list.insert(lastpred_B_idx + 1, 'B')
+     if 'I' not in extension_list and 'E' not in extension_list:
+         err_list.append( 'Either of I or E base extensions need to be present in the ISA string')
+         err = True

--- a/vendor/patches/riscv/riscv-config/0002-add-mstatus-UBE-bit.patch
+++ b/vendor/patches/riscv/riscv-config/0002-add-mstatus-UBE-bit.patch
@@ -1,0 +1,54 @@
+diff --git a/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml b/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
+index 981ee6247..a972efb14 100644
+--- a/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
++++ b/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
+@@ -636,6 +636,24 @@ hart_schema:
+                     - 0:1
+               default: {implemented: false}
+               check_with: s_check
++            ube:
++              type: dict
++              schema:
++                description: { type: string, default: control the endianness of memory accesses other than instruction fetches for user mode}
++                shadow: {type: string, default: , nullable: True}
++                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
++                msb: {type: integer, default: 6, allowed: [6]}
++                lsb: {type: integer, default: 6, allowed: [6]}
++                implemented: {type: boolean, default: true}
++                type:
++                  type: dict
++                  oneof:
++                  - schema: { warl: *ref_warl }
++                  - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
++                  - schema: { wlrl: *ref_wlrl }
++                  default: {ro_constant: 0}
++              default: {implemented: false}
++              check_with: u_check
+             mpie:
+               type: dict
+               schema:
+@@ -1049,6 +1067,24 @@ hart_schema:
+                     - 0:1
+               default: {implemented: false}
+               check_with: s_check
++            ube:
++              type: dict
++              schema:
++                description: { type: string, default: control the endianness of memory accesses other than instruction fetches for user mode}
++                shadow: {type: string, default: , nullable: True}
++                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
++                msb: {type: integer, default: 6, allowed: [6]}
++                lsb: {type: integer, default: 6, allowed: [6]}
++                implemented: {type: boolean, default: true}
++                type:
++                  type: dict
++                  oneof:
++                  - schema: { warl: *ref_warl }
++                  - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
++                  - schema: { wlrl: *ref_wlrl }
++                  default: {ro_constant: 0}
++              default: {implemented: false}
++              check_with: u_check
+             mpie:
+               type: dict
+               schema:

--- a/vendor/patches/riscv/riscv-config/0003-add-mtval-roconst0-schema.patch
+++ b/vendor/patches/riscv/riscv-config/0003-add-mtval-roconst0-schema.patch
@@ -1,0 +1,15 @@
+diff --git a/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml b/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
+index a972efb14..a7536375f 100644
+--- a/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
++++ b/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
+@@ -3594,7 +3594,9 @@ hart_schema:
+             lsb: {type: integer, default: 0, allowed: [0]}
+             type:
+               type: dict
+-              schema: { warl: *ref_warl }
++              oneof:
++              - schema: { ro_constant: {type: integer, default: 0x0, allowed: [0x0]}}
++              - schema: { warl: *ref_warl }
+               default:
+                 warl:
+                   dependency_fields: []

--- a/vendor/riscv/riscv-config/riscv_config/isa_validator.py
+++ b/vendor/riscv/riscv-config/riscv_config/isa_validator.py
@@ -60,7 +60,12 @@ def get_extension_list(isa):
         elif a1 == a2 and a3 > a4:
             err = True
             err_list.append( f"Within the Z{a1.lower()} category extension {zext_list[i]} must occur after {zext_list[i+1]}")
-        
+    if 'B' not in extension_list and (set(['Zba', 'Zbb', 'Zbs']) & set(extension_list) == set(['Zba', 'Zbb', 'Zbs'])):
+        # Insert 'B' at correct location: after any of its predecessors in canonical ordering.
+        # At least 'I' or 'E' must be present by definition.
+        B_preds = canonical_ordering[:canonical_ordering.find('B')]
+        lastpred_B_idx = max([pos for pos, char in enumerate(standard_isa) if char in list(B_preds)])
+        extension_list.insert(lastpred_B_idx + 1, 'B')
     if 'I' not in extension_list and 'E' not in extension_list:
         err_list.append( 'Either of I or E base extensions need to be present in the ISA string')
         err = True

--- a/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
+++ b/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
@@ -636,6 +636,24 @@ hart_schema:
                     - 0:1
               default: {implemented: false}
               check_with: s_check
+            ube:
+              type: dict
+              schema:
+                description: { type: string, default: control the endianness of memory accesses other than instruction fetches for user mode}
+                shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
+                msb: {type: integer, default: 6, allowed: [6]}
+                lsb: {type: integer, default: 6, allowed: [6]}
+                implemented: {type: boolean, default: true}
+                type:
+                  type: dict
+                  oneof:
+                  - schema: { warl: *ref_warl }
+                  - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
+                  - schema: { wlrl: *ref_wlrl }
+                  default: {ro_constant: 0}
+              default: {implemented: false}
+              check_with: u_check
             mpie:
               type: dict
               schema:
@@ -1049,6 +1067,24 @@ hart_schema:
                     - 0:1
               default: {implemented: false}
               check_with: s_check
+            ube:
+              type: dict
+              schema:
+                description: { type: string, default: control the endianness of memory accesses other than instruction fetches for user mode}
+                shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
+                msb: {type: integer, default: 6, allowed: [6]}
+                lsb: {type: integer, default: 6, allowed: [6]}
+                implemented: {type: boolean, default: true}
+                type:
+                  type: dict
+                  oneof:
+                  - schema: { warl: *ref_warl }
+                  - schema: {ro_constant: {type: integer, max: 0 , min : 0}}
+                  - schema: { wlrl: *ref_wlrl }
+                  default: {ro_constant: 0}
+              default: {implemented: false}
+              check_with: u_check
             mpie:
               type: dict
               schema:

--- a/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
+++ b/vendor/riscv/riscv-config/riscv_config/schemas/schema_isa.yaml
@@ -3594,7 +3594,9 @@ hart_schema:
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
               type: dict
-              schema: { warl: *ref_warl }
+              oneof:
+              - schema: { ro_constant: {type: integer, default: 0x0, allowed: [0x0]}}
+              - schema: { warl: *ref_warl }
               default:
                 warl:
                   dependency_fields: []


### PR DESCRIPTION
- Enable 'B' extension if Zba, Zbb and Zbs are all present.
- Add misa.ube bit description to ISA schema (rv32 and rv64).
- Update spec Makefile to remove intermediate files and logs.
- Add 'read-only constant 0' alternative for mtval.
- Add corresponding riscv-config vendor patches.