### PR TITLE
Modify ci to always check with Tandem and promote UVM TB use

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,9 +148,8 @@ smoke:
   parallel:
     matrix:
       - DV_SIMULATORS:
-        - "veri-testharness,spike"
         - "vcs-testharness"
-        - "questa-testharness,spike"
+        - "questa-testharness"
         - "vcs-uvm"
   script:
     - source $QUESTA_BASHRC
@@ -181,9 +180,10 @@ coremark:
     DASHBOARD_JOB_DESCRIPTION: "Performance indicator"
     DASHBOARD_SORT_INDEX: 5
     DASHBOARD_JOB_CATEGORY: "Performance"
+    SPIKE_TANDEM: 1
   script:
     - bash verif/regress/coremark.sh --no-print
-    - python3 .gitlab-ci/scripts/report_benchmark.py --coremark verif/sim/out_*/veri-testharness_sim/core_main.*.log
+    - python3 .gitlab-ci/scripts/report_benchmark.py --coremark verif/sim/out_*/vcs-uvm_sim/core_main.*.log
 
 hwconfig:
   extends:
@@ -317,9 +317,10 @@ dhrystone:
     DASHBOARD_JOB_DESCRIPTION: "Performance indicator"
     DASHBOARD_SORT_INDEX: 5
     DASHBOARD_JOB_CATEGORY: "Performance"
+    SPIKE_TANDEM: 1
   script:
     - bash verif/regress/dhrystone.sh
-    - python3 .gitlab-ci/scripts/report_benchmark.py --dhrystone verif/sim/out_*/veri-testharness_sim/dhrystone_main.*.log
+    - python3 .gitlab-ci/scripts/report_benchmark.py --dhrystone verif/sim/out_*/vcs-uvm_sim/dhrystone_main.*.log
 
 riscv_arch_test:
   extends:
@@ -348,6 +349,7 @@ compliance:
   after_script: *simu_after_script
 
 riscv-tests-v:
+  timeout : 2 hours
   extends:
     - .regress_test
   variables:
@@ -355,9 +357,10 @@ riscv-tests-v:
     DASHBOARD_JOB_DESCRIPTION: "Riscv-test regression suite (virtual)"
     DASHBOARD_SORT_INDEX: 3
     DASHBOARD_JOB_CATEGORY: "Test suites"
-    DV_SIMULATORS: "veri-testharness,spike"
+    DV_SIMULATORS: "vcs-testharness,spike"
     DV_TARGET: cv64a6_imafdc_sv39
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
+    SPIKE_TANDEM: 1
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script
 

--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -17,8 +17,8 @@ iterations = None
 # Keep it up-to-date with compiler version and core performance improvements
 # Will fail if the number of cycles is different from this one
 valid_cycles = {
-    'dhrystone': 215902,
-    'coremark': 534419,
+    'dhrystone': 250453,
+    'coremark': 582561,
 }
 
 for arg in sys.argv[1:]:

--- a/verif/regress/coremark.sh
+++ b/verif/regress/coremark.sh
@@ -27,7 +27,7 @@ source verif/regress/install-riscv-tests.sh
 source ./verif/sim/setup-env.sh
 
 if ! [ -n "$DV_SIMULATORS" ]; then
-  DV_SIMULATORS=veri-testharness
+  DV_SIMULATORS=vcs-uvm
 fi
 
 if ! [ -n "$UVM_VERBOSITY" ]; then
@@ -78,17 +78,15 @@ cflags=(
         -DNOPRINT
 )
 
-default_config="cv32a65x"
 isa="rv32imc_zba_zbb_zbc_zbs"
 
 set -x
 python3 cva6.py \
-        --target hwconfig \
-        --isa "$isa" \
-        --hwconfig_opts="$default_config" \
+        --target cv32a65x \
         --iss="$DV_SIMULATORS" \
         --iss_yaml=cva6.yaml \
         --c_tests "$src0" \
         --gcc_opts "${srcA[*]} ${cflags[*]}" \
         --linker ../tests/custom/common/test.ld \
+        --iss_timeout=2000 \
         $DV_OPTS

--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -22,7 +22,7 @@ source verif/regress/install-riscv-tests.sh
 source ./verif/sim/setup-env.sh
 
 if ! [ -n "$DV_SIMULATORS" ]; then
-  DV_SIMULATORS=veri-testharness
+  DV_SIMULATORS=vcs-uvm
 fi
 
 make clean
@@ -55,11 +55,10 @@ cflags=(
 
 set -x
 python3 cva6.py \
-        --target hwconfig \
-        --isa rv64imafdc \
-        --hwconfig_opts="cv64a6_imafdc_sv39 +CVA6ConfigNrLoadPipeRegs=0" \
+        --target cv32a65x \
         --iss="$DV_SIMULATORS" \
         --iss_yaml=cva6.yaml \
         --c_tests "$src0" \
         --gcc_opts "${srcA[*]} ${cflags[*]}" \
+        --iss_timeout=1000 \
         --linker ../tests/custom/common/test.ld

--- a/verif/regress/smoke-gen_tests.sh
+++ b/verif/regress/smoke-gen_tests.sh
@@ -28,7 +28,7 @@ if ! [ -n "$DV_TARGET" ]; then
 fi
 
 if ! [ -n "$DV_SIMULATORS" ]; then
-  DV_SIMULATORS=vcs-uvm,spike
+  DV_SIMULATORS=vcs-uvm
 fi
 
 cd verif/sim/

--- a/verif/regress/smoke-tests.sh
+++ b/verif/regress/smoke-tests.sh
@@ -58,12 +58,6 @@ if [[ "$DV_SIMULATORS" != *"uvm"* ]]; then
   python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS
   python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv32a60x.yaml --test rv32im-cadd-01 --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS  --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
   python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS --linker=../tests/custom/common/test.ld --gcc_opts="$CC_OPTS" $DV_OPTS
-  make -C ../.. clean
-  make clean_all
-  python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv64a6_mmu --iss=$DV_SIMULATORS $DV_OPTS
-  python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64ui-p-add --iss_yaml cva6.yaml --target cv64a6_mmu --iss=$DV_SIMULATORS $DV_OPTS
-  python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml --test rv64i_m-add-01 --iss_yaml cva6.yaml --target cv64a6_mmu --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
-  python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv64a6_mmu --iss=$DV_SIMULATORS --linker=../tests/custom/common/test.ld --gcc_opts="$CC_OPTS" $DV_OPTS
 fi
 make -C ../.. clean
 make clean_all


### PR DESCRIPTION
Spike Tandem is used for all jobs.
As Spike Tandem does not work with Verilator, Verilator is replaced by VCS.
cv64_MMU configuration jobs are removed.
VCS-uvm is preferred to vcs-testharness.