### PR TITLE
When NrPMPEntries == 8, set 2 upper PMPCfg and 8 upper CfgAddress as read-only CSRs

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1560,8 +1560,8 @@ module csr_regfile
         riscv::CSR_PMPCFG3: begin
           if (CVA6Cfg.XLEN == 32) begin
             for (int i = 0; i < 4; i++)
-              if (CVA6Cfg.NrPMPEntries == 8) pmpcfg_d[i+12] = '0;
-              else if (!pmpcfg_q[i+12].locked) pmpcfg_d[i+12] = csr_wdata[i*8+:8];
+            if (CVA6Cfg.NrPMPEntries == 8) pmpcfg_d[i+12] = '0;
+            else if (!pmpcfg_q[i+12].locked) pmpcfg_d[i+12] = csr_wdata[i*8+:8];
           end else begin
             update_access_exception = 1'b1;
           end

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1555,8 +1555,8 @@ module csr_regfile
         end
         riscv::CSR_PMPCFG2:
         for (int i = 0; i < (CVA6Cfg.XLEN / 8); i++)
-          if (CVA6Cfg.NrPMPEntries == 8) pmpcfg_d[i+8] = '0;
-          else if (!pmpcfg_q[i+8].locked) pmpcfg_d[i+8] = csr_wdata[i*8+:8];
+        if (CVA6Cfg.NrPMPEntries == 8) pmpcfg_d[i+8] = '0;
+        else if (!pmpcfg_q[i+8].locked) pmpcfg_d[i+8] = csr_wdata[i*8+:8];
         riscv::CSR_PMPCFG3: begin
           if (CVA6Cfg.XLEN == 32) begin
             for (int i = 0; i < 4; i++)


### PR DESCRIPTION
Related logic is not removed, this will be addressed in following PR