### PR TITLE
ci: use different variables for runner tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ variables:
   DV_TARGET: cv32a65x
 
 default:
-  tags: [$TAGS_RUNNER]
+  tags: [$TAGS_RUNNER_SIMU]
   artifacts:
     when: always
     paths:
@@ -72,6 +72,7 @@ stages:
 
 .setup_job:
   stage: setup
+  tags: [$TAGS_RUNNER]
   variables:
     GIT_SUBMODULE_STRATEGY: none
   rules: &on_dev
@@ -263,6 +264,7 @@ cvxif-regression:
 asic-synthesis:
   extends:
     - .synthesis_test
+  tags: [$TAGS_RUNNER_SYNTH]
   variables:
     DASHBOARD_JOB_TITLE: "ASIC Synthesis $DV_TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Synthesis indicator with specific Techno"
@@ -569,7 +571,7 @@ simu-gate:
 fpga-boot:
   extends:
     - .backend_test
-  tags: [fpga,shell]
+  tags: [$TAGS_RUNNER_FPGA]
   needs:
     - build_tools
     - fpga-build
@@ -614,6 +616,7 @@ code_coverage-report:
 
 check gitlab jobs status:
   stage: find failures
+  tags: [$TAGS_RUNNER]
   rules:
     - if: $DASHBOARD_URL && $CI_KIND != "none"
       when: on_failure
@@ -630,6 +633,7 @@ check gitlab jobs status:
 
 merge reports:
   stage: report
+  tags: [$TAGS_RUNNER]
   variables:
     GIT_SUBMODULE_STRATEGY: none
   rules:


### PR DESCRIPTION
This allows a more grained management of CI resources.