### PR TITLE
[interrupt verification] Add .uvmif support to global verif linker script

### DIFF
--- a/verif/sim/link.ld
+++ b/verif/sim/link.ld
@@ -24,6 +24,8 @@ SECTIONS
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
   . = ALIGN(0x1000);
+  .uvmif : { *(.uvmif) }
+  . = ALIGN(0x1000);
   .text : { *(.text) }
   . = ALIGN(0x1000);
   .text.startup : { *(.text.startup) }

--- a/verif/tests/custom/common/test.ld
+++ b/verif/tests/custom/common/test.ld
@@ -27,7 +27,8 @@ SECTIONS
 
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
-
+  . = ALIGN(0x1000);
+  .uvmif : { *(.uvmif) }
   . = ALIGN(0x1000);
   .uvmif : { *(.uvmif) }
 

--- a/verif/tests/custom/common/test.ld
+++ b/verif/tests/custom/common/test.ld
@@ -27,8 +27,10 @@ SECTIONS
 
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
+
   . = ALIGN(0x1000);
   .uvmif : { *(.uvmif) }
+
   . = ALIGN(0x1000);
   .text : { *(.text) }
 

--- a/verif/tests/custom/common/test.ld
+++ b/verif/tests/custom/common/test.ld
@@ -30,9 +30,6 @@ SECTIONS
   . = ALIGN(0x1000);
   .uvmif : { *(.uvmif) }
   . = ALIGN(0x1000);
-  .uvmif : { *(.uvmif) }
-
-  . = ALIGN(0x1000);
   .text : { *(.text) }
 
   /* data segment */


### PR DESCRIPTION
Fix broken heavy tests by aligning linker script content of the verification platform.

Future work: clean up linker script ecosystem so it uses a single verification linker script (with non-conflicting extensions if/where needed).