### PR TITLE
[Xcelium flow] xrun uvm rules

### DIFF
--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -147,8 +147,10 @@ spike:
 ###############################################################################
 ALL_VCS_FLAGS           = $(if $(VERDI), -kdb -debug_access+all -lca,) -sverilog -full64 -timescale=1ns/1ns
 VCS_WORK_DIR            = $(CVA6_REPO_DIR)/verif/sim/vcs_results/default/vcs.d
-VSIM_WORK_DIR            = $(CVA6_REPO_DIR)/verif/sim/vsim_results/default/vsim.d
-SIMV                    = $(VCS_WORK_DIR)/simv
+VSIM_WORK_DIR           = $(CVA6_REPO_DIR)/verif/sim/vsim_results/default/vsim.d
+VCS_SIMV                = $(VCS_WORK_DIR)/simv
+XRUN_WORK_DIR           = $(CVA6_REPO_DIR)/verif/sim/xrun_results
+XRUN_SIMV               = $(XRUN_WORK_DIR)/simv
 
 export CVA6_UVMT_DIR          = $(CVA6_REPO_DIR)/verif/tb/uvmt
 export CVA6_CORET_DIR          = $(CVA6_REPO_DIR)/verif/tb/core
@@ -214,7 +216,38 @@ ALL_UVM_FLAGS   = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
 	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon)) \
 	  -cm_seqnoconst -diag noconst \
 
