### PR TITLE
cv64a6_mmu: add RISC-V ISA documentation to main page

### DIFF
--- a/docs/06_cv64a6_mmu/index.rst
+++ b/docs/06_cv64a6_mmu/index.rst
@@ -1,4 +1,4 @@
-CV32A65X documentation
+CV64A6_MMU documentation
 ======================
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,5 +69,5 @@ The :doc:`CVA6 APU <05_cva6_apu/index>` describes an Application Processor Unit 
    01_cva6_user/index.rst
    03_cva6_design/index.rst
    04_cv32a65x/index.rst
+   06_cv64a6_mmu/index.rst
    05_cva6_apu/index.rst
-


### PR DESCRIPTION
This PR adds the RISC-V Instruction Set Manual tailored for cv64a6_mmu.