### PR TITLE
Retry FPGA boot in CI when failed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -512,6 +512,7 @@ fpga-boot:
     - source check_fpga_boot.sh
     - cd -
     - python3 .gitlab-ci/scripts/report_fpga_boot.py corev_apu/fpga/scripts/fpga_boot.rpt
+  retry: 1
 
 code_coverage-report:
   extends:


### PR DESCRIPTION
This job can sometime fail because of an unstable serial connection.

Most of the time, retrying the job fixes the issue, hence this PR.