### PR TITLE
Fix non-standard usage of SystemVerilog

### DIFF
--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -749,7 +749,7 @@ module ariane_testharness #(
 
 `ifdef VERILATOR
     initial begin
-        string verbosity = 0;
+        string verbosity;
         if ($value$plusargs("UVM_VERBOSITY=%s",verbosity)) begin
           uvm_set_verbosity_level(verbosity);
           `uvm_info("ariane_testharness", $sformatf("Set UVM_VERBOSITY to %s", verbosity), UVM_NONE)


### PR DESCRIPTION
Strings cannot be initially assigned to an integer without a cast.

Found by using Slang on CVA6 via [sv-tests](https://github.com/chipsalliance/sv-tests). This is the only error that Slang does not like, but it also prints some more warnings that probably should be fixed:

```
../../../third_party/cores/ariane/core/cache_subsystem/axi_adapter.sv:204:29: warning: finish argument must have value of 0, 1, or 2 [-Wfinish-num]
                else $fatal("Bursts of atomic operations are not supported");
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../third_party/cores/ariane/core/cache_subsystem/axi_adapter.sv:235:29: warning: finish argument must have value of 0, 1, or 2 [-Wfinish-num]
                else $fatal("Bursts of atomic operations are not supported");
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../third_party/cores/ariane/vendor/pulp-platform/axi/src/axi_id_prepend.sv:87:27: warning: implicit conversion from 'slv_aw_chan_t' to 'mst_aw_chan_t' [-Wimplicit-conv]
        mst_aw_chans_o[i] = slv_aw_chans_i[i];
                          ^ ~~~~~~~~~~~~~~~~~
../../../third_party/cores/ariane/vendor/pulp-platform/axi/src/axi_id_prepend.sv:88:27: warning: implicit conversion from 'slv_ar_chan_t' to 'mst_ar_chan_t' [-Wimplicit-conv]
        mst_ar_chans_o[i] = slv_ar_chans_i[i];
                          ^ ~~~~~~~~~~~~~~~~~
../../../third_party/cores/ariane/vendor/pulp-platform/axi/src/axi_id_prepend.sv:95:29: warning: implicit conversion from 'mst_b_chan_t' to 'slv_b_chan_t' [-Wimplicit-conv]
    assign slv_b_chans_o[i] = mst_b_chans_i[i];
                            ^ ~~~~~~~~~~~~~~~~
../../../third_party/cores/ariane/vendor/pulp-platform/axi/src/axi_id_prepend.sv:96:29: warning: implicit conversion from 'mst_r_chan_t' to 'slv_r_chan_t' [-Wimplicit-conv]
    assign slv_r_chans_o[i] = mst_r_chans_i[i];
                            ^ ~~~~~~~~~~~~~~~~
../../../third_party/cores/ariane/core/ex_stage.sv:684:51: warning: cannot select range of [15:0] from 'logic[0:0][63:0]' [-Wrange-oob]
          asid_to_be_flushed  <= rs2_forwarding_i[CVA6Cfg.ASID_WIDTH-1:0];
                                                  ^~~~~~~~~~~~~~~~~~~~~~
../../../third_party/cores/ariane/core/cva6.sv:1551:12: warning: initializing a static variable in a procedural context requires an explicit 'static' keyword [-Wexplicit-static]
      byte mode = "";
           ^~~~
../../../third_party/cores/ariane/corev_apu/tb/ariane_testharness.sv:752:16: warning: initializing a static variable in a procedural context requires an explicit 'static' keyword [-Wexplicit-static]
        string verbosity = 0;
               ^~~~~~~~~
../../../third_party/cores/ariane/corev_apu/tb/ariane_testharness.sv:752:26: error: no implicit conversion from 'int' to 'string'; explicit conversion exists, are you missing a cast?
        string verbosity = 0;
                         ^ ~
Top level design units:
    ariane_testharness

```

Related to https://github.com/chipsalliance/sv-tests/issues/5807.