### PR TITLE
Add CV64A6_MMU core in user manual

### DIFF
--- a/docs/01_cva6_user/CSR_CV64A6_MMU.rst
+++ b/docs/01_cva6_user/CSR_CV64A6_MMU.rst
@@ -1,0 +1,25 @@
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 Thales DIS design services SAS
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _CSR_CV64A6_MMU:
+
+
+CV64A6_MMU Control Status Registers
+==================================
+
+*This chapter is not yet available.*

--- a/docs/01_cva6_user/CSR_CV64A6_MMU_list.rst
+++ b/docs/01_cva6_user/CSR_CV64A6_MMU_list.rst
@@ -1,0 +1,25 @@
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 Thales DIS design services SAS
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _CSR_CV64A6_MMU_list:
+
+
+CV64A6_MMU Control Status Registers List
+=======================================
+
+*This chapter is not yet available.*

--- a/docs/01_cva6_user/CSR_Performance_Counters.rst
+++ b/docs/01_cva6_user/CSR_Performance_Counters.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Performance counters included"
    "CV32A60X", "No performance counters"
+   "CV64A6_MMU", "No performance counters"
 
 CSR performance counters control
 ================================

--- a/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
+++ b/docs/01_cva6_user/CVX_Interface_Coprocessor.rst
@@ -33,6 +33,7 @@ with external coprocessors.
 
    "CV32A60AX", "CV-X-IF included"
    "CV32A60X", "CV-X-IF included"
+   "CV64A6_MMU", "CV-X-IF included"
 
 
 CV-X-IF interface specification

--- a/docs/01_cva6_user/Interfaces.rst
+++ b/docs/01_cva6_user/Interfaces.rst
@@ -34,6 +34,7 @@ The AXI interface is described in a separate chapter.
 
    "CV32A60AX", "AXI implemented"
    "CV32A60X", "AXI implemented"
+   "CV64A6_MMU", "AXI implemented"
 
 Debug Interface
 ---------------
@@ -52,6 +53,7 @@ Debug Interface
 
    "CV32A60AX", "Debug interface implemented"
    "CV32A60X", "No debug interface"
+   "CV64A6_MMU", "Debug interface implemented"
 
 Interrupt Interface
 -------------------
@@ -77,3 +79,4 @@ For more information, refer to OpenPiton documents.
 
    "CV32A60AX", "No TRI interface"
    "CV32A60X", "No TRI interface"
+   "CV64A6_MMU", "No TRI interface"

--- a/docs/01_cva6_user/Introduction.rst
+++ b/docs/01_cva6_user/Introduction.rst
@@ -102,6 +102,7 @@ As of today, two configurations are being verified and addressed in this documen
 
    "**CV32A60AX**", "32-bit **application** core", "ASIC", "Machine, Supervisor, User", "RV32IMACZicsr_Zifencei_Zicount_Zba_Zbb_Zbc_Zbs_Zcb_Zicond", "Included"
    "**CV32A60X**", "32-bit **embedded** core", "ASIC", "Machine only", "RV32IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb", "Included"
+   "**CV64A6_MMU**", "64-bit **embedded** core with MMU", "ASIC", "Machine, Supervisor, User", "RV64IMCZicsr_Zifencei_Zba_Zbb_Zbc_Zbs_Zcb", "Included"
 
 CV32A60X is an interim part number until the team can decide if this configuration is single- or dual-issue.
 If the dual-issue architecture is selected, the part number will become CV32A65X to denote the extra performance.

--- a/docs/01_cva6_user/Programmer_View.rst
+++ b/docs/01_cva6_user/Programmer_View.rst
@@ -108,6 +108,29 @@ These extensions are available in CV32A60X:
    "RVZifencei - Instruction-Fetch Fence",                                  "✔"
    "RVZicond - Integer Conditional Operations(Ratification pending)",       ""
 
+CV64A6_MMU extensions
+~~~~~~~~~~~~~~~~~~~
+
+These extensions are available in CV64A6_MMU:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Extension", "Available in CV64A6_MMU"
+
+   "RV32I - Base Integer Instruction Set",                                  "✔"
+   "RV32A - Atomic Instructions",                                           ""
+   "RV32Zb* - Bit-Manipulation (Zba, Zbb, Zbc, Zbs)",                       "✔"
+   "RV32C - Compressed Instructions ",                                      "✔"
+   "RV32Zcb - Code Size Reduction",                                         "✔"
+   "RVZcmp - Code Size Reduction",                                          "✔"
+   "RV32D - Double precision floating-point",                               ""
+   "RV32F - Single precision floating-point",                               ""
+   "RV32M - Integer Multiply/Divide",                                       "✔"
+   "RVZicount - Performance Counters",                                      ""
+   "RVZicsr - Control and Status Register Instructions",                    "✔"
+   "RVZifencei - Instruction-Fetch Fence",                                  "✔"
+   "RVZicond - Integer Conditional Operations(Ratification pending)",       ""
 
 RISC-V Privileges
 -----------------
