### PR TITLE
improve dashboard-provided log

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,6 @@ smoke-tests:
         DV_TARGET: "cv32a65x"
   script:
     - if [[ $DV_SIMULATORS == *"questa"* ]]; then source $QUESTA_BASHRC; fi
-    - if [[ $DV_TARGET == *"65x"* ]]; then unset SPIKE_TANDEM; export DV_SIMULATORS=vcs-uvm,spike; fi
     - bash verif/regress/smoke-tests-$DV_TARGET.sh
     - !reference [.simu_after_script]
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,8 +131,8 @@ build_tools:
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
 
 .simu_after_script: &simu_after_script
-  - for i in $(find verif/sim/out*/[vq]*_sim -type f \( -name "*.csv" -o -name "*.iss" -o -name "*.yaml" \)) ; do head -10000 $i > artifacts/logs/$(basename $i).head ; done
-  - head -10000 verif/sim/logfile.log > artifacts/logs/logfile.log.head
+  - for i in $(find verif/sim/out*/[vq]*_sim -type f \( -name "*.csv" -o -name "*.iss" -o -name "*.yaml" \)) ; do tail -10000 $i > artifacts/logs/$(basename $i) ; done
+  - tail -10000 verif/sim/logfile.log > artifacts/logs/logfile.log
   - if [ -n "$SPIKE_TANDEM" ]; then python3 .gitlab-ci/scripts/report_tandem.py verif/sim/out*/"$DV_SIMULATORS"_sim; else python3 .gitlab-ci/scripts/report_simu.py verif/sim/logfile.log; fi
 
 smoke-tests:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,6 +153,7 @@ smoke-tests:
         DV_TARGET: "cv32a65x"
   script:
     - if [[ $DV_SIMULATORS == *"questa"* ]]; then source $QUESTA_BASHRC; fi
+    - if [[ $DV_TARGET == *"65x"* ]]; then unset SPIKE_TANDEM; export DV_SIMULATORS=vcs-uvm,spike; fi
     - bash verif/regress/smoke-tests-$DV_TARGET.sh
     - !reference [.simu_after_script]
 

--- a/.gitlab-ci/scripts/report_simu.py
+++ b/.gitlab-ci/scripts/report_simu.py
@@ -45,9 +45,9 @@ for i in list_of_tests:
 
     if with_logs:
         logsPath = "logs/" + os.environ.get("CI_JOB_ID") + "/artifacts/logs/"
-        output_log = logsPath + 'logfile.log.head'
-        tb_log = logsPath + test + "." + target + '.log.iss.head'
-        disassembly = logsPath + test + "." + target + '.csv.head'
+        output_log = logsPath + 'logfile.log'
+        tb_log = logsPath + test + "." + target + '.log.iss'
+        disassembly = logsPath + test + "." + target + '.csv'
         col = [target, isa, test, output_log, tb_log, disassembly]
     else:
         col = [target, isa, test]

--- a/.gitlab-ci/scripts/report_tandem.py
+++ b/.gitlab-ci/scripts/report_tandem.py
@@ -74,11 +74,11 @@ def add_test_row(report_file, metrics_table, with_logs):
 
         if with_logs:
             logs_path = "logs/" + os.environ.get("CI_JOB_ID") + "/artifacts/logs/"
-            output_log = logs_path + "logfile.log.head"
+            output_log = logs_path + "logfile.log"
             log_prefix = logs_path + report['test'] + "_" + str(report["iteration"]) + "." + report["target"] \
                 if "iteration" in report else logs_path + report['test'] + "." + report["target"]
-            tb_log = log_prefix + '.log.iss.head'
-            disassembly = log_prefix + '.log.csv.head'
+            tb_log = log_prefix + '.log.iss'
+            disassembly = log_prefix + '.log.csv'
 
             row.append(output_log)
             row.append(tb_log)

--- a/.gitlab-ci/scripts/report_tandem.py
+++ b/.gitlab-ci/scripts/report_tandem.py
@@ -47,6 +47,7 @@ def add_table_legend(metrics_table, with_logs):
 
     if with_logs:
         metrics_table.add_column("OUTPUT", "log")
+        metrics_table.add_column("TANDEM REPORT", "log")
         metrics_table.add_column("TB LOGS", "log")
         metrics_table.add_column("DISASSEMBLY", "log")
 
@@ -79,10 +80,12 @@ def add_test_row(report_file, metrics_table, with_logs):
                 if "iteration" in report else logs_path + report['test'] + "." + report["target"]
             tb_log = log_prefix + '.log.iss'
             disassembly = log_prefix + '.log.csv'
+            tandem_report = log_prefix + '.log.yaml'
 
             row.append(output_log)
             row.append(tb_log)
             row.append(disassembly)
+            row.append(tandem_report)
 
         if report["exit_cause"] == "SUCCESS" and report["exit_code"] == 0:
             metrics_table.add_pass(*row)

--- a/.gitlab-ci/scripts/report_tandem.py
+++ b/.gitlab-ci/scripts/report_tandem.py
@@ -83,9 +83,9 @@ def add_test_row(report_file, metrics_table, with_logs):
             tandem_report = log_prefix + '.log.yaml'
 
             row.append(output_log)
+            row.append(tandem_report)
             row.append(tb_log)
             row.append(disassembly)
-            row.append(tandem_report)
 
         if report["exit_cause"] == "SUCCESS" and report["exit_code"] == 0:
             metrics_table.add_pass(*row)

--- a/verif/regress/smoke-gen_tests.sh
+++ b/verif/regress/smoke-gen_tests.sh
@@ -33,6 +33,12 @@ if ! [ -n "$DV_TARGET" ]; then
   DV_TARGET=cv32a65x
 fi
 
+if ! [ -n "$UVM_VERBOSITY" ]; then
+    export UVM_VERBOSITY=UVM_NONE
+fi
+
+export DV_OPTS="$DV_OPTS --issrun_opts=+debug_disable=1+UVM_VERBOSITY=$UVM_VERBOSITY"
+
 cd verif/sim/
 cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
 python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_arithmetic_basic_test_comp --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300


### PR DESCRIPTION
* Due to the increased count of warnings, provide tail of log instead of head on the dashboard
* Add tandem yaml report file on the jobs reports
* Reduce UVM Verbosity on smoke gen tests