### PR TITLE
[Xcelium flow] xrun testharness rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ CFLAGS += -I$(QUESTASIM_HOME)/include         \
           -I$(VL_INC_DIR)/vltstd              \
           -I$(RISCV)/include                  \
           -I$(SPIKE_INSTALL_DIR)/include      \
-          -std=c++17 -I../corev_apu/tb/dpi -O3
+          -std=c++17 -Icorev_apu/tb/dpi -O3
 
 ifdef XCELIUM_HOME
 CFLAGS += -I$(XCELIUM_HOME)/tools/include
@@ -434,9 +434,9 @@ XRUN_COMPL_LOG     ?= xrun_compl.log
 XRUN_RUN_LOG       ?= xrun_run.log
 CVA6_HOME	   ?= $(realpath -s $(root-dir))
 
-XRUN_INCDIR :=+incdir+$(CVA6_HOME)/src/axi_node 	\
-	+incdir+$(CVA6_HOME)/src/common_cells/include 	\
-	+incdir+$(CVA6_HOME)/src/util
+XRUN_INCDIR :=+incdir+$(CVA6_HOME)/core/include 			\
+	+incdir+$(CVA6_HOME)/vendor/pulp-platform/axi/include/		\
+	+incdir+$(CVA6_HOME)/corev_apu/register_interface/include
 XRUN_TB := $(addprefix $(CVA6_HOME)/, corev_apu/tb/ariane_tb.sv)
 
 XRUN_COMP_FLAGS  ?= -64bit -disable_sem2009 -access +rwc 			\
@@ -491,7 +491,10 @@ xrun_sim: xrun_comp
 		$(XRUN_RUN)			\
 		+MAX_CYCLES=$(max_cycles)	\
 		+UVM_TESTNAME=$(test_case)	\
+		+time_out=2000000000            \
+		+tohost_addr=80001000           \
 		-l $(XRUN_RUN_LOG)		\
+		+gui				\
 		+permissive-off			\
 		++$(elf_file)
 

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,6 @@ src :=  $(if $(spike-tandem),verif/tb/core/uvma_core_cntrl_pkg.sv)              
         vendor/pulp-platform/common_cells/src/rstgen.sv                              \
         vendor/pulp-platform/common_cells/src/addr_decode.sv                         \
 	vendor/pulp-platform/common_cells/src/stream_register.sv                     \
-        vendor/pulp-platform/axi/src/axi_pkg.sv                                      \
         vendor/pulp-platform/axi/src/axi_cut.sv                                      \
         vendor/pulp-platform/axi/src/axi_join.sv                                     \
         vendor/pulp-platform/axi/src/axi_delayer.sv                                  \

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ export HPDCACHE_DIR
 # Sources
 # Package files -> compile first
 ariane_pkg := \
-              corev_apu/tb/axi_intf.sv                               \
               corev_apu/tb/ariane_axi_pkg.sv                         \
+              corev_apu/tb/axi_intf.sv                               \
               corev_apu/register_interface/src/reg_intf.sv           \
               corev_apu/tb/ariane_soc_pkg.sv                         \
               corev_apu/riscv-dbg/src/dm_pkg.sv                      \

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ CFLAGS += -I$(QUESTASIM_HOME)/include         \
           -I$(VL_INC_DIR)/vltstd              \
           -I$(RISCV)/include                  \
           -I$(SPIKE_INSTALL_DIR)/include      \
-          -std=c++17 -Icorev_apu/tb/dpi -O3
+          -std=c++17 -I$(CVA6_REPO_DIR)/corev_apu/tb/dpi -O3
 
 ifdef XCELIUM_HOME
 CFLAGS += -I$(XCELIUM_HOME)/tools/include

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ export HPDCACHE_DIR
 # Sources
 # Package files -> compile first
 ariane_pkg := \
-              corev_apu/tb/ariane_axi_pkg.sv                         \
               corev_apu/tb/axi_intf.sv                               \
+              corev_apu/tb/ariane_axi_pkg.sv                         \
               corev_apu/register_interface/src/reg_intf.sv           \
               corev_apu/tb/ariane_soc_pkg.sv                         \
               corev_apu/riscv-dbg/src/dm_pkg.sv                      \
