### PR TITLE
[RVFI] Connect RVFI.intr to enable interrupts on TANDEM

### DIFF
--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -41,6 +41,7 @@ spike_param_tree:
       mvendorid_override_mask : 0xFFFFFFFF
       mvendorid_override_value: 1538
       csr_counters_injection: true
+      interrupts_injection: true
       unified_traps: true
       mcycleh_implemented: false
       mhpmevent31_implemented: false

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -67,6 +67,8 @@ module cva6_rvfi
   logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs1_forwarding;
   logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs2_forwarding;
 
+  logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_intr;
+
   logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.VLEN-1:0] commit_instr_pc;
   fu_op [CVA6Cfg.NrCommitPorts-1:0] commit_instr_op;
   logic [CVA6Cfg.NrCommitPorts-1:0][REG_ADDR_SIZE-1:0] commit_instr_rs1;
@@ -274,14 +276,28 @@ module cva6_rvfi
   always_ff @(posedge clk_i) begin
     for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
       logic exception;
+      logic valid;
       exception = (i == 0) && commit_instr_valid[i] && ex_commit_valid && !commit_drop[i];
-      rvfi_instr_o[i].valid    <= (commit_ack[i] && !ex_commit_valid && !commit_drop[i]) ||
+      valid     = (commit_ack[i] && !ex_commit_valid && !commit_drop[i]) ||
         (exception && (ex_commit_cause == riscv::ENV_CALL_MMODE ||
                   ex_commit_cause == riscv::ENV_CALL_SMODE ||
                   ex_commit_cause == riscv::ENV_CALL_UMODE));
+      rvfi_instr_o[i].valid <= valid;
       rvfi_instr_o[i].insn <= mem_q[commit_pointer[i]].instr;
       // when trap, the instruction is not executed
       rvfi_instr_o[i].trap <= exception;
+
+      if (exception && ex_commit_cause[31]) begin
+        rvfi_intr[i] <= 'b101;
+      end else if (exception) begin
+        rvfi_intr[i] <= 'b11;
+      end
+      if (valid) begin
+        rvfi_intr[i] <= 0;
+      end
+
+      rvfi_instr_o[i].intr <= rvfi_intr[i];
+
       rvfi_instr_o[i].cause <= ex_commit_cause;
       rvfi_instr_o[i].mode <= (CVA6Cfg.DebugEn && debug_mode) ? 2'b10 : priv_lvl;
       rvfi_instr_o[i].ixl <= CVA6Cfg.XLEN == 64 ? 2 : 1;

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -283,9 +283,9 @@ module cva6_rvfi
                   ex_commit_cause == riscv::ENV_CALL_SMODE ||
                   ex_commit_cause == riscv::ENV_CALL_UMODE));
       rvfi_instr_o[i].valid <= valid;
-      rvfi_instr_o[i].insn <= mem_q[commit_pointer[i]].instr;
+      rvfi_instr_o[i].insn  <= mem_q[commit_pointer[i]].instr;
       // when trap, the instruction is not executed
-      rvfi_instr_o[i].trap <= exception;
+      rvfi_instr_o[i].trap  <= exception;
 
       if (exception && ex_commit_cause[31]) begin
         rvfi_intr[i] <= 'b101;

--- a/core/include/rvfi_types.svh
+++ b/core/include/rvfi_types.svh
@@ -7,9 +7,9 @@
   logic [config_pkg::NRET*64-1:0]               order; \
   logic [config_pkg::NRET*config_pkg::ILEN-1:0] insn; \
   logic [config_pkg::NRET-1:0]                  trap; \
-  logic [config_pkg::NRET*Cfg.XLEN-1:0]      cause; \
+  logic [config_pkg::NRET*Cfg.XLEN-1:0]        cause; \
   logic [config_pkg::NRET-1:0]                  halt; \
-  logic [config_pkg::NRET-1:0]                  intr; \
+  logic [config_pkg::NRET*Cfg.XLEN-1:0]         intr; \
   logic [config_pkg::NRET*2-1:0]                mode; \
   logic [config_pkg::NRET*2-1:0]                ixl; \
   logic [config_pkg::NRET*5-1:0]                rs1_addr; \

