### PR TITLE
refac: cva6 icache fsm hit

### DIFF
--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -427,7 +427,7 @@ module cva6_icache
           // we have a hit or an exception output valid result
         end else if (((|cl_hit && cache_en_q && !inv_q) || dreq_i.kill_req)) begin
           state_d = IDLE;
-          data_valid_obi = 1;  // just don't output in the case of dreq_i.kill_req
+          data_valid_obi = '1;  // just don't output in the case of dreq_i.kill_req
           // we can accept another request
           // and stay here, but only if no inval is coming in
           // note: we are not expecting ifill return packets here...

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -427,7 +427,7 @@ module cva6_icache
           // we have a hit or an exception output valid result
         end else if (((|cl_hit && cache_en_q && !inv_q) || dreq_i.kill_req)) begin
           state_d = IDLE;
-          data_valid_obi = dreq_i.kill_req;  // just don't output in this case
+          data_valid_obi = 1;  // just don't output in the case of dreq_i.kill_req
           // we can accept another request
           // and stay here, but only if no inval is coming in
           // note: we are not expecting ifill return packets here...

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -424,7 +424,7 @@ module cva6_icache
         // check if we have to flush
         if (flush_d) begin
           state_d = IDLE;
-          // we have a hit or an exception output valid result
+          // we have an exception
         end else if (dreq_i.kill_req) begin
           data_valid_obi = '1;  // just don't output in this case
           state_d = IDLE;
@@ -434,6 +434,7 @@ module cva6_icache
               state_d = READ;
             end
           end
+          // we have a hit
         end else if (|cl_hit && cache_en_q && !inv_q) begin
           data_valid_obi = '1;
           state_d = IDLE;

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -367,7 +367,7 @@ module cva6_icache
           // check if we have to flush
           if (flush_d) begin
             state_d = IDLE;
-            // we have an exception
+            // we have an exception output valid result
           end else if (dreq_i.kill_req) begin
             state_d = IDLE;
             if (!mem_rtrn_vld_i) begin
@@ -376,7 +376,7 @@ module cva6_icache
                 state_d = READ;
               end
             end
-            // we have a hit 
+            // we have a hit
           end else if (|cl_hit && cache_en_q && !inv_q) begin
             data_valid_obi_d = '1;
             state_d = IDLE;

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -367,7 +367,7 @@ module cva6_icache
           // check if we have to flush
           if (flush_d) begin
             state_d = IDLE;
-            // we have an exception output valid result
+            // we have an exception
           end else if (dreq_i.kill_req) begin
             state_d = IDLE;
             if (!mem_rtrn_vld_i) begin
@@ -424,7 +424,7 @@ module cva6_icache
         // check if we have to flush
         if (flush_d) begin
           state_d = IDLE;
-          // we have an exception
+          // we have an exception output valid result
         end else if (dreq_i.kill_req) begin
           data_valid_obi = '1;  // just don't output in this case
           state_d = IDLE;

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -425,9 +425,18 @@ module cva6_icache
         if (flush_d) begin
           state_d = IDLE;
           // we have a hit or an exception output valid result
-        end else if (((|cl_hit && cache_en_q && !inv_q) || dreq_i.kill_req)) begin
+        end else if (dreq_i.kill_req) begin
+          data_valid_obi = '1;  // just don't output in this case
           state_d = IDLE;
-          data_valid_obi = '1;  // just don't output in the case of dreq_i.kill_req
+          if (!mem_rtrn_vld_i) begin
+            dreq_o.ready = 1'b1;
+            if (dreq_i.req) begin
+              state_d = READ;
+            end
+          end
+        end else if (|cl_hit && cache_en_q && !inv_q) begin
+          data_valid_obi = '1;
+          state_d = IDLE;
           // we can accept another request
           // and stay here, but only if no inval is coming in
           // note: we are not expecting ifill return packets here...


### PR DESCRIPTION
- Aligned the description of obi_valid in the `READ` and `READ_BIS` states within `cva6_icache` (feature/interconnect branch)
- Modifications related to [this comment](https://github.com/openhwgroup/cva6/pull/2288#issuecomment-2198083248) mentioned in PR #2288 