### PR TITLE
docs: more fixes

### DIFF
--- a/config/gen_from_riscv_config/cv32a65x/csr/csr.adoc
+++ b/config/gen_from_riscv_config/cv32a65x/csr/csr.adoc
@@ -292,10 +292,10 @@ Description:: PMP configuration register
 |===
 | Bits | Field Name | Reset Value | Type | Legal Values | Description
 
-| [7:0] | PMP[I*4 +0]CFG | 0x0 | WARL | masked: & 0x8f | 0x0 | pmp configuration bits 
-| [15:8] | PMP[I*4 +1]CFG | 0x0 | WARL | masked: & 0x8f | 0x0 | pmp configuration bits 
-| [23:16] | PMP[I*4 +2]CFG | 0x0 | WARL | masked: & 0x8f | 0x0 | pmp configuration bits 
-| [31:24] | PMP[I*4 +3]CFG | 0x0 | WARL | masked: & 0x8f | 0x0 | pmp configuration bits 
+| [7:0] | PMP[I*4 +0]CFG | 0x0 | WARL | masked: & 0x8f \| 0x0 | pmp configuration bits 
+| [15:8] | PMP[I*4 +1]CFG | 0x0 | WARL | masked: & 0x8f \| 0x0 | pmp configuration bits 
+| [23:16] | PMP[I*4 +2]CFG | 0x0 | WARL | masked: & 0x8f \| 0x0 | pmp configuration bits 
+| [31:24] | PMP[I*4 +3]CFG | 0x0 | WARL | masked: & 0x8f \| 0x0 | pmp configuration bits 
 |===
 
 [[_PMPCFG2-15]]

--- a/config/gen_from_riscv_config/cv32a65x/csr/csr.adoc
+++ b/config/gen_from_riscv_config/cv32a65x/csr/csr.adoc
@@ -82,14 +82,14 @@ Description:: The mstatus register keeps track of and controls the hart's curren
 
 | 0 | UIE | 0x0 | ROCST | 0x0 | Stores the state of the user mode interrupts. 
 | 1 | SIE | 0x0 | ROCST | 0x0 | Stores the state of the supervisor mode interrupts. 
-| 2 | RESERVED_2 | 0x0 | WPRI |  | *Reserved* 
+| 2 | RESERVED_2 | 0x0 | WPRI |  | _Reserved_ 
 | 3 | MIE | 0x0 | WLRL | 0x0 - 0x1 | Stores the state of the machine mode interrupts. 
 | 4 | UPIE | 0x0 | ROCST | 0x0 | Stores the state of the user mode interrupts prior to the trap. 
 | 5 | SPIE | 0x0 | ROCST | 0x0 | Stores the state of the supervisor mode interrupts prior to the trap. 
 | 6 | UBE | 0x0 | ROCST | 0x0 | control the endianness of memory accesses other than instruction fetches for user mode 
 | 7 | MPIE | 0x0 | WLRL | 0x0 - 0x1 | Stores the state of the machine mode interrupts prior to the trap. 
 | 8 | SPP | 0x0 | ROCST | 0x0 | Stores the previous priority mode for supervisor. 
-| [10:9] | RESERVED_9 | 0x0 | WPRI |  | *Reserved* 
+| [10:9] | RESERVED_9 | 0x0 | WPRI |  | _Reserved_ 
 | [12:11] | MPP | 0x3 | WARL | 0x3 | Stores the previous priority mode for machine. 
 | [14:13] | FS | 0x0 | ROCST | 0x0 | Encodes the status of the floating-point unit, including the CSR fcsr and floating-point data registers. 
 | [16:15] | XS | 0x0 | ROCST | 0x0 | Encodes the status of additional user-mode extensions and associated state. 
@@ -100,7 +100,7 @@ Description:: The mstatus register keeps track of and controls the hart's curren
 | 21 | TW | 0x0 | ROCST | 0x0 | Supports intercepting the WFI instruction. 
 | 22 | TSR | 0x0 | ROCST | 0x0 | Supports intercepting the supervisor exception return instruction. 
 | 23 | SPELP | 0x0 | ROCST | 0x0 | Supervisor mode previous expected-landing-pad (ELP) state. 
