### PR TITLE
fix Spyglass job falsely reporting fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -230,6 +230,7 @@ spyglass:
     - make -C spyglass design_read
     - make -C spyglass lint_check
     - mv spyglass/sg_run_results/cva6_sg_reports/cva6_lint_lint_rtl artifacts/lint_reports
+    - cp spyglass/reference_summary.rpt artifacts/lint_reports
     - python3 .gitlab-ci/scripts/report_spyglass_lint.py spyglass/reference_summary.rpt artifacts/lint_reports/cva6_lint_lint_rtl/summary.rpt
 
 cvxif-regression:

--- a/.gitlab-ci/scripts/report_spyglass_lint.py
+++ b/.gitlab-ci/scripts/report_spyglass_lint.py
@@ -68,7 +68,10 @@ def compare_summaries(baseline_info, new_info):
                 message = (
                     f"Count changed from {baseline_dict[key][0]} to {new_dict[key][0]}"
                 )
-                comparison_results.append((*key, *value, "FAIL", message))
+                if key[0] == "ERROR" and new_dict[key][0] > baseline_dict[key][0]:
+                    comparison_results.append((*key, *value, "FAIL", message))
+                else:
+                    comparison_results.append((*key, *value, "PASS", message))
 
     severity_order = {"ERROR": 1, "WARNING": 2, "INFO": 3}
     comparison_results.sort(key=lambda x: severity_order[x[0]])
@@ -109,7 +112,7 @@ if __name__ == "__main__":
     new_info = extract_info(summary_rpt)
     comparison_results = compare_summaries(baseline_info, new_info)
     report = generate_spyglass_lint_report(comparison_results)
+    print(report.failed)
     report.dump()
-
     if report.failed:
         sys.exit(1)

--- a/.gitlab-ci/scripts/report_spyglass_lint.py
+++ b/.gitlab-ci/scripts/report_spyglass_lint.py
@@ -75,7 +75,7 @@ def compare_summaries(baseline_info, new_info):
     return comparison_results
 
 
-def report_spyglass_lint(comparison_results):
+def generate_spyglass_lint_report(comparison_results):
     metric = rb.TableStatusMetric("")
     metric.add_column("SEVERITY", "text")
     metric.add_column("RULE NAME", "text")
@@ -83,27 +83,19 @@ def report_spyglass_lint(comparison_results):
     metric.add_column("SHORT HELP", "text")
     metric.add_column("DIFF", "text")
 
-    failed_metric = False
-
     for severity, rule_name, count, short_help, check, status in comparison_results:
         line = [severity, rule_name, count, short_help, status]
         if check == "PASS":
             metric.add_pass(*line)
         else:
             metric.add_fail(*line)
-            failed_metric = True
 
     report = rb.Report()
     report.add_metric(metric)
 
-    if failed_metric:
-        report.fail()
-
     for value in metric.values:
         print(" | ".join(map(str, value)))
-    report.dump()
-
-    return not failed_metric
+    return report
 
 
 if __name__ == "__main__":
@@ -116,7 +108,8 @@ if __name__ == "__main__":
     baseline_info = extract_info(summary_ref_results)
     new_info = extract_info(summary_rpt)
     comparison_results = compare_summaries(baseline_info, new_info)
+    report = generate_spyglass_lint_report(comparison_results)
+    report.dump()
 
-    if not report_spyglass_lint(comparison_results):
-        print("Job failed due to differences in summaries")
+    if report.failed:
         sys.exit(1)


### PR DESCRIPTION
since https://github.com/openhwgroup/cva6/commit/12be3adb81ef37f17ef9ac958fec57e4a01a6dcd, it is possible to have a "pass" report but the job will fail because of the diff between the 2 reports (see pipeline 46167 on the [dashboard](https://riscv-ci.pages.thales-invia.fr/dashboard/)).

This fixes it using the report "failed" field instead of running diff.

Also added the reference summary in gitlab artifacts for easier investigation.