### PR TITLE
Enable tandem on gen tests in ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,6 +155,7 @@ gen_smoke:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Basic"
     DV_SIMULATORS: "vcs-uvm,spike"
+    SPIKE_TANDEM: 1
     COLLECT_SIMU_LOGS: 1
   script:
     - bash verif/regress/smoke-gen_tests.sh
@@ -296,7 +297,6 @@ riscv_arch_test:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
-    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-arch-test.sh
   after_script: *simu_after_script
 
@@ -309,7 +309,6 @@ compliance:
     DASHBOARD_SORT_INDEX: 2
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
-    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-compliance.sh
   after_script: *simu_after_script
 
@@ -324,7 +323,6 @@ riscv-tests-v:
     DV_SIMULATORS: "veri-testharness,spike"
     DV_TARGET: cv64a6_imafdc_sv39
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
-    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script
 
@@ -338,7 +336,6 @@ riscv-tests-p:
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-p.yaml"
-    COLLECT_SIMU_LOGS: 1
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script
 

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -704,6 +704,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
           elf = prefix + ".o"
           log = ("%s/%s_%d.%s.log" % (log_dir, test['test'], i, target))
           cmd = get_iss_cmd(base_cmd, elf, target, log)
+          yaml = ("%s/%s_%s.%s.log.yaml" % (log_dir, test['test'], i, target))
           if 'iss_opts' in test:
             cmd += ' '
             cmd += test['iss_opts']
@@ -713,6 +714,8 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
           else:
             run_cmd(cmd, timeout_s, debug_cmd = debug_cmd)
           logging.debug(cmd)
+          if (iss != "spike" and os.environ.get('SPIKE_TANDEM') != None):
+            analize_result_yaml(yaml)
 
 
 def iss_cmp(test_list, iss, target, output_dir, stop_on_first_error, exp, debug_cmd):


### PR DESCRIPTION
Enable Spike Tandem on gen tests in CI.

Display tandem result on the gen tests logs.

Also, remove log collection from heavy tests since they are temporarily not retrieved by the dashboard.