-| [30:24] | RESERVED_24 | 0x0 | WPRI |  | *Reserved* 
+| [30:24] | RESERVED_24 | 0x0 | WPRI |  | _Reserved_ 
 | 31 | SD | 0x0 | ROCST | 0x0 | Read-only bit that summarizes whether either the FS field or XS field signals the presence of some dirty state. 
 |===
 
@@ -116,7 +116,7 @@ Description:: misa is a read-write register reporting the ISA supported by the h
 | Bits | Field Name | Reset Value | Type | Legal Values | Description
 
 | [25:0] | EXTENSIONS | 0x1106 | ROCST | 0x1106 | Encodes the presence of the standard extensions, with a single bit per letter of the alphabet. 
-| [29:26] | RESERVED_26 | 0x0 | WPRI |  | *Reserved* 
+| [29:26] | RESERVED_26 | 0x0 | WPRI |  | _Reserved_ 
 | [31:30] | MXL | 0x1 | WARL | 0x1 | Encodes the native base integer ISA width. 
 |===
 
@@ -144,7 +144,7 @@ Description:: The mie register is an MXLEN-bit read/write register containing in
 | 10 | VSEIE | 0x0 | ROCST | 0x0 | VS-level External Interrupt enable. 
 | 11 | MEIE | 0x0 | WLRL | 0x0 - 0x1 | Machine External Interrupt enable. 
 | 12 | SGEIE | 0x0 | ROCST | 0x0 | HS-level External Interrupt enable. 
-| [31:13] | RESERVED_13 | 0x0 | WPRI |  | *Reserved* 
+| [31:13] | RESERVED_13 | 0x0 | WPRI |  | _Reserved_ 
 |===
 
 [[_MTVEC]]
@@ -173,14 +173,14 @@ Description:: The mstatush register keeps track of and controls the hart’s cur
 |===
 | Bits | Field Name | Reset Value | Type | Legal Values | Description
 
-| [3:0] | RESERVED_0 | 0x0 | WPRI |  | *Reserved* 
+| [3:0] | RESERVED_0 | 0x0 | WPRI |  | _Reserved_ 
 | 4 | SBE | 0x0 | ROCST | 0x0 | control the endianness of memory accesses other than instruction fetches for supervisor mode 
 | 5 | MBE | 0x0 | ROCST | 0x0 | control the endianness of memory accesses other than instruction fetches for machine mode 
 | 6 | GVA | 0x0 | ROCST | 0x0 | Stores the state of the supervisor mode interrupts. 
 | 7 | MPV | 0x0 | ROCST | 0x0 | Stores the state of the user mode interrupts. 
-| 8 | RESERVED_8 | 0x0 | WPRI |  | *Reserved* 
+| 8 | RESERVED_8 | 0x0 | WPRI |  | _Reserved_ 
 | 9 | MPELP | 0x0 | ROCST | 0x0 | Machine mode previous expected-landing-pad (ELP) state. 
-| [31:10] | RESERVED_10 | 0x0 | WPRI |  | *Reserved* 
+| [31:10] | RESERVED_10 | 0x0 | WPRI |  | _Reserved_ 
 |===
 
 [[_MHPMEVENT3-31]]
@@ -278,7 +278,7 @@ Description:: The mip register is an MXLEN-bit read/write register containing in
 | 10 | VSEIP | 0x0 | ROCST | 0x0 | VS-level External Interrupt Pending. 
 | 11 | MEIP | 0x0 | ROVAR | 0x0 - 0x1 | Machine External Interrupt Pending. 
 | 12 | SGEIP | 0x0 | ROCST | 0x0 | HS-level External Interrupt Pending. 
-| [31:13] | RESERVED_13 | 0x0 | WPRI |  | *Reserved* 
+| [31:13] | RESERVED_13 | 0x0 | WPRI |  | _Reserved_ 
 |===
 
 [[_PMPCFG0-1]]
