### PR TITLE
Increase Spike PMP granularity to 8.  Update yaml spec files accordingly.

### DIFF
--- a/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
@@ -18,6 +18,7 @@ spike_param_tree:
       marchid_override_mask: 0xFFFFFFFF
       marchid_override_value: 0x3
       misa_write_mask: 0x0
+      pmp_granularity: 8
       pmpaddr0: 0
       pmpcfg0: 0
       pmpregions_max: 64

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -18,6 +18,7 @@ spike_param_tree:
       marchid_override_mask: 0xFFFFFFFF
       marchid_override_value: 0x3
       misa_write_mask: 0x0
+      pmp_granularity: 8
       pmpaddr0: 0
       pmpcfg0: 0
       pmpregions_max: 64

--- a/config/riscv-config/cv32a65x/generated/isa_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/isa_gen.yaml
@@ -21,7 +21,7 @@ hart0:
     supported_xlen:
       - 32
     physical_addr_sz: 32
-    pmp_granularity: 4
+    pmp_granularity: 8
     misa:
         reset-val: 0x40001106
         rv32:

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -20,7 +20,7 @@ hart0: &hart0
   User_Spec_Version: '2.3'
   supported_xlen: [32]
   physical_addr_sz: 32
-  pmp_granularity: 4
+  pmp_granularity: 8
   misa:
    reset-val: 0x40001106 # B: bit 1, C: bit 2, I = bit 8, M = bit 12, Z = bit 25
    rv32:


### PR DESCRIPTION
Update `riscv-config` spec files and Spike Yaml file for CV32A65X.

Bump CVV to change Spike default PMP granularity to 8 and to include corresponding Spike Yaml parameter.