### PR TITLE
[riscv-config] Update PMP definitions in cv32q65x spec

### DIFF
--- a/config/gen_from_riscv_config/scripts/libs/utils.py
+++ b/config/gen_from_riscv_config/scripts/libs/utils.py
@@ -454,11 +454,7 @@ This allows to clearly represent read-write registers holding a single legal val
                         field.name.upper(),
                         field.fieldreset,
                         field.fieldaccess,
-                        (
-                            Render.bitmask(field.andMask, field.orMask)
-                            if field.andMask and field.orMask
-                            else field.bitlegal
-                        ),
+                        field.bitlegal,
                     ]
                     _line.append(field.fieldDesc)
                     reg_table.append(_line)
@@ -1014,9 +1010,11 @@ class CsrParser:
                                     if matches:
                                         expr_type = str(matches.group(2))
                                         if expr_type == "bitmask":
-                                            # legal_value is left at default, cf. Render.bitmask().
                                             andMask = str(matches.group(4))
                                             orMask = str(matches.group(5))
+                                            legal_value = Render.bitmask(
+                                                andMask, orMask
+                                            )
                                         elif expr_type == "in":
                                             if matches.group(3).find(",") >= 0:
                                                 # list ==> set of values

--- a/config/riscv-config/cv32a65x/generated/isa_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/isa_gen.yaml
@@ -2378,12 +2378,7 @@ hart0:
             pmp8cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp8cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2392,12 +2387,7 @@ hart0:
             pmp9cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp9cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2406,12 +2396,7 @@ hart0:
             pmp10cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp10cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2420,12 +2405,7 @@ hart0:
             pmp11cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp11cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2448,12 +2428,7 @@ hart0:
             pmp12cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp12cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2462,12 +2437,7 @@ hart0:
             pmp13cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp13cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2476,12 +2446,7 @@ hart0:
             pmp14cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp14cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2490,12 +2455,7 @@ hart0:
             pmp15cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp15cfg[7:0] in [0x00:0xFF]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2514,7 +2474,48 @@ hart0:
         priv_mode: M
     pmpcfg4:
         rv32:
-            accessible: false
+            accessible: true
+            pmp16cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp17cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp18cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp19cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp16cfg
+              - pmp17cfg
+              - pmp18cfg
+              - pmp19cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2523,7 +2524,48 @@ hart0:
         priv_mode: M
     pmpcfg5:
         rv32:
-            accessible: false
+            accessible: true
+            pmp20cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp21cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp22cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp23cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp20cfg
+              - pmp21cfg
+              - pmp22cfg
+              - pmp23cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2532,7 +2574,48 @@ hart0:
         priv_mode: M
     pmpcfg6:
         rv32:
-            accessible: false
+            accessible: true
+            pmp24cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp25cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp26cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp27cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp24cfg
+              - pmp25cfg
+              - pmp26cfg
+              - pmp27cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2541,7 +2624,48 @@ hart0:
         priv_mode: M
     pmpcfg7:
         rv32:
-            accessible: false
+            accessible: true
+            pmp28cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp29cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp30cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp31cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp28cfg
+              - pmp29cfg
+              - pmp30cfg
+              - pmp31cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2550,7 +2674,48 @@ hart0:
         priv_mode: M
     pmpcfg8:
         rv32:
-            accessible: false
+            accessible: true
+            pmp32cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp33cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp34cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp35cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp32cfg
+              - pmp33cfg
+              - pmp34cfg
+              - pmp35cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2559,7 +2724,48 @@ hart0:
         priv_mode: M
     pmpcfg9:
         rv32:
-            accessible: false
+            accessible: true
+            pmp36cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp37cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp38cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp39cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp36cfg
+              - pmp37cfg
+              - pmp38cfg
+              - pmp39cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2568,7 +2774,48 @@ hart0:
         priv_mode: M
     pmpcfg10:
         rv32:
