### PR TITLE
[Spike Yaml] HOTFIX: Add libyaml-cpp to preload list of RTL simulators.

### DIFF
--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -207,6 +207,7 @@ COMMON_RUN_ARGS = \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libcustomext \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libriscv \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libfesvr \
+	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libdisasm
 
 ALL_UVM_FLAGS   = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
@@ -315,6 +316,7 @@ xrun_uvm_run:
 	  $(XRUN_RUN)			\
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libriscv \
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libfesvr \
+	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libdisasm \
 	  ++$(elf) \
 	  +elf_file=$(elf) \


### PR DESCRIPTION
This PR fixes spurious CI failures during tandem job executions.
The root cause was an implicit path used to access the yaml-cpp shared library: instead of accessing the local copy of libyaml-cpp.so, the RTL simulators were accessing acopy of the lib located in the build space of Spike, and that space was eventually reclaimed for other CI jobs.