--- a/verif/env/uvme/cov/uvme_axi_covg.sv
+++ b/verif/env/uvme/cov/uvme_axi_covg.sv
@@ -264,22 +264,22 @@ task uvme_axi_covg_c::run_phase(uvm_phase phase);
      disable fork;
 
      if(aw_item != null) begin
-         `uvm_info(get_type_name(), $sformatf("WRITE REQ ITEM DETECTED"), UVM_LOW)
+         `uvm_info(get_type_name(), $sformatf("WRITE REQ ITEM DETECTED"), UVM_HIGH)
          w_axi_cg.sample(aw_item, RVA);
       end
 
      if(b_item != null) begin
-         `uvm_info(get_type_name(), $sformatf("WRITE RESP ITEM DETECTED"), UVM_LOW)
+         `uvm_info(get_type_name(), $sformatf("WRITE RESP ITEM DETECTED"), UVM_HIGH)
          b_axi_cg.sample(b_item, RVA, HPDCache);
       end
 
       if(ar_item != null) begin
-         `uvm_info(get_type_name(), $sformatf("READ ADDRESS ITEM DETECTED"), UVM_LOW)
+         `uvm_info(get_type_name(), $sformatf("READ ADDRESS ITEM DETECTED"), UVM_HIGH)
          ar_axi_cg.sample(ar_item, RVA, HPDCache);
       end
 
       if(r_item != null) begin
-         `uvm_info(get_type_name(), $sformatf("READ DATA ITEM DETECTED"), UVM_LOW)
+         `uvm_info(get_type_name(), $sformatf("READ DATA ITEM DETECTED"), UVM_HIGH)
          for(int i = 0; i <= r_item.m_len; i++) begin
             r_axi_cg.sample(r_item, i, RVA, HPDCache);
          end

--- a/verif/env/uvme/cov/uvme_axi_ext_covg.sv
+++ b/verif/env/uvme/cov/uvme_axi_ext_covg.sv
@@ -82,7 +82,7 @@ covergroup cg_axi_ar_order(string name)
    }
 
    ar_axi_outstanding_cross: cross outstanding_resp, outstanding_last_resp, arid1, arlen1, arid2, arlen2{
-      ignore_bins IGN_CROSS1 = binsof(outstanding_resp) intersect{1} && 
+      ignore_bins IGN_CROSS1 = binsof(outstanding_resp) intersect{1} &&
                                binsof(outstanding_last_resp) intersect{1};
    }
 
@@ -90,16 +90,16 @@ covergroup cg_axi_ar_order(string name)
       ignore_bins IGN_CROSS1 = binsof(outoforder_resp_id0) intersect{1} &&
                                binsof(outoforder_last_resp_id0) intersect{0} &&
                                binsof(arlen2) intersect{0};
-      ignore_bins IGN_CROSS2 = binsof(outoforder_resp_id0) intersect{0} && 
+      ignore_bins IGN_CROSS2 = binsof(outoforder_resp_id0) intersect{0} &&
                                binsof(outoforder_last_resp_id0) intersect{1} &&
                                binsof(arlen1) intersect{0};
    }
 
    aw_axi_outoforder_id1_cross: cross outoforder_resp_id1, outoforder_last_resp_id1, arlen1, arlen2{
-      ignore_bins IGN_CROSS1 = binsof(outoforder_resp_id1) intersect{1} && 
+      ignore_bins IGN_CROSS1 = binsof(outoforder_resp_id1) intersect{1} &&
                                binsof(outoforder_last_resp_id1) intersect{0} &&
                                binsof(arlen2) intersect{0};
-      ignore_bins IGN_CROSS2 = binsof(outoforder_resp_id1) intersect{0} && 
+      ignore_bins IGN_CROSS2 = binsof(outoforder_resp_id1) intersect{0} &&
                                binsof(outoforder_last_resp_id1) intersect{1} &&
                                binsof(arlen1) intersect{0};
    }
