### PR TITLE
Feat: add add cva6_hpdcache_icache_if_adapter (supports the simplified icache kill mechanism)

### DIFF
--- a/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
@@ -1,0 +1,226 @@
+// Copyright 2023 Commissariat a l'Energie Atomique et aux Energies
+//                Alternatives (CEA)
+//
+// Licensed under the Solderpad Hardware License, Version 2.1 (the “License”);
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Authors: Cesar Fuguet
+// Date: February, 2023
+// Description: Interface adapter for the CVA6 core
+module cva6_hpdcache_if_adapter
+//  Parameters
+//  {{{
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter hpdcache_pkg::hpdcache_cfg_t hpdcacheCfg = '0,
+    parameter type hpdcache_tag_t = logic,
+    parameter type hpdcache_req_offset_t = logic,
+    parameter type hpdcache_req_sid_t = logic,
+    parameter type hpdcache_req_t = logic,
+    parameter type hpdcache_rsp_t = logic,
+    parameter type dbus_req_t = logic,
+    parameter type dbus_rsp_t = logic,
+    parameter bit is_load_port = 1'b1
+)
+//  }}}
+
+//  Ports
+//  {{{
+(
+    //  Clock and active-low reset pins
+    input logic clk_i,
+    input logic rst_ni,
+
+    //  Port ID
+    input hpdcache_req_sid_t hpdcache_req_sid_i,
+
+    //  Request/response ports from/to the CVA6 core
+    input  dbus_req_t             cva6_req_i,
+    output dbus_rsp_t             cva6_req_o,
+    input  ariane_pkg::amo_req_t  cva6_amo_req_i,
+    output ariane_pkg::amo_resp_t cva6_amo_resp_o,
+
+    //  Request port to the L1 Dcache
+    output logic                        hpdcache_req_valid_o,
+    input  logic                        hpdcache_req_ready_i,
+    output hpdcache_req_t               hpdcache_req_o,
+    output logic                        hpdcache_req_abort_o,
+    output hpdcache_tag_t               hpdcache_req_tag_o,
+    output hpdcache_pkg::hpdcache_pma_t hpdcache_req_pma_o,
+
+    //  Response port from the L1 Dcache
+    input logic          hpdcache_rsp_valid_i,
+    input hpdcache_rsp_t hpdcache_rsp_i
+);
+  //  }}}
+
+  //  Internal nets and registers
+  //  {{{
+  logic forward_store, forward_amo;
+  logic hpdcache_req_is_uncacheable;
+  //  }}}
+
+  //  Request forwarding
+  //  {{{
+  generate
+    //  LOAD request
+    //  {{{
+    if (is_load_port == 1'b1) begin : load_port_gen
+      assign hpdcache_req_is_uncacheable = !config_pkg::is_inside_cacheable_regions(
+          CVA6Cfg,
+          {
+            {64 - CVA6Cfg.DCACHE_TAG_WIDTH{1'b0}}
+            , cva6_req_i.address_tag
+            , {CVA6Cfg.DCACHE_INDEX_WIDTH{1'b0}}
+          }
+      );
+
+      //    Request forwarding
+      assign hpdcache_req_valid_o = cva6_req_i.data_req,
+          hpdcache_req_o.addr_offset = cva6_req_i.address_index,
+          hpdcache_req_o.wdata = '0,
+          hpdcache_req_o.op = hpdcache_pkg::HPDCACHE_REQ_LOAD,
+          hpdcache_req_o.be = cva6_req_i.data_be,
+          hpdcache_req_o.size = cva6_req_i.data_size,
+          hpdcache_req_o.sid = hpdcache_req_sid_i,
+          hpdcache_req_o.tid = cva6_req_i.data_id,
+          hpdcache_req_o.need_rsp = 1'b1,
+          hpdcache_req_o.phys_indexed = 1'b0,
+          hpdcache_req_o.addr_tag = '0,  // unused on virtually indexed request
+          hpdcache_req_o.pma = '0;  // unused on virtually indexed request
+
+      assign hpdcache_req_abort_o = cva6_req_i.kill_req,
+          hpdcache_req_tag_o = cva6_req_i.address_tag,
+          hpdcache_req_pma_o.uncacheable = hpdcache_req_is_uncacheable,
+          hpdcache_req_pma_o.io = 1'b0;
+
+      //    Response forwarding
+      assign cva6_req_o.data_rvalid = hpdcache_rsp_valid_i,
+          cva6_req_o.data_rdata = hpdcache_rsp_i.rdata,
+          cva6_req_o.data_rid = hpdcache_rsp_i.tid,
+          cva6_req_o.data_gnt = hpdcache_req_ready_i;
+    end  //  }}}
+
+         //  {{{
+    else begin : store_amo_gen
+      //  STORE/AMO request
+      logic                 [63:0] amo_addr;
+      hpdcache_req_offset_t        amo_addr_offset;
+      hpdcache_tag_t               amo_tag;
+      logic amo_is_word, amo_is_word_hi;
+      logic                           [63:0] amo_data;
+      logic                           [ 7:0] amo_data_be;
+      hpdcache_pkg::hpdcache_req_op_t        amo_op;
+      logic                           [31:0] amo_resp_word;
+      logic                                  amo_pending_q;
+
+      //  AMO logic
+      //  {{{
+      always_comb begin : amo_op_comb
+        amo_addr = cva6_amo_req_i.operand_a;
+        amo_addr_offset = amo_addr[0+:hpdcacheCfg.reqOffsetWidth];
+        amo_tag = amo_addr[hpdcacheCfg.reqOffsetWidth+:hpdcacheCfg.tagWidth];
+        unique case (cva6_amo_req_i.amo_op)
+          ariane_pkg::AMO_LR:   amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_LR;
+          ariane_pkg::AMO_SC:   amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_SC;
+          ariane_pkg::AMO_SWAP: amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_SWAP;
+          ariane_pkg::AMO_ADD:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_ADD;
+          ariane_pkg::AMO_AND:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_AND;
+          ariane_pkg::AMO_OR:   amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_OR;
+          ariane_pkg::AMO_XOR:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_XOR;
+          ariane_pkg::AMO_MAX:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MAX;
+          ariane_pkg::AMO_MAXU: amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MAXU;
+          ariane_pkg::AMO_MIN:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MIN;
+          ariane_pkg::AMO_MINU: amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MINU;
+          default:              amo_op = hpdcache_pkg::HPDCACHE_REQ_LOAD;
+        endcase
+      end
+      //  }}}
+
+      //  Request forwarding
+      //  {{{
+      assign hpdcache_req_is_uncacheable = !config_pkg::is_inside_cacheable_regions(
+          CVA6Cfg,
+          {
+            {64 - CVA6Cfg.DCACHE_TAG_WIDTH{1'b0}}
+            , hpdcache_req_o.addr_tag,
+            {CVA6Cfg.DCACHE_INDEX_WIDTH{1'b0}}
+          }
+      );
+
+      assign amo_is_word = (cva6_amo_req_i.size == 2'b10);
+      assign amo_is_word_hi = cva6_amo_req_i.operand_a[2];
+      if (CVA6Cfg.XLEN == 64) begin : amo_data_64_gen
+        assign amo_data    = amo_is_word ? {2{cva6_amo_req_i.operand_b[0+:32]}} : cva6_amo_req_i.operand_b;
+        assign amo_data_be = amo_is_word_hi ? 8'hf0 : amo_is_word ? 8'h0f : 8'hff;
+      end else begin : amo_data_32_gen
+        assign amo_data    = {32'b0, cva6_amo_req_i.operand_b};
+        assign amo_data_be = 8'h0f;
+      end
+
+      assign forward_store = cva6_req_i.data_req;
+      assign forward_amo = cva6_amo_req_i.req;
+
+      assign hpdcache_req_valid_o = forward_store | (forward_amo & ~amo_pending_q);
+      assign hpdcache_req_o.addr_offset = forward_amo ? amo_addr_offset : cva6_req_i.address_index;
+      assign hpdcache_req_o.wdata = forward_amo ? amo_data : cva6_req_i.data_wdata;
+      assign hpdcache_req_o.op = forward_amo ? amo_op : hpdcache_pkg::HPDCACHE_REQ_STORE;
+      assign hpdcache_req_o.be = forward_amo ? amo_data_be : cva6_req_i.data_be;
+      assign hpdcache_req_o.size = forward_amo ? cva6_amo_req_i.size : cva6_req_i.data_size;
+      assign hpdcache_req_o.sid = hpdcache_req_sid_i;
+      assign hpdcache_req_o.tid = forward_amo ? '1 : '0;
+      assign hpdcache_req_o.need_rsp = forward_amo;
+      assign hpdcache_req_o.phys_indexed = 1'b1;
+      assign hpdcache_req_o.addr_tag = forward_amo ? amo_tag : cva6_req_i.address_tag;
+      assign hpdcache_req_o.pma.uncacheable = hpdcache_req_is_uncacheable;
+      assign hpdcache_req_o.pma.io = 1'b0;
+      assign hpdcache_req_abort_o = 1'b0;  // unused on physically indexed requests
+      assign hpdcache_req_tag_o = '0;  // unused on physically indexed requests
+      assign hpdcache_req_pma_o = '0;  // unused on physically indexed requests
+      //  }}}
+
+      //  Response forwarding
+      //  {{{
+      if (CVA6Cfg.XLEN == 64) begin : amo_resp_64_gen
+        assign amo_resp_word = amo_is_word_hi
+                             ? hpdcache_rsp_i.rdata[0][32 +: 32]
+                             : hpdcache_rsp_i.rdata[0][0  +: 32];
+      end else begin : amo_resp_32_gen
+        assign amo_resp_word = hpdcache_rsp_i.rdata[0];
+      end
+
+      assign cva6_req_o.data_rvalid = hpdcache_rsp_valid_i && (hpdcache_rsp_i.tid != '1);
+      assign cva6_req_o.data_rdata = hpdcache_rsp_i.rdata;
+      assign cva6_req_o.data_rid = hpdcache_rsp_i.tid;
+      assign cva6_req_o.data_gnt = hpdcache_req_ready_i;
+
+      assign cva6_amo_resp_o.ack = hpdcache_rsp_valid_i && (hpdcache_rsp_i.tid == '1);
+      assign cva6_amo_resp_o.result = amo_is_word ? {{32{amo_resp_word[31]}}, amo_resp_word}
+                                                        : hpdcache_rsp_i.rdata[0];
+      //  }}}
+
+      always_ff @(posedge clk_i or negedge rst_ni) begin : amo_pending_ff
+        if (!rst_ni) begin
+          amo_pending_q <= 1'b0;
+        end else begin
+          amo_pending_q <=
+              ( cva6_amo_req_i.req  & hpdcache_req_ready_i & ~amo_pending_q) |
+              (~cva6_amo_resp_o.ack & amo_pending_q);
+        end
+      end
+    end
+    //  }}}
+  endgenerate
+  //  }}}
+
+  //  Assertions
+  //  {{{
+  //    pragma translate_off
+  forward_one_request_assert :
+  assert property (@(posedge clk_i) ($onehot0({forward_store, forward_amo})))
+  else $error("Only one request shall be forwarded");
+  //    pragma translate_on
+  //  }}}
+endmodule

--- a/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
@@ -6,10 +6,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 // You may obtain a copy of the License at https://solderpad.org/licenses/
 //
-// Authors: Cesar Fuguet
-// Date: February, 2023
-// Description: Interface adapter for the CVA6 core
-module cva6_hpdcache_if_adapter
+// Authors: Akiho Kawada
+// Date: June, 2024
+// Description: Icache Interface adapter for the CVA6 core
+module cva6_hpdcache_icache_if_adapter
 //  Parameters
 //  {{{
 #(
@@ -20,9 +20,11 @@ module cva6_hpdcache_if_adapter
     parameter type hpdcache_req_sid_t = logic,
     parameter type hpdcache_req_t = logic,
     parameter type hpdcache_rsp_t = logic,
-    parameter type dbus_req_t = logic,
-    parameter type dbus_rsp_t = logic,
-    parameter bit is_load_port = 1'b1
+    parameter type fetch_dreq_t = logic,
+    parameter type fetch_drsp_t = logic,
+    parameter type obi_fetch_req_t = logic,
+    parameter type obi_fetch_rsp_t = logic,
+    parameter logic [CVA6Cfg.MEM_TID_WIDTH-1:0] RdTxId = 0
 )
 //  }}}
 
@@ -37,10 +39,10 @@ module cva6_hpdcache_if_adapter
     input hpdcache_req_sid_t hpdcache_req_sid_i,
 
     //  Request/response ports from/to the CVA6 core
-    input  dbus_req_t             cva6_req_i,
-    output dbus_rsp_t             cva6_req_o,
-    input  ariane_pkg::amo_req_t  cva6_amo_req_i,
-    output ariane_pkg::amo_resp_t cva6_amo_resp_o,
+    input fetch_dreq_t fetch_dreq_i,
+    output fetch_drsp_t fetch_dreq_o,
+    input obi_fetch_req_t obi_fetch_req_i,
+    output obi_fetch_rsp_t obi_fetch_rsp_o,
 
     //  Request port to the L1 Dcache
     output logic                        hpdcache_req_valid_o,
@@ -58,169 +60,66 @@ module cva6_hpdcache_if_adapter
 
   //  Internal nets and registers
   //  {{{
-  logic forward_store, forward_amo;
   logic hpdcache_req_is_uncacheable;
+  localparam int ICACHE_CL_SIZE = $clog2(CVA6Cfg.ICACHE_LINE_WIDTH / 8);
+  localparam int ICACHE_WORD_SIZE = 3;
+  localparam int ICACHE_MEM_REQ_CL_SIZE =
+    (CVA6Cfg.AxiDataWidth <= CVA6Cfg.ICACHE_LINE_WIDTH) ?
+      $clog2(
+      CVA6Cfg.AxiDataWidth / 8
+  ) : ICACHE_CL_SIZE;
   //  }}}
 
   //  Request forwarding
   //  {{{
-  generate
-    //  LOAD request
-    //  {{{
-    if (is_load_port == 1'b1) begin : load_port_gen
-      assign hpdcache_req_is_uncacheable = !config_pkg::is_inside_cacheable_regions(
-          CVA6Cfg,
-          {
-            {64 - CVA6Cfg.DCACHE_TAG_WIDTH{1'b0}}
-            , cva6_req_i.address_tag
-            , {CVA6Cfg.DCACHE_INDEX_WIDTH{1'b0}}
-          }
-      );
-
-      //    Request forwarding
-      assign hpdcache_req_valid_o = cva6_req_i.data_req,
-          hpdcache_req_o.addr_offset = cva6_req_i.address_index,
-          hpdcache_req_o.wdata = '0,
-          hpdcache_req_o.op = hpdcache_pkg::HPDCACHE_REQ_LOAD,
-          hpdcache_req_o.be = cva6_req_i.data_be,
-          hpdcache_req_o.size = cva6_req_i.data_size,
-          hpdcache_req_o.sid = hpdcache_req_sid_i,
-          hpdcache_req_o.tid = cva6_req_i.data_id,
-          hpdcache_req_o.need_rsp = 1'b1,
-          hpdcache_req_o.phys_indexed = 1'b0,
-          hpdcache_req_o.addr_tag = '0,  // unused on virtually indexed request
-          hpdcache_req_o.pma = '0;  // unused on virtually indexed request
-
-      assign hpdcache_req_abort_o = cva6_req_i.kill_req,
-          hpdcache_req_tag_o = cva6_req_i.address_tag,
-          hpdcache_req_pma_o.uncacheable = hpdcache_req_is_uncacheable,
-          hpdcache_req_pma_o.io = 1'b0;
-
-      //    Response forwarding
-      assign cva6_req_o.data_rvalid = hpdcache_rsp_valid_i,
-          cva6_req_o.data_rdata = hpdcache_rsp_i.rdata,
-          cva6_req_o.data_rid = hpdcache_rsp_i.tid,
-          cva6_req_o.data_gnt = hpdcache_req_ready_i;
-    end  //  }}}
-
-         //  {{{
-    else begin : store_amo_gen
-      //  STORE/AMO request
-      logic                 [63:0] amo_addr;
-      hpdcache_req_offset_t        amo_addr_offset;
-      hpdcache_tag_t               amo_tag;
-      logic amo_is_word, amo_is_word_hi;
-      logic                           [63:0] amo_data;
-      logic                           [ 7:0] amo_data_be;
-      hpdcache_pkg::hpdcache_req_op_t        amo_op;
-      logic                           [31:0] amo_resp_word;
-      logic                                  amo_pending_q;
-
-      //  AMO logic
-      //  {{{
-      always_comb begin : amo_op_comb
-        amo_addr = cva6_amo_req_i.operand_a;
-        amo_addr_offset = amo_addr[0+:hpdcacheCfg.reqOffsetWidth];
-        amo_tag = amo_addr[hpdcacheCfg.reqOffsetWidth+:hpdcacheCfg.tagWidth];
-        unique case (cva6_amo_req_i.amo_op)
-          ariane_pkg::AMO_LR:   amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_LR;
-          ariane_pkg::AMO_SC:   amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_SC;
-          ariane_pkg::AMO_SWAP: amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_SWAP;
-          ariane_pkg::AMO_ADD:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_ADD;
-          ariane_pkg::AMO_AND:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_AND;
-          ariane_pkg::AMO_OR:   amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_OR;
-          ariane_pkg::AMO_XOR:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_XOR;
-          ariane_pkg::AMO_MAX:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MAX;
-          ariane_pkg::AMO_MAXU: amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MAXU;
-          ariane_pkg::AMO_MIN:  amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MIN;
-          ariane_pkg::AMO_MINU: amo_op = hpdcache_pkg::HPDCACHE_REQ_AMO_MINU;
-          default:              amo_op = hpdcache_pkg::HPDCACHE_REQ_LOAD;
-        endcase
-      end
-      //  }}}
-
-      //  Request forwarding
-      //  {{{
-      assign hpdcache_req_is_uncacheable = !config_pkg::is_inside_cacheable_regions(
-          CVA6Cfg,
-          {
-            {64 - CVA6Cfg.DCACHE_TAG_WIDTH{1'b0}}
-            , hpdcache_req_o.addr_tag,
-            {CVA6Cfg.DCACHE_INDEX_WIDTH{1'b0}}
-          }
-      );
-
-      assign amo_is_word = (cva6_amo_req_i.size == 2'b10);
-      assign amo_is_word_hi = cva6_amo_req_i.operand_a[2];
-      if (CVA6Cfg.XLEN == 64) begin : amo_data_64_gen
-        assign amo_data    = amo_is_word ? {2{cva6_amo_req_i.operand_b[0+:32]}} : cva6_amo_req_i.operand_b;
-        assign amo_data_be = amo_is_word_hi ? 8'hf0 : amo_is_word ? 8'h0f : 8'hff;
-      end else begin : amo_data_32_gen
-        assign amo_data    = {32'b0, cva6_amo_req_i.operand_b};
-        assign amo_data_be = 8'h0f;
-      end
-
-      assign forward_store = cva6_req_i.data_req;
-      assign forward_amo = cva6_amo_req_i.req;
-
-      assign hpdcache_req_valid_o = forward_store | (forward_amo & ~amo_pending_q);
-      assign hpdcache_req_o.addr_offset = forward_amo ? amo_addr_offset : cva6_req_i.address_index;
-      assign hpdcache_req_o.wdata = forward_amo ? amo_data : cva6_req_i.data_wdata;
-      assign hpdcache_req_o.op = forward_amo ? amo_op : hpdcache_pkg::HPDCACHE_REQ_STORE;
-      assign hpdcache_req_o.be = forward_amo ? amo_data_be : cva6_req_i.data_be;
-      assign hpdcache_req_o.size = forward_amo ? cva6_amo_req_i.size : cva6_req_i.data_size;
-      assign hpdcache_req_o.sid = hpdcache_req_sid_i;
-      assign hpdcache_req_o.tid = forward_amo ? '1 : '0;
-      assign hpdcache_req_o.need_rsp = forward_amo;
-      assign hpdcache_req_o.phys_indexed = 1'b1;
-      assign hpdcache_req_o.addr_tag = forward_amo ? amo_tag : cva6_req_i.address_tag;
-      assign hpdcache_req_o.pma.uncacheable = hpdcache_req_is_uncacheable;
-      assign hpdcache_req_o.pma.io = 1'b0;
-      assign hpdcache_req_abort_o = 1'b0;  // unused on physically indexed requests
-      assign hpdcache_req_tag_o = '0;  // unused on physically indexed requests
-      assign hpdcache_req_pma_o = '0;  // unused on physically indexed requests
-      //  }}}
-
-      //  Response forwarding
-      //  {{{
-      if (CVA6Cfg.XLEN == 64) begin : amo_resp_64_gen
-        assign amo_resp_word = amo_is_word_hi
-                             ? hpdcache_rsp_i.rdata[0][32 +: 32]
-                             : hpdcache_rsp_i.rdata[0][0  +: 32];
-      end else begin : amo_resp_32_gen
-        assign amo_resp_word = hpdcache_rsp_i.rdata[0];
-      end
-
-      assign cva6_req_o.data_rvalid = hpdcache_rsp_valid_i && (hpdcache_rsp_i.tid != '1);
-      assign cva6_req_o.data_rdata = hpdcache_rsp_i.rdata;
-      assign cva6_req_o.data_rid = hpdcache_rsp_i.tid;
-      assign cva6_req_o.data_gnt = hpdcache_req_ready_i;
-
-      assign cva6_amo_resp_o.ack = hpdcache_rsp_valid_i && (hpdcache_rsp_i.tid == '1);
-      assign cva6_amo_resp_o.result = amo_is_word ? {{32{amo_resp_word[31]}}, amo_resp_word}
-                                                        : hpdcache_rsp_i.rdata[0];
-      //  }}}
-
-      always_ff @(posedge clk_i or negedge rst_ni) begin : amo_pending_ff
-        if (!rst_ni) begin
-          amo_pending_q <= 1'b0;
-        end else begin
-          amo_pending_q <=
-              ( cva6_amo_req_i.req  & hpdcache_req_ready_i & ~amo_pending_q) |
-              (~cva6_amo_resp_o.ack & amo_pending_q);
-        end
-      end
-    end
-    //  }}}
-  endgenerate
-  //  }}}
-
-  //  Assertions
+  //  LOAD request
   //  {{{
-  //    pragma translate_off
-  forward_one_request_assert :
-  assert property (@(posedge clk_i) ($onehot0({forward_store, forward_amo})))
-  else $error("Only one request shall be forwarded");
-  //    pragma translate_on
+
+  assign hpdcache_req_is_uncacheable = !config_pkg::is_inside_cacheable_regions(
+      CVA6Cfg,
+      {
+        {64 - CVA6Cfg.PLEN{1'b0}},
+        obi_fetch_req_i.a.addrr[CVA6Cfg.ICACHE_TAG_WIDTH+CVA6Cfg.ICACHE_INDEX_WIDTH-1:CVA6Cfg.ICACHE_INDEX_WIDTH],
+        {CVA6Cfg.ICACHE_INDEX_WIDTH{1'b0}}
+      }
+  );
+
+  //    Request forwarding
+  assign hpdcache_req_valid_o = fetch_dreq_i.data_req,
+      hpdcache_req_o.addr_offset = fetch_dreq_i.vaddr[CVA6Cfg.ICACHE_INDEX_WIDTH-1:3],
+      hpdcache_req_o.wdata = '0,
+      hpdcache_req_o.op = hpdcache_pkg::HPDCACHE_REQ_LOAD,
+      hpdcache_req_o.be = obi_fetch_req_i.a.data_be,
+      hpdcache_req_o.size = hpdcache_req_is_uncacheable ? ICACHE_WORD_SIZE : ICACHE_MEM_REQ_CL_SIZE,
+      hpdcache_req_o.sid = '0,
+      hpdcache_req_o.tid = RdTxId,  // TODO
+      hpdcache_req_o.need_rsp = 1'b1,
+      hpdcache_req_o.phys_indexed = 1'b0,
+      hpdcache_req_o.addr_tag = '0,  // unused on virtually indexed request
+      hpdcache_req_o.pma = '0;  // unused on virtually indexed request
+
+  assign hpdcache_req_abort_o = fetch_dreq_i.kill_req,
+      hpdcache_req_tag_o = obi_fetch_req_i.a.addrr[CVA6Cfg.ICACHE_TAG_WIDTH+CVA6Cfg.ICACHE_INDEX_WIDTH-1:CVA6Cfg.ICACHE_INDEX_WIDTH],
+      hpdcache_req_pma_o.uncacheable = hpdcache_req_is_uncacheable,
+      hpdcache_req_pma_o.io = 1'b0;
+
+  //    Response forwarding
+  assign cva6_req_o.data_rvalid = hpdcache_rsp_valid_i,
+      cva6_req_o.data_rdata = hpdcache_rsp_i.rdata,
+      cva6_req_o.data_rid = hpdcache_rsp_i.tid,
+      cva6_req_o.data_gnt = hpdcache_req_ready_i;
+
+  assign fetch_obi_rsp_o.gnt = hpdcache_req_ready_i,  // TODO
+      fetch_obi_rsp_o.gntpar = !hpdcache_req_ready_i,  // TODO
+      fetch_obi_rsp_o.rvalid = hpdcache_rsp_valid_i,  // TODO
+      fetch_obi_rsp_o.rvalidpar = !hpdcache_rsp_valid_i,  // TODO
+      fetch_obi_rsp_o.r.rid = '0,
+      fetch_obi_rsp_o.r.r_optional.exokay = '0,
+      fetch_obi_rsp_o.r.r_optional.rchk = '0,
+      fetch_obi_rsp_o.r.err = '0,
+      fetch_obi_rsp_o.r.rdata = hpdcache_rsp_i.rdata,
+      fetch_obi_rsp_o.r.r_optional.ruser = '0;
   //  }}}
+  //  }}}
+
 endmodule


### PR DESCRIPTION
- I will discard PR #2238  and work on it here.
  - changed base branch from `master` to `feature/interconnect`
- The parts highlighted in light pink are the ones we want to implement in this PR.
![port adapter](https://github.com/openhwgroup/cva6/assets/115288734/c7cb5766-5506-4cf1-960f-8db01e2d28e2)
