### PR TITLE
superscalar add second ALU

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -414,6 +414,8 @@ module cva6
   logic [CVA6Cfg.XLEN-1:0] fpu_result_ex_id;
   logic fpu_valid_ex_id;
   exception_t fpu_exception_ex_id;
+  // ALU2
+  logic [SUPERSCALAR:0] alu2_valid_id_ex;
   // Accelerator
   logic stall_acc_id;
   scoreboard_entry_t issue_instr_id_acc;
@@ -755,6 +757,8 @@ module cva6
       .fpu_valid_o           (fpu_valid_id_ex),
       .fpu_fmt_o             (fpu_fmt_id_ex),
       .fpu_rm_o              (fpu_rm_id_ex),
+      // ALU2
+      .alu2_valid_o          (alu2_valid_id_ex),
       // CSR
       .csr_valid_o           (csr_valid_id_ex),
       // CVXIF
@@ -864,6 +868,8 @@ module cva6
       .fpu_result_o            (fpu_result_ex_id),
       .fpu_valid_o             (fpu_valid_ex_id),
       .fpu_exception_o         (fpu_exception_ex_id),
+      // ALU2
+      .alu2_valid_i            (alu2_valid_id_ex),
       .amo_valid_commit_i      (amo_valid_commit),
       .amo_req_o               (amo_req),
       .amo_resp_i              (amo_resp),

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -448,7 +448,7 @@ module ex_stage
     end
 
     alu #(
-        .CVA6Cfg(CVA6Cfg),
+        .CVA6Cfg  (CVA6Cfg),
         .fu_data_t(fu_data_t)
     ) alu2_i (
         .clk_i,

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -130,6 +130,8 @@ module ex_stage
     output logic fpu_valid_o,
     // FPU exception - ISSUE_STAGE
     output exception_t fpu_exception_o,
+    // ALU2 instruction is valid - ISSUE_STAGE
+    input logic [SUPERSCALAR:0] alu2_valid_i,
     // CVXIF instruction is valid - ISSUE_STAGE
     input logic [SUPERSCALAR:0] x_valid_i,
     // CVXIF is ready - ISSUE_STAGE
@@ -386,6 +388,12 @@ module ex_stage
   // ----------------
   // FPU
   // ----------------
+  logic fpu_valid;
+  logic [CVA6Cfg.TRANS_ID_BITS-1:0] fpu_trans_id;
+  logic [CVA6Cfg.XLEN-1:0] fpu_result;
+  logic alu2_valid;
+  logic [CVA6Cfg.XLEN-1:0] alu2_result;
+
   generate
     if (CVA6Cfg.FpPresent) begin : fpu_gen
       fu_data_t fpu_data;
@@ -413,19 +421,70 @@ module ex_stage
           .fpu_rm_i,
           .fpu_frm_i,
           .fpu_prec_i,
-          .fpu_trans_id_o,
-          .result_o(fpu_result_o),
-          .fpu_valid_o,
+          .fpu_trans_id_o(fpu_trans_id),
+          .result_o(fpu_result),
+          .fpu_valid_o(fpu_valid),
           .fpu_exception_o
       );
     end else begin : no_fpu_gen
       assign fpu_ready_o     = '0;
-      assign fpu_trans_id_o  = '0;
-      assign fpu_result_o    = '0;
-      assign fpu_valid_o     = '0;
+      assign fpu_trans_id    = '0;
+      assign fpu_result      = '0;
+      assign fpu_valid       = '0;
       assign fpu_exception_o = '0;
     end
   endgenerate
+
+  // ----------------
+  // ALU2
+  // ----------------
+  fu_data_t alu2_data;
+  if (SUPERSCALAR) begin : alu2_gen
+    always_comb begin
+      alu2_data = alu2_valid_i[0] ? fu_data_i[0] : '0;
+      if (alu2_valid_i[1]) begin
+        alu2_data = fu_data_i[1];
+      end
+    end
+
+    alu #(
+        .CVA6Cfg(CVA6Cfg),
+        .fu_data_t(fu_data_t)
+    ) alu2_i (
+        .clk_i,
+        .rst_ni,
+        .fu_data_i       (alu2_data),
+        .result_o        (alu2_result),
+        .alu_branch_res_o(  /* this ALU does not handle branching */)
+    );
+  end else begin
+    assign alu2_data   = '0;
+    assign alu2_result = '0;
+  end
+
+  // result MUX
+  // This is really explicit so that synthesis tools can elide unused signals
+  if (SUPERSCALAR) begin
+    if (CVA6Cfg.FpPresent) begin
+      assign fpu_valid_o    = fpu_valid || |alu2_valid_i;
+      assign fpu_result_o   = fpu_valid ? fpu_result   : alu2_result;
+      assign fpu_trans_id_o = fpu_valid ? fpu_trans_id : alu2_data.trans_id;
+    end else begin
+      assign fpu_valid_o    = |alu2_valid_i;
+      assign fpu_result_o   = alu2_result;
+      assign fpu_trans_id_o = alu2_data.trans_id;
+    end
+  end else begin
+    if (CVA6Cfg.FpPresent) begin
+      assign fpu_valid_o    = fpu_valid;
+      assign fpu_result_o   = fpu_result;
+      assign fpu_trans_id_o = fpu_trans_id;
+    end else begin
+      assign fpu_valid_o    = '0;
+      assign fpu_result_o   = '0;
+      assign fpu_trans_id_o = '0;
+    end
+  end
 
   // ----------------
   // Load-Store Unit

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -811,6 +811,20 @@ module issue_read_operands
       );
   end
 
