### PR TITLE
check spike version in cva6.py

### DIFF
--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1032,7 +1032,7 @@ def check_verilator_version():
 
 def check_tools_version():
   check_cc_version()
-  # check_spike_version()
+  check_spike_version()
   check_verilator_version()
 
 


### PR DESCRIPTION
check version check seem to have been commented by mistake, this pr fixes it