### PR TITLE
MTVAL is read-only zero when TvalEn = 0

### DIFF
--- a/.gitlab-ci/expected_synth.yml
+++ b/.gitlab-ci/expected_synth.yml
@@ -1,4 +1,4 @@
 cv32a6_embedded:
   gates: 110095
 cv32a65x:
-  gates: 128644
+  gates: 129342

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -529,7 +529,9 @@ module csr_regfile
         riscv::CSR_MSCRATCH: csr_rdata = mscratch_q;
         riscv::CSR_MEPC: csr_rdata = mepc_q;
         riscv::CSR_MCAUSE: csr_rdata = mcause_q;
-        riscv::CSR_MTVAL: csr_rdata = mtval_q;
+        riscv::CSR_MTVAL:
+        if (CVA6Cfg.TvalEn) csr_rdata = mtval_q;
+        else csr_rdata = '0;
         riscv::CSR_MTINST:
         if (CVA6Cfg.RVH) csr_rdata = mtinst_q;
         else read_access_exception = 1'b1;
@@ -1382,7 +1384,6 @@ module csr_regfile
         riscv::CSR_MCAUSE: mcause_d = csr_wdata;
         riscv::CSR_MTVAL: begin
           if (CVA6Cfg.TvalEn) mtval_d = csr_wdata;
-          else update_access_exception = 1'b1;
         end
         riscv::CSR_MTINST:
         if (CVA6Cfg.RVH) mtinst_d = {{CVA6Cfg.XLEN - 32{1'b0}}, csr_wdata[31:0]};


### PR DESCRIPTION
Do not gen exception when writing into MTVAL
The related logic will be removed in following PRs.