-            accessible: false
+            accessible: true
+            pmp40cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp41cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp42cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp43cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp40cfg
+              - pmp41cfg
+              - pmp42cfg
+              - pmp43cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2577,7 +2824,48 @@ hart0:
         priv_mode: M
     pmpcfg11:
         rv32:
-            accessible: false
+            accessible: true
+            pmp44cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp45cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp46cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp47cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp44cfg
+              - pmp45cfg
+              - pmp46cfg
+              - pmp47cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2586,7 +2874,48 @@ hart0:
         priv_mode: M
     pmpcfg12:
         rv32:
-            accessible: false
+            accessible: true
+            pmp48cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp49cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp50cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp51cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp48cfg
+              - pmp49cfg
+              - pmp50cfg
+              - pmp51cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2595,7 +2924,48 @@ hart0:
         priv_mode: M
     pmpcfg13:
         rv32:
-            accessible: false
+            accessible: true
+            pmp52cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp53cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp54cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp55cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp52cfg
+              - pmp53cfg
+              - pmp54cfg
+              - pmp55cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2604,7 +2974,48 @@ hart0:
         priv_mode: M
     pmpcfg14:
         rv32:
-            accessible: false
+            accessible: true
+            pmp56cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp57cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp58cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp59cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp56cfg
+              - pmp57cfg
+              - pmp58cfg
+              - pmp59cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -2613,7 +3024,48 @@ hart0:
         priv_mode: M
     pmpcfg15:
         rv32:
-            accessible: false
+            accessible: true
+            pmp60cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 7
+                lsb: 0
+            pmp61cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 15
+                lsb: 8
+            pmp62cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 23
+                lsb: 16
+            pmp63cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+                description: pmp configuration bits
+                shadow:
+                shadow_type: rw
+                msb: 31
+                lsb: 24
+            fields:
+              - pmp60cfg
+              - pmp61cfg
+              - pmp62cfg
+              - pmp63cfg
         rv64:
             accessible: false
         reset-val: 0
