### PR TITLE
csr_regfile: Fix S-mode traps when H extension is enabled

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1829,25 +1829,23 @@ module csr_regfile
 
       // trap to supervisor mode
       if (CVA6Cfg.RVS && trap_to_priv_lvl == riscv::PRIV_LVL_S) begin
-        if (CVA6Cfg.RVH) begin
-          if (trap_to_v) begin
-            // update sstatus
-            vsstatus_d.sie = 1'b0;
-            vsstatus_d.spie = vsstatus_q.sie;
-            // this can either be user or supervisor mode
-            vsstatus_d.spp = priv_lvl_q[0];
-            // set cause
-            vscause_d = ex_i.cause[CVA6Cfg.XLEN-1] ? {ex_i.cause[CVA6Cfg.XLEN-1:2], 2'b01} : ex_i.cause;
-            // set epc
-            vsepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
-            // set vstval
-            vstval_d        = (ariane_pkg::ZERO_TVAL
-                                        && (ex_i.cause inside {
-                                          riscv::ILLEGAL_INSTR,
-                                          riscv::BREAKPOINT,
-                                          riscv::ENV_CALL_UMODE
-                                        } || ex_i.cause[CVA6Cfg.XLEN-1])) ? '0 : ex_i.tval;
-          end
+        if (CVA6Cfg.RVH && trap_to_v) begin
+          // update sstatus
+          vsstatus_d.sie = 1'b0;
+          vsstatus_d.spie = vsstatus_q.sie;
+          // this can either be user or supervisor mode
+          vsstatus_d.spp = priv_lvl_q[0];
+          // set cause
+          vscause_d = ex_i.cause[CVA6Cfg.XLEN-1] ? {ex_i.cause[CVA6Cfg.XLEN-1:2], 2'b01} : ex_i.cause;
+          // set epc
+          vsepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
+          // set vstval
+          vstval_d        = (ariane_pkg::ZERO_TVAL
+                             && (ex_i.cause inside {
+                             riscv::ILLEGAL_INSTR,
+                             riscv::BREAKPOINT,
+                             riscv::ENV_CALL_UMODE
+                             } || ex_i.cause[CVA6Cfg.XLEN-1])) ? '0 : ex_i.tval;
         end else begin
           // update sstatus
           mstatus_d.sie = 1'b0;


### PR DESCRIPTION
Since #2346, if Hypervisor extension is enabled, the logic required to properly trap to S mode is excluded. Fix this by adjusting the if condition.