### PR TITLE
Fix wrong axi signal in docs

### DIFF
--- a/docs/01_cva6_user/AXI_Interface.rst
+++ b/docs/01_cva6_user/AXI_Interface.rst
@@ -95,7 +95,7 @@ Table 2.1 shows the global AXI memory interface signals.
      - Clock source
      - | Global clock signal. Synchronous signals are sampled on the
        | rising edge of the global clock.
-   * - **WDATA**
+   * - **ARESETn**
      - Reset source
      - | Global reset signal. This signal is active-LOW.
 


### PR DESCRIPTION
I was reading through the docs and spotted a typo for the AXI signal name.