### PR TITLE
[Xcelium flow] Clean DPI void function import

### DIFF
--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -132,7 +132,7 @@ module ariane_tb;
         if (binary != "") begin
             `uvm_info( "Core Test", $sformatf("Preloading ELF: %s", binary), UVM_LOW)
 
-            void'(read_elf(binary));
+            read_elf(binary);
             // wait with preloading, otherwise randomization will overwrite the existing value
             wait(clk_i);
 
@@ -142,7 +142,7 @@ module ariane_tb;
                 automatic int num_words = (len+7)/8;
                 `uvm_info( "Core Test", $sformatf("Loading Address: %x, Length: %x", address, len), UVM_NONE)
                 buffer = new [num_words*8];
-                void'(read_section_sv(address, buffer));
+                read_section_sv(address, buffer);
                 // preload memories
                 // 64-bit
                 for (int i = 0; i < num_words; i++) begin

--- a/corev_apu/tb/ariane_tb.sv
+++ b/corev_apu/tb/ariane_tb.sv
@@ -27,7 +27,7 @@ import uvm_pkg::*;
 `define READ_ELF_T
 import "DPI-C" function void read_elf(input string filename);
 import "DPI-C" function byte get_section(output longint address, output longint len);
-import "DPI-C" context function read_section_sv(input longint address, inout byte buffer[]);
+import "DPI-C" context function void read_section_sv(input longint address, inout byte buffer[]);
 `endif
 
 module ariane_tb;

--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -16,7 +16,7 @@ import "DPI-C" function byte read_symbol (input string symbol_name, inout longin
 `define READ_ELF_T
 import "DPI-C" function void read_elf(input string filename);
 import "DPI-C" function byte get_section(output longint address, output longint len);
-import "DPI-C" context function read_section_sv(input longint address, inout byte buffer[]);
+import "DPI-C" context function void read_section_sv(input longint address, inout byte buffer[]);
 `endif
 
 

--- a/verif/env/uvme/uvme_cva6_pkg.sv
+++ b/verif/env/uvme/uvme_cva6_pkg.sv
@@ -55,7 +55,7 @@ package uvme_cva6_pkg;
    import config_pkg::*;
    import "DPI-C" function void read_elf(input string filename);
    import "DPI-C" function byte get_section(output longint address, output longint len);
-   import "DPI-C" context function read_section_sv(input longint address, inout byte buffer[]);
+   import "DPI-C" context function void read_section_sv(input longint address, inout byte buffer[]);
 
   // Default legal opcode and funct7 for RV32I instructions
   bit [6:0]  legal_i_opcode[$] = '{7'b0000011,

--- a/verif/env/uvme/vseq/uvme_axi_fw_preload_seq.sv
+++ b/verif/env/uvme/vseq/uvme_axi_fw_preload_seq.sv
@@ -51,14 +51,14 @@ task uvme_axi_fw_preload_seq_c::body();
    void'(uvcl.get_arg_value("+elf_file=", binary));
 
    if (binary != "") begin
-      void'(read_elf(binary));
+      read_elf(binary);
       wait(p_sequencer.cntxt.axi_vi.clk);
       // while there are more sections to process
       while (get_section(address, len)) begin
          automatic int num_words0 = (len+7)/8;
          `uvm_info( "Core Test", $sformatf("Loading Address: %x, Length: %x", address, len), UVM_HIGH)
          buffer = new [num_words0*8];
-         void'(read_section_sv(address, buffer));
+         read_section_sv(address, buffer);
          // preload memories
          // 64-bit
          for (int i = 0; i < num_words0; i++) begin

--- a/verif/tb/uvmt/cva6_tb_wrapper.sv
+++ b/verif/tb/uvmt/cva6_tb_wrapper.sv
@@ -280,7 +280,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
 
            if (binary != "") begin
 
-               void'(read_elf(binary));
+               read_elf(binary);
                wait(clk_i);
 
                last_load_address = 'hFFFFFFFF;
@@ -289,7 +289,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
                    automatic int num_words0 = (len+7)/8;
                    `uvm_info( "Core Test", $sformatf("Loading Address: %x, Length: %x", address, len), UVM_LOW)
                    buffer = new [num_words0*8];
-                   void'(read_section_sv(address, buffer));
+                   read_section_sv(address, buffer);
                    // preload memories
                    // 64-bit
                    for (int i = 0; i < num_words0; i++) begin


### PR DESCRIPTION
This PR aims at cleaning the DPI import in cva6 repository. It is preferable to let void at import and to not cast the result of the function when it is called.

It contributes to task https://github.com/openhwgroup/cva6/issues/1829