### PR TITLE
cv32a65x doc: split unpriv and priv HTML pages

### DIFF
--- a/docs/04_cv32a65x/index.rst
+++ b/docs/04_cv32a65x/index.rst
@@ -4,6 +4,6 @@ CV32A65X documentation
 .. toctree::
    :maxdepth: 1
 
-   riscv/index.rst
+   riscv/unpriv.rst
+   riscv/priv.rst
    design/source/index.rst
-   

--- a/docs/04_cv32a65x/riscv/priv.rst
+++ b/docs/04_cv32a65x/riscv/priv.rst
@@ -1,0 +1,14 @@
+..
+   Copyright (c) 2024 Thales
+   Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+   You may obtain a copy of the License at https://solderpad.org/licenses/
+
+   Original Author: Jean-Roch COULON - Thales
+
+Privileged RISC-V ISA for CV32A65X
+==================================
+
+.. raw:: html
+   :file: priv-isa-cv32a65x.html

--- a/docs/04_cv32a65x/riscv/unpriv.rst
+++ b/docs/04_cv32a65x/riscv/unpriv.rst
@@ -12,9 +12,3 @@ Unprivileged RISC-V ISA for CV32A65X
 
 .. raw:: html
    :file: unpriv-isa-cv32a65x.html
-
-Privileged RISC-V ISA for CV32A65X
-==================================
-
-.. raw:: html
-   :file: priv-isa-cv32a65x.html


### PR DESCRIPTION
To have two different HTML pages for tailored RISC-V spec (one for unpriv and one for priv) on ReadTheDocs