@@ -355,7 +355,7 @@ Description:: the register controls the operation of the i-cache unit.
 | Bits | Field Name | Reset Value | Type | Legal Values | Description
 
 | 0 | ICACHE | 0x1 | RW | 0x1 | bit for cache-enable of instruction cache 
-| [31:1] | RESERVED_1 | 0x0 | WPRI |  | *Reserved* 
+| [31:1] | RESERVED_1 | 0x0 | WPRI |  | _Reserved_ 
 |===
 
 [[_DCACHE]]
@@ -370,7 +370,7 @@ Description:: the register controls the operation of the d-cache unit.
 | Bits | Field Name | Reset Value | Type | Legal Values | Description
 
 | 0 | DCACHE | 0x1 | RW | 0x1 | bit for cache-enable of data cache 
-| [31:1] | RESERVED_1 | 0x0 | WPRI |  | *Reserved* 
+| [31:1] | RESERVED_1 | 0x0 | WPRI |  | _Reserved_ 
 |===
 
 [[_MCYCLE]]

--- a/config/gen_from_riscv_config/scripts/libs/utils.py
+++ b/config/gen_from_riscv_config/scripts/libs/utils.py
@@ -552,7 +552,7 @@ class AdocAddressBlock(AddressBlockClass):
             return "RO"
         else:
             return "RW"
-        
+
     def generate_label(self, name):
         return "_" + name.replace('[','').replace(']','').upper()
 
@@ -573,24 +573,24 @@ class AdocAddressBlock(AddressBlockClass):
         r += "  SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1\n"
         r += "  Author: Abdessamii Oukalrazqou\n"
         r += "////\n\n"
-        
+
         r += "=== %s\n\n"%self.name
         r += "==== Conventions\n\n"
-        
+
         r += "In the subsequent sections, register fields are labeled with one of the following abbreviations:\n\n"
-        
+
         r += "* WPRI (Writes Preserve Values, Reads Ignore Values): read/write field reserved\n"
         r += "for future use.  For forward compatibility, implementations that do not\n"
         r += "furnish these fields must make them read-only zero.\n"
-        
+
         r += "* WLRL (Write/Read Only Legal Values): read/write CSR field that specifies\n"
         r += "behavior for only a subset of possible bit encodings, with other bit encodings\n"
         r += "reserved.\n"
-        
+
         r += "* WARL (Write Any Values, Reads Legal Values): read/write CSR fields which are\n"
         r += "only defined for a subset of bit encodings, but allow any value to be written\n"
         r += "while guaranteeing to return a legal value whenever read.\n"
-       
+
         r += "* ROCST (Read-Only Constant): A special case of WARL field which admits only one\n"
         r += "legal value, and therefore, behaves as a constant field that silently ignores\n"
         r += "writes.\n"
@@ -598,12 +598,12 @@ class AdocAddressBlock(AddressBlockClass):
         r += "* ROVAR (Read-Only Variable): A special case of WARL field which can take\n"
         r += "multiple legal values but cannot be modified by software and depends only on\n"
         r += "the architectural state of the hart.\n\n"
-        
+
         r += "In particular, a register that is not internally divided\n"
         r += "into multiple fields can be considered as containing a single field of XLEN bits.\n"
         r += "This allows to clearly represent read-write registers holding a single legal value\n"
         r += "(typically zero).\n\n"
-        
+
         r += "==== Register Summary\n\n"
 
         r += "|===\n"
@@ -629,7 +629,7 @@ class AdocAddressBlock(AddressBlockClass):
                     # RO/RW privileges are encoded in register address.
                     r += "Privilege:: %s\n"%(reg.access + self.get_access_privilege(reg))
                     r += "Description:: %s\n\n"%(reg.desc)
-                    
+
                 reg_table = []
                 for field in reg.field:
                     if field.bitWidth == 1:  # only one bit -> no range needed
@@ -658,10 +658,10 @@ class AdocAddressBlock(AddressBlockClass):
                 r += "| Bits | Field Name | Reset Value | Type | Legal Values | Description\n\n"
                 for reg in reg_table:
                     for col in reg:
-                        r +="| %s "%col.replace('\n','')
+                        r +="| %s "%col.replace('\n','').replace('|', '\|')
                     r += "\n"
                 r += "|===\n\n"