-ALL_SIMV_UVM_FLAGS      = +vcs+lic+wait $(issrun_opts) \
+ALL_SIMV_UVM_FLAGS      = +vcs+lic+wait -licwait 20  \
+		-sv_lib $(CVA6_REPO_DIR)/verif/core-v-verif/lib/dpi_dasm/lib/Linux64/libdpi_dasm +signature=I-ADD-01.signature_output \
+		+UVM_TESTNAME=uvmt_cva6_firmware_test_c
+
+ALL_XRUN_UVM_FLAGS      = -elaborate -messages -sv +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/ \
+	  $(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_LOW -uvm -uvmhome CDNS-1.2 \
+	  -64 +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src \
+	  +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/tb/uvmt \
+	  -xmerror CUNOTB -nowarn CUDEFB -nowarn CUSRCH -warn_multiple_driver -relax_svbtis -timescale 1ns/1ps -status -access +rwc -log   $(XRUN_WORK_DIR)/tb_compile.log
+##-relax_svbtis
+##ALL_XRUN_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) 
+ALL_XRUN_SIMV_UVM_FLAGS      =  +sv_lib=$(CVA6_REPO_DIR)/verif/core-v-verif/lib/dpi_dasm/lib/Linux64/libdpi_dasm.so 
+##		+UVM_TESTNAME=uvmt_cva6_firmware_test_c
+
+##XRUN_RUN_FLAGS := -R -64bit -disable_sem2009 -uvmhome CDNS-1.2  +UVM_VERBOSITY=UVM_LOW -svseed 1 -access +rwc -sv -timescale 1ns/1ps		
+		          
+XRUN_RUN_FLAGS := -R -messages -status -64bit -licqueue -noupdate -log xrun.log -uvmhome CDNS-1.2  +UVM_VERBOSITY=UVM_LOW -svseed 1 		
+		          
+##                          -xceligen on=1903	
+
+XRUN_DISABLED_WARNINGS := BIGWIX 	\
+                        ZROMCW 		\
+			STRINT 		\
+			ENUMERR 	\
+			SPDUSD		\
+			RNDXCELON
+
+XRUN_DISABLED_WARNINGS 	:= $(patsubst %, -nowarn %, $(XRUN_DISABLED_WARNINGS))
+
+XRUN_RUN = $(XRUN_RUN_FLAGS) 		\
+	   $(ALL_XRUN_SIMV_UVM_FLAGS)	\
+	   $(XRUN_DISABLED_WARNINGS)	
 
 ifneq ($(DEBUG),)               # If RTL DEBUG support requested
   ifneq ($(VERDI),)             #   If VERDI interactive mode requested, use GUI and do not run simulation
@@ -314,12 +347,81 @@ questa-uvm:
 	make questa_uvm_run
 
 
+xrun_dpi-library = $(XRUN_WORK_DIR)/work-dpi
+
+xrun_dpi_build:
+	mkdir -p $(xrun_dpi-library)
+	$(CXX) -shared -fPIC -std=c++17 -Bsymbolic -I$(CVA6_REPO_DIR)/corev_apu/tb/dpi -O3 -I$(SPIKE_ROOT)/include \
+	-I$(XCELIUM_HOME)/tools/include -I$(XCELIUM_HOME)/tools/xcelium/include -I$(RISCV)/include -c $(CVA6_REPO_DIR)/corev_apu/tb/dpi/elfloader.cc \
+	-o $(xrun_dpi-library)/elfloader.o
+	$(CXX) -shared -m64 -o $(xrun_dpi-library)/libdpi.so $(xrun_dpi-library)/elfloader.o -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib
+#	$(CXX) -shared -m64 -o $(xrun_dpi-library)/ariane_dpi.so $(xrun_dpi-library)/elfloader.o -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib
+
+xrun_uvm_comp: xrun_dpi_build
+	@echo "[XRUN] Building Model"
+	mkdir -p $(XRUN_WORK_DIR)
+	cd $(XRUN_WORK_DIR) && \
+          xrun $(ALL_XRUN_UVM_FLAGS) \
+          -xmlibdirpath ${XRUN_WORK_DIR}/work-dpi \
+          -sv_lib  $(xrun_dpi-library)/libdpi.so \
+          -f $(FLIST_CORE) \
+          -f $(FLIST_TB) \
+          -f $(CVA6_UVMT_DIR)/uvmt_cva6.flist \
+          $(cov-comp-opt) $(isscomp_opts)\
+	  -top uvmt_cva6_tb
+
+xrun_uvm_run:
+	@echo "[XRUN] Running"
+	cd $(XRUN_WORK_DIR) && 	\
+	  xrun +permissive			\
+	  $(XRUN_RUN)			\
+          -xmlibdirpath ${XRUN_WORK_DIR}/work-dpi \
+          +sv_lib=$(xrun_dpi-library)/libdpi.so \
+          +define+UVM_NO_DEPRECATED  \
+	  +MAX_CYCLES=$(max_cycles)	\
+	  +UVM_CONFIG_DB_TRACE	\
+	  +UVM_TESTNAME=uvmt_cva6_firmware_test_c	\
+	  +time_out=2000000000            \
+	  +tohost_addr=80001000           \
+	  -gui				\
+	  +permissive-off			
+##		++$(elf-bin)
+
+#	$(if $(TRACE_FAST), unset VERDI_HOME ;) \
+#	cd $(VCS_WORK_DIR)/ && \
+#	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
+#	++$(elf) \
+#	+PRELOAD=$(elf) \
+#	+tohost_addr=$(shell $$RISCV/bin/riscv-none-elf-nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
+#	-sv_lib $(dpi-library)/ariane_dpi \
+#	$(cov-run-opt) $(issrun_opts) && \
+#	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CVA6_REPO_DIR)/verif/sim/ && \
+#	{ [ -z "`ls $(VCS_WORK_DIR)/*.$(SIMV_TRACE_EXTN)`" ] || \
+#	  for i in `ls $(VCS_WORK_DIR)/*.$(SIMV_TRACE_EXTN)` ; do mv $$i $(CVA6_REPO_DIR)/verif/sim/`basename $$i` ; done || \
+#	  true ; }
+
+xrun-uvm: xrun_uvm_comp xrun_uvm_run
+#	make xrun_uvm_comp
+#	make xrun_uvm_run
+#	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
+#	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
+#	[ -z "`ls *.$(SIMV_TRACE_EXTN)`" ] || \
+#          for i in `ls *.$(SIMV_TRACE_EXTN)` ; do mv $$i `dirname $(log)`/`basename $(log) .log`.$(target).$$i ; done || true
+
+#xrun_comp_gen_inst:$(filelist)
+#	$(comp_sv_cmd) $(comp_sv_opt) -log tb_sv_compile.log $(filter %.sv %.v, $^)
+#	@touch $@
+
 generate_cov_dash:
 	urg -warn none -hvp_proj cva6_embedded -format both -group instcov_for_score -hvp_attributes weight+description+Comment -dir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -tgl portsonly
 
 vcs_clean_all:
 	@echo "[VCS] Cleanup (entire vcs_work dir)"
 	rm -rf $(CVA6_REPO_DIR)/verif/sim/vcs_results/ verdiLog/ simv* *.daidir *.vpd *.fsdb *.db csrc ucli.key vc_hdrs.h novas* inter.fsdb uart
+
+xrun_clean_all:
+	@echo "[XRUN] Cleanup (entire xrun_work dir)"
+#	rm -rf $(XRUN_WORK_DIR) 
 
 ###############################################################################
 # testharness specific commands, variables
@@ -366,6 +468,12 @@ clean_all: vcs_clean_all
 	rm -f trace*.log
 	rm -f trace*.dasm
 	rm -f *.vpd *.fsdb *.vcd *.fst
+
+#xrun_clean_all: xrun_clean_all
+#	rm -f *.txt
+#	rm -f trace*.log
+#	rm -f trace*.dasm
+##	rm -f *.vpd *.fsdb *.vcd *.fst
 
 help:
 	@echo "Shell environment:"

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -223,16 +223,10 @@ ALL_SIMV_UVM_FLAGS      = +vcs+lic+wait -licwait 20  \
 ALL_XRUN_UVM_FLAGS      = -elaborate -messages -sv +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/ \
 	  $(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_LOW -uvm -uvmhome CDNS-1.2 \
 	  -64 +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src \
-	  +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/cva6/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/cva6/tb/uvmt \
+	  +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/tb/uvmt \
 	  -xmerror CUNOTB -nowarn CUDEFB -nowarn CUSRCH -warn_multiple_driver -relax_svbtis -timescale 1ns/1ps -status -access +rwc -log   $(XRUN_WORK_DIR)/tb_compile.log
 
-##	  +incdir+$(CVA6_UVME_PATH) +incdir+$(CVA6_UVMT_PATH) 
-##-relax_svbtis
-##ALL_XRUN_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) 
 ALL_XRUN_SIMV_UVM_FLAGS      =  +sv_lib=$(CVA6_REPO_DIR)/tools/spike/lib/libdisasm +signature=I-ADD-01.signature_output
-##		+UVM_TESTNAME=uvmt_cva6_firmware_test_c
-
-##XRUN_RUN_FLAGS := -R -64bit -disable_sem2009 -uvmhome CDNS-1.2  +UVM_VERBOSITY=UVM_LOW -svseed 1 -access +rwc -sv -timescale 1ns/1ps		
 		          
 XRUN_RUN_FLAGS := -R -messages -status -64bit -licqueue -noupdate -log xrun.log -uvmhome CDNS-1.2  +UVM_VERBOSITY=UVM_LOW -svseed 1 		
 		          
@@ -361,9 +355,6 @@ xrun_uvm_comp:
           -f $(CVA6_UVMT_PATH)/uvmt_cva6.flist \
           $(cov-comp-opt) $(isscomp_opts)\
 	  -top uvmt_cva6_tb
-
-##          -f $(FLIST_TB) \
-##          -f $(CVA6_UVMT_PATH)/uvmt_cva6.flist \
 
 xrun_uvm_run:
 	@echo "[XRUN] Running"

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -373,9 +373,8 @@ xrun_uvm_run:
 	  +elf_file=$(elf) \
           +define+UVM_NO_DEPRECATED  \
 	  +UVM_TESTNAME=uvmt_cva6_firmware_test_c	\
-	  +tohost_addr=$(shell ${RISCV}/bin/riscv32-unknown-elf-nm -B $(elf) | grep -w tohost | cut -d' ' -f1)          \
-	  $(cov-comp-opt) $(issrun_opts)    \
-	  -gui				\
+	  +tohost_addr=$(shell ${RISCV}/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1)          \
+	  $(cov-comp-opt) $(issrun_opts)
 	  			
 
 xrun-uvm: xrun_uvm_comp xrun_uvm_run

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -145,12 +145,9 @@ spike:
 ###############################################################################
 # UVM specific commands, variables
 ###############################################################################
-ALL_VCS_FLAGS           = $(if $(VERDI), -kdb -debug_access+all -lca,) -sverilog -full64 -timescale=1ns/1ns
 VCS_WORK_DIR            = $(CVA6_REPO_DIR)/verif/sim/vcs_results/default/vcs.d
 VSIM_WORK_DIR           = $(CVA6_REPO_DIR)/verif/sim/vsim_results/default/vsim.d
-VCS_SIMV                = $(VCS_WORK_DIR)/simv
 XRUN_WORK_DIR           = $(CVA6_REPO_DIR)/verif/sim/xrun_results
-XRUN_SIMV               = $(XRUN_WORK_DIR)/simv
 
 export CVA6_UVMT_DIR          = $(CVA6_REPO_DIR)/verif/tb/uvmt
 export CVA6_CORET_DIR          = $(CVA6_REPO_DIR)/verif/tb/core

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -223,7 +223,7 @@ ALL_SIMV_UVM_FLAGS      = +vcs+lic+wait -licwait 20  \
 ALL_XRUN_UVM_FLAGS      = -elaborate -messages -sv +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/ \
 	  $(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_LOW -uvm -uvmhome CDNS-1.2 \
 	  -64 +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src \
-	  +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/tb/uvmt \
+	  +incdir+$(CVA6_REPO_DIR)/verif/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/tb/uvmt \
 	  -xmerror CUNOTB -nowarn CUDEFB -nowarn CUSRCH -warn_multiple_driver -relax_svbtis -timescale 1ns/1ps -status -access +rwc -log   $(XRUN_WORK_DIR)/tb_compile.log
 
 ALL_XRUN_SIMV_UVM_FLAGS      =  +sv_lib=$(CVA6_REPO_DIR)/tools/spike/lib/libdisasm +signature=I-ADD-01.signature_output
@@ -271,6 +271,7 @@ ALL_SIMV_UVM_FLAGS += +scoreboard_enabled=0
 ALL_XRUN_SIMV_UVM_FLAGS += +scoreboard_enabled=0
 endif
 
+### VCS UVM rules
 vcs_uvm_comp:
 	@echo "[VCS] Building Model"
 	mkdir -p $(VCS_WORK_DIR)
@@ -299,6 +300,40 @@ vcs-uvm: vcs_uvm_comp vcs_uvm_run
 	# Generate disassembled log.
 	$(tool_path)/spike-dasm --isa=$(variant) < ./vcs_results/default/vcs.d/trace_rvfi_hart_00.dasm > $(log)
 
+
+### XRUN UVM rules
+xrun_uvm_comp: 
+	@echo "[XRUN] Building Model"
+	mkdir -p $(XRUN_WORK_DIR)
+	cd $(XRUN_WORK_DIR) && \
+          xrun $(ALL_XRUN_UVM_FLAGS) \
+          -f $(FLIST_CORE) \
+          -f $(FLIST_TB) \
+          -f $(CVA6_UVMT_PATH)/uvmt_cva6.flist \
+          $(cov-comp-opt) $(isscomp_opts)\
+	  -top uvmt_cva6_tb
+
+xrun_uvm_run:
+	@echo "[XRUN] Running"
+	cd $(XRUN_WORK_DIR) && 	\
+	  xrun 			\
+	  $(XRUN_RUN)			\
+	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libriscv \
+	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libfesvr \
+	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libdisasm \
+	  ++$(elf) \
+	  +elf_file=$(elf) \
+          +define+UVM_NO_DEPRECATED  \
+	  +UVM_TESTNAME=uvmt_cva6_firmware_test_c	\
+	  +tohost_addr=$(shell ${RISCV}/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1)          \
+	  $(cov-comp-opt) $(issrun_opts)
+	  			
+
+xrun-uvm: xrun_uvm_comp xrun_uvm_run
+	$(tool_path)/spike-dasm --isa=$(variant) < ./xrun_results/trace_rvfi_hart_00.dasm > $(log)
+
+
+### QUESTA UVM rules
 questa_uvm_comp:
 	@echo "[QUESTA] Building Model"
 	mkdir -p $(VSIM_WORK_DIR)
@@ -324,7 +359,7 @@ questa_uvm_comp:
 questa_uvm_run:
 	@echo "[QUESTA] Running Model"
 	vsim -64  \
-	  $(COMMON_RUN_ARGS) \
+	  $(COMMON_RUN_UVM_FLAGS) \
 	  -sv_lib $(QUESTASIM_HOME)/uvm-1.2/linux_x86_64/uvm_dpi \
 	  -c -do "run -all; " \
 	  -work $(VSIM_WORK_DIR) -t 1ns \
@@ -345,35 +380,6 @@ questa-uvm:
 	make questa_uvm_run
 
 
-xrun_uvm_comp: 
-	@echo "[XRUN] Building Model"
-	mkdir -p $(XRUN_WORK_DIR)
-	cd $(XRUN_WORK_DIR) && \
-          xrun $(ALL_XRUN_UVM_FLAGS) \
-          -f $(FLIST_CORE) \
-          -f $(FLIST_TB) \
-          -f $(CVA6_UVMT_PATH)/uvmt_cva6.flist \
-          $(cov-comp-opt) $(isscomp_opts)\
-	  -top uvmt_cva6_tb
-
-xrun_uvm_run:
-	@echo "[XRUN] Running"
-	cd $(XRUN_WORK_DIR) && 	\
-	  xrun 			\
-	  $(XRUN_RUN)			\
-	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libriscv \
-	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libfesvr \
-	  ++$(elf) \
-	  +elf_file=$(elf) \
-          +define+UVM_NO_DEPRECATED  \
-	  +UVM_TESTNAME=uvmt_cva6_firmware_test_c	\
-	  +tohost_addr=$(shell ${RISCV}/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1)          \
-	  $(cov-comp-opt) $(issrun_opts)
-	  			
-
-xrun-uvm: xrun_uvm_comp xrun_uvm_run
-	$(tool_path)/spike-dasm --isa=$(variant) < ./xrun_results/trace_rvfi_hart_00.dasm > $(log)
-
 generate_cov_dash:
 	urg -warn none -hvp_proj cva6_embedded -format both -group instcov_for_score -hvp_attributes weight+description+Comment -dir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -tgl portsonly
 
@@ -384,23 +390,6 @@ vcs_clean_all:
 xrun_clean_all:
 	@echo "[XRUN] Cleanup (entire xrun_work dir)"
 	rm -rf $(CVA6_REPO_DIR)/verif/sim/xrun_results/
-
-
-xrun-testharness:
-	@echo "[XRUN-TESTHARNESS] Running"
-	@echo "[XRUN-TESTHARNESS] $(path_var)"
-	@echo "[XRUN-TESTHARNESS] $(XRUN_WORK_DIR)"
-	@echo "[XRUN-TESTHARNESS] $(elf)"
-
-	mkdir -p $(XRUN_WORK_DIR)
-
-	make -C $(path_var) work-dpi/xrun_ariane_dpi.so
-	@echo "[XRUN-TESTHARNESS] $(elf)"
-
-	make -C $(path_var) xrun_sim target=$(target) defines=$(subst +define+,,$(isscomp_opts))$(if $(spike-tandem),SPIKE_TANDEM=1)
-	@echo "[XRUN-TESTHARNESS1] $(elf)"
-
-	$(CVA6_REPO_DIR)/tools/spike/spike-dasm --isa=$(variant) < ./xrun_results/xcelium.d/trace_rvfi_hart_00.dasm > $(log)
 
 
 ###############################################################################
@@ -431,6 +420,18 @@ veri-testharness:
 	# Generate disassembled log.
 	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
+
+xrun-testharness:
+	@echo "[XRUN-TESTHARNESS] Running"
+	@echo "[XRUN-TESTHARNESS] $(path_var)"
+	@echo "[XRUN-TESTHARNESS] $(XRUN_WORK_DIR)"
+	@echo "[XRUN-TESTHARNESS] $(elf)"
+	mkdir -p $(XRUN_WORK_DIR)
+	make -C $(path_var) work-dpi/xrun_ariane_dpi.so
+	@echo "[XRUN-TESTHARNESS] $(elf)"
+	make -C $(path_var) xrun_sim target=$(target) defines=$(subst +define+,,$(isscomp_opts))$(if $(spike-tandem),SPIKE_TANDEM=1)
+	@echo "[XRUN-TESTHARNESS1] $(elf)"
+	$(CVA6_REPO_DIR)/tools/spike/spike-dasm --isa=$(variant) < ./xrun_results/xcelium.d/trace_rvfi_hart_00.dasm > $(log)
 
 questa-testharness:
 	mkdir -p $(path_var)/tmp

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -223,8 +223,10 @@ ALL_SIMV_UVM_FLAGS      = +vcs+lic+wait -licwait 20  \
 ALL_XRUN_UVM_FLAGS      = -elaborate -messages -sv +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/ \
 	  $(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_LOW -uvm -uvmhome CDNS-1.2 \
 	  -64 +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src \
-	  +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/$(CV_CORE_LC)/tb/uvmt \
+	  +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/cva6/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/core-v-verif/cva6/tb/uvmt \
 	  -xmerror CUNOTB -nowarn CUDEFB -nowarn CUSRCH -warn_multiple_driver -relax_svbtis -timescale 1ns/1ps -status -access +rwc -log   $(XRUN_WORK_DIR)/tb_compile.log
+
+##	  +incdir+$(CVA6_UVME_PATH) +incdir+$(CVA6_UVMT_PATH) 
 ##-relax_svbtis
 ##ALL_XRUN_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) 
 ALL_XRUN_SIMV_UVM_FLAGS      =  +sv_lib=$(CVA6_REPO_DIR)/tools/spike/lib/libdisasm +signature=I-ADD-01.signature_output
@@ -349,8 +351,6 @@ questa-uvm:
 	make questa_uvm_run
 
 
-xrun_dpi-library = $(XRUN_WORK_DIR)/work-dpi
-
 xrun_uvm_comp: 
 	@echo "[XRUN] Building Model"
 	mkdir -p $(XRUN_WORK_DIR)
@@ -358,9 +358,12 @@ xrun_uvm_comp:
           xrun $(ALL_XRUN_UVM_FLAGS) \
           -f $(FLIST_CORE) \
           -f $(FLIST_TB) \
-          -f $(CVA6_UVMT_DIR)/uvmt_cva6.flist \
+          -f $(CVA6_UVMT_PATH)/uvmt_cva6.flist \
           $(cov-comp-opt) $(isscomp_opts)\
 	  -top uvmt_cva6_tb
+
+##          -f $(FLIST_TB) \
+##          -f $(CVA6_UVMT_PATH)/uvmt_cva6.flist \
 
 xrun_uvm_run:
 	@echo "[XRUN] Running"
@@ -378,6 +381,7 @@ xrun_uvm_run:
 	  			
 
 xrun-uvm: xrun_uvm_comp xrun_uvm_run
+	$(tool_path)/spike-dasm --isa=$(variant) < ./xrun_results/trace_rvfi_hart_00.dasm > $(log)
 
 generate_cov_dash:
 	urg -warn none -hvp_proj cva6_embedded -format both -group instcov_for_score -hvp_attributes weight+description+Comment -dir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -tgl portsonly
@@ -388,7 +392,25 @@ vcs_clean_all:
 
 xrun_clean_all:
 	@echo "[XRUN] Cleanup (entire xrun_work dir)"
-#	rm -rf $(XRUN_WORK_DIR) 
+	rm -rf $(CVA6_REPO_DIR)/verif/sim/xrun_results/
+
+
+xrun-testharness:
+	@echo "[XRUN-TESTHARNESS] Running"
+	@echo "[XRUN-TESTHARNESS] $(path_var)"
+	@echo "[XRUN-TESTHARNESS] $(XRUN_WORK_DIR)"
+	@echo "[XRUN-TESTHARNESS] $(elf)"
+
+	mkdir -p $(XRUN_WORK_DIR)
+
+	make -C $(path_var) work-dpi/xrun_ariane_dpi.so
+	@echo "[XRUN-TESTHARNESS] $(elf)"
+
+	make -C $(path_var) xrun_sim target=$(target) defines=$(subst +define+,,$(isscomp_opts))$(if $(spike-tandem),SPIKE_TANDEM=1)
+	@echo "[XRUN-TESTHARNESS1] $(elf)"
+
+	$(CVA6_REPO_DIR)/tools/spike/spike-dasm --isa=$(variant) < ./xrun_results/xcelium.d/trace_rvfi_hart_00.dasm > $(log)
+
 
 ###############################################################################
 # testharness specific commands, variables
@@ -430,17 +452,11 @@ questa-testharness:
 # Common targets and rules
 ###############################################################################
 
-clean_all: vcs_clean_all
+clean_all: vcs_clean_all 
 	rm -f *.txt
 	rm -f trace*.log
 	rm -f trace*.dasm
 	rm -f *.vpd *.fsdb *.vcd *.fst
-
-#xrun_clean_all: xrun_clean_all
-#	rm -f *.txt
-#	rm -f trace*.log
-#	rm -f trace*.dasm
-##	rm -f *.vpd *.fsdb *.vcd *.fst
 
 help:
 	@echo "Shell environment:"

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -349,21 +349,11 @@ questa-uvm:
 
 xrun_dpi-library = $(XRUN_WORK_DIR)/work-dpi
 
-xrun_dpi_build:
-	mkdir -p $(xrun_dpi-library)
-	$(CXX) -shared -fPIC -std=c++17 -Bsymbolic -I$(CVA6_REPO_DIR)/corev_apu/tb/dpi -O3 -I$(SPIKE_ROOT)/include \
-	-I$(XCELIUM_HOME)/tools/include -I$(XCELIUM_HOME)/tools/xcelium/include -I$(RISCV)/include -c $(CVA6_REPO_DIR)/corev_apu/tb/dpi/elfloader.cc \
-	-o $(xrun_dpi-library)/elfloader.o
-	$(CXX) -shared -m64 -o $(xrun_dpi-library)/libdpi.so $(xrun_dpi-library)/elfloader.o -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib
-#	$(CXX) -shared -m64 -o $(xrun_dpi-library)/ariane_dpi.so $(xrun_dpi-library)/elfloader.o -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib
-
-xrun_uvm_comp: xrun_dpi_build
+xrun_uvm_comp: 
 	@echo "[XRUN] Building Model"
 	mkdir -p $(XRUN_WORK_DIR)
 	cd $(XRUN_WORK_DIR) && \
           xrun $(ALL_XRUN_UVM_FLAGS) \
-          -xmlibdirpath ${XRUN_WORK_DIR}/work-dpi \
-          -sv_lib  $(xrun_dpi-library)/libdpi.so \
           -f $(FLIST_CORE) \
           -f $(FLIST_TB) \
           -f $(CVA6_UVMT_DIR)/uvmt_cva6.flist \
@@ -375,8 +365,8 @@ xrun_uvm_run:
 	cd $(XRUN_WORK_DIR) && 	\
 	  xrun +permissive			\
 	  $(XRUN_RUN)			\
-          -xmlibdirpath ${XRUN_WORK_DIR}/work-dpi \
-          +sv_lib=$(xrun_dpi-library)/libdpi.so \
+	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libriscv \
+	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libfesvr \
           +define+UVM_NO_DEPRECATED  \
 	  +MAX_CYCLES=$(max_cycles)	\
 	  +UVM_CONFIG_DB_TRACE	\
@@ -385,32 +375,8 @@ xrun_uvm_run:
 	  +tohost_addr=80001000           \
 	  -gui				\
 	  +permissive-off			
-##		++$(elf-bin)
-
-#	$(if $(TRACE_FAST), unset VERDI_HOME ;) \
-#	cd $(VCS_WORK_DIR)/ && \
-#	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
-#	++$(elf) \
-#	+PRELOAD=$(elf) \
-#	+tohost_addr=$(shell $$RISCV/bin/riscv-none-elf-nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
-#	-sv_lib $(dpi-library)/ariane_dpi \
-#	$(cov-run-opt) $(issrun_opts) && \
-#	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CVA6_REPO_DIR)/verif/sim/ && \
-#	{ [ -z "`ls $(VCS_WORK_DIR)/*.$(SIMV_TRACE_EXTN)`" ] || \
-#	  for i in `ls $(VCS_WORK_DIR)/*.$(SIMV_TRACE_EXTN)` ; do mv $$i $(CVA6_REPO_DIR)/verif/sim/`basename $$i` ; done || \
-#	  true ; }
 
 xrun-uvm: xrun_uvm_comp xrun_uvm_run
-#	make xrun_uvm_comp
-#	make xrun_uvm_run
-#	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
-#	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
-#	[ -z "`ls *.$(SIMV_TRACE_EXTN)`" ] || \
-#          for i in `ls *.$(SIMV_TRACE_EXTN)` ; do mv $$i `dirname $(log)`/`basename $(log) .log`.$(target).$$i ; done || true
-
-#xrun_comp_gen_inst:$(filelist)
-#	$(comp_sv_cmd) $(comp_sv_opt) -log tb_sv_compile.log $(filter %.sv %.v, $^)
-#	@touch $@
 
 generate_cov_dash:
 	urg -warn none -hvp_proj cva6_embedded -format both -group instcov_for_score -hvp_attributes weight+description+Comment -dir vcs_results/default/vcs.d/simv.vdb -plan cva6.hvp -tgl portsonly

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -227,7 +227,7 @@ ALL_XRUN_UVM_FLAGS      = -elaborate -messages -sv +incdir+$(XCELIUM_HOME)/tools
 	  -xmerror CUNOTB -nowarn CUDEFB -nowarn CUSRCH -warn_multiple_driver -relax_svbtis -timescale 1ns/1ps -status -access +rwc -log   $(XRUN_WORK_DIR)/tb_compile.log
 ##-relax_svbtis
 ##ALL_XRUN_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) 
-ALL_XRUN_SIMV_UVM_FLAGS      =  +sv_lib=$(CVA6_REPO_DIR)/verif/core-v-verif/lib/dpi_dasm/lib/Linux64/libdpi_dasm.so 
+ALL_XRUN_SIMV_UVM_FLAGS      =  +sv_lib=$(CVA6_REPO_DIR)/tools/spike/lib/libdisasm +signature=I-ADD-01.signature_output
 ##		+UVM_TESTNAME=uvmt_cva6_firmware_test_c
 
 ##XRUN_RUN_FLAGS := -R -64bit -disable_sem2009 -uvmhome CDNS-1.2  +UVM_VERBOSITY=UVM_LOW -svseed 1 -access +rwc -sv -timescale 1ns/1ps		
@@ -268,9 +268,11 @@ ifneq ($(DEBUG),)               # If RTL DEBUG support requested
 endif
 
 ifneq ($(SPIKE_TANDEM),)
-COMMON_RUN_ARGS += +tandem_enabled=1
+ALL_SIMV_UVM_FLAGS += +scoreboard_enabled=1
+ALL_XRUN_SIMV_UVM_FLAGS += +scoreboard_enabled=1
 else
-COMMON_RUN_ARGS += +tandem_enabled=0
+ALL_SIMV_UVM_FLAGS += +scoreboard_enabled=0
+ALL_XRUN_SIMV_UVM_FLAGS += +scoreboard_enabled=0
 endif
 
 vcs_uvm_comp:
@@ -363,18 +365,18 @@ xrun_uvm_comp:
 xrun_uvm_run:
 	@echo "[XRUN] Running"
 	cd $(XRUN_WORK_DIR) && 	\
-	  xrun +permissive			\
+	  xrun 			\
 	  $(XRUN_RUN)			\
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libriscv \
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libfesvr \
+	  ++$(elf) \
+	  +elf_file=$(elf) \
           +define+UVM_NO_DEPRECATED  \
-	  +MAX_CYCLES=$(max_cycles)	\
-	  +UVM_CONFIG_DB_TRACE	\
 	  +UVM_TESTNAME=uvmt_cva6_firmware_test_c	\
-	  +time_out=2000000000            \
-	  +tohost_addr=80001000           \
+	  +tohost_addr=$(shell ${RISCV}/bin/riscv32-unknown-elf-nm -B $(elf) | grep -w tohost | cut -d' ' -f1)          \
+	  $(cov-comp-opt) $(issrun_opts)    \
 	  -gui				\
-	  +permissive-off			
+	  			
 
 xrun-uvm: xrun_uvm_comp xrun_uvm_run
 

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -213,9 +213,7 @@ ALL_UVM_FLAGS   = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
 	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon)) \
 	  -cm_seqnoconst -diag noconst \
 
-ALL_SIMV_UVM_FLAGS      = +vcs+lic+wait -licwait 20  \
-		-sv_lib $(CVA6_REPO_DIR)/verif/core-v-verif/lib/dpi_dasm/lib/Linux64/libdpi_dasm +signature=I-ADD-01.signature_output \
-		+UVM_TESTNAME=uvmt_cva6_firmware_test_c
+ALL_SIMV_UVM_FLAGS      = +vcs+lic+wait $(issrun_opts) \
 
 ALL_XRUN_UVM_FLAGS      = -elaborate -messages -sv +incdir+$(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/ \
 	  $(XCELIUM_HOME)/tools.lnx86/methodology/UVM/CDNS-1.2/sv/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_LOW -uvm -uvmhome CDNS-1.2 \
@@ -226,8 +224,6 @@ ALL_XRUN_UVM_FLAGS      = -elaborate -messages -sv +incdir+$(XCELIUM_HOME)/tools
 ALL_XRUN_SIMV_UVM_FLAGS      =  +sv_lib=$(CVA6_REPO_DIR)/tools/spike/lib/libdisasm +signature=I-ADD-01.signature_output
 		          
 XRUN_RUN_FLAGS := -R -messages -status -64bit -licqueue -noupdate -log xrun.log -uvmhome CDNS-1.2  +UVM_VERBOSITY=UVM_LOW -svseed 1 		
-		          
-##                          -xceligen on=1903	
 
 XRUN_DISABLED_WARNINGS := BIGWIX 	\
                         ZROMCW 		\


### PR DESCRIPTION
This PR aims at updating the rules into `cva6/verif/sim/Makefile` to support **uvmt_cva6_tb** (in `cva6/verif/tb/uvmt`) on **Cadence Xcelium**.
Nevertheless, this PR is not enough to launch _cva6.py_ with _xrun_uvm DV_SIMULATOR_. Further PRs will follow.

It contributes to task https://github.com/openhwgroup/cva6/issues/1829