### PR TITLE
Performance tb

### DIFF
--- a/verif/env/uvme/cov/uvme_interrupt_covg.sv
+++ b/verif/env/uvme/cov/uvme_interrupt_covg.sv
@@ -105,7 +105,10 @@ function void uvme_interrupt_covg_c::build_phase(uvm_phase phase);
       `uvm_fatal("CFG", "Configuration handle is null")
    end
 
-   interrupt_cg = new("interrupt_cg");
+   if (!cfg.disable_all_csr_checks)
+      interrupt_cg = new("interrupt_cg");
+   else
+      `uvm_warning(get_type_name(), "Interrupt coverage will not be scored since config disable_all_csr_checks is true")
 
    mon_trn_fifo   = new("mon_trn_fifo" , this);
 
@@ -117,10 +120,11 @@ task uvme_interrupt_covg_c::run_phase(uvm_phase phase);
 
    `uvm_info(get_type_name(), "The Interrupt env coverage model is running", UVM_LOW);
 
-  forever begin
-      mon_trn_fifo.get(mon_trn);
-      interrupt_cg.sample(mon_trn.instr);
-    end
+   if (!cfg.disable_all_csr_checks)
+     forever begin
+         mon_trn_fifo.get(mon_trn);
+         interrupt_cg.sample(mon_trn.instr);
+     end
 
 endtask : run_phase
 

--- a/verif/env/uvme/uvme_cva6_env.sv
+++ b/verif/env/uvme/uvme_cva6_env.sv
@@ -223,7 +223,8 @@ function void uvme_cva6_env_c::connect_phase(uvm_phase phase);
       csr_reg_predictor.map     = csr_reg_block.default_map;
       csr_reg_predictor.adapter = csr_reg_adapter;
       csr_reg_block.default_map.set_auto_predict(0);
-      isacov_agent.monitor.ap.connect(csr_reg_predictor.bus_in);
+      if (cfg.cov_model_enabled)
+         isacov_agent.monitor.ap.connect(csr_reg_predictor.bus_in);
    end
 
 endfunction: connect_phase
@@ -289,6 +290,9 @@ function void uvme_cva6_env_c::create_env_components();
 
    if (cfg.scoreboard_enabled) begin
       predictor = uvme_cva6_prd_c::type_id::create("predictor", this);
+   end
+
+   if (cfg.scoreboard_enabled || cfg.tandem_enabled) begin
       sb        = uvme_cva6_sb_c ::type_id::create("sb"       , this);
    end
 

--- a/verif/env/uvme/uvme_cva6_sb.sv
+++ b/verif/env/uvme/uvme_cva6_sb.sv
@@ -457,6 +457,10 @@ task uvme_cva6_sb_c::run_phase(uvm_phase phase);
 
   super.run_phase(phase);
 
+  if (cfg.scoreboard_enabled && cfg.disable_all_csr_checks)
+      `uvm_warning(get_type_name(),"Scoreboard enabled while config disable_all_csr_checks is true. Cycle and Trap will not be scoreboarded nor checked");
+
+  if (cfg.scoreboard_enabled && !cfg.disable_all_csr_checks)
   fork
       begin
           forever begin

--- a/verif/regress/coremark.sh
+++ b/verif/regress/coremark.sh
@@ -92,4 +92,5 @@ python3 cva6.py \
         --c_tests "$src0" \
         --gcc_opts "${srcA[*]} ${cflags[*]}" \
         --iss_timeout=2000 \
+        --issrun_opts="+tb_performance_mode" \
         $DV_OPTS

--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -63,4 +63,5 @@ python3 cva6.py \
         --iss="$DV_SIMULATORS" \
         --iss_yaml=cva6.yaml \
         --c_tests "$src0" \
+        --issrun_opts="+tb_performance_mode" \
         --gcc_opts "${srcA[*]} ${cflags[*]}"

--- a/verif/regress/dv-riscv-arch-test.sh
+++ b/verif/regress/dv-riscv-arch-test.sh
@@ -36,4 +36,4 @@ else
 fi
 
 cd verif/sim
-python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
+python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS --issrun_opts="+tb_performance_mode" $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld

--- a/verif/regress/dv-riscv-compliance.sh
+++ b/verif/regress/dv-riscv-compliance.sh
@@ -29,5 +29,5 @@ if ! [ -n "$DV_SIMULATORS" ]; then
 fi
 
 cd verif/sim
-python3 cva6.py --testlist=../tests/testlist_riscv-compliance-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_riscv-compliance-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS --issrun_opts="+tb_performance_mode" $DV_OPTS
 cd -

--- a/verif/regress/dv-riscv-tests.sh
+++ b/verif/regress/dv-riscv-tests.sh
@@ -36,6 +36,6 @@ fi
 cd verif/sim
 for TESTLIST in $DV_TESTLISTS
 do
-  python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml $DV_OPTS
+  python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --issrun_opts="+tb_performance_mode" $DV_OPTS
 done
 cd -

--- a/verif/tests/uvmt/base-tests/uvmt_cva6_base_test.sv
+++ b/verif/tests/uvmt/base-tests/uvmt_cva6_base_test.sv
@@ -70,7 +70,14 @@ class uvmt_cva6_base_test_c extends uvm_test;
    constraint env_cfg_cons {
       env_cfg.enabled         == 1;
       env_cfg.is_active       == UVM_ACTIVE;
-      env_cfg.trn_log_enabled == 1;
+      if (!env_cfg.performance_mode) {
+         env_cfg.trn_log_enabled == 1;
+      } else {
+         env_cfg.trn_log_enabled           == 0;
+         env_cfg.cov_model_enabled         == 0;
+         env_cfg.force_disable_csr_checks  == 1;
+         env_cfg.scoreboard_enabled        == 0;
+      }
    }
 
    constraint axi_agent_cfg_cons {


### PR DESCRIPTION
Add performance_mode to be set in line command using +tb_performance_mode to speed up simulation time by disabling functional coverage, agents logger, rvfi csr checks and scoreboard. 
This +tb_performance_mode switch has also been added in related regression tests