### PR TITLE
Exclude page fault exceptions if mmu isn't supported

### DIFF
--- a/verif/env/uvme/cov/uvme_exception_covg.sv
+++ b/verif/env/uvme/cov/uvme_exception_covg.sv
@@ -21,6 +21,7 @@
 covergroup cg_exception(
     string name,
     bit pmp_supported,
+    bit MmuPresent,
     bit unaligned_access_supported,
     bit ext_c_supported,
     bit mode_u_supported,
@@ -63,6 +64,7 @@ covergroup cg_exception(
 
     bins ENV_CALL_MMODE = {11} iff (instr.trap);
 
+    ignore_bins IGN_PAGE_FAULT_EXC = {12, 13, 15} iff (!MmuPresent);
     bins INSTR_PAGE_FAULT = {12} iff (instr.trap);
 
     bins LOAD_PAGE_FAULT  = {13} iff (instr.trap);
@@ -199,6 +201,7 @@ function void uvme_exception_cov_model_c::build_phase(uvm_phase phase);
 
    exception_cg = new("exception_cg",
                       .pmp_supported(cfg.pmp_supported),
+                      .MmuPresent(cfg.MmuPresent),
                       .unaligned_access_supported(cfg.unaligned_access_supported),
                       .ext_c_supported(cfg.ext_c_supported),
                       .mode_u_supported(cfg.mode_u_supported),

--- a/verif/env/uvme/uvme_cva6_cfg.sv
+++ b/verif/env/uvme/uvme_cva6_cfg.sv
@@ -56,6 +56,9 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
    // Zihpm extension
    rand bit                      ext_zihpm_supported;
 
+   // MMU support
+   rand bit                      MmuPresent;
+
    // Handle to RTL configuration
    rand cva6_cfg_t         CVA6Cfg;
 
@@ -70,6 +73,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
       `uvm_field_int (                         HPDCache_supported          , UVM_DEFAULT          )
       `uvm_field_int (                         nr_pmp_entries              , UVM_DEFAULT          )
       `uvm_field_int (                         ext_zihpm_supported         , UVM_DEFAULT          )
+      `uvm_field_int (                         MmuPresent                  , UVM_DEFAULT          )
       `uvm_field_int (                         sys_clk_period            , UVM_DEFAULT + UVM_DEC)
 
       `uvm_field_object(clknrst_cfg, UVM_DEFAULT)
@@ -146,6 +150,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
 
       DirectVecOnly           == CVA6Cfg.DirectVecOnly;
       TvalEn                  == CVA6Cfg.TvalEn;
+      MmuPresent              == CVA6Cfg.MmuPresent;
    }
 
    constraint ext_const {


### PR DESCRIPTION
This MR add mmu present parameter in UVM testbench, and use it to exclude page fault exceptions