@@ -151,13 +151,13 @@ $(warning XCELIUM_HOME not set which is necessary for compiling DPIs when using 
 endif
 
 # this list contains the standalone components
-src :=  core/include/$(target)_config_pkg.sv                                         \
-        $(if $(spike-tandem),verif/tb/core/uvma_core_cntrl_pkg.sv)                   \
+src :=  $(if $(spike-tandem),verif/tb/core/uvma_core_cntrl_pkg.sv)                   \
         $(if $(spike-tandem),verif/tb/core/uvma_cva6pkg_utils_pkg.sv)                \
         $(if $(spike-tandem),verif/tb/core/uvma_rvfi_pkg.sv)                         \
         $(if $(spike-tandem),verif/tb/core/uvmc_rvfi_reference_model_pkg.sv)         \
         $(if $(spike-tandem),verif/tb/core/uvmc_rvfi_scoreboard_pkg.sv)              \
         $(if $(spike-tandem),corev_apu/tb/common/spike.sv)                           \
+        core/cva6_rvfi.sv                                                            \
         corev_apu/src/ariane.sv                                                      \
         $(wildcard corev_apu/bootrom/*.sv)                                           \
         $(wildcard corev_apu/clint/*.sv)                                             \
@@ -184,6 +184,7 @@ src :=  core/include/$(target)_config_pkg.sv                                    
         vendor/pulp-platform/common_cells/src/rstgen.sv                              \
         vendor/pulp-platform/common_cells/src/addr_decode.sv                         \
 	vendor/pulp-platform/common_cells/src/stream_register.sv                     \
+        vendor/pulp-platform/axi/src/axi_pkg.sv                                      \
         vendor/pulp-platform/axi/src/axi_cut.sv                                      \
         vendor/pulp-platform/axi/src/axi_join.sv                                     \
         vendor/pulp-platform/axi/src/axi_delayer.sv                                  \
@@ -353,6 +354,12 @@ $(dpi-library)/ariane_dpi.so: $(dpi)
 	# Compile C-code and generate .so file
 	$(CXX) -shared -m64 -o $(dpi-library)/ariane_dpi.so $? -L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv
 
+$(dpi-library)/xrun_ariane_dpi.so: $(dpi)
+	# Make Dir work-dpi
+	mkdir -p $(dpi-library)
+	# Compile C-code and generate .so file
+	$(CXX) -shared -m64 -o $(dpi-library)/xrun_ariane_dpi.so $? -L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv
+
 # single test runs on Questa can be started by calling make <testname>, e.g. make towers.riscv
 # the test names are defined in ci/riscv-asm-tests.list, and in ci/riscv-benchmarks.list
 # if you want to run in batch mode, use make <testname> batch-mode=1
@@ -429,7 +436,8 @@ check-benchmarks:
 XRUN               ?= xrun
 XRUN_WORK_DIR      ?= xrun_work
 XRUN_RESULTS_DIR   ?= xrun_results
-XRUN_UVMHOME_ARG   ?= CDNS-1.2-ML
+##XRUN_UVMHOME_ARG   ?= CDNS-1.2-ML
+XRUN_UVMHOME_ARG   ?= CDNS-1.2
 XRUN_COMPL_LOG     ?= xrun_compl.log
 XRUN_RUN_LOG       ?= xrun_run.log
 CVA6_HOME	   ?= $(realpath -s $(root-dir))
@@ -437,16 +445,24 @@ CVA6_HOME	   ?= $(realpath -s $(root-dir))
 XRUN_INCDIR :=+incdir+$(CVA6_HOME)/core/include 			\
 	+incdir+$(CVA6_HOME)/vendor/pulp-platform/axi/include/		\
 	+incdir+$(CVA6_HOME)/corev_apu/register_interface/include
+
 XRUN_TB := $(addprefix $(CVA6_HOME)/, corev_apu/tb/ariane_tb.sv)
 
-XRUN_COMP_FLAGS  ?= -64bit -disable_sem2009 -access +rwc 			\
-		    -sv -v93 -uvm -uvmhome $(XRUN_UVMHOME_ARG) 			\
-		    -sv_lib $(CVA6_HOME)/$(dpi-library)/ariane_dpi.so		\
+##XRUN_COMP_FLAGS  ?= -64bit -disable_sem2009 -access +rwc 			\
+##		    -sv -v93 -uvm -uvmhome $(XRUN_UVMHOME_ARG) 			\
+##		    -sv_lib $(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so		\
+##		    -smartorder -sv -top worklib.$(top_level)			\
+##		    -xceligen on=1903 +define+$(defines) -timescale 1ns/1ps	
+XRUN_COMP_FLAGS  ?= -64bit -v200x -disable_sem2009 -access +rwc 			\
+		    -sv -uvm -uvmhome $(XRUN_UVMHOME_ARG) 			\
+		    -sv_lib $(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so		\
 		    -smartorder -sv -top worklib.$(top_level)			\
-		    -xceligen on=1903 +define+$(defines) -timescale 1ns/1ps	\
+		    -timescale 1ns/1ps	
 
-XRUN_RUN_FLAGS := -R -64bit -disable_sem2009 -access +rwc -timescale 1ns/1ps		\
-		-sv_lib	$(CVA6_HOME)/$(dpi-library)/ariane_dpi.so -xceligen on=1903	\
+##XRUN_RUN_FLAGS := -R -64bit -disable_sem2009 -access +rwc -timescale 1ns/1ps		\
+##		-sv_lib	$(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so -xceligen on=1903	
+
+XRUN_RUN_FLAGS := -R -messages -status -64bit -licqueue -noupdate -uvmhome CDNS-1.2 -sv_lib $(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so +UVM_VERBOSITY=UVM_LOW  		
 
 XRUN_DISABLED_WARNINGS := BIGWIX 	\
 			ZROMCW 		\
@@ -460,21 +476,21 @@ XRUN_DISABLED_WARNINGS 	:= $(patsubst %, -nowarn %, $(XRUN_DISABLED_WARNINGS))
 XRUN_COMP = $(XRUN_COMP_FLAGS)		\
 	$(XRUN_DISABLED_WARNINGS) 	\
 	$(XRUN_INCDIR)		      	\
+	-f ../core/Flist.cva6    	\
 	$(filter %.sv, $(ariane_pkg)) 	\
-	$(filter %.vhd, $(uart_src))  	\
 	$(filter %.sv, $(src))	      	\
-	-f ../core/Flist.cva6    	    \
-	$(filter %.sv, $(XRUN_TB))	\
+	$(filter %.vhd, $(uart_src))  	\
+	$(filter %.sv, $(XRUN_TB))	
 
 XRUN_RUN = $(XRUN_RUN_FLAGS) 		\
-	$(XRUN_DISABLED_WARNINGS)	\
+	$(XRUN_DISABLED_WARNINGS)	
 
 xrun_clean:
 	@echo "[XRUN] clean up"
 	rm -rf $(XRUN_RESULTS_DIR)
 	rm -rf $(dpi-library)
 
-xrun_comp: $(dpi-library)/ariane_dpi.so
+xrun_comp: $(dpi-library)/xrun_ariane_dpi.so
 	@echo "[XRUN] Building Model"
 	mkdir -p $(XRUN_RESULTS_DIR)
 	cd $(XRUN_RESULTS_DIR) && $(XRUN)   \
@@ -491,13 +507,15 @@ xrun_sim: xrun_comp
 		$(XRUN_RUN)			\
 		+MAX_CYCLES=$(max_cycles)	\
 		+UVM_TESTNAME=$(test_case)	\
-		+time_out=2000000000            \
-		+tohost_addr=80001000           \
-		-l $(XRUN_RUN_LOG)		\
+		+time_out=200000000000            \
+		+tohost_addr=$(shell ${RISCV}/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1)          \
+		-log $(XRUN_RUN_LOG)		\
 		+gui				\
 		+permissive-off			\
-		++$(elf_file)
+		+elf_file=$(elf)           \
+		++$(elf)
 
+##		+tohost_addr=80001000           \
 #-e "set_severity_pack_assert_off {warning}; set_pack_assert_off {numeric_std}" TODO: This will remove assertion warning at the beginning of the simulation.
 
 xrun_all: xrun_clean xrun_comp xrun_sim

--- a/Makefile
+++ b/Makefile
@@ -447,19 +447,11 @@ XRUN_INCDIR :=+incdir+$(CVA6_HOME)/core/include 			\
 
 XRUN_TB := $(addprefix $(CVA6_HOME)/, corev_apu/tb/ariane_tb.sv)
 
-##XRUN_COMP_FLAGS  ?= -64bit -disable_sem2009 -access +rwc 			\
-##		    -sv -v93 -uvm -uvmhome $(XRUN_UVMHOME_ARG) 			\
-##		    -sv_lib $(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so		\
-##		    -smartorder -sv -top worklib.$(top_level)			\
-##		    -xceligen on=1903 +define+$(defines) -timescale 1ns/1ps	
 XRUN_COMP_FLAGS  ?= -64bit -v200x -disable_sem2009 -access +rwc 			\
 		    -sv -uvm -uvmhome $(XRUN_UVMHOME_ARG) 			\
 		    -sv_lib $(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so		\
 		    -smartorder -sv -top worklib.$(top_level)			\
-		    -timescale 1ns/1ps	
-
-##XRUN_RUN_FLAGS := -R -64bit -disable_sem2009 -access +rwc -timescale 1ns/1ps		\
-##		-sv_lib	$(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so -xceligen on=1903	
+		    -timescale 1ns/1ps
 
 XRUN_RUN_FLAGS := -R -messages -status -64bit -licqueue -noupdate -uvmhome CDNS-1.2 -sv_lib $(CVA6_HOME)/$(dpi-library)/xrun_ariane_dpi.so +UVM_VERBOSITY=UVM_LOW  		
 
@@ -513,9 +505,6 @@ xrun_sim: xrun_comp
 		+permissive-off			\
 		+elf_file=$(elf)           \
 		++$(elf)
-
-##		+tohost_addr=80001000           \
-#-e "set_severity_pack_assert_off {warning}; set_pack_assert_off {numeric_std}" TODO: This will remove assertion warning at the beginning of the simulation.
 
 xrun_all: xrun_clean xrun_comp xrun_sim
 


### PR DESCRIPTION
This PR aims at updating the rules into `cva6/Makefile` to support **ariane_testharness** on **Cadence Xcelium**.
Nevertheless, this PR is not enough to launch `make xrun_all`. Further PRs will follow.

It contributes to task https://github.com/openhwgroup/cva6/issues/1829