### PR TITLE
ci: print results in job logs

### DIFF
--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -72,13 +72,5 @@ report = rb.Report(f"{cycles//1000} kCycles")
 report.add_metric(score_metric)
 report.dump()
 
-filename = re.sub(r"[^\w\.\\\/]", "_", os.environ["CI_JOB_NAME"])
-path = "artifacts/reports/" + filename + ".yml"
-with open(path, "r") as f:
-    log = [l.strip() for l in f.readlines()]
-for index, line in enumerate(log):
-    if "MHz" in line or "cycles" in line:
-        print(log[index + 1], log[index])
-
 if report.failed:
     sys.exit(1)

--- a/.gitlab-ci/scripts/report_builder.py
+++ b/.gitlab-ci/scripts/report_builder.py
@@ -172,12 +172,19 @@ class Report:
 
     def dump(self, path=None):
         """
-        Create report file
+        Print results and create report file
 
         By default the output path is build from $CI_JOB_NAME
         """
+        for metric in self.metrics:
+            print(metric.values)
+
         if path is None:
-            filename = re.sub(r'[^\w\.\\\/]', '_', os.environ["CI_JOB_NAME"])
-            path = 'artifacts/reports/'+filename+'.yml'
-        with open(path, 'w') as f:
-            yaml.dump(self.to_doc(), f)
+            ci_job_name = os.environ.get("CI_JOB_NAME")
+            if ci_job_name is not None:
+                filename = re.sub(r'[^\w\.\\\/]', '_', ci_job_name)
+                path = 'artifacts/reports/'+filename+'.yml'
+
+        if path is not None:
+            with open(path, 'w') as f:
+                yaml.dump(self.to_doc(), f)


### PR DESCRIPTION
This modification allows:

- printing the results in the terminal
- running the script from the terminal (without the environment variables from CI)

The yaml report is only built in CI, but the results are always printed.

Pretty printing is not a goal of this PR and could be added later on.