### PR TITLE
CSR verification : modify CSR env verif based on new specification

### DIFF
--- a/verif/env/uvme/reg/cva6_csr_reg_block.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_block.sv
@@ -144,10 +144,6 @@ class cva6_csr_reg_block extends uvm_reg_block;
   rand reg_mhpmcounterh29  mhpmcounterh29; 
   rand reg_mhpmcounterh30  mhpmcounterh30; 
   rand reg_mhpmcounterh31  mhpmcounterh31; 
-  rand reg_cycle  cycle; 
-  rand reg_instret  instret; 
-  rand reg_cycleh  cycleh; 
-  rand reg_instreth  instreth; 
   rand reg_mvendorid  mvendorid; 
   rand reg_marchid  marchid; 
   rand reg_mimpid  mimpid; 
@@ -656,22 +652,6 @@ class cva6_csr_reg_block extends uvm_reg_block;
     mhpmcounterh31.configure(this, null, "mhpmcounterh31");
     mhpmcounterh31.build();
 
-    cycle = reg_cycle::type_id::create("cycle", null, get_full_name());
-    cycle.configure(this, null, "cycle");
-    cycle.build();
-
-    instret = reg_instret::type_id::create("instret", null, get_full_name());
-    instret.configure(this, null, "instret");
-    instret.build();
-
-    cycleh = reg_cycleh::type_id::create("cycleh", null, get_full_name());
-    cycleh.configure(this, null, "cycleh");
-    cycleh.build();
-
-    instreth = reg_instreth::type_id::create("instreth", null, get_full_name());
-    instreth.configure(this, null, "instreth");
-    instreth.build();
-
     mvendorid = reg_mvendorid::type_id::create("mvendorid", null, get_full_name());
     mvendorid.configure(this, null, "mvendorid");
     mvendorid.build();
