### PR TITLE
[benchmarks] Pass DV_OPTS to dhrystone execution.

### DIFF
--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -69,4 +69,5 @@ python3 cva6.py \
         --iss="$DV_SIMULATORS" \
         --iss_yaml=cva6.yaml \
         --c_tests "$src0" \
-        --gcc_opts "${srcA[*]} ${cflags[*]}"
+        --gcc_opts "${srcA[*]} ${cflags[*]}" \
+        $DV_OPTS


### PR DESCRIPTION
Fix the dhrystone execution script so that any ISS options accumulated in shell variable `DV_OPTS` are duly propagated to `cva6.py`.