-                        
+
         return r
 
 class InstadocBlock(InstructionBlockClass):
@@ -678,7 +678,7 @@ class InstadocBlock(InstructionBlockClass):
         InstrNameList = [reg.key for reg in self.Instructionlist]
         InstrDescrList = [reg.descr for reg in self.Instructionlist]
         InstrExtList = [reg.Extension_Name for reg in self.Instructionlist]
-        
+
         r += "////\n"
         r += "  Copyright (c) 2024 OpenHW Group\n"
         r += "  Copyright (c) 2024 Thales\n"
@@ -688,7 +688,7 @@ class InstadocBlock(InstructionBlockClass):
 
         r += "=== %s\n\n"%self.name
         r += "==== Instructions\n\n"
-            
+
         r += "|===\n"
         r += "|Subset Name | Name | Description\n\n"
         for i, _ in enumerate(InstrNameList):
@@ -696,7 +696,7 @@ class InstadocBlock(InstructionBlockClass):
                     str(InstrNameList[i]),
                     str(InstrDescrList[i]).replace('\n',''))
         r += "|===\n\n"
-                    
+
         for reg in self.Instructionlist:
             reg_table = []
             if len(reg.Name) > 0:

--- a/config/gen_from_riscv_config/scripts/libs/utils.py
+++ b/config/gen_from_riscv_config/scripts/libs/utils.py
@@ -658,6 +658,8 @@ class AdocAddressBlock(AddressBlockClass):
                 r += "| Bits | Field Name | Reset Value | Type | Legal Values | Description\n\n"
                 for reg in reg_table:
                     for col in reg:
+                        if col == 'Reserved':
+                            col = "_Reserved_"
                         r +="| %s "%col.replace('\n','').replace('|', '\|')
                     r += "\n"
                 r += "|===\n\n"
@@ -1106,7 +1108,7 @@ class CsrParser:
                         legal = ""
                         fieldaccess = "WPRI"
                         bitWidth = int(item_[len(item_) - 1]) - int(item_[0]) + 1
