### PR TITLE
[Vector] :bug: Fix `fence` bug 

### DIFF
--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -285,7 +285,7 @@ module acc_dispatcher
       };
       // Wait until the instruction is no longer speculative.
       acc_req_valid      = insn_ready_q[acc_insn_queue_o.trans_id] ||
-                           (acc_commit && insn_pending_q[acc_commit_trans_id]);
+                           (acc_commit && insn_pending_q[acc_commit_trans_id] && !flush_unissued_instr_i);
       acc_insn_queue_pop = acc_req_valid && acc_req_ready;
     end
   end


### PR DESCRIPTION
The controller flushes the pipeline and all the unissued instructions in the presence of instructions with side effects (e.g., `fence`).
The accelerator dispatcher buffer (now used with the Ara RVV Vector processor) is flushed when this happens and avoids accepting a new instruction in that cycle, but it does not prevent the actual issuing of instructions during a flush cycle.

This fix avoids the issue during a flush cycle.