### PR TITLE
cv32a65x CI: Enlarge cache to increase bench result and switch from -O3 to -Os compiler option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,10 +184,10 @@ smoke-bench:
   parallel:
     matrix:
       - BENCH: "dhrystone"
-        DV_HWCONFIG_OPTS: ["cv32a65x"]
+        DV_HWCONFIG_OPTS: ["cv32a65x IcacheByteSize=32768 IcacheSetAssoc=8 DcacheByteSize=32768 DcacheSetAssoc=8"]
   script:
-    - bash verif/regress/"$BENCH".sh --no-print
-    - python3 .gitlab-ci/scripts/report_benchmark.py --"$BENCH"_"$DV_HWCONFIG_OPTS" verif/sim/out_*/vcs-uvm_sim/"$BENCH"_main.*.log
+    - bash verif/regress/"$BENCH"_smoke.sh --no-print
+    - python3 .gitlab-ci/scripts/report_benchmark.py --"$BENCH"_cv32a65x verif/sim/out_*/vcs-uvm_sim/"$BENCH"_main.*.log
 
 hwconfig:
   extends:
@@ -326,16 +326,16 @@ benchmarks:
     matrix:
       - BENCH: "dhrystone"
         ISSUE: "single"
-        DV_HWCONFIG_OPTS: ["cv32a65x SuperscalarEn=0 IcacheByteSize=16384 IcacheSetAssoc=4 DcacheByteSize=32768 DcacheSetAssoc=8"]
+        DV_HWCONFIG_OPTS: ["cv32a65x SuperscalarEn=0 IcacheByteSize=32768 IcacheSetAssoc=8 DcacheByteSize=32768 DcacheSetAssoc=8"]
       - BENCH: "dhrystone"
         ISSUE: "dual"
-        DV_HWCONFIG_OPTS: ["cv32a65x IcacheByteSize=16384 IcacheSetAssoc=4 DcacheByteSize=32768 DcacheSetAssoc=8"]
+        DV_HWCONFIG_OPTS: ["cv32a65x IcacheByteSize=32768 IcacheSetAssoc=8 DcacheByteSize=32768 DcacheSetAssoc=8"]
       - BENCH: "coremark"
         ISSUE: "single"
-        DV_HWCONFIG_OPTS: ["cv32a65x SuperscalarEn=0 IcacheByteSize=16384 IcacheSetAssoc=4 DcacheByteSize=32768 DcacheSetAssoc=8"]
+        DV_HWCONFIG_OPTS: ["cv32a65x SuperscalarEn=0 IcacheByteSize=32768 IcacheSetAssoc=8 DcacheByteSize=32768 DcacheSetAssoc=8"]
       - BENCH: "coremark"
         ISSUE: "dual"
-        DV_HWCONFIG_OPTS: ["cv32a65x IcacheByteSize=16384 IcacheSetAssoc=4 DcacheByteSize=32768 DcacheSetAssoc=8"]
+        DV_HWCONFIG_OPTS: ["cv32a65x IcacheByteSize=32768 IcacheSetAssoc=8 DcacheByteSize=32768 DcacheSetAssoc=8"]
   script:
     - bash verif/regress/"$BENCH".sh
     - python3 .gitlab-ci/scripts/report_benchmark.py --"$BENCH"_"$ISSUE" verif/sim/out_*/vcs-uvm_sim/"$BENCH"_main.*.log

--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -23,7 +23,7 @@ valid_cycles = {
     "dhrystone_single": 26392,
     "coremark_dual": 530099,
     "coremark_single": 673184,
-    "dhrystone_cv32a65x": 21530,
+    "dhrystone_cv32a65x": 33736,
 }
 
 for arg in sys.argv[1:]:

--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -21,9 +21,9 @@ iterations = None
 valid_cycles = {
     "dhrystone_dual": 21530,
     "dhrystone_single": 26392,
-    "coremark_dual": 531457,
-    "coremark_single": 672500,
-    "dhrystone_cv32a65x": 24740,
+    "coremark_dual": 530099,
+    "coremark_single": 673184,
+    "dhrystone_cv32a65x": 21530,
 }
 
 for arg in sys.argv[1:]:

--- a/verif/regress/dhrystone_smoke.sh
+++ b/verif/regress/dhrystone_smoke.sh
@@ -48,7 +48,7 @@ cflags=(
         -nostdlib
         -nostartfiles
         -lgcc
-        -O3 --no-inline
+        -Os --no-inline
         -Wno-implicit-function-declaration
         -Wno-implicit-int
         -I../tests/custom/env


### PR DESCRIPTION
- Cache can slow down execution, enlarging them generates better bench results.
- As cv32a65x targets embedded devices, switch to -Os compiler option to reduce code size