-                        fieldDesc = "*Reserved*"
+                        fieldDesc = "Reserved"
                         bitlegal = legal
                         fieldreset = hex(
                             int(resetValue, 16) >> (bitlsb) & ((1 << ((bitWidth))) - 1)

--- a/docs/04_cv32a65x/design/design-cv32a65x.html
+++ b/docs/04_cv32a65x/design/design-cv32a65x.html
@@ -3540,7 +3540,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
@@ -3596,7 +3596,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[12:11]</p></td>
@@ -3684,7 +3684,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">31</p></td>
@@ -3753,7 +3753,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[31:30]</p></td>
@@ -3918,7 +3918,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -4032,7 +4032,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
@@ -4072,7 +4072,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">9</p></td>
@@ -4088,7 +4088,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -4518,7 +4518,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -4839,7 +4839,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -4900,7 +4900,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WPRI</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Reserved</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Reserved</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -13091,7 +13091,7 @@ by 4</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-26 14:42:57 +0200
+Last updated 2024-07-26 16:50:22 +0200
 </div>
 </div>
 </body>

--- a/docs/04_cv32a65x/design/design-cv32a65x.html
+++ b/docs/04_cv32a65x/design/design-cv32a65x.html
@@ -511,21 +511,23 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_MCAUSE">3.4.3.9. MCAUSE</a></li>
 <li><a href="#_MTVAL">3.4.3.10. MTVAL</a></li>
 <li><a href="#_MIP">3.4.3.11. MIP</a></li>
-<li><a href="#_PMPCFG0-3">3.4.3.12. PMPCFG[0-3]</a></li>
-<li><a href="#_PMPADDR0-15">3.4.3.13. PMPADDR[0-15]</a></li>
-<li><a href="#_ICACHE">3.4.3.14. ICACHE</a></li>
-<li><a href="#_DCACHE">3.4.3.15. DCACHE</a></li>
-<li><a href="#_MCYCLE">3.4.3.16. MCYCLE</a></li>
-<li><a href="#_MINSTRET">3.4.3.17. MINSTRET</a></li>
-<li><a href="#_MHPMCOUNTER3-31">3.4.3.18. MHPMCOUNTER[3-31]</a></li>
-<li><a href="#_MCYCLEH">3.4.3.19. MCYCLEH</a></li>
-<li><a href="#_MINSTRETH">3.4.3.20. MINSTRETH</a></li>
-<li><a href="#_MHPMCOUNTER3-31H">3.4.3.21. MHPMCOUNTER[3-31]H</a></li>
-<li><a href="#_MVENDORID">3.4.3.22. MVENDORID</a></li>
-<li><a href="#_MARCHID">3.4.3.23. MARCHID</a></li>
-<li><a href="#_MIMPID">3.4.3.24. MIMPID</a></li>
-<li><a href="#_MHARTID">3.4.3.25. MHARTID</a></li>
-<li><a href="#_MCONFIGPTR">3.4.3.26. MCONFIGPTR</a></li>
+<li><a href="#_PMPCFG0-1">3.4.3.12. PMPCFG[0-1]</a></li>
+<li><a href="#_PMPCFG2-15">3.4.3.13. PMPCFG[2-15]</a></li>
+<li><a href="#_PMPADDR0-7">3.4.3.14. PMPADDR[0-7]</a></li>
+<li><a href="#_PMPADDR8-63">3.4.3.15. PMPADDR[8-63]</a></li>
+<li><a href="#_ICACHE">3.4.3.16. ICACHE</a></li>
+<li><a href="#_DCACHE">3.4.3.17. DCACHE</a></li>
+<li><a href="#_MCYCLE">3.4.3.18. MCYCLE</a></li>
+<li><a href="#_MINSTRET">3.4.3.19. MINSTRET</a></li>
+<li><a href="#_MHPMCOUNTER3-31">3.4.3.20. MHPMCOUNTER[3-31]</a></li>
+<li><a href="#_MCYCLEH">3.4.3.21. MCYCLEH</a></li>
+<li><a href="#_MINSTRETH">3.4.3.22. MINSTRETH</a></li>
+<li><a href="#_MHPMCOUNTER3-31H">3.4.3.23. MHPMCOUNTER[3-31]H</a></li>
+<li><a href="#_MVENDORID">3.4.3.24. MVENDORID</a></li>
+<li><a href="#_MARCHID">3.4.3.25. MARCHID</a></li>
+<li><a href="#_MIMPID">3.4.3.26. MIMPID</a></li>
+<li><a href="#_MHARTID">3.4.3.27. MHARTID</a></li>
+<li><a href="#_MCONFIGPTR">3.4.3.28. MCONFIGPTR</a></li>
 </ul>
 </li>
 </ul>
@@ -3368,14 +3370,26 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">The mip register is an MXLEN-bit read/write register containing information on pending interrupts.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x3a0-0x3a3</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code><a href="#_PMPCFG0-3">PMPCFG[0-3]</a></code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3a0-0x3a1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><a href="#_PMPCFG0-1">PMPCFG[0-1]</a></code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">MRW</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">PMP configuration register</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x3b0-0x3bf</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code><a href="#_PMPADDR0-15">PMPADDR[0-15]</a></code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3a2-0x3af</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><a href="#_PMPCFG2-15">PMPCFG[2-15]</a></code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MRW</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP configuration register</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3b0-0x3b7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><a href="#_PMPADDR0-7">PMPADDR[0-7]</a></code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MRW</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Physical memory protection address register</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3b8-0x3ef</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><a href="#_PMPADDR8-63">PMPADDR[8-63]</a></code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">MRW</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Physical memory protection address register</p></td>
 </tr>
@@ -3533,7 +3547,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MIE</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WLRL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0 - 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0 - 0x1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Stores the state of the machine mode interrupts.</p></td>
 </tr>
 <tr>
@@ -3565,7 +3579,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MPIE</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WLRL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0 - 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0 - 0x1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Stores the state of the machine mode interrupts prior to the trap.</p></td>
 </tr>
 <tr>
@@ -3855,7 +3869,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MTIE</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WLRL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0 - 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0 - 0x1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Machine Timer Interrupt enable.</p></td>
 </tr>
 <tr>
@@ -3887,7 +3901,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MEIE</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WLRL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0 - 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0 - 0x1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Machine External Interrupt enable.</p></td>
 </tr>
 <tr>
@@ -4126,7 +4140,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MHPMEVENT[I]</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The mhpmevent is a MXLEN-bit event register which controls mhpmcounter3.</p></td>
 </tr>
 </tbody>
@@ -4285,7 +4299,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">EXCEPTION_CODE</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WLRL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0 - 15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0 - 0x8, 0xb</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Encodes the exception code.</p></td>
 </tr>
 <tr>
@@ -4346,7 +4360,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MTVAL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The mtval is a warl register that holds the address of the instruction which caused the exception.</p></td>
 </tr>
 </tbody>
@@ -4455,7 +4469,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MTIP</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROVAR</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0 - 0x1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Machine Timer Interrupt Pending.</p></td>
 </tr>
 <tr>
@@ -4487,7 +4501,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MEIP</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROVAR</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0 - 0x1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Machine External Interrupt Pending.</p></td>
 </tr>
 <tr>
@@ -4510,12 +4524,12 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_PMPCFG0-3">3.4.3.12. PMPCFG[0-3]</h5>
+<h5 id="_PMPCFG0-1">3.4.3.12. PMPCFG[0-1]</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
 <dd>
-<p>0x3a0-0x3a3</p>
+<p>0x3a0-0x3a1</p>
 </dd>
 <dt class="hdlist1">Reset Value</dt>
 <dd>
@@ -4553,46 +4567,123 @@ This allows to clearly represent read-write registers holding a single legal val
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[7:0]</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 + 0]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +0]CFG</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WARL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00 - 0xFF</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">masked: &amp; 0x8f | 0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[15:8]</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 + 1]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +1]CFG</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WARL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00 - 0xFF</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">masked: &amp; 0x8f | 0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[23:16]</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 + 2]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +2]CFG</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WARL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00 - 0xFF</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">masked: &amp; 0x8f | 0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">[31:24]</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 + 3]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +3]CFG</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">WARL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00 - 0xFF</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">masked: &amp; 0x8f | 0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_PMPADDR0-15">3.4.3.13. PMPADDR[0-15]</h5>
+<h5 id="_PMPCFG2-15">3.4.3.13. PMPCFG[2-15]</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
 <dd>
