### PR TITLE
Fix mstatus.mpp in relation to the possible legal values

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1283,11 +1283,10 @@ module csr_regfile
             mstatus_d.tw   = riscv::Off;
             mstatus_d.mprv = riscv::Off;
           end
-          // If h-extension is not enabled, priv level HS is reserved
-          if (!CVA6Cfg.RVH) begin
-            if (mstatus_d.mpp == riscv::PRIV_LVL_HS) begin
-              mstatus_d.mpp = riscv::PRIV_LVL_U;
-            end
+          if ((!CVA6Cfg.RVH & mstatus_d.mpp == riscv::PRIV_LVL_HS) |
+              (!CVA6Cfg.RVS & mstatus_d.mpp == riscv::PRIV_LVL_S) |
+              (!CVA6Cfg.RVU & mstatus_d.mpp == riscv::PRIV_LVL_U)) begin
+            mstatus_d.mpp = mstatus_q.mpp;
           end
           mstatus_d.wpri3 = 9'b0;
           mstatus_d.wpri1 = 1'b0;


### PR DESCRIPTION
The possible legal value depend on the cva6 config: RVU, RVH, RVS.
When writing an illegal value, the previous mstatus.mpp value is kept