@@ -815,11 +795,7 @@ class cva6_csr_reg_block extends uvm_reg_block;
     default_map.add_reg(mhpmcounterh28, 'hb9c, "RW");  
     default_map.add_reg(mhpmcounterh29, 'hb9d, "RW");  
     default_map.add_reg(mhpmcounterh30, 'hb9e, "RW");  
-    default_map.add_reg(mhpmcounterh31, 'hb9f, "RW");  
-    default_map.add_reg(cycle, 'hC00, "RO");  
-    default_map.add_reg(instret, 'hC02, "RO");  
-    default_map.add_reg(cycleh, 'hC80, "RO");  
-    default_map.add_reg(instreth, 'hC82, "RO");  
+    default_map.add_reg(mhpmcounterh31, 'hb9f, "RW");   
     default_map.add_reg(mvendorid, 'hF11, "RO");  
     default_map.add_reg(marchid, 'hF12, "RO");  
     default_map.add_reg(mimpid, 'hF13, "RO");  

--- a/verif/env/uvme/reg/cva6_csr_reg_file.sv
+++ b/verif/env/uvme/reg/cva6_csr_reg_file.sv
@@ -86,36 +86,67 @@ class reg_mstatus extends csr_reg;
       option.per_instance = 1;
       SD: coverpoint data[31:31] {
          bins legal_values[] = {0};
-         //GIT ISSUE #1417: illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
+         illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
       }
-      TSR: coverpoint data[22:22];
-      TW: coverpoint data[21:21];
-      TVM: coverpoint data[20:20];
-      MXR: coverpoint data[19:19];
-      SUM: coverpoint data[18:18];
-      MPRV: coverpoint data[17:17];
+      TSR: coverpoint data[22:22] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
+      TW: coverpoint data[21:21] {
+         bins legal_values[] = {0};
+         // issue#2228 illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
+      // TODO : need configuration on these coverpoints
+      TVM: coverpoint data[20:20] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
+      MXR: coverpoint data[19:19] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
+      SUM: coverpoint data[18:18] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
+      MPRV: coverpoint data[17:17] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
       XS: coverpoint data[16:15] {
          bins legal_values[] = {0};
-         illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
       }
       FS: coverpoint data[14:13] {
          bins legal_values[] = {0};
-         illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
       }
-      MPP: coverpoint data[12:11];
+      MPP: coverpoint data[12:11] {
+         bins legal_values[] = {3};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {3}));
+      }
       VS: coverpoint data[10:9] {
          bins legal_values[] = {0};
-         illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
       }
-      SPP: coverpoint data[8:8];
+      SPP: coverpoint data[8:8] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
       MPIE: coverpoint data[7:7];
       UBE: coverpoint data[6:6] {
          bins legal_values[] = {0};
-         illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
       }
-      SPIE: coverpoint data[5:5];
+      SPIE: coverpoint data[5:5] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
       MIE: coverpoint data[3:3];
-      SIE: coverpoint data[1:1];
+      SIE: coverpoint data[1:1] {
+         bins legal_values[] = {0};
+         ignore_bins illegal_values = {[0:$]} with (!(item inside {0}));
+      }
   endgroup
 
   covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
@@ -471,8 +502,8 @@ class reg_mtvec extends csr_reg;
          bins other_values[3] = {[1:$]};
       }
       MODE: coverpoint data[1:0] {
-         bins legal_values[] = {0,1};
-         illegal_bins illegal_values = {[0:$]} with (!(item inside {0,1}));
+         bins legal_values[] = {0};
+         illegal_bins illegal_values = {[0:$]} with (!(item inside {0}));
       } 
   endgroup
 
@@ -2613,11 +2644,11 @@ class reg_mtval extends csr_reg;
   endgroup
 
   covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_mtval.mtval__write_cp";
+      option.name = "csr_mtval__write_cg";
       option.per_instance = 1;
-      mtval: coverpoint data[31:0]{
-         bins ZERO[]  = {0};
-         bins other_values[3]  = {[1:$]};
+      mtval: coverpoint data[31:0] {
+         bins reset_value = {0};
+         bins other_values[3] = {[1:$]};
       }
   endgroup
 
@@ -8092,266 +8123,6 @@ class reg_mhpmcounterh31 extends csr_reg;
 endclass
 
 
-class reg_cycle extends csr_reg;
-  `uvm_object_utils(reg_cycle)
-
-  //---------------------------------------
-  // fields instance 
-  //--------------------------------------- 
-  rand uvm_reg_field count;
-   
-
-  covergroup reg_rd_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_cycle__read_cg";
-      option.per_instance = 1;
-      count: coverpoint data[31:0] {
-         bins reset_value  = {[0:10000]};
-         bins other_values[3] = {[10001:$]};
-      }
-      count_overflow: coverpoint data[31:0] {
-         bins overflow = ([32'hFFFFFBFF:$] => [0:10000]);
-      }
-  endgroup
-
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_cycle.cycle__write_cp";
-      option.per_instance = 1;
-      count: coverpoint data[31:0]{
-         bins reset_value  = {0};
-         bins other_values[3] = {[1:$]};
-      }
-  endgroup
-
-  //---------------------------------------
-  // Constructor 
-  //---------------------------------------
-  function new (string name = "reg_cycle");
-    super.new(name);
-    set_privilege_level(U_LEVEL);
-    reg_rd_cg = new();
-    reg_rd_cg.set_inst_name("csr_reg_cov.cycle.cycle__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.cycle.cycle__write_cg");
-  endfunction
-
-  //---------------------------------------
-  // build_phase - 
-  // 1. Create the fields
-  // 2. Configure the fields
-  //---------------------------------------  
-  function void build; 
-   
-    count = uvm_reg_field::type_id::create("count");   
-    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
-  endfunction
-
-  virtual function void sample(uvm_reg_data_t data, uvm_reg_data_t byte_en,bit is_read, uvm_reg_map map);
-    if (get_coverage(UVM_CVR_FIELD_VALS)) begin
-      if (is_read)
-         reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
-    end     
-  endfunction
-
-endclass
-
-
-class reg_instret extends csr_reg;
-  `uvm_object_utils(reg_instret)
-
-  //---------------------------------------
-  // fields instance 
-  //--------------------------------------- 
-  rand uvm_reg_field count;
-   
-
-  covergroup reg_rd_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_instret__read_cg";
-      option.per_instance = 1;
-      count: coverpoint data[31:0] {
-         bins reset_value  = {[0:1000]};
-         bins other_values[3] = {[1001:$]};
-      }
-      count_overflow: coverpoint data[31:0] {
-         bins overflow = ([32'hFFFFFC17:$] => [0:100]);
-      }
-  endgroup
-
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_instret.instret__write_cp";
-      option.per_instance = 1;
-      count: coverpoint data[31:0] {
-         bins reset_value  = {0};
-         bins other_values[3] = {[1:$]};
-      }
-  endgroup
-
-  //---------------------------------------
-  // Constructor 
-  //---------------------------------------
-  function new (string name = "reg_instret");
-    super.new(name);
-    set_privilege_level(U_LEVEL);
-    reg_rd_cg = new();
-    reg_rd_cg.set_inst_name("csr_reg_cov.instret.instret__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.instret.instret__write_cg");
-  endfunction
-
-  //---------------------------------------
-  // build_phase - 
-  // 1. Create the fields
-  // 2. Configure the fields
-  //---------------------------------------  
-  function void build; 
-   
-    count = uvm_reg_field::type_id::create("count");   
-    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
-  endfunction
-
-  virtual function void sample(uvm_reg_data_t data, uvm_reg_data_t byte_en,bit is_read, uvm_reg_map map);
-    if (get_coverage(UVM_CVR_FIELD_VALS)) begin
-      if (is_read)
-         reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
-    end     
-  endfunction
-
-endclass
-
-
-class reg_cycleh extends csr_reg;
-  `uvm_object_utils(reg_cycleh)
-
-  //---------------------------------------
-  // fields instance 
-  //--------------------------------------- 
-  rand uvm_reg_field count;
-   
-
-  covergroup reg_rd_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_cycleh__read_cg";
-      option.per_instance = 1;
-      count: coverpoint data[31:0] {
-         bins reset_value  = {0};
-         bins other_values[3] = {[1:$]};
-      }
-      count_overflow: coverpoint data[31:0] {
-         bins overflow = ([32'hFFFFFBFF:$] => [0:1000]);
-      }
-  endgroup
-
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_cycleh.cycleh__write_cp";
-      option.per_instance = 1;
-      count: coverpoint data[31:0] {
-         bins reset_value  = {0};
-         bins other_values[3] = {[1:$]};
-      }
-  endgroup
-
-  //---------------------------------------
-  // Constructor 
-  //---------------------------------------
-  function new (string name = "reg_cycleh");
-    super.new(name);
-    set_privilege_level(U_LEVEL);
-    reg_rd_cg = new();
-    reg_rd_cg.set_inst_name("csr_reg_cov.cycleh.cycleh__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.cycleh.cycleh__write_cg");
-  endfunction
-
-  //---------------------------------------
-  // build_phase - 
-  // 1. Create the fields
-  // 2. Configure the fields
-  //---------------------------------------  
-  function void build; 
-   
-    count = uvm_reg_field::type_id::create("count");   
-    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
-  endfunction
-
-  virtual function void sample(uvm_reg_data_t data, uvm_reg_data_t byte_en,bit is_read, uvm_reg_map map);
-    if (get_coverage(UVM_CVR_FIELD_VALS)) begin
-      if (is_read)
-         reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
-    end     
-  endfunction
-
-endclass
-
-
-class reg_instreth extends csr_reg;
-  `uvm_object_utils(reg_instreth)
-
-  //---------------------------------------
-  // fields instance 
-  //--------------------------------------- 
-  rand uvm_reg_field count;
-   
-
-  covergroup reg_rd_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_instreth__read_cg";
-      option.per_instance = 1;
-      count: coverpoint data[31:0] {
-         bins reset_value  = {0};
-         bins other_values[3] = {[1:$]};
-      }
-      count_overflow: coverpoint data[31:0] {
-         bins overflow = ([32'hFFFFFFEF:$] => [0:10]);
-      }
-  endgroup
-
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_instreth.instreth__write_cp";
-      option.per_instance = 1;
-      count: coverpoint data[31:0] {
-         bins reset_value  = {0};
-         bins other_values[3] = {[1:$]};
-      }
-  endgroup
-
-  //---------------------------------------
-  // Constructor 
-  //---------------------------------------
-  function new (string name = "reg_instreth");
-    super.new(name);
-    set_privilege_level(U_LEVEL);
-    reg_rd_cg = new();
-    reg_rd_cg.set_inst_name("csr_reg_cov.instreth.instreth__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.instreth.instreth__write_cg");
-  endfunction
-
-  //---------------------------------------
-  // build_phase - 
-  // 1. Create the fields
-  // 2. Configure the fields
-  //---------------------------------------  
-  function void build; 
-   
-    count = uvm_reg_field::type_id::create("count");   
-    count.configure(.parent(this), .size(32), .lsb_pos(0), .access("RO"), .volatile(0), .reset(0), .has_reset(1), .is_rand(1),  .individually_accessible(0));  
-  endfunction
-
-  virtual function void sample(uvm_reg_data_t data, uvm_reg_data_t byte_en,bit is_read, uvm_reg_map map);
-    if (get_coverage(UVM_CVR_FIELD_VALS)) begin
-      if (is_read)
-         reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
-    end     
-  endfunction
-
-endclass
-
-
 class reg_mvendorid extends csr_reg;
   `uvm_object_utils(reg_mvendorid)
 
@@ -8373,19 +8144,6 @@ class reg_mvendorid extends csr_reg;
       }
   endgroup
 
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_mvendorid.mvendorid__write_cp";
-      option.per_instance = 1;
-      bank: coverpoint data[31:7] {
-         bins reset_value  = {'hC};
-         bins other_values[3] = {[0:$]} with (!(item inside {'hC0}));
-      }
-      offset: coverpoint data[6:0]{
-         bins reset_value  = {'h2};
-         bins other_values[3] = {[0:$]} with (!(item inside {'h20}));
-      }
-  endgroup
-
   //---------------------------------------
   // Constructor 
   //---------------------------------------
@@ -8394,8 +8152,6 @@ class reg_mvendorid extends csr_reg;
     set_privilege_level(M_LEVEL);
     reg_rd_cg = new();
     reg_rd_cg.set_inst_name("csr_reg_cov.mvendorid.mvendorid__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.mvendorid.mvendorid__write_cg");
   endfunction
 
   //---------------------------------------
@@ -8416,8 +8172,6 @@ class reg_mvendorid extends csr_reg;
     if (get_coverage(UVM_CVR_FIELD_VALS)) begin
       if (is_read)
          reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
     end     
   endfunction
 
@@ -8441,15 +8195,6 @@ class reg_marchid extends csr_reg;
       }
   endgroup
 
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_marchid.marchid__write_cp";
-      option.per_instance = 1;
-      architecture_id: coverpoint data[31:0] {
-         bins reset_value  = {'h3};
-         bins other_values[3] = {[0:$]} with (!(item inside {'h3}));
-      }
-  endgroup
-
   //---------------------------------------
   // Constructor 
   //---------------------------------------
@@ -8458,8 +8203,6 @@ class reg_marchid extends csr_reg;
     set_privilege_level(M_LEVEL);
     reg_rd_cg = new();
     reg_rd_cg.set_inst_name("csr_reg_cov.marchid.marchid__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.marchid.marchid__write_cg");
   endfunction
 
   //---------------------------------------
@@ -8477,8 +8220,6 @@ class reg_marchid extends csr_reg;
     if (get_coverage(UVM_CVR_FIELD_VALS)) begin
       if (is_read)
          reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
     end     
   endfunction
 
@@ -8502,15 +8243,6 @@ class reg_mimpid extends csr_reg;
       }
   endgroup
 
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_mimpid.mimpid__write_cp";
-      option.per_instance = 1;
-      implementation: coverpoint data[31:0] {
-         bins reset_value  = {0};
-         bins other_values[3] = {[0:$]} with (!(item inside {0}));
-      }
-  endgroup
-
   //---------------------------------------
   // Constructor 
   //---------------------------------------
@@ -8519,8 +8251,6 @@ class reg_mimpid extends csr_reg;
     set_privilege_level(M_LEVEL);
     reg_rd_cg = new();
     reg_rd_cg.set_inst_name("csr_reg_cov.mimpid.mimpid__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.mimpid.mimpid__write_cg");
   endfunction
 
   //---------------------------------------
@@ -8538,8 +8268,6 @@ class reg_mimpid extends csr_reg;
     if (get_coverage(UVM_CVR_FIELD_VALS)) begin
       if (is_read)
          reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
     end     
   endfunction
 
@@ -8563,15 +8291,6 @@ class reg_mhartid extends csr_reg;
       }
   endgroup
 
-  covergroup reg_wr_cg with function sample(uvm_reg_data_t data);
-      option.name = "csr_mhartid.mhartid__write_cp";
-      option.per_instance = 1;
-      hart_id: coverpoint data[31:0] {
-         bins reset_value  = {0};
-         bins other_values[3] = {[0:$]} with (!(item inside {0}));
-      }
-  endgroup
-
   //---------------------------------------
   // Constructor 
   //---------------------------------------
@@ -8580,8 +8299,6 @@ class reg_mhartid extends csr_reg;
     set_privilege_level(M_LEVEL);
     reg_rd_cg = new();
     reg_rd_cg.set_inst_name("csr_reg_cov.mhartid.mhartid__read_cg");
-    reg_wr_cg = new();
-    reg_wr_cg.set_inst_name("csr_reg_cov.mhartid.mhartid__write_cg");
   endfunction
 
   //---------------------------------------
@@ -8599,8 +8316,6 @@ class reg_mhartid extends csr_reg;
     if (get_coverage(UVM_CVR_FIELD_VALS)) begin
       if (is_read)
          reg_rd_cg.sample(data);
-      else
-         reg_wr_cg.sample(data);
     end     
   endfunction
 

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -725,34 +725,14 @@ plan "CVA6 Verification Master Plan";
         endfeature
         feature "CSR access";
             description = "CSR registers access.\nSpecification: Done, Dvplan: Done, Verification execution: Done";
-            feature CYCLE;
-                measure Group CYCLE;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.cycle.cycle__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.cycle.cycle__write_cg";
-                endmeasure
-            endfeature
-            feature CYCLEH;
-                measure Group CYCLEH;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.cycleh.cycleh__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.cycleh.cycleh__write_cg";
-                endmeasure
-            endfeature
             feature ICACHE;
                 measure Group ICACHE;
                     source = "group instance: uvme_cva6_pkg.csr_reg_cov.icache.icache__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.icache.icache__write_cg";
                 endmeasure
             endfeature
-            feature INSTRET;
-                measure Group INSTRET;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.instret.instret__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.instret.instret__write_cg";
-                endmeasure
-            endfeature
-            feature INSTRETH;
-                measure Group INSTRETH;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.instreth.instreth__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.instreth.instreth__write_cg";
-                endmeasure
-            endfeature
             feature MARCHID;
                 measure Group MARCHID;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.marchid.marchid__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.marchid.marchid__write_cg";
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.marchid.marchid__read_cg";
                 endmeasure
             endfeature
             feature MCAUSE;
@@ -767,7 +747,7 @@ plan "CVA6 Verification Master Plan";
             endfeature
             feature MHARTID;
                 measure Group MHARTID;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhartid.mhartid__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.mhartid.mhartid__write_cg";
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mhartid.mhartid__read_cg";
                 endmeasure
             endfeature
             feature MIE;
@@ -777,7 +757,7 @@ plan "CVA6 Verification Master Plan";
             endfeature
             feature MIMPID;
                 measure Group MIMPID;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mimpid.mimpid__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.mimpid.mimpid__write_cg";
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mimpid.mimpid__read_cg";
                 endmeasure
             endfeature
             feature MIP;
@@ -817,7 +797,7 @@ plan "CVA6 Verification Master Plan";
             endfeature
             feature MVENDORID;
                 measure Group MVENDORID;
-                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mvendorid.mvendorid__read_cg", "group instance: uvme_cva6_pkg.csr_reg_cov.mvendorid.mvendorid__write_cg";
+                    source = "group instance: uvme_cva6_pkg.csr_reg_cov.mvendorid.mvendorid__read_cg";
                 endmeasure
             endfeature
             feature PMPADDR0;

--- a/verif/tests/custom/csr_embedded/csr_counters_overflow.S
+++ b/verif/tests/custom/csr_embedded/csr_counters_overflow.S
@@ -19,8 +19,6 @@ csr_cycle_overflow:
     csrw mcycle, x3
     
     #Read backs registers
-    csrr x14, cycle
-    csrr x14, cycleh
     csrr x14, mcycle
     csrr x14, mcycleh
 
@@ -35,8 +33,6 @@ csr_cycle_overflow:
     nop
 
     #Read backs registers. cycle and mcycle should be arround 0, cycleh and mcycleh should increment by 1
-    csrr x14, cycle
-    csrr x14, cycleh
     csrr x14, mcycle
     csrr x14, mcycleh
 
@@ -47,8 +43,6 @@ csr_cycle_overflow:
     csrw mcycle, x3
 
     #Read backs registers
-    csrr x14, cycle
-    csrr x14, cycleh
     csrr x14, mcycle
     csrr x14, mcycleh
     
@@ -63,8 +57,6 @@ csr_cycle_overflow:
     nop
         
     #Read backs registers, cycle and mcycle should be arround 0, cycleh and mcycleh should be 0
-    csrr x14, cycle
-    csrr x14, cycleh
     csrr x14, mcycle
     csrr x14, mcycleh
 
@@ -76,8 +68,6 @@ csr_instert_overflow:
     csrw minstret, x3
     
     #Read backs registers
-    csrr x14, instret
-    csrr x14, instreth
     csrr x14, minstret
     csrr x14, minstreth
 
@@ -100,8 +90,6 @@ csr_instert_overflow:
     nop
 
     #Read backs registers. instret and minstret should be arround 0, instreth and minstreth should increment by 1
-    csrr x14, instret
-    csrr x14, instreth
     csrr x14, minstret
     csrr x14, minstreth
 
@@ -112,8 +100,6 @@ csr_instert_overflow:
     csrw minstret, x3
 
     #Read backs registers
-    csrr x14, instret
-    csrr x14, instreth
     csrr x14, minstret
     csrr x14, minstreth
     
@@ -136,8 +122,6 @@ csr_instert_overflow:
     nop
         
     #Read backs registers, instret and minstret should be arround 0, instreth and minstreth should be 0
-    csrr x14, instret
-    csrr x14, instreth
     csrr x14, minstret
     csrr x14, minstreth
 

--- a/verif/tests/custom/csr_embedded/csrcs_test.S
+++ b/verif/tests/custom/csr_embedded/csrcs_test.S
@@ -11,6 +11,54 @@ csrcs:
     #User ignored registers: 
 
     ##########################
+    #MTVAL testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h16}
+    ##########################
+    #MTVAL Write clear/set value 0x1f
+    li x3, 0xffffffe0
+    csrrc x14, 0x343, x3
+    li x3, 0x1f
+    csrrs x14, 0x343, x3
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0x0
+    li x3, 0xffffffff
+    csrrc x14, 0x343, x3
+    li x3, 0x0
+    csrrs x14, 0x343, x3
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0x15
+    li x3, 0xffffffea
+    csrrc x14, 0x343, x3
+    li x3, 0x15
+    csrrs x14, 0x343, x3
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0xa
+    li x3, 0xfffffff5
+    csrrc x14, 0x343, x3
+    li x3, 0xa
+    csrrs x14, 0x343, x3
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0x16
+    li x3, 0xffffffe9
+    csrrc x14, 0x343, x3
+    li x3, 0x16
+    csrrs x14, 0x343, x3
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    ##########################
     #MHPMEVENT22 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h16} 
     ##########################
     #MHPMEVENT22 Write clear/set value 0x1f

--- a/verif/tests/custom/csr_embedded/csrcsi_test.S
+++ b/verif/tests/custom/csr_embedded/csrcsi_test.S
@@ -11,6 +11,44 @@ csrcsi:
     #User ignored registers: 
 
     ##########################
+    #MTVAL testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'hb}
+    ##########################
+    #MTVAL Write clear/set value 0x1f
+    csrrci x14, 0x343, 0x0
+    csrrsi x14, 0x343, 0x1f
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0x0
+    csrrci x14, 0x343, 0x1f
+    csrrsi x14, 0x343, 0x0
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0x15
+    csrrci x14, 0x343, 0xa
+    csrrsi x14, 0x343, 0x15
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0xa
+    csrrci x14, 0x343, 0x15
+    csrrsi x14, 0x343, 0xa
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write clear/set value 0xb
+    csrrci x14, 0x343, 0x14
+    csrrsi x14, 0x343, 0xb
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    ##########################
     #MHPMCOUNTER23 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'hb} 
     ##########################
     #MHPMCOUNTER23 Write clear/set value 0x1f

--- a/verif/tests/custom/csr_embedded/csrrst_test.S
+++ b/verif/tests/custom/csr_embedded/csrrst_test.S
@@ -34,9 +34,6 @@ csrrst:
     #MHPMEVENT28 read value
     csrr x14, 0x33c
 
-    #INSTRETH read value
-    csrr x14, 0xc82
-
     #MHPMCOUNTERH9 read value
     csrr x14, 0xb89
 
@@ -85,9 +82,6 @@ csrrst:
     #MHPMCOUNTER13 read value
     csrr x14, 0xb0d
 
-    #INSTRET read value
-    csrr x14, 0xc02
-
     #MHPMCOUNTERH19 read value
     csrr x14, 0xb93
 
@@ -114,9 +108,6 @@ csrrst:
 
     #MHPMCOUNTERH15 read value
     csrr x14, 0xb8f
-
-    #CYCLE read value
-    csrr x14, 0xc00
 
     #MHPMEVENT27 read value
     csrr x14, 0x33b
@@ -180,9 +171,6 @@ csrrst:
 
     #MHPMEVENT17 read value
     csrr x14, 0x331
-
-    #CYCLEH read value
-    csrr x14, 0xc80
 
     #PMPADDR10 read value
     csrr x14, 0x3ba

--- a/verif/tests/custom/csr_embedded/csrrw_test.S
+++ b/verif/tests/custom/csr_embedded/csrrw_test.S
@@ -3985,6 +3985,44 @@ csrrw:
     #CYCLE WR skipped since it's a RO register
 
     ##########################
+    #MTVAL testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'h162b0d42}
+    ##########################
+    #MTVAL Write value 0xffffffff
+    li x3, 0xffffffff
+    csrw 0X343, x3
+
+    #MTVAL read value
+    csrr x14, 0X343
+
+    #MTVAL Write value 0x0
+    li x3, 0x0
+    csrw 0X343, x3
+
+    #MTVAL read value
+    csrr x14, 0X343
+
+    #MTVAL Write value 0x55555555
+    li x3, 0x55555555
+    csrw 0X343, x3
+
+    #MTVAL read value
+    csrr x14, 0X343
+
+    #MTVAL Write value 0xaaaaaaaa
+    li x3, 0xaaaaaaaa
+    csrw 0X343, x3
+
+    #MTVAL read value
+    csrr x14, 0X343
+
+    #MTVAL Write value 0x162b0d42
+    li x3, 0x162b0d42
+    csrw 0X343, x3
+
+    #MTVAL read value
+    csrr x14, 0X343
+
+    ##########################
     #MHPMCOUNTERH10 testing W/R values '{'hffffffff, 'h0, 'h55555555, 'haaaaaaaa, 'h162b0d42} 
     ##########################
     #MHPMCOUNTERH10 Write value 0xffffffff

--- a/verif/tests/custom/csr_embedded/csrrwi_test.S
+++ b/verif/tests/custom/csr_embedded/csrrwi_test.S
@@ -308,7 +308,7 @@ csrrwi:
     csrr x14, 0x3bc
 
     ##########################
-    #PMPADDR11 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h16} 
+    #PMPADDR11 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h16}
     ##########################
     #PMPADDR11 Write immediate value 0x1f
     csrrwi x14, 0x3bb, 0x1f
@@ -339,6 +339,39 @@ csrrwi:
 
     #PMPADDR11 read value
     csrr x14, 0x3bb
+
+    ##########################
+    #MTVAL testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h18}
+    ##########################
+    #MTVAL Write immediate value 0x1f
+    csrrwi x14, 0x343, 0x1f
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write immediate value 0x0
+    csrrwi x14, 0x343, 0x0
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write immediate value 0x15
+    csrrwi x14, 0x343, 0x15
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write immediate value 0xa
+    csrrwi x14, 0x343, 0xa
+
+    #MTVAL read value
+    csrr x14, 0x343
+
+    #MTVAL Write immediate value 0x18
+    csrrwi x14, 0x343, 0x18
+
+    #MTVAL read value
+    csrr x14, 0x343
 
     ##########################
     #MHPMCOUNTERH11 testing W/R values '{'h1f, 'h0, 'h15, 'ha, 'h18} 


### PR DESCRIPTION
This MR has multiple changes on the CSRs verification env :
1. Update HVP remove write coverage on RO CSRs, also remove unsupported 
2. Update CSR tests
3. Update exception coverage
4. Update CSRs coverage model base on new spec