@@ -3004,7 +3456,14 @@ hart0:
         priv_mode: M
     pmpaddr16:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3013,7 +3472,14 @@ hart0:
         priv_mode: M
     pmpaddr17:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3022,7 +3488,14 @@ hart0:
         priv_mode: M
     pmpaddr18:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3031,7 +3504,14 @@ hart0:
         priv_mode: M
     pmpaddr19:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3040,7 +3520,14 @@ hart0:
         priv_mode: M
     pmpaddr20:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3049,7 +3536,14 @@ hart0:
         priv_mode: M
     pmpaddr21:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3058,7 +3552,14 @@ hart0:
         priv_mode: M
     pmpaddr22:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3067,7 +3568,14 @@ hart0:
         priv_mode: M
     pmpaddr23:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3076,7 +3584,14 @@ hart0:
         priv_mode: M
     pmpaddr24:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3085,7 +3600,14 @@ hart0:
         priv_mode: M
     pmpaddr25:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3094,7 +3616,14 @@ hart0:
         priv_mode: M
     pmpaddr26:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3103,7 +3632,14 @@ hart0:
         priv_mode: M
     pmpaddr27:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3112,7 +3648,14 @@ hart0:
         priv_mode: M
     pmpaddr28:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3121,7 +3664,14 @@ hart0:
         priv_mode: M
     pmpaddr29:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3130,7 +3680,14 @@ hart0:
         priv_mode: M
     pmpaddr30:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3139,7 +3696,14 @@ hart0:
         priv_mode: M
     pmpaddr31:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3148,7 +3712,14 @@ hart0:
         priv_mode: M
     pmpaddr32:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3157,7 +3728,14 @@ hart0:
         priv_mode: M
     pmpaddr33:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3166,7 +3744,14 @@ hart0:
         priv_mode: M
     pmpaddr34:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3175,7 +3760,14 @@ hart0:
         priv_mode: M
     pmpaddr35:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3184,7 +3776,14 @@ hart0:
         priv_mode: M
     pmpaddr36:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3193,7 +3792,14 @@ hart0:
         priv_mode: M
     pmpaddr37:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3202,7 +3808,14 @@ hart0:
         priv_mode: M
     pmpaddr38:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3211,7 +3824,14 @@ hart0:
         priv_mode: M
     pmpaddr39:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3220,7 +3840,14 @@ hart0:
         priv_mode: M
     pmpaddr40:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3229,7 +3856,14 @@ hart0:
         priv_mode: M
     pmpaddr41:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3238,7 +3872,14 @@ hart0:
         priv_mode: M
     pmpaddr42:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3247,7 +3888,14 @@ hart0:
         priv_mode: M
     pmpaddr43:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3256,7 +3904,14 @@ hart0:
         priv_mode: M
     pmpaddr44:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3265,7 +3920,14 @@ hart0:
         priv_mode: M
     pmpaddr45:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3274,7 +3936,14 @@ hart0:
         priv_mode: M
     pmpaddr46:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3283,7 +3952,14 @@ hart0:
         priv_mode: M
     pmpaddr47:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3292,7 +3968,14 @@ hart0:
         priv_mode: M
     pmpaddr48:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3301,7 +3984,14 @@ hart0:
         priv_mode: M
     pmpaddr49:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3310,7 +4000,14 @@ hart0:
         priv_mode: M
     pmpaddr50:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3319,7 +4016,14 @@ hart0:
         priv_mode: M
     pmpaddr51:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3328,7 +4032,14 @@ hart0:
         priv_mode: M
     pmpaddr52:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3337,7 +4048,14 @@ hart0:
         priv_mode: M
     pmpaddr53:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3346,7 +4064,14 @@ hart0:
         priv_mode: M
     pmpaddr54:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3355,7 +4080,14 @@ hart0:
         priv_mode: M
     pmpaddr55:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3364,7 +4096,14 @@ hart0:
         priv_mode: M
     pmpaddr56:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3373,7 +4112,14 @@ hart0:
         priv_mode: M
     pmpaddr57:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3382,7 +4128,14 @@ hart0:
         priv_mode: M
     pmpaddr58:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3391,7 +4144,14 @@ hart0:
         priv_mode: M
     pmpaddr59:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3400,7 +4160,14 @@ hart0:
         priv_mode: M
     pmpaddr60:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3409,7 +4176,14 @@ hart0:
         priv_mode: M
     pmpaddr61:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3418,7 +4192,14 @@ hart0:
         priv_mode: M
     pmpaddr62:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0
@@ -3427,7 +4208,14 @@ hart0:
         priv_mode: M
     pmpaddr63:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
+            fields: []
+            shadow:
+            shadow_type: rw
+            msb: 31
+            lsb: 0
         rv64:
             accessible: false
         reset-val: 0

--- a/config/riscv-config/cv32a65x/generated/isa_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/isa_gen.yaml
@@ -2241,7 +2241,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp0cfg[7:0] in [0x00:0xFF]
+                          - pmp0cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits
@@ -2255,7 +2255,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp1cfg[7:0] in [0x00:0xFF]
+                          - pmp1cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits
@@ -2269,7 +2269,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp2cfg[7:0] in [0x00:0xFF]
+                          - pmp2cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits
@@ -2283,7 +2283,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp3cfg[7:0] in [0x00:0xFF]
+                          - pmp3cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits
@@ -2311,7 +2311,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp4cfg[7:0] in [0x00:0xFF]
+                          - pmp4cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits
@@ -2325,7 +2325,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp5cfg[7:0] in [0x00:0xFF]
+                          - pmp5cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits
@@ -2339,7 +2339,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp6cfg[7:0] in [0x00:0xFF]
+                          - pmp6cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits
@@ -2353,7 +2353,7 @@ hart0:
                     warl:
                         dependency_fields: []
                         legal:
-                          - pmp7cfg[7:0] in [0x00:0xFF]
+                          - pmp7cfg[7:0] bitmask [0x8f, 0x0]
                         wr_illegal:
                           - unchanged
                 description: pmp configuration bits

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -1003,7 +1003,7 @@ hart0: &hart0
                          - unchanged 
             pmp1cfg:
                 implemented: true
-                type: 
+                type:
                     warl:
                        dependency_fields: []
                        legal:
@@ -1012,7 +1012,7 @@ hart0: &hart0
                          - unchanged 
             pmp2cfg:
                 implemented: true
-                type: 
+                type:
                     warl:
                        dependency_fields: []
                        legal:
@@ -1021,7 +1021,7 @@ hart0: &hart0
                          - unchanged 
             pmp3cfg:
                 implemented: true
-                type: 
+                type:
                     warl:
                        dependency_fields: []
                        legal:
@@ -1036,7 +1036,7 @@ hart0: &hart0
             accessible: true
             pmp4cfg:
                 implemented: true
-                type: 
+                type:
                     warl:
                        dependency_fields: []
                        legal:
@@ -1045,7 +1045,7 @@ hart0: &hart0
                          - unchanged 
             pmp5cfg:
                 implemented: true
-                type: 
+                type:
                     warl:
                        dependency_fields: []
                        legal:
@@ -1054,7 +1054,7 @@ hart0: &hart0
                          - unchanged 
             pmp6cfg:
                 implemented: true
-                type: 
+                type:
                     warl:
                        dependency_fields: []
                        legal:
@@ -1063,7 +1063,7 @@ hart0: &hart0
                          - unchanged 
             pmp7cfg:
                 implemented: true
-                type: 
+                type:
                     warl:
                        dependency_fields: []
                        legal:
@@ -1078,40 +1078,20 @@ hart0: &hart0
             accessible: true
             pmp8cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp8cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
             pmp9cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp9cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
             pmp10cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp10cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
             pmp11cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp11cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1120,119 +1100,291 @@ hart0: &hart0
             accessible: true
             pmp12cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp12cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
             pmp13cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp13cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
             pmp14cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp14cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
             pmp15cfg:
                 implemented: true
-                type: 
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp15cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg4:
         rv32:
-            accessible: false
+            accessible: true
+            pmp16cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp17cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp18cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp19cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg5:
         rv32:
-            accessible: false
+            accessible: true
+            pmp20cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp21cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp22cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp23cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg6:
         rv32:
-            accessible: false
+            accessible: true
+            pmp24cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp25cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp26cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp27cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg7:
         rv32:
-            accessible: false
+            accessible: true
+            pmp28cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp29cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp30cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp31cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg8:
         rv32:
-            accessible: false
+            accessible: true
+            pmp32cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp33cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp34cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp35cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg9:
         rv32:
-            accessible: false
+            accessible: true
+            pmp36cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp37cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp38cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp39cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg10:
         rv32:
-            accessible: false
+            accessible: true
+            pmp40cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp41cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp42cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp43cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg11:
         rv32:
-            accessible: false
+            accessible: true
+            pmp44cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp45cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp46cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp47cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg12:
         rv32:
-            accessible: false
+            accessible: true
+            pmp48cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp49cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp50cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp51cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg13:
         rv32:
-            accessible: false
+            accessible: true
+            pmp52cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp53cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp54cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp55cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg14:
         rv32:
-            accessible: false
+            accessible: true
+            pmp56cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp57cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp58cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp59cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpcfg15:
         rv32:
