### PR TITLE
Provide the correct environment for doc build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,7 @@ build:
     - cmake
     - bison
     - flex
+    - pango
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,10 @@
 
 version: 2
 
+submodules:
+  include:
+    - docs/riscv-isa/riscv-isa-manual
+
 build:
   os: "ubuntu-20.04"
   tools:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ build:
     - bison
     - flex
     - libpango1.0-dev
-    - gdk-pixbuf-2.0
+    - gdk-pixbuf
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,7 @@ build:
     ruby: "3.3"
   apt_packages:
     - cmake
+    - bison
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,6 @@ build:
     - flex
     - libpango1.0-dev
     - libgdk-pixbuf2.0-0
-    - gdk-pixbuf-2.0
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,8 @@ build:
     python: "3.9"
     nodejs: "20"
     ruby: "3.3"
+  apt_packages:
+    - cmake
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,7 @@ build:
     - flex
     - libpango1.0-dev
     - libgdk-pixbuf2.0-0
+    - gdk-pixbuf-2.0
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ build:
     - bison
     - flex
     - libpango1.0-dev
-    - gdk-pixbuf-2.0
+    - libgdk-pixbuf2.0-0
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
     - cmake
     - bison
     - flex
-    - pango
+    - libpango1.0-dev
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,7 @@ build:
   apt_packages:
     - cmake
     - bison
+    - flex
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,7 @@ build:
     - bison
     - flex
     - libpango1.0-dev
+    - gdk-pixbuf-2.0
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ build:
     - bison
     - flex
     - libpango1.0-dev
-    - gdk-pixbuf
+    - gdk-pixbuf-2.0
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,7 @@ build:
     - flex
     - libpango1.0-dev
     - libgdk-pixbuf2.0-0
+    - libgtk2.0-dev
   jobs:
     post_install:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies


### PR DESCRIPTION
Install the required packages for read the docs build.
This PR aims at fixing the documentation build on the infrastructure side.
The build process is still broken: executing `make -C docs` will throw an error, this will be solved on another pull request.