### PR TITLE
Update README.md : Updated gcc-toolchain-builder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd cva6
 git submodule update --init --recursive
 ```
 
-2. Install the GCC Toolchain [build prerequisites](util/gcc-toolchain-builder/README.md#Prerequisites) then [the toolchain itself](util/gcc-toolchain-builder/README.md#Getting-started).
+2. Install the GCC Toolchain [build prerequisites](util/toolchain-builder/README.md#Prerequisites) then [the toolchain itself](util/toolchain-builder/README.md#Getting-started).
 
 :warning: It is **strongly recommended** to use the toolchain built with the provided scripts.
 


### PR DESCRIPTION
cva6/gcc-toolchain-builder has been renamed to cva6/toolchain-builder in the main repo. 

README file should be aligned with this update.