### PR TITLE
Add illegal instruction to cover corner case in decoder

### DIFF
--- a/verif/tests/custom/isacov/illegal_isa.S
+++ b/verif/tests/custom/isacov/illegal_isa.S
@@ -24,8 +24,10 @@ main:
 
   #Cover Illegal funct7 corner case
   .4byte 0x5ad8f33
-  #Cover zext.h with instr[24:20] != 0 in RV32 corner case
+  #Cover illegal instruction similar to zext.h bitmanip instruction instr[24:20] != 0 in RV32 corner case
   .4byte 0x08824ab3
+  #Cover illegal instruction similar to ctz bitmanip instruction with instr[24:20] != 1 in RV32 corner case
+  .4byte 0x60971C13
   #End of test
   j test_pass
 


### PR DESCRIPTION
This add another illegal test to cover ctz bitmanip instruction with [24:20] != 5'h1, to increase decoder's code coverage