### PR TITLE
[Spike tandem] Fix Yaml config files for CV32A65X. Fix Questa tandem. Add workaround for AXI end-of-test asserts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ ifdef preload
 endif
 
 ifdef spike-tandem
-    questa-cmd += -gblso $(SPIKE_INSTALL_DIR)/lib/libriscv.so
+    questa-cmd += -gblso $(SPIKE_INSTALL_DIR)/lib/libyaml-cpp.so -gblso $(SPIKE_INSTALL_DIR)/lib/libriscv.so
 endif
 
 # remote bitbang is enabled

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -8,24 +8,25 @@ spike_param_tree:
   generic_core_config: false
   max_steps: 200000
   max_steps_enabled: false
-  isa: rv32imczicsr_zicntr_zifencei_zcb_zba_zbb_zbc_zbs
+  isa: rv32imczicsr_zcb_zba_zbb_zbc_zbs
   priv: M
-  cores:
-  - isa: rv32imc_zba_zbb_zbs_zbc_zicsr_zifencei
-    boot_addr: 2147483648
-    marchid: 3
-    misa_we: false
-    misa_we_enable: true
-    pmpaddr0: 0
-    pmpcfg0: 0
-    pmpregions: 64
-    usable_pmpregions: 8
-    priv: M
-    status_fs_field_we: false
-    status_fs_field_we_enable: false
-    status_vs_field_we: false
-    status_vs_field_we_enable: false
-    mstatus_write_mask: 136
-    mstatus_override_mask: 6144
-    mtval_write_mask: 0
-    unified_traps: true
+  core_configs:
+    -
+      isa: rv32imc_zba_zbb_zbs_zbc_zicsr
+      boot_addr: 2147483648
+      marchid: 3
+      misa_we: false
+      misa_we_enable: true
+      pmpaddr0: 0
+      pmpcfg0: 0
+      pmpregions: 64
+      usable_pmpregions: 8
+      priv: M
+      status_fs_field_we: false
+      status_fs_field_we_enable: false
+      status_vs_field_we: false
+      status_vs_field_we_enable: false
+      mstatus_write_mask: 136
+      mstatus_override_mask: 6144
+      mtval_write_mask: 0
+      unified_traps: true

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -12,7 +12,7 @@ spike_param_tree:
   priv: M
   core_configs:
     -
-      isa: rv32imc_zba_zbb_zbs_zbc_zicsr
+      isa: rv32imczicsr_zcb_zba_zbb_zbc_zbs
       boot_addr: 2147483648
       marchid: 3
       misa_we: false

--- a/config/riscv-config/cv32a65x/generated/isa_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/isa_gen.yaml
@@ -16,7 +16,7 @@
 
 hart_ids: [0]
 hart0:
-    ISA: RV32IMCZicsr_Zicntr_Zcb_Zba_Zbb_Zbc_Zbs
+    ISA: RV32IMCZicsr_Zcb_Zba_Zbb_Zbc_Zbs
     User_Spec_Version: '2.3'
     supported_xlen:
       - 32

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -16,7 +16,7 @@
 
 hart_ids: [0]
 hart0: &hart0
-  ISA: RV32IMCZicsr_Zicntr_Zcb_Zba_Zbb_Zbc_Zbs
+  ISA: RV32IMCZicsr_Zcb_Zba_Zbb_Zbc_Zbs
   User_Spec_Version: '2.3'
   supported_xlen: [32]
   physical_addr_sz: 32

--- a/verif/regress/install-spike.sh
+++ b/verif/regress/install-spike.sh
@@ -45,8 +45,10 @@ if ! [ -f "$SPIKE_INSTALL_DIR/bin/spike" ]; then
   if [[ ! -z "$BOOST_INSTALL_DIR" ]]; then
       WITH_BOOST="--with-boost=${BOOST_INSTALL_DIR}"
   fi
-  if [[ ! -f config.log ]]; then
+  if [ ! -f config.log ]; then
       ../configure --prefix="$SPIKE_INSTALL_DIR" ${WITH_BOOST}
+  else
+      echo "Spike build dir contains 'config.log', skipping 'configure' step ..."
   fi
   # Build both shared and static versions of the yaml-cpp library in sequence
   # prior to building Spike.

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -66,8 +66,7 @@ spike_yaml ?= $(CVA6_REPO_DIR)/config/gen_from_riscv_config/$(target)/spike/spik
 spike_params_final = $(spike_params)
 ifneq ($(wildcard $(spike_yaml)),)
   spike_params_final := $(spike_params_final) --param-file $(spike_yaml)
-  # TODO Renable yaml plusarg
-  #spike-yaml-plusarg = +config_file=$(CVA6_REPO_DIR)/config/gen_from_riscv_config/$(target)/spike/spike.yaml
+  spike-yaml-plusarg = +config_file=$(spike_yaml)
 endif
 
 ##############################################

--- a/verif/tests/uvmt/compliance-tests/uvmt_cva6_firmware_test.sv
+++ b/verif/tests/uvmt/compliance-tests/uvmt_cva6_firmware_test.sv
@@ -168,9 +168,14 @@ task uvmt_cva6_firmware_test_c::run_phase(uvm_phase phase);
    uvm_config_db#(int)::set(null, "", "test_exit_code", { 0'b0, tb_exit_vif.tb_exit_o[31:1] });
    // Let the termination-triggering instruction appear in the log.
    @(posedge env_cntxt.clknrst_cntxt.vif.clk);
+   // Let all pending AXI requests settle.
+   // FIXME TODO: Insert this delay in AXI agent rather than here,
+   // based on AXI state and latency setting.
+   `uvm_info("TEST", "Running a 100-cycle delay to settle AXI requests...", UVM_NONE);
+   repeat (100) @(posedge env_cntxt.clknrst_cntxt.vif.clk);
+   `uvm_info("TEST", "Running a 100-cycle delay to settle AXI requests... DONE", UVM_NONE);
    // Allow termination from now on.
    phase.drop_objection(this);
-   repeat (100) @(posedge env_cntxt.clknrst_cntxt.vif.clk);
 
 endtask : run_phase
 


### PR DESCRIPTION
Fix incorrect structure of the Spike Yaml file.
Fix ISA strings in riscv-config spec and outputs.
Fix Questa tandem invocation.
Add 100 cycle delay after end of test to settle outstanding AXI requests when using UVM.
