### PR TITLE
RVFI : For synchronous trap, check mcause MSB also

### DIFF
--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -284,8 +284,8 @@ module cva6_rvfi
                   ex_commit_cause == riscv::ENV_CALL_UMODE));
       rvfi_instr_o[i].valid <= valid;
       rvfi_instr_o[i].insn  <= mem_q[commit_pointer[i]].instr;
-      // when trap, the instruction is not executed
-      rvfi_instr_o[i].trap  <= exception;
+      // when synchronous trap, the instruction is not executed
+      rvfi_instr_o[i].trap  <= exception && !ex_commit_cause[31];
 
       if (exception && ex_commit_cause[31]) begin
         rvfi_intr[i] <= 'b101;


### PR DESCRIPTION
According to RVFI spec, trap is for synchronous trap only, so we should check MCAUSE msb to distinguish between synchronous and asynchronous