### PR TITLE
[CI DEBUG] Track cause of failures in Spike version check.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,13 +107,17 @@ build_tools:
     - mkdir -p artifacts/tools/
     - mv tools/spike artifacts/tools/
 
+.copy_spike_artifacts: &copy_spike_artifacts
+  - mkdir -p tools
+  - mv artifacts/tools/spike tools
+  - /sbin/ldconfig -N tools/spike/lib
+
 .fe_smoke_test:
   stage: light tests
   rules: *on_dev
   before_script:
     - git -C verif/core-v-verif fetch --unshallow
-    - mkdir -p tools
-    - mv artifacts/tools/spike tools
+    - !reference [.copy_spike_artifacts]
     - rm -rf artifacts/
     - mkdir -p artifacts/{reports,logs}
     - python3 .gitlab-ci/scripts/report_fail.py
@@ -471,8 +475,7 @@ simu-gate:
     TARGET: $DV_TARGET
   script:
     - git -C verif/core-v-verif fetch --unshallow
-    - mkdir -p tools
-    - mv artifacts/tools/spike tools
+    - !reference [.copy_spike_artifacts]
     - echo $PERIOD
     - source ./verif/sim/setup-env.sh
     - git clone ${SYNTH_SCRIPT} ${SYNTH_SCRIPT_PATH}

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ vcs: vcs_build
 # Build the TB and module using QuestaSim
 build: $(library) $(library)/.build-srcs $(library)/.build-tb $(dpi-library)/ariane_dpi.so
 	# Optimize top level
-	$(VOPT) -64 -work $(library)  $(top_level) -o $(top_level)_optimized +acc -check_synthesis -dpilib $(SPIKE_INSTALL_DIR)/lib/libriscv -dpilib $(SPIKE_INSTALL_DIR)/lib/lifesvr  $(vopt_flag)
+	$(VOPT) -64 -work $(library)  $(top_level) -o $(top_level)_optimized +acc -check_synthesis -dpilib $(SPIKE_INSTALL_DIR)/lib/libriscv -dpilib $(SPIKE_INSTALL_DIR)/lib/libfesvr -dpilib $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp $(vopt_flag)
 
 # src files
 $(library)/.build-srcs: $(library)
@@ -368,13 +368,13 @@ $(dpi-library)/%.o: corev_apu/tb/dpi/%.cc $(dpi_hdr)
 $(dpi-library)/ariane_dpi.so: $(dpi)
 	mkdir -p $(dpi-library)
 	# Compile C-code and generate .so file
-	$(CXX) -shared -m64 -o $(dpi-library)/ariane_dpi.so $? -L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv
+	$(CXX) -shared -m64 -o $(dpi-library)/ariane_dpi.so $? -L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv -lyaml-cpp
 
 $(dpi-library)/xrun_ariane_dpi.so: $(dpi)
 	# Make Dir work-dpi
 	mkdir -p $(dpi-library)
 	# Compile C-code and generate .so file
-	$(CXX) -shared -m64 -o $(dpi-library)/xrun_ariane_dpi.so $? -L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv
+	$(CXX) -shared -m64 -o $(dpi-library)/xrun_ariane_dpi.so $? -L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv -lyaml-cpp
 
 # single test runs on Questa can be started by calling make <testname>, e.g. make towers.riscv
 # the test names are defined in ci/riscv-asm-tests.list, and in ci/riscv-benchmarks.list
@@ -387,7 +387,7 @@ generate-trace-vsim:
 sim: build
 	$(VSIM) +permissive $(questa-flags) $(questa-cmd) -lib $(library) +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) \
 	+BASEDIR=$(riscv-test-dir) $(uvm-flags) -sv_lib $(SPIKE_INSTALL_DIR)/lib/libriscv -sv_lib $(SPIKE_INSTALL_DIR)/lib/libfesvr \
-	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libdisasm  \
+	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libdisasm -sv_lib $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
 	${top_level}_optimized +permissive-off +elf_file=$(elf_file) ++$(elf_file) ++$(target-options)
 
 $(riscv-asm-tests): build

--- a/Makefile
+++ b/Makefile
@@ -618,7 +618,7 @@ verilate_command := $(verilator) --no-timing verilator_config.vlt               
                     $(if $(DEBUG), --trace-structs,)                                                             \
                     $(if $(TRACE_COMPACT), --trace-fst $(VL_INC_DIR)/verilated_fst_c.cpp)                        \
                     $(if $(TRACE_FAST), --trace $(VL_INC_DIR)/verilated_vcd_c.cpp)                               \
