### PR TITLE
spyglass: remove WRN_1024 warnings

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -110,7 +110,7 @@ module alu
   assign adder_in_b         = operand_b_neg;
 
   // actual adder
-  assign adder_result_ext_o = $unsigned(adder_in_a) + $unsigned(adder_in_b);
+  assign adder_result_ext_o = adder_in_a + adder_in_b;
   assign adder_result       = adder_result_ext_o[CVA6Cfg.XLEN:1];
   assign adder_z_flag       = ~|adder_result;
 

--- a/core/serdiv.sv
+++ b/core/serdiv.sv
@@ -127,7 +127,7 @@ module serdiv
   assign shift_a = (lzc_a_no_one) ? WIDTH : {1'b0, lzc_a_result};
   assign div_shift = {1'b0, lzc_b_result} - shift_a;
 
-  assign op_b = op_b_i <<< $unsigned(div_shift);
+  assign op_b = op_b_i <<< div_shift;
 
   // the division is zero if |opB| > |opA| and can be terminated
   assign div_res_zero_d = (load_en) ? div_shift[$high(div_shift)] : div_res_zero_q;

--- a/spyglass/reference_summary.rpt
+++ b/spyglass/reference_summary.rpt
@@ -5,6 +5,7 @@
 #     Report Name      : summary
 #     Report Created by: asintzoff
 #     Report Created on:  Wed Aug 14 07:46:49 2024
+#     Report Created on:  Wed Aug 14 15:02:57 2024
 #     Working Directory: /home/asintzoff/git-repo/tss/cva6/spyglass
 #     SpyGlass Version : SpyGlass_vS-2021.09-SP2-3
 #     Policy Name      : SpyGlass(SpyGlass_vS-2021.09-SP2-03)
@@ -17,9 +18,9 @@
 #                        starc(SpyGlass_vS-2021.09-SP2-03)
 #                        starc2005(SpyGlass_vS-2021.09-SP2-03)
 #
-#     Total Number of Generated Messages :       1024
+#     Total Number of Generated Messages :       1021
 #     Number of Waived Messages          :        322
-#     Number of Reported Messages        :        702
+#     Number of Reported Messages        :        699
 #     Number of Overlimit Messages       :          0
 #
 #
@@ -67,10 +68,6 @@ WARNING    SYNTH_5064           38    Non-synthesizable statements are
 WARNING    SYNTH_5143           11    Initial block is ignored for synthesis 
 WARNING    SYNTH_89             4     Initial Assignment at Declaration is 
                                       ignored by synthesis. 
-WARNING    WRN_1024             3     Signed argument is passed to $signed 
-                                      system function call, or unsigned 
-                                      argument passed to $unsigned system 
-                                      function call. 
 WARNING    WRN_27               1     Bit-select should not be out-of-range. 
 INFO       DetectTopDesignUnits 1     Identify the top-level design units in 
                                       user design. 


### PR DESCRIPTION
Signed argument is passed to  system function call, or unsigned
argument passed to  system function call.