### PR TITLE
cv64a6_imafdch_sv39_wb_config: Fix undefined parameter

### DIFF
--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -75,7 +75,7 @@ package cva6_config_pkg;
   localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
       XLEN: unsigned'(CVA6ConfigXlen),
       FpgaEn: bit'(CVA6ConfigFpgaEn),
-      TechnoCut: bit'(CVA6ConfigTechnoCut),
+      TechnoCut: bit'(0),
       SuperscalarEn: bit'(0),
       NrCommitPorts: unsigned'(2),
       AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),


### PR DESCRIPTION
The parameter `CVA6ConfigTechnoCut` is undefined and causes elaboration errors. Align this with the other configurations and set it to constant `0`.