### PR TITLE
[FPGA HOTFIX] Add ariane_peripherals.sv  and ariane_testharness.sv to fpga_filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -726,6 +726,8 @@ fpga_filter += $(addprefix $(root-dir), src/util/instr_trace_item.sv)
 fpga_filter += $(addprefix $(root-dir), common/local/util/instr_tracer.sv)
 fpga_filter += $(addprefix $(root-dir), vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv)
 fpga_filter += $(addprefix $(root-dir), common/local/util/tc_sram_wrapper.sv)
+fpga_filter += $(addprefix $(root-dir), corev_apu/tb/ariane_peripherals.sv)
+fpga_filter += $(addprefix $(root-dir), corev_apu/tb/ariane_testharness.sv)
 
 src/bootrom/bootrom_$(XLEN).sv:
 	$(MAKE) -C corev_apu/fpga/src/bootrom BOARD=$(BOARD) XLEN=$(XLEN) bootrom_$(XLEN).sv


### PR DESCRIPTION
On some Xilinx's Vivado installation, `ariane_peripherals.sv` file is not overwritten by `ariane_peripherals_xilinx.sv` during `update_compile_order -fileset [current_fileset]`
It would make `ariane_xilinx.sv` invalid as a top and `ariane_testharness.sv` would replace it.

I'm removing `ariane_peripherals.sv` and `ariane_testharness.sv` from `add_sources.tcl` given to Vivado to avoid file conflicts.