### PR TITLE
[Xcelium flow] Fix initialization of memory array for simulation

### DIFF
--- a/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
+++ b/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
@@ -163,7 +163,10 @@ module tc_sram #(
     // write memory array
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
-        sram <= init_val;
+        // Fix to avoid runtime space reaching maximum capacity in simulation
+        foreach (init_val[i]) begin
+          sram[i] <= init_val[i];
+        end
         for (int i = 0; i < NumPorts; i++) begin
           r_addr_q[i] <= {AddrWidth{1'b0}};
           // initialize the read output register for each port


### PR DESCRIPTION
This PR aims at fixing sram initialization in **tc_sram** memory model.
Initialization of SRAM in tc_sram.sv model is exceeding tool limit at runtime. Simple fix is to use a for loop instead of assigning the whole signal.

It contributes to task https://github.com/openhwgroup/cva6/issues/1829