### PR TITLE
Adding support for Scalar Cryptography Extension (Crossbar permutation instructions, Zbkx)

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -782,6 +782,8 @@ module decoder
                   if (CVA6Cfg.ZKN) instruction_o.op = ariane_pkg::PACK_H;  //packh
                   else illegal_instr_bm = 1'b1;
                 end
+                {7'b001_0100, 3'b100} : if (CVA6Cfg.ZKN) instruction_o.op = ariane_pkg::XPERM8; else illegal_instr_bm = 1'b1; // xperm8
+                {7'b001_0100, 3'b010} : if (CVA6Cfg.ZKN) instruction_o.op = ariane_pkg::XPERM4; else illegal_instr_bm = 1'b1; // xperm4
                 // Zero Extend Op RV32 encoding
                 {
                   7'b000_0100, 3'b100

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -498,7 +498,10 @@ package ariane_pkg;
     BREV8,
     // Zip instructions
     UNZIP,
-    ZIP
+    ZIP,
+    // Xperm instructions
+    XPERM8,
+    XPERM4
   } fu_op;
 
   function automatic logic op_is_branch(input fu_op op);

--- a/docs/01_cva6_user/RISCV_Instructions_RvZbkx.rst
+++ b/docs/01_cva6_user/RISCV_Instructions_RvZbkx.rst
@@ -1,0 +1,86 @@
+..
+   Copyright (c) 2023 OpenHW Group
+   Copyright (c) 2023 10xEngineers
+
+   SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+.. Level 1
+   =======
+
+   Level 2
+   -------
+
+   Level 3
+   ~~~~~~~
+
+   Level 4
+   ^^^^^^^
+
+.. _cva6_riscv_instructions_RV32Zbkx:
+
+*Applicability of this chapter to configurations:*
+
+.. csv-table::
+   :widths: auto
+   :align: left
+   :header: "Configuration", "Implementation"
+
+   "CV32A60AX", "Implemented extension"
+   "CV64A6_MMU", "Implemented extension"
+
+=============================
+RVZbkx: Crossbar permutation instructions
+=============================
+
+The following instructions comprise the Zbkx extension:
+
+Xperm instructions
+--------------------
+The xperm instructions perform permutation operations on a register. They use indices extracted from rs2 to select data chunks (bytes for xperm8 or nibbles for xperm4) from rs1. The selected data is then placed into the destination register (rd) at positions corresponding to the extracted indices in rs2. If an index in rs2 is out of range, the corresponding chunk in rd is set to 0.
+
++-----------+-----------+-----------------------+
+| RV32      | RV64      | Mnemonic              |
++===========+===========+=======================+
+| ✔         | ✔         | xperm8 rd, rs1, rs2   |
++-----------+-----------+-----------------------+
+| ✔         | ✔         | xperm4 rd, rs1, rs2   |
++-----------+-----------+-----------------------+
+
+
+RV32 and RV64 Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+- **XPERM8**: Crossbar permutation (bytes)
+
+    **Format**: xperm8 rd, rs1, rs2
+
+    **Description**: The xperm8 instruction operates on bytes. The rs1 register contains a vector of XLEN/8 8-bit elements. The rs2 register contains a vector of XLEN/8 8-bit indexes. The result is each element in rs2 replaced by the indexed element in rs1, or zero if the index into rs2 is out of bounds.
+
+    **Pseudocode**: foreach (i from 0 to xlen by 8) {
+                        if (rs2[i*8+:8]<(xlen/8))
+                            X(rd)[i*8+:8] = rs1[rs2[i*8+:8]*8+:8];
+                        else
+                            X(rd)[i*8+:8] = 8'b0;
+                    }
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE
+
+- **XPERM4**: Crossbar permutation (nibbles)
+
+    **Format**: xperm4 rd, rs1, rs2 
+
+    **Description**: The xperm4 instruction operates on nibbles. The rs1 register contains a vector of XLEN/4 4-bit elements. The rs2 register contains a vector of XLEN/4 4-bit indexes. The result is each element in rs2 replaced by the indexed element in rs1, or zero if the index into rs2 is out of bounds.
+
+    **Pseudocode**: foreach (i from 0 to xlen by 4) {
+                        if (rs2[i*4+:4]<(xlen/4))
+                            X(rd)[i*4+:4] = rs1[rs2[i*4+:4]*4+:4];
+                        else
+                            X(rd)[i*4+:4] = 4'b0;
+                    }
+
+    **Invalid values**: NONE
+
+    **Exception raised**: NONE

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -882,7 +882,7 @@ def load_config(args, cwd):
       args.isa  = "rv64gc_zba_zbb_zbs_zbc"
     elif base in ("cv64a6_imafdc_sv39", "cv64a6_imafdc_sv39_hpdcache"):
       args.mabi = "lp64d"
-      args.isa  = "rv64gc_zba_zbb_zbs_zbc_zbkb"
+      args.isa  = "rv64gc_zba_zbb_zbs_zbc_zbkb_zbkx"
     elif base == "cv32a60x":
       args.mabi = "ilp32"
       args.isa  = "rv32imc_zba_zbb_zbs_zbc"

--- a/verif/tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml
+++ b/verif/tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml
@@ -987,3 +987,13 @@ testlist:
     <<: *common_test_config
     iterations: 1
     asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/K/src/brev8-01.S
+
+  - test: rv64i_m-xperm8-01
+    iterations: 1
+    <<: *common_test_config
+    asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/K/src/xperm8-01.S
+
+  - test: rv64i_m-xperm4-01
+    iterations: 1
+    <<: *common_test_config
+    asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/K/src/xperm4-01.S


### PR DESCRIPTION
### Introduction
This PR adds support for Zbkx extension in the CVA6 core. It also adds the documentation and tests for this extension. These changes have been tested with self-written single instruction tests and with the riscv-arch-tests. This PR is part of a series of PRs that will add the complete support for the Zkn - NIST Algorithm Suite extension.

### Implementation
**Zbkx Extension:**
Added support for the Zbkx instruction set. It essentially expands the Bitmanip extension with additional instructions useful in cryptography. These instructions are xperm8, xperm4.

### Modifications
The complete Zkn extension will be added under the ZKN bit for ease of use. This configuration will also require the RVB (bitmanip) bit to be set.
Updated the ALU and decoder to recognize and handle Zbkx instructions.
Documentation and Reference
The official RISC-V Cryptography Extensions Volume I was followed to ensure alignment with ratification. The relevant documentation for the Zbkx instruction was also added.

### Verification
**Assembly Tests:**
The instructions were tested and verified with the K module of both 32 bit and 64 bit versions of the riscv-arch-tests to ensure proper functionality. These tests check for ISA compliance, edge cases and use assertions to ensure expected behavior. The tests include:

- xperm8-01.S
- xperm4-01.S
