### PR TITLE
Increase simulation time on CSR tests

### DIFF
--- a/verif/regress/dv-csr-embedded-tests.sh
+++ b/verif/regress/dv-csr-embedded-tests.sh
@@ -31,6 +31,6 @@ if ! [ -n "$DV_SIMULATORS" ]; then
 fi
 
 cd verif/sim/
-python3 cva6.py --testlist=../tests/testlist_csr_embedded.yaml --iss_yaml cva6.yaml --target $DV_TARGET --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1
+python3 cva6.py --testlist=../tests/testlist_csr_embedded.yaml --iss_yaml cva6.yaml --target $DV_TARGET --iss=$DV_SIMULATORS $DV_OPTS --priv=m --iss_timeout 600
 
 cd -


### PR DESCRIPTION
This MR increase simulation time for CSR tests, after enabling superscalar sumilation time increase and this lead to timeout error for some CSR tests