### PR TITLE
[Xcelium flow] corev dv yaml

### DIFF
--- a/verif/env/corev-dv/simulator.yaml
+++ b/verif/env/corev-dv/simulator.yaml
@@ -28,7 +28,7 @@
               -64
               +incdir+<setting>
               +incdir+<user_extension>
-              -f <cwd>/dv/files.f
+              -f <cwd>/../env/corev-dv/cva6-files.f
               +define+UVM_REGEX_NO_DPI
               -timescale 1ns/10ps
 	      -status

--- a/verif/env/corev-dv/simulator.yaml
+++ b/verif/env/corev-dv/simulator.yaml
@@ -17,6 +17,36 @@
 
 ###### This file is based on <cwd>/cva6-simuator.yaml
 
+- tool: xrun
+  compile:
+    cmd: 
+      - "xrun -elaborate
+              -messages
+              -sv
+              -uvm 
+              -uvmhome CDNS-1.2
+              -64
+              +incdir+<setting>
+              +incdir+<user_extension>
+              -f <cwd>/dv/files.f
+              +define+UVM_REGEX_NO_DPI
+              -timescale 1ns/10ps
+	      -status
+	      -access +rwc
+              -log <out>/compile.log  <cmp_opts> <cov_opts> "
+    cov_opts: >
+#              -coverage all <out>
+#	      -nowarn COVDEF
+  
+#      -cm_dir <out>/test.vdb
+#              -f <cwd>/../env/corev-dv/cva6_instr_base_test.sv
+  sim:
+    cmd: >
+      xrun -R -messages -licqueue +gen="true" <sim_opts> -svseed <seed>  <cov_opts> 
+      
+    cov_opts: >
+#      -cm_dir <out>/test.vdb -cm_log /dev/null -cm_name test_<seed>_<test_id>
+
 - tool: vcs
   compile:
     cmd:
@@ -36,3 +66,4 @@
       <out>/vcs_simv +vcs+lic+wait gen="true" <sim_opts> +ntb_random_seed=<seed> <cov_opts>
     cov_opts: >
       -cm_dir <out>/test.vdb -cm_log /dev/null -cm_name test_<seed>_<test_id>
+

--- a/verif/env/corev-dv/simulator.yaml
+++ b/verif/env/corev-dv/simulator.yaml
@@ -35,17 +35,11 @@
 	      -access +rwc
               -log <out>/compile.log  <cmp_opts> <cov_opts> "
     cov_opts: >
-#              -coverage all <out>
-#	      -nowarn COVDEF
-  
-#      -cm_dir <out>/test.vdb
-#              -f <cwd>/../env/corev-dv/cva6_instr_base_test.sv
   sim:
     cmd: >
       xrun -R -messages -licqueue +gen="true" <sim_opts> -svseed <seed>  <cov_opts> 
       
     cov_opts: >
-#      -cm_dir <out>/test.vdb -cm_log /dev/null -cm_name test_<seed>_<test_id>
 
 - tool: vcs
   compile:


### PR DESCRIPTION
This PR aims at adding xrun rule in `verif/env/corev-dv/simulator.yaml`, which is a step to support Cadence xcelium simulator while using riscv-dv instruction generator.
It contributes to task  #1829 