### PR TITLE
[Xcelium flow] Xrun compile fixes

### DIFF
--- a/common/local/util/instr_tracer.sv
+++ b/common/local/util/instr_tracer.sv
@@ -20,7 +20,7 @@
 module instr_tracer #(
   parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
   parameter type bp_resolve_t = logic,
-  parameter type scoreboard_entry_t = logic,
+  parameter type scoreboard_entry_t = logic[303:0], // Fix for xcelium bug at runtime: does not have enough memory space reserved for scoreboard_entry
   parameter type interrupts_t = logic,
   parameter type exception_t = logic,
   parameter interrupts_t INTERRUPTS = '0

--- a/common/local/util/sram.sv
+++ b/common/local/util/sram.sv
@@ -106,8 +106,8 @@ end
           // synthesis translate_off
           begin: i_tc_sram_wrapper_user
             begin: i_tc_sram
-              logic init_val;
               localparam type data_t = logic [63:0];
+              data_t init_val [0:0];
               data_t sram [NUM_WORDS-1:0] /* verilator public_flat */;
             end
           end

--- a/core/cache_subsystem/cva6_hpdcache_wrapper.sv
+++ b/core/cache_subsystem/cva6_hpdcache_wrapper.sv
@@ -17,7 +17,7 @@ module cva6_hpdcache_wrapper
 //  {{{
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
-    parameter hpdcache_pkg::hpdcache_cfg_t HPDcacheCfg,
+    parameter hpdcache_pkg::hpdcache_cfg_t HPDcacheCfg = '0,
     parameter type dcache_req_i_t = logic,
     parameter type dcache_req_o_t = logic,
     parameter int NumPorts = 4,


### PR DESCRIPTION
This PR provides several fixes that allow Xcelium Cadence simulator to compile.

It provided the followings fixes:
- init_val data_type in sram
- size of scoreboard parameter for trace: at run time, not enough memory is dedicated (get trace output clean)
- init hpdcache config in parameter type

Nevertheless, this PR is not enough to launch cva6.py with xrun-uvm or xrun-testharness DV_SIMULATOR. Further PRs will follow.

It contributes to task https://github.com/openhwgroup/cva6/issues/1829