### PR TITLE
Makefile : passing the tandem_enable value into UVM testbench

### DIFF
--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -257,11 +257,11 @@ ifneq ($(DEBUG),)               # If RTL DEBUG support requested
 endif
 
 ifneq ($(SPIKE_TANDEM),)
-ALL_SIMV_UVM_FLAGS += +scoreboard_enabled=1
-ALL_XRUN_SIMV_UVM_FLAGS += +scoreboard_enabled=1
+ALL_SIMV_UVM_FLAGS += +tandem_enabled=1
+ALL_XRUN_SIMV_UVM_FLAGS += +tandem_enabled=1
 else
-ALL_SIMV_UVM_FLAGS += +scoreboard_enabled=0
-ALL_XRUN_SIMV_UVM_FLAGS += +scoreboard_enabled=0
+ALL_SIMV_UVM_FLAGS += +tandem_enabled=0
+ALL_XRUN_SIMV_UVM_FLAGS += +tandem_enabled=0
 endif
 
 ### VCS UVM rules


### PR DESCRIPTION
This a fix to actived the tandem mode only by export SPIKE_TANDEM=1, the param in the testbench has been changed but not in the Makefile