### PR TITLE
Exclude HPD cache module from code coverage

### DIFF
--- a/verif/sim/cov-exclude-mod.lst
+++ b/verif/sim/cov-exclude-mod.lst
@@ -13,3 +13,4 @@
 -tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.genblk6.i_cva6_rvfi_combi
 -tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.i_cva6_rvfi_probes
 -tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.i_frontend.i_instr_queue.i_unread_*
+-tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.gen_cache_hpd.i_cache_subsystem


### PR DESCRIPTION
This MR exclude the HPDCACHE module from Code coverage report