### PR TITLE
cv64a6_mmu: set NrPMPEntries to 16 (fixes #2244)

### DIFF
--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -67,7 +67,7 @@ package cva6_config_pkg;
       DmBaseAddress: 64'h0,
       TvalEn: bit'(0),
       DirectVecOnly: bit'(1),
-      NrPMPEntries: unsigned'(64),
+      NrPMPEntries: unsigned'(16),
       PMPCfgRstVal: {16{64'h0}},
       PMPAddrRstVal: {16{64'h0}},
       PMPEntryReadOnly: 16'd0,


### PR DESCRIPTION
RTL does not support >16 entries yet.