### PR TITLE
report_benchmark.py: fix Dhrystone cycles after PR #2484

### DIFF
--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -17,7 +17,7 @@ iterations = None
 # Keep it up-to-date with compiler version and core performance improvements
 # Will fail if the number of cycles is different from this one
 valid_cycles = {
-    'dhrystone': 220885,
+    'dhrystone': 215902,
     'coremark': 534419,
 }
 


### PR DESCRIPTION
after commit 111df66 the CVA6 configuration used for Dhrystone benchmark is rv64gc_zba_zbb_zbs_zbc instead of rv64imafdc_zicsr_zifencei

therefore the number of cycles is reduced