### PR TITLE
Draft HPDIcache (extended hpdcache)

### DIFF
--- a/core/Flist.cva6
+++ b/core/Flist.cva6
@@ -184,6 +184,7 @@ ${HPDCACHE_DIR}/rtl/src/utils/hpdcache_mem_to_axi_write.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_subsystem.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
 ${CVA6_REPO_DIR}/core/cache_subsystem/cva6_hpdcache_wrapper.sv
 ${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_1rw.sv
 ${HPDCACHE_DIR}/rtl/src/common/macros/behav/hpdcache_sram_wbyteenable_1rw.sv

--- a/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
@@ -116,12 +116,11 @@ module cva6_hpdcache_icache_if_adapter
 
   //    Response forwarding
   assign dreq_o.ready = hpdcache_req_ready_i;
-  //   dreq_o.invalid_data = hpdcache_req_ready_i; // need this? (valid or killed)
-  logic obi_gnt_q, obi_gnt_d;  // TODO, need to fix
+  logic obi_gnt_q, obi_gnt_d;  // TODO
 
-  assign obi_gnt_d = fetch_obi_req_i.req;
+  assign obi_gnt_d = dreq_i.req;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : obi_gnt_gen  // TODO
+  always_ff @(posedge clk_i or negedge rst_ni) begin : obi_gnt_gen
     if (!rst_ni) begin
       obi_gnt_q <= '0;
     end else begin

--- a/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
@@ -7,7 +7,7 @@
 // You may obtain a copy of the License at https://solderpad.org/licenses/
 //
 // Authors: Akiho Kawada
-// Date: June, 2024
+// Date: July, 2024
 // Description: Icache Interface adapter for the CVA6 core
 module cva6_hpdcache_icache_if_adapter
 //  Parameters
@@ -24,7 +24,7 @@ module cva6_hpdcache_icache_if_adapter
     parameter type fetch_drsp_t = logic,
     parameter type obi_fetch_req_t = logic,
     parameter type obi_fetch_rsp_t = logic,
-    parameter logic [CVA6Cfg.MEM_TID_WIDTH-1:0] RdTxId = 0
+    parameter logic [CVA6Cfg.MEM_TID_WIDTH-1:0] RdTxId = 0  // TODO
 )
 //  }}}
 
@@ -39,10 +39,10 @@ module cva6_hpdcache_icache_if_adapter
     input hpdcache_req_sid_t hpdcache_req_sid_i,
 
     //  Request/response ports from/to the CVA6 core
-    input fetch_dreq_t fetch_dreq_i,
-    output fetch_drsp_t fetch_dreq_o,
-    input obi_fetch_req_t obi_fetch_req_i,
-    output obi_fetch_rsp_t obi_fetch_rsp_o,
+    input fetch_dreq_t dreq_i,
+    output fetch_drsp_t dreq_o,
+    input obi_fetch_req_t fetch_obi_req_i,
+    output obi_fetch_rsp_t fetch_obi_rsp_o,
 
     //  Request port to the L1 Dcache
     output logic                        hpdcache_req_valid_o,
@@ -58,9 +58,8 @@ module cva6_hpdcache_icache_if_adapter
 );
   //  }}}
 
-  //  Internal nets and registers
-  //  {{{
-  logic hpdcache_req_is_uncacheable;
+  // localparam ICACHE_OFFSET_WIDTH = $clog2(CVA6Cfg.ICACHE_LINE_WIDTH / 8);
+  localparam ICACHE_OFFSET_WIDTH = 3;
   localparam int ICACHE_CL_SIZE = $clog2(CVA6Cfg.ICACHE_LINE_WIDTH / 8);
   localparam int ICACHE_WORD_SIZE = 3;
   localparam int ICACHE_MEM_REQ_CL_SIZE =
@@ -68,57 +67,90 @@ module cva6_hpdcache_icache_if_adapter
       $clog2(
       CVA6Cfg.AxiDataWidth / 8
   ) : ICACHE_CL_SIZE;
+
+  //  Internal nets and registers
+  //  {{{
+  logic hpdcache_req_is_uncacheable;
+  logic va_transferred_q, va_transferred_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : transferred_state_magnegement
+    if (!rst_ni) begin
+      va_transferred_q <= '0;
+    end else begin
+      va_transferred_q <= va_transferred_d;
+    end
+  end
+
+  assign va_transferred_d = dreq_i.req & hpdcache_req_ready_i;
   //  }}}
 
   //  Request forwarding
   //  {{{
