### PR TITLE
csr_regfile.sv: if no U-mode, mstatus.tw is read-only 0 (fix #2228)

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1278,6 +1278,7 @@ module csr_regfile
             mstatus_d.tsr  = riscv::Off;
           end
           if (!CVA6Cfg.RVU) begin
+            mstatus_d.tw   = riscv::Off;
             mstatus_d.mprv = riscv::Off;
           end
           // If h-extension is not enabled, priv level HS is reserved


### PR DESCRIPTION
force 0 in tw field when writing mstatus