### PR TITLE
[riscv-config] Add memory map entry to platform schema and to CV32A65X platform spec.

### DIFF
--- a/config/riscv-config/cv32a65x/generated/platform_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/platform_gen.yaml
@@ -21,6 +21,27 @@ reset:
 mtime:
     implemented: true
     address: 0x20000
+memory_map:
+  -
+    memory_region:
+        name: bootrom
+        base_addr: 0x10000
+        size: 0x10000
+        description: System boot ROM
+        attributes:
+            read_only: true
+            cached: false
+  -
+    memory_region:
+        name: dram
+        base_addr: 0x80000000
+        size: 0x40000000
+        description: System (D)RAM
+        attributes:
+            executable: true
+            cached: true
+            non_idempotent: false
+            read_only: false
 mtimecmp:
     implemented: false
 mtval_condition_writes:

--- a/config/riscv-config/cv32a65x/spec/platform_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/platform_spec.yaml
@@ -21,3 +21,16 @@ reset:
 mtime:
   implemented: True
   address: 0x20000
+memory_map:
+  - memory_region:
+      name: bootrom
+      base_addr: 0x10000
+      size: 0x1000
+      description: System boot ROM
+      attributes:
+        read_only: True
+  - memory_region:
+      name: dram
+      base_addr: 0x80000000
+      size: 0x40000000
+      description: System (D)RAM

--- a/config/riscv-config/cv32a65x/spec/platform_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/platform_spec.yaml
@@ -19,16 +19,17 @@ nmi:
 reset:
   label: reset_vector
 mtime:
-  implemented: True
+  implemented: true
   address: 0x20000
 memory_map:
   - memory_region:
       name: bootrom
       base_addr: 0x10000
-      size: 0x1000
+      size: 0x10000
       description: System boot ROM
       attributes:
-        read_only: True
+        read_only: true
+        cached: false
   - memory_region:
       name: dram
       base_addr: 0x80000000

--- a/vendor/riscv/riscv-config/riscv_config/schemas/schema_platform.yaml
+++ b/vendor/riscv/riscv-config/riscv_config/schemas/schema_platform.yaml
@@ -326,3 +326,69 @@ zicbo_cache_block_sz:
       check_with: cache_block_size
   default:
     implemented: False
+
+###
+#memory_map
+#--------
+#
+# - **Description**: Memory map - list of memory regions with their attributes
+# - **Constraints**:
+#
+#   - All addresses must be non-negative (0 or higher)
+#   - All sizes must be non-negative (0 or higher)
+#
+# - **Examples**:
+#
+#   .. code-block:: yaml
+#
+#     memory_map:
+#       - memory_region:
+#           name: bootrom
+#           base_addr: 0x10000
+#           size: 0x1000
+#           description: System boot ROM
+#           attributes:
+#             read_only: True
+#       - memory_region:
+#           name: dram
+#           base_addr: 0x80000000
+#           size: 0x40000000
+#           description: Main memory
+
+memory_map:
+  type: list
+  schema:
+    type: dict
+    schema:
+      memory_region:
+        type: dict
+        schema:
+          description:
+            type: string
+            default: A homogeneous memory region
+          name:
+            type: string
+            required: True
+          base_addr:
+            type: integer
+            min: 0
+            required: True
+          size:
+            type: integer
+            min: 0
+            required: True
+          attributes:
+            type: dict
+            schema:
+              executable:
+                type: boolean
+              cached:
+                type: boolean
+              non_idempotent:
+                type: boolean
+              read_only:
+                type: boolean
+            default: { executable: True, cached: True, non_idempotent: False, read_only: False }
+            required: True
+        required: True
+    required: True


### PR DESCRIPTION
Extend riscv-config to allow representing memory maps.  Add memory map information to CV32A65X platform spec.