### PR TITLE
Update uvml_mem use for core-v-verif's PR: 2480/2481/2482

### DIFF
--- a/verif/env/uvme/uvme_cva6_cntxt.sv
+++ b/verif/env/uvme/uvme_cva6_cntxt.sv
@@ -27,6 +27,8 @@
  */
 class uvme_cva6_cntxt_c extends uvm_object;
 
+  typedef uvml_mem_c#(cva6_config_pkg::CVA6ConfigAxiAddrWidth)   uvml_mem_cva6;
+
    // Agent context handles
    uvma_clknrst_cntxt_c    clknrst_cntxt;
    uvma_cvxif_cntxt_c      cvxif_cntxt;
@@ -34,8 +36,8 @@ class uvme_cva6_cntxt_c extends uvm_object;
    uvma_cva6_core_cntrl_cntxt_c  core_cntrl_cntxt;
    uvma_rvfi_cntxt_c       rvfi_cntxt;
 
-// Memory modelling
-   rand uvml_mem_c                   mem;
+   // Memory modelling
+   rand uvml_mem_cva6      mem;
 
    // Events
    uvm_event  sample_cfg_e;
@@ -71,11 +73,13 @@ function uvme_cva6_cntxt_c::new(string name="uvme_cva6_cntxt");
    clknrst_cntxt   = uvma_clknrst_cntxt_c::type_id::create("clknrst_cntxt");
    core_cntrl_cntxt   = uvma_cva6_core_cntrl_cntxt_c::type_id::create("core_cntrl_cntxt");
    axi_cntxt       = uvma_axi_cntxt_c::type_id::create("axi_cntxt");
-   mem = uvml_mem_c#()::type_id::create("mem");
+   mem = uvml_mem_cva6::type_id::create("mem");
    rvfi_cntxt      = uvma_rvfi_cntxt_c#()::type_id::create("rvfi_cntxt");
 
    sample_cfg_e   = new("sample_cfg_e"  );
    sample_cntxt_e = new("sample_cntxt_e");
+
+   mem.mem_default = MEM_DEFAULT_0;
 
 endfunction : new
 

--- a/verif/env/uvme/uvme_cva6_env.sv
+++ b/verif/env/uvme/uvme_cva6_env.sv
@@ -178,6 +178,8 @@ function void uvme_cva6_env_c::build_phase(uvm_phase phase);
          cntxt = uvme_cva6_cntxt_c::type_id::create("cntxt");
       end
 
+      cntxt.axi_cntxt.mem = cntxt.mem;
+
       if ($test$plusargs("tandem_enabled"))
           $value$plusargs("tandem_enabled=%b",cfg.tandem_enabled);
 

--- a/verif/env/uvme/uvme_cva6_pkg.sv
+++ b/verif/env/uvme/uvme_cva6_pkg.sv
@@ -27,6 +27,8 @@
 `include "uvml_hrtbt_macros.sv"
 `include "uvml_sb_macros.sv"
 
+`include "uvml_mem_macros.sv"
+`include "uvma_axi_macros.sv"
 `include "uvma_clknrst_macros.sv"
 `include "uvma_cvxif_macros.sv"
 `include "uvma_isacov_macros.sv"

--- a/verif/env/uvme/vseq/uvme_axi_fw_preload_seq.sv
+++ b/verif/env/uvme/vseq/uvme_axi_fw_preload_seq.sv
@@ -41,8 +41,6 @@ endclass : uvme_axi_fw_preload_seq_c
 function uvme_axi_fw_preload_seq_c::new(string name="uvma_axi_fw_preload_seq");
 
    super.new(name);
-   mem = uvml_mem_c#()::type_id::create("mem");
-   mem.mem_default = MEM_DEFAULT_0;
 
 endfunction : new
 
@@ -66,16 +64,15 @@ task uvme_axi_fw_preload_seq_c::body();
             for (int j = 0; j < 8; j++) begin
                 mem_row[j] = buffer[i*8 + j];
             end
-            mem.write(address + i*8 + 0, mem_row[0]);
-            mem.write(address + i*8 + 1, mem_row[1]);
-            mem.write(address + i*8 + 2, mem_row[2]);
-            mem.write(address + i*8 + 3, mem_row[3]);
-            mem.write(address + i*8 + 4, mem_row[4]);
-            mem.write(address + i*8 + 5, mem_row[5]);
-            mem.write(address + i*8 + 6, mem_row[6]);
-            mem.write(address + i*8 + 7, mem_row[7]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 0, mem_row[0]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 1, mem_row[1]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 2, mem_row[2]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 3, mem_row[3]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 4, mem_row[4]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 5, mem_row[5]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 6, mem_row[6]);
+            p_sequencer.cntxt.mem.write(address + i*8 + 7, mem_row[7]);
          end
-          p_sequencer.cntxt.mem = mem;
       end
    end
 

--- a/verif/tb/uvmt/uvmt_cva6_pkg.sv
+++ b/verif/tb/uvmt/uvmt_cva6_pkg.sv
@@ -44,6 +44,8 @@ package uvmt_cva6_pkg;
    import uvma_cva6pkg_utils_pkg::*;
    import uvml_hrtbt_pkg::*;
    import uvml_logs_pkg::*;
+   import uvml_mem_pkg::*;
+   import uvma_axi_pkg::*;
 
    // Constants / Structs / Enums
    `include "uvmt_cva6_constants.sv"


### PR DESCRIPTION
Refer to [core-v-verif's](https://github.com/openhwgroup/core-v-verif) below PR(s), this PR updates cva6 testbench accordingly.

https://github.com/openhwgroup/core-v-verif/pull/2480
https://github.com/openhwgroup/core-v-verif/pull/2481
https://github.com/openhwgroup/core-v-verif/pull/2482
