### PR TITLE
csr: reduce to one commit port

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -35,7 +35,7 @@ module csr_regfile
     // halt requested - CONTROLLER
     output logic halt_csr_o,
     // Instruction to be committed - ID_STAGE
-    input scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
+    input scoreboard_entry_t commit_instr_i,
     // Commit acknowledged a instruction -> increase instret CSR - COMMIT_STAGE
     input logic [CVA6Cfg.NrCommitPorts-1:0] commit_ack_i,
     // Address from which to start booting, mtvec is set to the same address - SUBSYSTEM
@@ -2000,11 +2000,11 @@ module csr_regfile
         dcsr_d.prv = priv_lvl_o;
         dcsr_d.v   = (!CVA6Cfg.RVH) ? 1'b0 : v_q;
         // valid CTRL flow change
-        if (commit_instr_i[0].fu == CTRL_FLOW) begin
+        if (commit_instr_i.fu == CTRL_FLOW) begin
           // we saved the correct target address during execute
           dpc_d = {
-            {CVA6Cfg.XLEN - CVA6Cfg.VLEN{commit_instr_i[0].bp.predict_address[CVA6Cfg.VLEN-1]}},
-            commit_instr_i[0].bp.predict_address
+            {CVA6Cfg.XLEN - CVA6Cfg.VLEN{commit_instr_i.bp.predict_address[CVA6Cfg.VLEN-1]}},
+            commit_instr_i.bp.predict_address
           };
           // exception valid
         end else if (ex_i.valid) begin
@@ -2015,8 +2015,8 @@ module csr_regfile
           // consecutive PC
         end else begin
           dpc_d = {
-            {CVA6Cfg.XLEN - CVA6Cfg.VLEN{commit_instr_i[0].pc[CVA6Cfg.VLEN-1]}},
-            commit_instr_i[0].pc + (commit_instr_i[0].is_compressed ? 'h2 : 'h4)
+            {CVA6Cfg.XLEN - CVA6Cfg.VLEN{commit_instr_i.pc[CVA6Cfg.VLEN-1]}},
+            commit_instr_i.pc + (commit_instr_i.is_compressed ? 'h2 : 'h4)
           };
         end
         debug_mode_d   = 1'b1;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -1088,7 +1088,7 @@ module cva6
       .time_irq_i,
       .flush_o                 (flush_csr_ctrl),
       .halt_csr_o              (halt_csr_ctrl),
-      .commit_instr_i          (commit_instr_id_commit),
+      .commit_instr_i          (commit_instr_id_commit[0]),
       .commit_ack_i            (commit_ack),
       .boot_addr_i             (boot_addr_i[CVA6Cfg.VLEN-1:0]),
       .hart_id_i               (hart_id_i[CVA6Cfg.XLEN-1:0]),


### PR DESCRIPTION
Only the first commit port is used by CSR.