### PR TITLE
put dhrystone in smoke job group and coremark in regress job group

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,7 +174,7 @@ gen_smoke:
 
 coremark:
   extends:
-    - .fe_smoke_test
+    - .regress_test
   variables:
     DASHBOARD_JOB_TITLE: "CoreMark"
     DASHBOARD_JOB_DESCRIPTION: "Performance indicator"
@@ -311,7 +311,7 @@ fpga-build:
 
 dhrystone:
   extends:
-    - .regress_test
+    - .fe_smoke_test
   variables:
     DASHBOARD_JOB_TITLE: "Dhrystone"
     DASHBOARD_JOB_DESCRIPTION: "Performance indicator"


### PR DESCRIPTION
Coremark is too long for short regression, 21 minutes. Swapt with Dhrystone which i shorter, 10 minutes