@@ -119,7 +119,7 @@ class uvme_axi_ext_covg_c extends uvm_component;
    int t_r1l_to_ar;  // <0 (outstanding)
    int t_r1_to_r2;   // <0 (r2 run before r1)
    int t_r1l_to_r2l; // <0 (last r2 run before last r1)
-   
+
    int write_resp_status = 0;
    int read_resp_status  = 0;
 
@@ -219,7 +219,7 @@ task uvme_axi_ext_covg_c::run_phase(uvm_phase phase);
         get_ar_item();
         get_r_item();
      join_any
-     
+
      if(aw_trs_fifo.size() == 2 && write_resp_status == 2) begin
         aw_time_operations();
         aw_axi_order_cg.sample(t_b1_to_aw, t_w1_to_aw);
@@ -233,7 +233,7 @@ task uvme_axi_ext_covg_c::run_phase(uvm_phase phase);
         ar_trs_fifo = new [ar_trs_fifo.size()-1] (ar_trs_fifo);
         read_resp_status--;
      end
-     
+
      disable fork;
    end
 
@@ -244,7 +244,7 @@ task uvme_axi_ext_covg_c::get_aw_item();
 
    uvma_axi_transaction_c  aw_item;
    uvme_axi_cov_aw_req_fifo.get(aw_item);
-   `uvm_info(get_type_name(), $sformatf("WRITE REQ ITEM DETECTED"), UVM_LOW)
+   `uvm_info(get_type_name(), $sformatf("WRITE REQ ITEM DETECTED"), UVM_HIGH)
    aw_trs_fifo = new [aw_trs_fifo.size()+1] (aw_trs_fifo);
    aw_trs_fifo[aw_trs_fifo.size()-1] = new aw_item;
 
@@ -255,7 +255,7 @@ task uvme_axi_ext_covg_c::get_ar_item();
 
    uvma_axi_transaction_c  ar_item;
    uvme_axi_cov_ar_req_fifo.get(ar_item);
-   `uvm_info(get_type_name(), $sformatf("READ REQ ITEM DETECTED"), UVM_LOW)
+   `uvm_info(get_type_name(), $sformatf("READ REQ ITEM DETECTED"), UVM_HIGH)
    ar_trs_fifo = new [ar_trs_fifo.size()+1] (ar_trs_fifo);
    ar_trs_fifo[ar_trs_fifo.size()-1] = new ar_item;
 
@@ -266,7 +266,7 @@ task uvme_axi_ext_covg_c::get_b_item();
 
    uvma_axi_transaction_c  b_item;
    uvme_axi_cov_b_resp_fifo.get(b_item);
-   `uvm_info(get_type_name(), $sformatf("WRITE RESP ITEM DETECTED"), UVM_LOW)
+   `uvm_info(get_type_name(), $sformatf("WRITE RESP ITEM DETECTED"), UVM_HIGH)
    foreach(aw_trs_fifo[i]) begin
       if (aw_trs_fifo[i].m_id == b_item.m_id) begin
          aw_trs_fifo[i].m_resp = b_item.m_resp;
@@ -285,7 +285,7 @@ task uvme_axi_ext_covg_c::get_r_item();
 
    uvma_axi_transaction_c  r_item;
    uvme_axi_cov_r_resp_fifo.get(r_item);
-   `uvm_info(get_type_name(), $sformatf("READ RESP ITEM DETECTED"), UVM_LOW)
+   `uvm_info(get_type_name(), $sformatf("READ RESP ITEM DETECTED"), UVM_HIGH)
    foreach(ar_trs_fifo[i]) begin
       if (ar_trs_fifo[i].m_id == r_item.m_id) begin
          ar_trs_fifo[i].m_resp.push_back(r_item.m_resp[0]);


### PR DESCRIPTION
* Connect intr as it was not connected on the RVFI tracer
* Lower verbosity to uvme_axi_covg
* Add unified_traps as a param for yaml