-                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv -ldisasm $(if $(PROFILE), -g -pg,) -lpthread $(if $(TRACE_COMPACT), -lz,)" \
+                    -LDFLAGS "-L$(RISCV)/lib -L$(SPIKE_INSTALL_DIR)/lib -Wl,-rpath,$(RISCV)/lib -Wl,-rpath,$(SPIKE_INSTALL_DIR)/lib -lfesvr -lriscv -ldisasm -lyaml-cpp $(if $(PROFILE), -g -pg,) -lpthread $(if $(TRACE_COMPACT), -lz,)" \
                     -CFLAGS "$(CFLAGS)$(if $(PROFILE), -g -pg,) -DVL_DEBUG -I$(SPIKE_INSTALL_DIR)"               \
                     $(if $(SPIKE_TANDEM), +define+SPIKE_TANDEM, )                                                \
                     --cc --vpi                                                                                   \

--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ vcs_build: $(dpi-library)/ariane_dpi.so
 vcs: vcs_build
 	cd $(vcs-library) && \
 	 ./simv +permissive $(if $(VERDI), -verdi -do $(root-dir)/init_testharness.do,) \
-		+elf_file=$(elf_file) ++$(elf_file) $(if $(spike-tandem),-sv_lib $(SPIKE_INSTALL_DIR)/libriscv) \
+		+elf_file=$(elf_file) ++$(elf_file) $(if $(spike-tandem), -sv_lib $(SPIKE_INSTALL_DIR)/libyaml-cpp) -sv_lib $(SPIKE_INSTALL_DIR)/libriscv \
 		-sv_lib ../work-dpi/ariane_dpi | tee vcs.log
 
 # Build the TB and module using QuestaSim
@@ -386,8 +386,8 @@ generate-trace-vsim:
 
 sim: build
 	$(VSIM) +permissive $(questa-flags) $(questa-cmd) -lib $(library) +MAX_CYCLES=$(max_cycles) +UVM_TESTNAME=$(test_case) \
-	+BASEDIR=$(riscv-test-dir) $(uvm-flags) -sv_lib $(SPIKE_INSTALL_DIR)/lib/libriscv -sv_lib $(SPIKE_INSTALL_DIR)/lib/libfesvr \
-	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libdisasm -sv_lib $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
+	+BASEDIR=$(riscv-test-dir) $(uvm-flags) -sv_lib $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp -sv_lib $(SPIKE_INSTALL_DIR)/lib/libriscv -sv_lib $(SPIKE_INSTALL_DIR)/lib/libfesvr \
+	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libdisasm \
 	${top_level}_optimized +permissive-off +elf_file=$(elf_file) ++$(elf_file) ++$(target-options)
 
 $(riscv-asm-tests): build

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ git submodule update --init --recursive
 
 :warning: It is **strongly recommended** to use the toolchain built with the provided scripts.
 
-3. Set the RISCV environment variable.
+3. Install `cmake`, version 3.14 or higher.
+
+4. Set the RISCV environment variable.
 ```sh
 export RISCV=/path/to/toolchain/installation/directory
 ```
 
-4. Install `help2man` and `device-tree-compiler` packages. 
+5. Install `help2man` and `device-tree-compiler` packages.
 
 For Debian-based Linux distributions, run :
 
@@ -44,13 +46,13 @@ For Debian-based Linux distributions, run :
 sudo apt-get install help2man device-tree-compiler
 ```
 
-5. Install the riscv-dv requirements:
+6. Install the riscv-dv requirements:
 
 ```sh
 pip3 install -r verif/sim/dv/requirements.txt
 ```
 
-6. Run these commands to install a custom Spike and Verilator (i.e. these versions must be used to simulate the CVA6) and [these](#running-regression-tests-simulations) tests suites.
+7. Run these commands to install a custom Spike and Verilator (i.e. these versions must be used to simulate the CVA6) and [these](#running-regression-tests-simulations) tests suites.
 ```sh
 # DV_SIMULATORS is detailed in the next section
 export DV_SIMULATORS=veri-testharness,spike

--- a/verif/regress/install-spike.sh
+++ b/verif/regress/install-spike.sh
@@ -50,8 +50,8 @@ if ! [ -f "$SPIKE_INSTALL_DIR/bin/spike" ]; then
   fi
   # Build both shared and static versions of the yaml-cpp library in sequence
   # prior to building Spike.
-  make yaml-cpp
   make yaml-cpp-static