@@ -158,6 +181,19 @@ These privilege modes are available in CV32A60X:
    "S - Supervior",                 ""
    "U - User",                      ""
 
+CV64A6_MMU privilege modes
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These privilege modes are available in CV64A6_MMU:
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Privileges", "Available in CV64A6_MMU"
+
+   "M - Machine",                   "✔"
+   "S - Supervior",                 "✔"
+   "U - User",                      "✔"
 
 RISC-V Virtual Memory
 ---------------------
@@ -209,6 +245,10 @@ CV32A60X virtual memory
 
 CV32A60X integrates no MMU and only supports the **Bare** addressing mode.
 
+CV64A6_MMU virtual memory
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+CV64A6_MMU integrates an MMU and supports both the **Bare** and **Sv39** addressing modes.
 
 Memory Alignment
 ----------------

--- a/docs/01_cva6_user/RISCV_Instructions_RV32A.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32A.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Not implemented extension"
+   "CV64A6_MMU", "Not implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64A, that includes additional instructions.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RV32C.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32C.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64C, that includes a different list of instructions.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RV32I.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32I.rst
@@ -29,6 +29,7 @@ This chapter is applicable to all CV32A6 configurations.
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
 **Note**: CV64A6 implements RV64I that includes additional instructions.
 

--- a/docs/01_cva6_user/RISCV_Instructions_RV32M.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32M.rst
@@ -29,6 +29,7 @@ This chapter is applicable to all CV32A6 configurations.
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
 **Note**: CV64A6 implements RV64M that includes additional instructions.
 

--- a/docs/01_cva6_user/RISCV_Instructions_RV32ZCb.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RV32ZCb.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
 **Note**: This chapter is specific to CV32A6 configurations. CV64A6 configurations implement as an option RV64Zcb, that includes one additional instruction.
    

--- a/docs/01_cva6_user/RISCV_Instructions_RVZba.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZba.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
    
 ======================================

--- a/docs/01_cva6_user/RISCV_Instructions_RVZbb.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZbb.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
 =============================
 RVZbb: Basic bit-manipulation

--- a/docs/01_cva6_user/RISCV_Instructions_RVZbc.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZbc.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
    
 =================================

--- a/docs/01_cva6_user/RISCV_Instructions_RVZbs.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZbs.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
    
 ==============================

--- a/docs/01_cva6_user/RISCV_Instructions_RVZcmp.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZcmp.rst
@@ -26,6 +26,7 @@
    :header: "Configuration", "Implementation"
 
    "CV32A60X", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
 
 **Note**: Zcmp is primarily targeted at embedded class CPUs due to implementation complexity. Additionally, it is not compatible with architecture class profiles.  
 

--- a/docs/01_cva6_user/RISCV_Instructions_RVZicond.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RVZicond.rst
@@ -27,6 +27,7 @@
 
    "CV32A60AX", "Implemented extension"
    "CV32A60X", "Not implemented extension"
+   "CV64A6_MMU", "Not implemented extension"
 
 **Note**: RV32Zicond and RV64Zicond are identical.
 

--- a/docs/01_cva6_user/index.rst
+++ b/docs/01_cva6_user/index.rst
@@ -49,6 +49,8 @@ CVA6 User Manual
    CV32A60X CSR Details <CSR_CV32A60X>
    CV32A60AX CSR List <CSR_CV32A60AX_list>
    CV32A60AX CSR Details <CSR_CV32A60AX>
+   CV64A6_MMU CSR List <CSR_CV64A6_MMU_list>
+   CV64A6_MMU CSR Details <CSR_CV64A6_MMU>
    CV64A6 CSR <CV64A6_Control_Status_Registers>
    CSR_Cache_Control
    CSR Performance Counters <CSR_Performance_Counters>


### PR DESCRIPTION
In the CVA6 user manual, two configurations are already explicit. 
This commit adds another one : CV64A6_MMU.

This MR is independant from the MR adding design documentation for CV64A6_MMU