### PR TITLE
[Spike Yaml] Integrate Spike Yaml support.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -476,7 +476,6 @@ simu-gate:
     - git -C verif/core-v-verif fetch --unshallow
     - mkdir -p tools
     - mv artifacts/tools/spike tools
-    - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
     - echo $PERIOD
     - source ./verif/sim/setup-env.sh
     - git clone ${SYNTH_SCRIPT} ${SYNTH_SCRIPT_PATH}

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,9 @@ compile_flag     += -incr -64 -nologo -quiet -suppress 13262 -suppress 8607 -per
 vopt_flag += -suppress 2085 -suppress 7063 -suppress 2698 -suppress 13262
 
 uvm-flags        += +UVM_NO_RELNOTES +UVM_VERBOSITY=UVM_LOW
-questa-flags     += -t 1ns -64 $(gui-sim) $(QUESTASIM_FLAGS) +tohost_addr=$(tohost_addr) +define+QUESTA -suppress 3356 -suppress 3579
+questa-flags     += -t 1ns -64 $(gui-sim) $(QUESTASIM_FLAGS) \
+			+tohost_addr=$(hell ${RISCV}/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
+			+core_name=$(target) +define+QUESTA -suppress 3356 -suppress 3579
 compile_flag_vhd += -64 -nologo -quiet -2008
 
 # Iterate over all include directories and write them with +incdir+ prefixed

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -12,6 +12,7 @@ spike_param_tree:
   priv: M
   core_configs:
     - isa: rv32imc_zba_zbb_zbs_zbc_zicsr_zifencei
+      boot_addr: 0x10000
       marchid: 0x3
       misa_we: false
       misa_we_enable: true
@@ -25,4 +26,5 @@ spike_param_tree:
       misa_we: false
       mstatus_write_mask: 0x00000088
       mstatus_override_mask: 0x00001800
-
+      mtval_write_mask: 0x00000000
+      unified_traps: true

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -9,7 +9,7 @@ spike_param_tree:
   max_steps: 200000
   max_steps_enabled: false
   isa: rv32imc_zba_zbb_zbs_zbc_zicsr_zifencei
-  priv: MSU
+  priv: M
   core_configs:
     - isa: rv32imc_zba_zbb_zbs_zbc_zicsr_zifencei
       marchid: 0x3
@@ -21,8 +21,8 @@ spike_param_tree:
       pmpaddr0: 0x0
       pmpcfg0: 0x0
       pmpregions: 0x0
-      priv: MSU
-      status_fs_field_we: false
-      status_fs_field_we_enable: false
-      status_vs_field_we: false
-      status_vs_field_we_enable: false
+      priv: M
+      misa_we: false
+      mstatus_write_mask: 0x00000088
+      mstatus_override_mask: 0x00001800
+

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -12,7 +12,7 @@ spike_param_tree:
   priv: M
   core_configs:
     - isa: rv32imc_zba_zbb_zbs_zbc_zicsr_zifencei
-      boot_addr: 0x10000
+      boot_addr: 0x80000000
       marchid: 0x3
       misa_we: false
       misa_we_enable: true

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -10,7 +10,7 @@ spike_param_tree:
   max_steps_enabled: false
   isa: rv32imc_zba_zbb_zbs_zbc_zicsr_zifencei
   priv: M
-  core_configs:
+  cores:
     - isa: rv32imc_zba_zbb_zbs_zbc_zicsr_zifencei
       boot_addr: 0x80000000
       marchid: 0x3

--- a/corev_apu/tb/common/spike.sv
+++ b/corev_apu/tb/common/spike.sv
@@ -58,6 +58,7 @@ module spike #(
 
         if ($test$plusargs("core_name")) begin
           $value$plusargs("core_name=%s", core_name);
+          `uvm_info("SPIKE", $sformatf("### core_name = '%s'", core_name), UVM_INFO);
         end
 
         rvfi_initialize(st);

--- a/corev_apu/tb/common/spike.sv
+++ b/corev_apu/tb/common/spike.sv
@@ -49,9 +49,9 @@ module spike #(
 
     st_core_cntrl_cfg st;
     bit sim_finished;
+    string core_name = "cva6";
 
     initial begin
-        string core_name = "cva6";
         st = cva6pkg_to_core_cntrl_cfg(st);
         st.boot_addr_valid = 1'b1;
         st.boot_addr = 64'h0x10000;

--- a/corev_apu/tb/common/spike.sv
+++ b/corev_apu/tb/common/spike.sv
@@ -58,7 +58,7 @@ module spike #(
 
         if ($test$plusargs("core_name")) begin
           $value$plusargs("core_name=%s", core_name);
-          `uvm_info("SPIKE", $sformatf("### core_name = '%s'", core_name), UVM_INFO);
+          `uvm_info("SPIKE", $sformatf("### core_name = '%s'", core_name), UVM_LOW);
         end
 
         rvfi_initialize(st);

--- a/verif/regress/install-spike.sh
+++ b/verif/regress/install-spike.sh
@@ -48,6 +48,10 @@ if ! [ -f "$SPIKE_INSTALL_DIR/bin/spike" ]; then
   if [[ ! -f config.log ]]; then
       ../configure --prefix="$SPIKE_INSTALL_DIR" ${WITH_BOOST}
   fi
+  # Build both shared and static versions of the yaml-cpp library in sequence
+  # prior to building Spike.
+  make yaml-cpp
+  make yaml-cpp-static
   make -j${NUM_JOBS}
   echo "Installing Spike in '$SPIKE_INSTALL_DIR'..."
   make install

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -141,7 +141,7 @@ endif
 spike:
 	LD_LIBRARY_PATH="$$(realpath ../../tools/spike/lib):$$LD_LIBRARY_PATH" \
 		$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) --priv=$(priv) $(spike_params_final) -l $(elf)
-	cp $(log).iss $(log)
+	grep -v '^\([[]\|/top/\)' $(log).iss > $(log)
 
 ###############################################################################
 # UVM specific commands, variables
@@ -191,6 +191,7 @@ COMMON_COMP_UVM_FLAGS = \
 COMMON_PLUS_ARGS = \
 	++$(elf) \
 	+elf_file=$(elf) \
+	+core_name=$(target) \
         $(spike-yaml-plusarg) \
 	+tohost_addr=$(shell $$RISCV/bin/$(CV_SW_PREFIX)nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
 	+signature=$(elf).signature_output +UVM_TESTNAME=uvmt_cva6_firmware_test_c \

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -186,6 +186,7 @@ export SPIKE_PATH = $(CORE_V_VERIF)/vendor/riscv/riscv-isa-sim/
 
 COMMON_COMP_UVM_FLAGS = \
 	  +incdir+$(CVA6_REPO_DIR)/verif/env/uvme +incdir+$(CVA6_REPO_DIR)/verif/tb/uvmt \
+	  +core_name=$(target) \
 	  $(if $(spike-tandem), +define+SPIKE_TANDEM=1)
 
 COMMON_PLUS_ARGS = \
@@ -429,7 +430,7 @@ xrun-testharness:
 
 questa-testharness:
 	mkdir -p $(path_var)/tmp
-	make -C $(path_var) sim target=$(target) defines=$(subst +define+,,$(isscomp_opts)) batch-mode=1 elf_file=$(elf) \
+	make -C $(path_var) sim target=$(target) defines=$(subst +define+,,$(isscomp_opts)+core_name=$(target)) batch-mode=1 elf_file=$(elf) \
 	# TODO: Add support for waveform collection.
 	$(tool_path)/spike-dasm --isa=$(variant) < $(path_var)/trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) $(path_var)/trace_rvfi_hart_00.dasm

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -63,8 +63,9 @@ endif
 spike_yaml ?= $(CVA6_REPO_DIR)/config/gen_from_riscv_config/$(target)/spike/spike.yaml
 
 # Set up flags for Spike solo and tandem invocations, but only if parameter file exists.
+spike_params_final = $(spike_params)
 ifneq ($(wildcard $(spike_yaml)),)
-  spike_params += --yaml-param $(spike_yaml)
+  spike_params_final := $(spike_params_final) --param-file $(spike_yaml)
   spike-yaml-plusarg = +config_file=$(CVA6_REPO_DIR)/config/gen_from_riscv_config/$(target)/spike/spike.yaml
 endif
 
@@ -139,7 +140,7 @@ endif
 ###############################################################################
 spike:
 	LD_LIBRARY_PATH="$$(realpath ../../tools/spike/lib):$$LD_LIBRARY_PATH" \
-		$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) --priv=$(priv) $(spike_params) -l $(elf)
+		$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) --priv=$(priv) $(spike_params_final) -l $(elf)
 	cp $(log).iss $(log)
 
 ###############################################################################
@@ -193,7 +194,6 @@ COMMON_PLUS_ARGS = \
         $(spike-yaml-plusarg) \
 	+tohost_addr=$(shell $$RISCV/bin/$(CV_SW_PREFIX)nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
 	+signature=$(elf).signature_output +UVM_TESTNAME=uvmt_cva6_firmware_test_c \
-	$(spike-yaml-plusarg) \
 	+report_file=$(log).yaml +core_name=$(target)
 
 ifneq ($(UVM_VERBOSITY),)
@@ -437,7 +437,7 @@ questa-testharness:
 # Common targets and rules
 ###############################################################################
 
-clean_all: vcs_clean_all 
+clean_all: vcs_clean_all
 	rm -f *.txt
 	rm -f trace*.log
 	rm -f trace*.dasm

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -158,6 +158,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spi
       else:
         cmd = re.sub(r"\<variant\>", isa, cmd)
         cmd = re.sub(r"\<priv\>", priv, cmd)
+        cmd = re.sub(r"\<target\>", target, cmd)
       return cmd
   logging.error("Cannot find ISS %0s" % iss)
   sys.exit(RET_FAIL)

--- a/verif/sim/cva6.yaml
+++ b/verif/sim/cva6.yaml
@@ -18,7 +18,7 @@
   # Always keep this value in sync with the settings of RTL simulators (cf.
   # <issrun_opts> values below).
   cmd: >
-    make spike steps=2000000 variant=<variant> priv=<priv> elf=<elf> tool_path=<tool_path> log=<log> spike_params='<spike_params>'
+    make spike steps=2000000 target=<target> variant=<variant> priv=<priv> elf=<elf> tool_path=<tool_path> log=<log> spike_params='<spike_params>'
 
 ###############################################################################
 # Verilator

--- a/verif/sim/cva6_spike_log_to_trace_csv.py
+++ b/verif/sim/cva6_spike_log_to_trace_csv.py
@@ -121,9 +121,10 @@ def read_spike_trace(path, full_trace):
     # true. Otherwise, we are in state EFFECT if instr is not None, otherwise we
     # are in state INSTR.
 
+    start_trampoline_re = re.compile(r'core.*: 0x0*10000 ')
     end_trampoline_re = re.compile(r'core.*: 0x0*10010 ')
 
-    in_trampoline = True
+    in_trampoline = False
     instr = None
 
     with open(path, 'r') as handle:
@@ -132,6 +133,9 @@ def read_spike_trace(path, full_trace):
                 # The TRAMPOLINE state
                 if end_trampoline_re.match(line):
                     in_trampoline = False
+                continue
+            elif start_trampoline_re.match(line):
+                in_trampoline = True
                 continue
 
             if instr is None:


### PR DESCRIPTION
- always pass target info to 'make spike'
- add Yaml file arg only if target-specific file exists
- update core-v-verif
- update CV32A65X Spike Yaml configuration.