-  //  LOAD request
-  //  {{{
-
   assign hpdcache_req_is_uncacheable = !config_pkg::is_inside_cacheable_regions(
       CVA6Cfg,
       {
         {64 - CVA6Cfg.PLEN{1'b0}},
-        obi_fetch_req_i.a.addrr[CVA6Cfg.ICACHE_TAG_WIDTH+CVA6Cfg.ICACHE_INDEX_WIDTH-1:CVA6Cfg.ICACHE_INDEX_WIDTH],
+        fetch_obi_req_i.a.addr[CVA6Cfg.ICACHE_TAG_WIDTH+CVA6Cfg.ICACHE_INDEX_WIDTH-1:CVA6Cfg.ICACHE_INDEX_WIDTH], // TODO
         {CVA6Cfg.ICACHE_INDEX_WIDTH{1'b0}}
       }
   );
 
   //    Request forwarding
-  assign hpdcache_req_valid_o = fetch_dreq_i.data_req,
-      hpdcache_req_o.addr_offset = fetch_dreq_i.vaddr[CVA6Cfg.ICACHE_INDEX_WIDTH-1:3],
+  assign hpdcache_req_valid_o = dreq_i.req,
+      hpdcache_req_o.addr_offset = dreq_i.vaddr[CVA6Cfg.ICACHE_INDEX_WIDTH-1:0],
       hpdcache_req_o.wdata = '0,
       hpdcache_req_o.op = hpdcache_pkg::HPDCACHE_REQ_LOAD,
-      hpdcache_req_o.be = obi_fetch_req_i.a.data_be,
-      hpdcache_req_o.size = hpdcache_req_is_uncacheable ? ICACHE_WORD_SIZE : ICACHE_MEM_REQ_CL_SIZE,
+      hpdcache_req_o.be = fetch_obi_req_i.a.be,
+      hpdcache_req_o.size = hpdcache_req_is_uncacheable ? ICACHE_WORD_SIZE : ICACHE_MEM_REQ_CL_SIZE, // TODO
       hpdcache_req_o.sid = '0,
-      hpdcache_req_o.tid = RdTxId,  // TODO
+      hpdcache_req_o.tid = RdTxId,  // TODO 
       hpdcache_req_o.need_rsp = 1'b1,
       hpdcache_req_o.phys_indexed = 1'b0,
       hpdcache_req_o.addr_tag = '0,  // unused on virtually indexed request
       hpdcache_req_o.pma = '0;  // unused on virtually indexed request
 
-  assign hpdcache_req_abort_o = fetch_dreq_i.kill_req,
-      hpdcache_req_tag_o = obi_fetch_req_i.a.addrr[CVA6Cfg.ICACHE_TAG_WIDTH+CVA6Cfg.ICACHE_INDEX_WIDTH-1:CVA6Cfg.ICACHE_INDEX_WIDTH],
+  assign hpdcache_req_abort_o = va_transferred_q & (dreq_i.kill_req | ~fetch_obi_req_i.req),
+      hpdcache_req_tag_o = fetch_obi_req_i.a.addr[CVA6Cfg.ICACHE_TAG_WIDTH+CVA6Cfg.ICACHE_INDEX_WIDTH-1:CVA6Cfg.ICACHE_INDEX_WIDTH],
       hpdcache_req_pma_o.uncacheable = hpdcache_req_is_uncacheable,
       hpdcache_req_pma_o.io = 1'b0;
 
   //    Response forwarding
-  assign cva6_req_o.data_rvalid = hpdcache_rsp_valid_i,
-      cva6_req_o.data_rdata = hpdcache_rsp_i.rdata,
-      cva6_req_o.data_rid = hpdcache_rsp_i.tid,
-      cva6_req_o.data_gnt = hpdcache_req_ready_i;
+  assign dreq_o.ready = hpdcache_req_ready_i;  // TODO
+  //   dreq_o.invalid_data = hpdcache_req_ready_i; // need this? (valid or killed)
+  logic obi_gnt;  // TODO, need to fix
 
-  assign fetch_obi_rsp_o.gnt = hpdcache_req_ready_i,  // TODO
-      fetch_obi_rsp_o.gntpar = !hpdcache_req_ready_i,  // TODO
-      fetch_obi_rsp_o.rvalid = hpdcache_rsp_valid_i,  // TODO
-      fetch_obi_rsp_o.rvalidpar = !hpdcache_rsp_valid_i,  // TODO
-      fetch_obi_rsp_o.r.rid = '0,
-      fetch_obi_rsp_o.r.r_optional.exokay = '0,
-      fetch_obi_rsp_o.r.r_optional.rchk = '0,
-      fetch_obi_rsp_o.r.err = '0,
-      fetch_obi_rsp_o.r.rdata = hpdcache_rsp_i.rdata,
-      fetch_obi_rsp_o.r.r_optional.ruser = '0;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : obi_gnt_gen  // TODO
+    if (!rst_ni) begin
+      obi_gnt <= '0;
+    end else begin
+      obi_gnt <= hpdcache_req_ready_i;
+    end
+  end
+
+  logic which_half_d, which_half_q;
+  assign which_half_d = (fetch_obi_req_i.req) ? fetch_obi_req_i.a.addr[2] : which_half_q;
+
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : gen_offset
+    if (!rst_ni) begin
+      which_half_q <= '0;
+    end else begin
+      which_half_q <= which_half_d;
+    end
+  end
+
+  assign fetch_obi_rsp_o.gnt = obi_gnt,
+      fetch_obi_rsp_o.gntpar = !obi_gnt,
+      fetch_obi_rsp_o.rvalid = hpdcache_rsp_valid_i,
+      fetch_obi_rsp_o.rvalidpar = !hpdcache_rsp_valid_i,
+      fetch_obi_rsp_o.r.rid = hpdcache_rsp_i.tid,
+      fetch_obi_rsp_o.r.r_optional.exokay = '0,  // need this?
+      fetch_obi_rsp_o.r.r_optional.rchk = '0,  // need this?
+      fetch_obi_rsp_o.r.err = hpdcache_rsp_i.error,  // need this?
+      fetch_obi_rsp_o.r.rdata = hpdcache_rsp_i.rdata[0][{
+        which_half_q, 5'b0
+      }+:CVA6Cfg.FETCH_WIDTH],
+      fetch_obi_rsp_o.r.r_optional.ruser = '0;  // TODO
   //  }}}
   //  }}}
 

--- a/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_icache_if_adapter.sv
@@ -115,15 +115,17 @@ module cva6_hpdcache_icache_if_adapter
       hpdcache_req_pma_o.io = 1'b0;
 
   //    Response forwarding
-  assign dreq_o.ready = hpdcache_req_ready_i;  // TODO
+  assign dreq_o.ready = hpdcache_req_ready_i;
   //   dreq_o.invalid_data = hpdcache_req_ready_i; // need this? (valid or killed)
-  logic obi_gnt;  // TODO, need to fix
+  logic obi_gnt_q, obi_gnt_d;  // TODO, need to fix
+
+  assign obi_gnt_d = fetch_obi_req_i.req;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : obi_gnt_gen  // TODO
     if (!rst_ni) begin
-      obi_gnt <= '0;
+      obi_gnt_q <= '0;
     end else begin
-      obi_gnt <= hpdcache_req_ready_i;
+      obi_gnt_q <= obi_gnt_d;
     end
   end
 
@@ -139,14 +141,14 @@ module cva6_hpdcache_icache_if_adapter
     end
   end
 
-  assign fetch_obi_rsp_o.gnt = obi_gnt,
-      fetch_obi_rsp_o.gntpar = !obi_gnt,
+  assign fetch_obi_rsp_o.gnt = obi_gnt_q,
+      fetch_obi_rsp_o.gntpar = !obi_gnt_q,
       fetch_obi_rsp_o.rvalid = hpdcache_rsp_valid_i,
       fetch_obi_rsp_o.rvalidpar = !hpdcache_rsp_valid_i,
       fetch_obi_rsp_o.r.rid = hpdcache_rsp_i.tid,
-      fetch_obi_rsp_o.r.r_optional.exokay = '0,  // need this?
-      fetch_obi_rsp_o.r.r_optional.rchk = '0,  // need this?
-      fetch_obi_rsp_o.r.err = hpdcache_rsp_i.error,  // need this?
+      fetch_obi_rsp_o.r.r_optional.exokay = '0,
+      fetch_obi_rsp_o.r.r_optional.rchk = '0,
+      fetch_obi_rsp_o.r.err = hpdcache_rsp_i.error,
       fetch_obi_rsp_o.r.rdata = hpdcache_rsp_i.rdata[0][{
         which_half_q, 5'b0
       }+:CVA6Cfg.FETCH_WIDTH],

--- a/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv
@@ -47,13 +47,23 @@ module cva6_hpdcache_subsystem_axi_arbiter
 
     //  Interfaces from/to I$
     //  {{{
-    input  logic             icache_miss_valid_i,
-    output logic             icache_miss_ready_o,
-    input  icache_req_t      icache_miss_i,
-    input  hpdcache_mem_id_t icache_miss_id_i,
+    input  logic              icache_uc_read_valid_i,
+    output logic              icache_uc_read_ready_o,
+    input  hpdcache_mem_req_t icache_uc_read_i,
+    input  hpdcache_mem_id_t  icache_uc_read_id_i,
 
-    output logic         icache_miss_resp_valid_o,
-    output icache_rtrn_t icache_miss_resp_o,
+    input  logic                 icache_uc_read_resp_ready_i,
+    output logic                 icache_uc_read_resp_valid_o,
+    output hpdcache_mem_resp_r_t icache_uc_read_resp_o,
+
+    input  logic              icache_miss_valid_i,
+    output logic              icache_miss_ready_o,
+    input  hpdcache_mem_req_t icache_miss_i,
+    input  hpdcache_mem_id_t  icache_miss_id_i,
+
+    input  logic                 icache_miss_resp_ready_i,
+    output logic                 icache_miss_resp_valid_o,
+    output hpdcache_mem_resp_r_t icache_miss_resp_o,
     //  }}}
 
     //  Interfaces from/to D$
@@ -114,186 +124,38 @@ module cva6_hpdcache_subsystem_axi_arbiter
 
   //  Internal type definitions
   //  {{{
-
   localparam int MEM_RESP_RT_DEPTH = (1 << CVA6Cfg.MEM_TID_WIDTH);
   typedef hpdcache_mem_id_t [MEM_RESP_RT_DEPTH-1:0] mem_resp_rt_t;
-  typedef logic [CVA6Cfg.ICACHE_LINE_WIDTH-1:0] icache_resp_data_t;
-  //  }}}
-
-  //  Adapt the I$ interface to the HPDcache memory interface
-  //  {{{
-  localparam int ICACHE_CL_WORDS = CVA6Cfg.ICACHE_LINE_WIDTH / 64;
-  localparam int ICACHE_CL_WORD_INDEX = $clog2(ICACHE_CL_WORDS);
-  localparam int ICACHE_CL_SIZE = $clog2(CVA6Cfg.ICACHE_LINE_WIDTH / 8);
-  localparam int ICACHE_WORD_SIZE = 3;
-  localparam int ICACHE_MEM_REQ_CL_LEN =
-    (CVA6Cfg.ICACHE_LINE_WIDTH + CVA6Cfg.AxiDataWidth - 1)/CVA6Cfg.AxiDataWidth;
-  localparam int ICACHE_MEM_REQ_CL_SIZE =
-    (CVA6Cfg.AxiDataWidth <= CVA6Cfg.ICACHE_LINE_WIDTH) ?
-      $clog2(
-      CVA6Cfg.AxiDataWidth / 8
-  ) : ICACHE_CL_SIZE;
-
-  //    I$ request
-  hpdcache_mem_req_t icache_miss_req_wdata;
-  logic icache_miss_req_w, icache_miss_req_wok;
-
-  hpdcache_mem_req_t icache_miss_req_rdata;
-  logic icache_miss_req_r, icache_miss_req_rok;
-
-  logic icache_miss_pending_q;
-
-  //  This FIFO has two functionnalities:
-  //  -  Stabilize the ready-valid protocol. The ICACHE can abort a valid
-  //     transaction without receiving the corresponding ready signal. This
-  //     behavior is not supported by AXI.
-  //  -  Cut a possible long timing path.
-  hpdcache_fifo_reg #(
-      .FIFO_DEPTH (1),
-      .fifo_data_t(hpdcache_mem_req_t)
-  ) i_icache_miss_req_fifo (
-      .clk_i,
-      .rst_ni,
-
-      .w_i    (icache_miss_req_w),
-      .wok_o  (icache_miss_req_wok),
-      .wdata_i(icache_miss_req_wdata),
-
-      .r_i    (icache_miss_req_r),
-      .rok_o  (icache_miss_req_rok),
-      .rdata_o(icache_miss_req_rdata)
-  );
-
-  assign icache_miss_req_w = icache_miss_valid_i, icache_miss_ready_o = icache_miss_req_wok;
-
-  assign icache_miss_req_wdata.mem_req_addr = icache_miss_i.paddr,
-      icache_miss_req_wdata.mem_req_len = icache_miss_i.nc ? 0 : ICACHE_MEM_REQ_CL_LEN - 1,
-      icache_miss_req_wdata.mem_req_size      = icache_miss_i.nc ? ICACHE_WORD_SIZE : ICACHE_MEM_REQ_CL_SIZE,
-      icache_miss_req_wdata.mem_req_id = icache_miss_i.tid,
-      icache_miss_req_wdata.mem_req_command = hpdcache_pkg::HPDCACHE_MEM_READ,
-      icache_miss_req_wdata.mem_req_atomic = hpdcache_pkg::hpdcache_mem_atomic_e'(0),
-      icache_miss_req_wdata.mem_req_cacheable = ~icache_miss_i.nc;
-
-
-  //    I$ response
-  logic icache_miss_resp_w, icache_miss_resp_wok;
-  hpdcache_mem_resp_r_t icache_miss_resp_wdata;
-
-  logic icache_miss_resp_data_w, icache_miss_resp_data_wok;
-  logic icache_miss_resp_data_r, icache_miss_resp_data_rok;
-  icache_resp_data_t icache_miss_resp_data_rdata;
-
-  logic icache_miss_resp_meta_w, icache_miss_resp_meta_wok;
-  logic icache_miss_resp_meta_r, icache_miss_resp_meta_rok;
-  hpdcache_mem_id_t  icache_miss_resp_meta_id;
-
-  icache_resp_data_t icache_miss_rdata;
-
-  generate
-    if (CVA6Cfg.AxiDataWidth < CVA6Cfg.ICACHE_LINE_WIDTH) begin
-      hpdcache_fifo_reg #(
-          .FIFO_DEPTH (1),
-          .fifo_data_t(hpdcache_mem_id_t)
-      ) i_icache_refill_meta_fifo (
-          .clk_i,
-          .rst_ni,
-
-          .w_i    (icache_miss_resp_meta_w),
-          .wok_o  (icache_miss_resp_meta_wok),
-          .wdata_i(icache_miss_resp_wdata.mem_resp_r_id),
-
-          .r_i    (icache_miss_resp_meta_r),
-          .rok_o  (icache_miss_resp_meta_rok),
-          .rdata_o(icache_miss_resp_meta_id)
-      );
-
-      hpdcache_data_upsize #(
-          .WR_WIDTH(CVA6Cfg.AxiDataWidth),
-          .RD_WIDTH(CVA6Cfg.ICACHE_LINE_WIDTH),
-          .DEPTH   (1)
-      ) i_icache_hpdcache_data_upsize (
-          .clk_i,
-          .rst_ni,
-
-          .w_i    (icache_miss_resp_data_w),
-          .wlast_i(icache_miss_resp_wdata.mem_resp_r_last),
-          .wok_o  (icache_miss_resp_data_wok),
-          .wdata_i(icache_miss_resp_wdata.mem_resp_r_data),
-
-          .r_i    (icache_miss_resp_data_r),
-          .rok_o  (icache_miss_resp_data_rok),
-          .rdata_o(icache_miss_resp_data_rdata)
-      );
-
-      assign icache_miss_resp_meta_r = 1'b1, icache_miss_resp_data_r = 1'b1;
-
-      assign icache_miss_resp_meta_w = icache_miss_resp_w & icache_miss_resp_wdata.mem_resp_r_last;
-
-      assign icache_miss_resp_data_w = icache_miss_resp_w;
-
-      assign icache_miss_resp_wok = icache_miss_resp_data_wok & (
-               icache_miss_resp_meta_wok | ~icache_miss_resp_wdata.mem_resp_r_last);
-
-      assign icache_miss_rdata = icache_miss_resp_data_rdata;
-
-    end else begin
-      assign icache_miss_resp_data_rok = icache_miss_resp_w;
-      assign icache_miss_resp_meta_rok = icache_miss_resp_w;
-      assign icache_miss_resp_wok = 1'b1;
-      assign icache_miss_resp_meta_id = icache_miss_resp_wdata.mem_resp_r_id;
-      assign icache_miss_resp_data_rdata = icache_miss_resp_wdata.mem_resp_r_data;
-
-      //  In the case of uncacheable accesses, the Icache expects the data to be right-aligned
-      always_comb begin : icache_miss_resp_data_comb
-        if (!icache_miss_req_rdata.mem_req_cacheable) begin
-          automatic logic [ICACHE_CL_WORD_INDEX - 1:0] icache_miss_word_index;
-          automatic logic [63:0] icache_miss_word;
-          icache_miss_word_index = icache_miss_req_rdata.mem_req_addr[3+:ICACHE_CL_WORD_INDEX];
-          icache_miss_word = icache_miss_resp_data_rdata[icache_miss_word_index*64+:64];
-          icache_miss_rdata = {{CVA6Cfg.ICACHE_LINE_WIDTH - 64{1'b0}}, icache_miss_word};
-        end else begin
-          icache_miss_rdata = icache_miss_resp_data_rdata;
-        end
-      end
-    end
-  endgenerate
-
-  assign icache_miss_resp_valid_o = icache_miss_resp_meta_rok,
-      icache_miss_resp_o.rtype = wt_cache_pkg::ICACHE_IFILL_ACK,
-      icache_miss_resp_o.user = '0,
-      icache_miss_resp_o.inv = '0,
-      icache_miss_resp_o.tid = icache_miss_resp_meta_id,
-      icache_miss_resp_o.data = icache_miss_rdata;
-
-  //  consume the Icache miss on the arrival of the response. The request
-  //  metadata is decoded to forward the correct word in case of uncacheable
-  //  Icache access
-  assign icache_miss_req_r = icache_miss_resp_meta_rok;
   //  }}}
 
   //  Read request arbiter
   //  {{{
-  logic              mem_req_read_ready     [2:0];
-  logic              mem_req_read_valid     [2:0];
-  hpdcache_mem_req_t mem_req_read           [2:0];
+  logic              mem_req_read_ready     [3:0];
+  logic              mem_req_read_valid     [3:0];
+  hpdcache_mem_req_t mem_req_read           [3:0];
 
   logic              mem_req_read_ready_arb;
   logic              mem_req_read_valid_arb;
   hpdcache_mem_req_t mem_req_read_arb;
 
-  assign mem_req_read_valid[0] = icache_miss_req_rok & ~icache_miss_pending_q,
-      mem_req_read[0] = icache_miss_req_rdata;
+  assign icache_miss_ready_o = mem_req_read_ready[0],
+      mem_req_read_valid[0] = icache_miss_valid_i,
+      mem_req_read[0] = icache_miss_i;
 
-  assign dcache_miss_ready_o = mem_req_read_ready[1],
-      mem_req_read_valid[1] = dcache_miss_valid_i,
-      mem_req_read[1] = dcache_miss_i;
+  assign icache_uc_read_ready_o = mem_req_read_ready[1],
+      mem_req_read_valid[1] = icache_uc_read_valid_i,
+      mem_req_read[1] = icache_uc_read_i;
 
-  assign dcache_uc_read_ready_o = mem_req_read_ready[2],
-      mem_req_read_valid[2] = dcache_uc_read_valid_i,
-      mem_req_read[2] = dcache_uc_read_i;
+  assign dcache_miss_ready_o = mem_req_read_ready[2],
+      mem_req_read_valid[2] = dcache_miss_valid_i,
+      mem_req_read[2] = dcache_miss_i;
+
+  assign dcache_uc_read_ready_o = mem_req_read_ready[3],
+      mem_req_read_valid[3] = dcache_uc_read_valid_i,
+      mem_req_read[3] = dcache_uc_read_i;
 
   hpdcache_mem_req_read_arbiter #(
-      .N                 (3),
+      .N                 (4),
       .hpdcache_mem_req_t(hpdcache_mem_req_t)
   ) i_mem_req_read_arbiter (
       .clk_i,
@@ -315,21 +177,22 @@ module cva6_hpdcache_subsystem_axi_arbiter
   logic                 mem_resp_read_valid;
   hpdcache_mem_resp_r_t mem_resp_read;
 
-  logic                 mem_resp_read_ready_arb[2:0];
-  logic                 mem_resp_read_valid_arb[2:0];
-  hpdcache_mem_resp_r_t mem_resp_read_arb      [2:0];
+  logic                 mem_resp_read_ready_arb[3:0];
+  logic                 mem_resp_read_valid_arb[3:0];
+  hpdcache_mem_resp_r_t mem_resp_read_arb      [3:0];
 
   mem_resp_rt_t         mem_resp_read_rt;
 
   always_comb begin
     for (int i = 0; i < MEM_RESP_RT_DEPTH; i++) begin
       mem_resp_read_rt[i] = (i == int'(   icache_miss_id_i)) ? 0 :
-                            (i == int'(dcache_uc_read_id_i)) ? 2 : 1;
+                            (i == int'(   icache_uc_read_id_i)) ? 1 :
+                            (i == int'(dcache_uc_read_id_i)) ? 3 : 2;
     end
   end
 
   hpdcache_mem_resp_demux #(
-      .N        (3),
+      .N        (4),
       .resp_t   (hpdcache_mem_resp_r_t),
       .resp_id_t(hpdcache_mem_id_t)
   ) i_mem_resp_read_demux (
@@ -348,17 +211,21 @@ module cva6_hpdcache_subsystem_axi_arbiter
       .mem_resp_rt_i(mem_resp_read_rt)
   );
 
-  assign icache_miss_resp_w = mem_resp_read_valid_arb[0],
-      icache_miss_resp_wdata = mem_resp_read_arb[0],
-      mem_resp_read_ready_arb[0] = icache_miss_resp_wok;
+  assign icache_miss_resp_valid_o = mem_resp_read_valid_arb[0],
+      icache_miss_resp_o = mem_resp_read_arb[0],
+      mem_resp_read_ready_arb[0] = icache_miss_resp_ready_i;
 
-  assign dcache_miss_resp_valid_o = mem_resp_read_valid_arb[1],
-      dcache_miss_resp_o = mem_resp_read_arb[1],
-      mem_resp_read_ready_arb[1] = dcache_miss_resp_ready_i;
+  assign icache_uc_read_resp_valid_o = mem_resp_read_valid_arb[1],
+      icache_uc_read_resp_o = mem_resp_read_arb[1],
+      mem_resp_read_ready_arb[1] = icache_uc_read_resp_ready_i;
 
-  assign dcache_uc_read_resp_valid_o = mem_resp_read_valid_arb[2],
-      dcache_uc_read_resp_o = mem_resp_read_arb[2],
-      mem_resp_read_ready_arb[2] = dcache_uc_read_resp_ready_i;
+  assign dcache_miss_resp_valid_o = mem_resp_read_valid_arb[2],
+      dcache_miss_resp_o = mem_resp_read_arb[2],
+      mem_resp_read_ready_arb[2] = dcache_miss_resp_ready_i;
+
+  assign dcache_uc_read_resp_valid_o = mem_resp_read_valid_arb[3],
+      dcache_uc_read_resp_o = mem_resp_read_arb[3],
+      mem_resp_read_ready_arb[3] = dcache_uc_read_resp_ready_i;
   //  }}}
 
   //  Write request arbiter
@@ -468,17 +335,6 @@ module cva6_hpdcache_subsystem_axi_arbiter
       mem_resp_write_ready_arb[1] = dcache_uc_write_resp_ready_i;
   //  }}}
 
-  //  I$ miss pending
-  //  {{{
-  always_ff @(posedge clk_i or negedge rst_ni) begin : icache_miss_pending_ff
-    if (!rst_ni) begin
-      icache_miss_pending_q <= 1'b0;
-    end else begin
-      icache_miss_pending_q <= ( (icache_miss_req_rok & mem_req_read_ready[0]) & ~icache_miss_pending_q) |
-                               (~(icache_miss_req_r   & icache_miss_req_rok)   &  icache_miss_pending_q);
-    end
-  end
-  // }}}
 
   //  AXI adapters
   //  {{{

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1344,8 +1344,6 @@ module cva6
         .dbus_rsp_t(dbus_rsp_t),
         .obi_fetch_req_t(obi_fetch_req_t),
         .obi_fetch_rsp_t(obi_fetch_rsp_t),
-        .obi_dbus_req_t(obi_dbus_req_t),
-        .obi_dbus_rsp_t(obi_dbus_rsp_t),
         .NumPorts  (NumPorts),
         .axi_ar_chan_t(axi_ar_chan_t),
         .axi_aw_chan_t(axi_aw_chan_t),


### PR DESCRIPTION
- extended ver. of cva6_hpdcache_axi_arbiter: support for HPICache
- extended ver. of cva6_hpdcache_subsystem: support for HPICache
- cva6_hpdcache_icache_if_adapter: new adapter for Icache 