+  make yaml-cpp
   make -j${NUM_JOBS}
   echo "Installing Spike in '$SPIKE_INSTALL_DIR'..."
   make install

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -201,12 +201,13 @@ ifneq ($(UVM_VERBOSITY),)
 COMMON_PLUS_ARGS += +UVM_VERBOSITY=$(UVM_VERBOSITY)
 endif
 
+# Libraries that provide symbols for other libs must come first.
 COMMON_RUN_ARGS = \
 	$(COMMON_PLUS_ARGS) $(issrun_opts) \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libcustomext \
+	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libriscv \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libfesvr \
-	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
 	-sv_lib $(SPIKE_INSTALL_DIR)/lib/libdisasm
 
 ALL_UVM_FLAGS   = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
@@ -308,14 +309,15 @@ xrun_uvm_comp:
           $(cov-comp-opt) $(isscomp_opts)\
 	  -top uvmt_cva6_tb
 
+# Libraries that provide symbols for other libs must come first.
 xrun_uvm_run:
 	@echo "[XRUN] Running"
 	cd $(XRUN_WORK_DIR) && 	\
 	  xrun 			\
 	  $(XRUN_RUN)			\
+	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libriscv \
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libfesvr \
-	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libyaml-cpp \
 	  +sv_lib=$(SPIKE_INSTALL_DIR)/lib/libdisasm \
 	  ++$(elf) \
 	  +elf_file=$(elf) \

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1108,24 +1108,36 @@ def check_spike_version():
 
   if user_spike_version.returncode != 0:
     # Re-run 'spike -v' and print contents of stdout and stderr.
-    logging.info(f"Stdout of Spike version check:\n\n{user_spike_stdout_string}\n")
-    logging.info(f"Stderr of Spike version check:\n\n{user_spike_stderr_string}")
-    # Run 'ldd' on Spike binary and print contents of stdout and stderr.
+    logging.info("Spike version check ('$SPIKE_PATH/spike -v')")
+    logging.info(f"- stdout:\n\n{user_spike_stdout_string}\n")
+    logging.info(f"- stderr:\n\n{user_spike_stderr_string}")
+    # Print current configuration of dynamic linker cache.
+    ldconfig = subprocess.run(
+        "/sbin/ldconfig", capture_output=True, text=True, shell=True
+    )
+    ldconfig_stdout = ldconfig.stdout.strip()
+    ldconfig_stderr = ldconfig.stderr.strip()
+    logging.info("LDCONFIG cache state ('ldconfig -p')")
+    logging.info(f"- stdout:\n\n{ldconfig_stdout}\n")
+    logging.info(f"- stderr:\n\n{ldconfig_stderr}")
+     # Run 'ldd' on Spike binary and print contents of stdout and stderr.
     spike_ldd = subprocess.run(
         "/bin/ldd $SPIKE_PATH/spike", capture_output=True, text=True, shell=True
     )
     spike_ldd_stdout = spike_ldd.stdout.strip()
     spike_ldd_stderr = spike_ldd.stderr.strip()
-    logging.info(f"Stdout of Spike LDD check:\n\n{spike_ldd_stdout}\n")
-    logging.info(f"Stderr of Spike version check:\n\n{spike_ldd_stderr}")
+    logging.info("Spike LDD check ('ldd $SPIKE_PATH/spike')")
+    logging.info(f"- stdout:\n\n{spike_ldd_stdout}\n")
+    logging.info(f"- stderr:\n\n{spike_ldd_stderr}")
     # Run 'ls -l' on Spike lib directory and print contents of stdout and stderr.
     spike_lib_ls = subprocess.run(
         "ls -l $SPIKE_PATH/../lib", capture_output=True, text=True, shell=True
     )
     spike_lib_stdout = spike_lib_ls.stdout.strip()
     spike_lib_stderr = spike_lib_ls.stderr.strip()
-    logging.info(f"Stdout of Spike version check:\n\n{spike_lib_stdout}\n")
-    logging.info(f"Stderr of Spike version check:\n\n{spike_lib_stderr}")
+    logging.info("Stdout of Spike library check ('ls -l $SPIKE_PATH/../lib')")
+    logging.info(f"- stdout:\n\n{spike_lib_stdout}\n")
+    logging.info(f"- stderr:\n\n{spike_lib_stderr}")
 
     incorrect_version_exit("Spike", "- unknown -", spike_version)
 

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1107,8 +1107,8 @@ def check_spike_version():
   user_spike_stderr_string = user_spike_version.stderr.strip()
 
   if user_spike_version.returncode != 0:
-    logging.info("Stdout of Spike version check:\n\n{user_spike_stdout_string}\n")
-    logging.info("Stderr of Spike version check:\n\n{user_spike_stderr_string}")
+    logging.info(f"Stdout of Spike version check:\n\n{user_spike_stdout_string}\n")
+    logging.info(f"Stderr of Spike version check:\n\n{user_spike_stderr_string}")
     incorrect_version_exit("Spike", "- unknown -", spike_version)
 
   logging.info(f"Spike Version: {user_spike_stderr_string}")

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1103,15 +1103,18 @@ def check_spike_version():
   # Get Spike User version
   get_env_var("SPIKE_PATH")
   user_spike_version = subprocess.run("$SPIKE_PATH/spike -v", capture_output=True, text=True, shell=True)
-  user_spike_version_string = user_spike_version.stderr.strip()
+  user_spike_stdout_string = user_spike_version.stdout.strip()
+  user_spike_stderr_string = user_spike_version.stderr.strip()
 
   if user_spike_version.returncode != 0:
+    logging.info("Stdout of Spike version check:\n\n{user_spike_stdout_string}\n")
+    logging.info("Stderr of Spike version check:\n\n{user_spike_stderr_string}")
     incorrect_version_exit("Spike", "- unknown -", spike_version)
 
-  logging.info(f"Spike Version: {user_spike_version_string}")
+  logging.info(f"Spike Version: {user_spike_stderr_string}")
 
-  if user_spike_version_string != spike_version:
-    incorrect_version_exit("Spike", user_spike_version_string, spike_version)
+  if user_spike_stderr_string != spike_version:
+    incorrect_version_exit("Spike", user_spike_stderr_string, spike_version)
 
 
 def check_verilator_version():

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1107,8 +1107,26 @@ def check_spike_version():
   user_spike_stderr_string = user_spike_version.stderr.strip()
 
   if user_spike_version.returncode != 0:
+    # Re-run 'spike -v' and print contents of stdout and stderr.
     logging.info(f"Stdout of Spike version check:\n\n{user_spike_stdout_string}\n")
     logging.info(f"Stderr of Spike version check:\n\n{user_spike_stderr_string}")
+    # Run 'ldd' on Spike binary and print contents of stdout and stderr.
+    spike_ldd = subprocess.run(
+        "/bin/ldd $SPIKE_PATH/spike", capture_output=True, text=True, shell=True
+    )
+    spike_ldd_stdout = spike_ldd.stdout.strip()
+    spike_ldd_stderr = spike_ldd.stderr.strip()
+    logging.info(f"Stdout of Spike LDD check:\n\n{spike_ldd_stdout}\n")
+    logging.info(f"Stderr of Spike version check:\n\n{spike_ldd_stderr}")
+    # Run 'ls -l' on Spike lib directory and print contents of stdout and stderr.
+    spike_lib_ls = subprocess.run(
+        "ls -l $SPIKE_PATH/../lib", capture_output=True, text=True, shell=True
+    )
+    spike_lib_stdout = spike_lib_ls.stdout.strip()
+    spike_lib_stderr = spike_lib_ls.stderr.strip()
+    logging.info(f"Stdout of Spike version check:\n\n{spike_lib_stdout}\n")
+    logging.info(f"Stderr of Spike version check:\n\n{spike_lib_stderr}")
+
     incorrect_version_exit("Spike", "- unknown -", spike_version)
 
   logging.info(f"Spike Version: {user_spike_stderr_string}")

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1111,16 +1111,7 @@ def check_spike_version():
     logging.info("Spike version check ('$SPIKE_PATH/spike -v')")
     logging.info(f"- stdout:\n\n{user_spike_stdout_string}\n")
     logging.info(f"- stderr:\n\n{user_spike_stderr_string}")
-    # Print current configuration of dynamic linker cache.
-    ldconfig = subprocess.run(
-        "/sbin/ldconfig", capture_output=True, text=True, shell=True
-    )
-    ldconfig_stdout = ldconfig.stdout.strip()
-    ldconfig_stderr = ldconfig.stderr.strip()
-    logging.info("LDCONFIG cache state ('ldconfig -p')")
-    logging.info(f"- stdout:\n\n{ldconfig_stdout}\n")
-    logging.info(f"- stderr:\n\n{ldconfig_stderr}")
-     # Run 'ldd' on Spike binary and print contents of stdout and stderr.
+    # Run 'ldd' on Spike binary and print contents of stdout and stderr.
     spike_ldd = subprocess.run(
         "/bin/ldd $SPIKE_PATH/spike", capture_output=True, text=True, shell=True
     )


### PR DESCRIPTION
Add diagnostics messages to verif/sim/cva6.py to help tracking intermittent Spike failures seen in thales-invia CI runs.