-            accessible: false
+            accessible: true
+            pmp60cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp61cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp62cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
+            pmp63cfg:
+                implemented: true
+                type:
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   mcycle:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1245,7 +1397,7 @@ hart0: &hart0
   minstret:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1258,7 +1410,7 @@ hart0: &hart0
   mcycleh:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1271,7 +1423,7 @@ hart0: &hart0
   minstreth:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1284,7 +1436,7 @@ hart0: &hart0
   pmpaddr0:
         rv32:
             accessible: true            
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1297,7 +1449,7 @@ hart0: &hart0
   pmpaddr1:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1310,7 +1462,7 @@ hart0: &hart0
   pmpaddr2:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1323,7 +1475,7 @@ hart0: &hart0
   pmpaddr3:
         rv32:
             accessible: true            
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1336,7 +1488,7 @@ hart0: &hart0
   pmpaddr4:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1349,7 +1501,7 @@ hart0: &hart0
   pmpaddr5:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1362,7 +1514,7 @@ hart0: &hart0
   pmpaddr6:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1375,7 +1527,7 @@ hart0: &hart0
   pmpaddr7:
         rv32:
             accessible: true
-            type: 
+            type:
                 warl:
                     dependency_fields: []
                     legal:
@@ -1388,7 +1540,7 @@ hart0: &hart0
   pmpaddr8:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
@@ -1396,7 +1548,7 @@ hart0: &hart0
   pmpaddr9:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
@@ -1404,7 +1556,7 @@ hart0: &hart0
   pmpaddr10:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
@@ -1412,7 +1564,7 @@ hart0: &hart0
   pmpaddr11:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
@@ -1420,7 +1572,7 @@ hart0: &hart0
   pmpaddr12:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
@@ -1428,7 +1580,7 @@ hart0: &hart0
   pmpaddr13:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
@@ -1436,7 +1588,7 @@ hart0: &hart0
   pmpaddr14:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
@@ -1444,296 +1596,392 @@ hart0: &hart0
   pmpaddr15:
         rv32:
             accessible: true
-            type: 
+            type:
                 ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
   pmpaddr16:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr17:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr18:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr19:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr20:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr21:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr22:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr23:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr24:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr25:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr26:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr27:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr28:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr29:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr30:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr31:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr32:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr33:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr34:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr35:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr36:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr37:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr38:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr39:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr40:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr41:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr42:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr43:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr44:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr45:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr46:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr47:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr48:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr49:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr50:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr51:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr52:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr53:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr54:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr55:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr56:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr57:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr58:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr59:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr60:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr61:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr62:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 
   pmpaddr63:
         rv32:
-            accessible: false
+            accessible: true
+            type:
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0 

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -998,7 +998,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp0cfg[7:0] in [0x00:0xFF]
+                         - pmp0cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
             pmp1cfg:
@@ -1007,7 +1007,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp1cfg[7:0] in [0x00:0xFF]
+                         - pmp1cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
             pmp2cfg:
@@ -1016,7 +1016,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp2cfg[7:0] in [0x00:0xFF]
+                         - pmp2cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
             pmp3cfg:
@@ -1025,7 +1025,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp3cfg[7:0] in [0x00:0xFF]
+                         - pmp3cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
         rv64:
@@ -1040,7 +1040,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp4cfg[7:0] in [0x00:0xFF]
+                         - pmp4cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
             pmp5cfg:
@@ -1049,7 +1049,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp5cfg[7:0] in [0x00:0xFF]
+                         - pmp5cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
             pmp6cfg:
@@ -1058,7 +1058,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp6cfg[7:0] in [0x00:0xFF]
+                         - pmp6cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
             pmp7cfg:
@@ -1067,7 +1067,7 @@ hart0: &hart0
                     warl:
                        dependency_fields: []
                        legal:
-                         - pmp7cfg[7:0] in [0x00:0xFF]
+                         - pmp7cfg[7:0] bitmask [0x8f, 0x0]
                        wr_illegal:
                          - unchanged 
         rv64:


### PR DESCRIPTION
Align the specification of the PMPADDRn and PMPCFGn registers of CV32A65X on current design:

- all 64 PMP entries are accessible
- only 8 lowest-numbered entries are modifiable
- PMP entries 8 through 63 are read-only zero.
- bits 6:4 of lowest 8 PMPnCFG fields (located in PMPCFG0 and PMPCFG1) are read-only zero.