-<p>0x3b0-0x3bf</p>
+<p>0x3a2-0x3af</p>
+</dd>
+<dt class="hdlist1">Reset Value</dt>
+<dd>
+<p>0x00000000</p>
+</dd>
+<dt class="hdlist1">Privilege</dt>
+<dd>
+<p>MRW</p>
+</dd>
+<dt class="hdlist1">Description</dt>
+<dd>
+<p>PMP configuration register</p>
+</dd>
+</dl>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Bits</th>
+<th class="tableblock halign-left valign-top">Field Name</th>
+<th class="tableblock halign-left valign-top">Reset Value</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Legal Values</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[7:0]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +0]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[15:8]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +1]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[23:16]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +2]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[31:24]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMP[I*4 +3]CFG</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">pmp configuration bits</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_PMPADDR0-7">3.4.3.14. PMPADDR[0-7]</h5>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Address</dt>
+<dd>
+<p>0x3b0-0x3b7</p>
 </dd>
 <dt class="hdlist1">Reset Value</dt>
 <dd>
@@ -4640,7 +4731,60 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_ICACHE">3.4.3.14. ICACHE</h5>
+<h5 id="_PMPADDR8-63">3.4.3.15. PMPADDR[8-63]</h5>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Address</dt>
+<dd>
+<p>0x3b8-0x3ef</p>
+</dd>
+<dt class="hdlist1">Reset Value</dt>
+<dd>
+<p>0x00000000</p>
+</dd>
+<dt class="hdlist1">Privilege</dt>
+<dd>
+<p>MRW</p>
+</dd>
+<dt class="hdlist1">Description</dt>
+<dd>
+<p>Physical memory protection address register</p>
+</dd>
+</dl>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Bits</th>
+<th class="tableblock halign-left valign-top">Field Name</th>
+<th class="tableblock halign-left valign-top">Reset Value</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Legal Values</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[31:0]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PMPADDR[I]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Physical memory protection address register</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_ICACHE">3.4.3.16. ICACHE</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -4701,7 +4845,7 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_DCACHE">3.4.3.15. DCACHE</h5>
+<h5 id="_DCACHE">3.4.3.17. DCACHE</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -4762,7 +4906,7 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MCYCLE">3.4.3.16. MCYCLE</h5>
+<h5 id="_MCYCLE">3.4.3.18. MCYCLE</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -4815,7 +4959,7 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MINSTRET">3.4.3.17. MINSTRET</h5>
+<h5 id="_MINSTRET">3.4.3.19. MINSTRET</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -4868,7 +5012,7 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MHPMCOUNTER3-31">3.4.3.18. MHPMCOUNTER[3-31]</h5>
+<h5 id="_MHPMCOUNTER3-31">3.4.3.20. MHPMCOUNTER[3-31]</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -4914,14 +5058,14 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MHPMCOUNTER[I]</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The mhpmcounter is a 64-bit counter. Returns lower 32 bits in RV32I mode.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MCYCLEH">3.4.3.19. MCYCLEH</h5>
+<h5 id="_MCYCLEH">3.4.3.21. MCYCLEH</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -4974,7 +5118,7 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MINSTRETH">3.4.3.20. MINSTRETH</h5>
+<h5 id="_MINSTRETH">3.4.3.22. MINSTRETH</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -5027,7 +5171,7 @@ This allows to clearly represent read-write registers holding a single legal val
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MHPMCOUNTER3-31H">3.4.3.21. MHPMCOUNTER[3-31]H</h5>
+<h5 id="_MHPMCOUNTER3-31H">3.4.3.23. MHPMCOUNTER[3-31]H</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -5073,14 +5217,14 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MHPMCOUNTER[I]H</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The mhpmcounterh returns the upper half word in RV32I systems.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MVENDORID">3.4.3.22. MVENDORID</h5>
+<h5 id="_MVENDORID">3.4.3.24. MVENDORID</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -5126,14 +5270,14 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MVENDORID</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000602</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000602</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x602</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">32-bit read-only register providing the JEDEC manufacturer ID of the provider of the core.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MARCHID">3.4.3.23. MARCHID</h5>
+<h5 id="_MARCHID">3.4.3.25. MARCHID</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -5179,14 +5323,14 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MARCHID</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000003</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000003</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">MXLEN-bit read-only register encoding the base microarchitecture of the hart.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MIMPID">3.4.3.24. MIMPID</h5>
+<h5 id="_MIMPID">3.4.3.26. MIMPID</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -5232,14 +5376,14 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MIMPID</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Provides a unique encoding of the version of the processor implementation.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MHARTID">3.4.3.25. MHARTID</h5>
+<h5 id="_MHARTID">3.4.3.27. MHARTID</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -5285,14 +5429,14 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MHARTID</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">MXLEN-bit read-only register containing the integer ID of the hardware thread running the code.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_MCONFIGPTR">3.4.3.26. MCONFIGPTR</h5>
+<h5 id="_MCONFIGPTR">3.4.3.28. MCONFIGPTR</h5>
 <div class="dlist">
 <dl>
 <dt class="hdlist1">Address</dt>
@@ -5338,7 +5482,7 @@ This allows to clearly represent read-write registers holding a single legal val
 <td class="tableblock halign-left valign-top"><p class="tableblock">MCONFIGPTR</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ROCST</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0x00000000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">MXLEN-bit read-only register that holds the physical address of a configuration data structure.</p></td>
 </tr>
 </tbody>
@@ -12947,7 +13091,7 @@ by 4</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-07-26 10:49:21 +0200
+Last updated 2024-07-26 14:42:57 +0200
 </div>
 </div>
 </body>


### PR DESCRIPTION
- Correctly handle pipes in table cells
- Show "reserved" as italic instead of bold