+  // FPU does not declare that it will return a result the subsequent cycle so
+  // it is not possible for issue stage to know when ALU2 can be used if there
+  // is an FPU.  As there are discussions to change the FPU, I did not explore
+  // its architecture to create this "FPU returns next cycle" signal.  Also, a
+  // "lookahead" optimization should be added to be performant with FPU:  when
+  // issue port 2 is issuing to FPU, issue port 1 should issue to ALU1 instead
+  // of ALU2 so that FPU is not busy.  However, if FPU has a minimum execution
+  // time of 2 cycles, it is possible to simply not raise fus_busy[1].alu2.
+  initial begin
+    assert (!(SUPERSCALAR && CVA6Cfg.FpPresent))
+    else
+      $fatal(1, "FPU is not yet supported in superscalar CVA6, see comments above this assertion.");
+  end
+
   for (genvar i = 0; i <= SUPERSCALAR; i++) begin
     assert property (@(posedge clk_i) (branch_valid_q) |-> (!$isunknown(
         fu_data_q[i].operand_a

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -96,6 +96,8 @@ module issue_read_operands
     output logic [1:0] fpu_fmt_o,
     // FPU rm field from isntruction - TO_BE_COMPLETED
     output logic [2:0] fpu_rm_o,
+    // ALU output is valid - TO_BE_COMPLETED
+    output logic [SUPERSCALAR:0] alu2_valid_o,
     // CSR result is valid - TO_BE_COMPLETED
     output logic [SUPERSCALAR:0] csr_valid_o,
     // CVXIF result is valid - TO_BE_COMPLETED
@@ -140,6 +142,7 @@ module issue_read_operands
   logic [   SUPERSCALAR:0] fpu_valid_q;
   logic [             1:0] fpu_fmt_q;
   logic [             2:0] fpu_rm_q;
+  logic [   SUPERSCALAR:0] alu2_valid_q;
   logic [   SUPERSCALAR:0] lsu_valid_q;
   logic [   SUPERSCALAR:0] csr_valid_q;
   logic [   SUPERSCALAR:0] branch_valid_q;
@@ -171,6 +174,7 @@ module issue_read_operands
   assign fpu_valid_o = fpu_valid_q;
   assign fpu_fmt_o = fpu_fmt_q;
   assign fpu_rm_o = fpu_rm_q;
+  assign alu2_valid_o = alu2_valid_q;
   assign cvxif_valid_o = CVA6Cfg.CvxifEn ? cvxif_valid_q : '0;
   assign cvxif_off_instr_o = CVA6Cfg.CvxifEn ? cvxif_off_instr_q : '0;
   assign stall_issue_o = stall[0];
@@ -450,6 +454,7 @@ module issue_read_operands
       fpu_valid_q    <= '0;
       fpu_fmt_q      <= '0;
       fpu_rm_q       <= '0;
+      alu2_valid_q   <= '0;
       csr_valid_q    <= '0;
       branch_valid_q <= '0;
     end else begin
@@ -459,6 +464,7 @@ module issue_read_operands
       fpu_valid_q    <= '0;
       fpu_fmt_q      <= '0;
       fpu_rm_q       <= '0;
+      alu2_valid_q   <= '0;
       csr_valid_q    <= '0;
       branch_valid_q <= '0;
       // Exception pass through:
@@ -503,6 +509,7 @@ module issue_read_operands
         lsu_valid_q    <= '0;
         mult_valid_q   <= '0;
         fpu_valid_q    <= '0;
+        alu2_valid_q   <= '0;
         csr_valid_q    <= '0;
         branch_valid_q <= '0;
       end

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -82,6 +82,8 @@ module issue_stage
     output logic [1:0] fpu_fmt_o,
     // FPU rm field - EX_STAGE
     output logic [2:0] fpu_rm_o,
+    // ALU2 FU is valid - EX_STAGE
+    output logic [SUPERSCALAR:0] alu2_valid_o,
     // CSR is valid - EX_STAGE
     output logic [SUPERSCALAR:0] csr_valid_o,
     // CVXIF FU is valid - EX_STAGE
@@ -231,6 +233,7 @@ module issue_stage
       .rd_clobber_gpr_i   (rd_clobber_gpr_sb_iro),
       .rd_clobber_fpr_i   (rd_clobber_fpr_sb_iro),
       .alu_valid_o        (alu_valid_o),
+      .alu2_valid_o       (alu2_valid_o),
       .branch_valid_o     (branch_valid_o),
       .csr_valid_o        (csr_valid_o),
       .cvxif_valid_o      (x_issue_valid_o),


### PR DESCRIPTION
With this PR, CVA6 can be configured to be superscalar.

There is still work in progress to improve performance further:

Make *superscalar* a configuration parameter instead of a `localparam`