### PR TITLE
cache_ctrl: Generalise AXI offset generation

### DIFF
--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -117,7 +117,8 @@ module cache_ctrl
     // cache-line offset -> multiple of XLEN
     cl_offset = mem_req_q.index[CVA6Cfg.DCACHE_OFFSET_WIDTH-1:$clog2(CVA6Cfg.XLEN/8)] <<
         $clog2(CVA6Cfg.XLEN);  // shift by log2(XLEN) to the left
-    axi_offset = '0;
+    // XLEN offset within AXI request
+    axi_offset = (mem_req_q.index >> $clog2(CVA6Cfg.XLEN / 8)) << $clog2(CVA6Cfg.XLEN);
     // default assignments
     state_d = state_q;
     mem_req_d = mem_req_q;
@@ -137,11 +138,6 @@ module cache_ctrl
     we_o = '0;
 
     mem_req_d.killed |= req_port_i.kill_req;
-
-    if (CVA6Cfg.XLEN == 32) begin
-      axi_offset = mem_req_q.index[$clog2(CVA6Cfg.AxiDataWidth/8)-1:$clog2(CVA6Cfg.XLEN/8)] <<
-          $clog2(CVA6Cfg.XLEN);
-    end
 
     case (state_q)
 


### PR DESCRIPTION
For `XLEN = 64`, some tools (e.g. VCS) still elaborate the offset generation block for `XLEN = 32`, throwing an elaboration error (illegal bit access). Hence, VCS can currently not build the 64-bit WB configuration of CVA6. Fix this by generating the AXI offset in an equivalent, parameter-agnostic and tool-friendly way.