### PR TITLE
:bug: Fix icache AXI read len

### DIFF
--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -178,7 +178,7 @@ module wt_axi_adapter
       axi_rd_addr = {{CVA6Cfg.AxiAddrWidth - CVA6Cfg.PLEN{1'b0}}, icache_data.paddr};
       axi_rd_size = MaxNumWords[2:0];  // always request max number of words in case of ifill
       if (!icache_data.nc) begin
-        axi_rd_blen = AxiRdBlenDcache[AxiBlenWidth-1:0];
+        axi_rd_blen = AxiRdBlenIcache[AxiBlenWidth-1:0];
       end
     end
 


### PR DESCRIPTION
I think this bug was introduced by a [copy-paste mistake](https://github.com/openhwgroup/cva6/commit/9877af5eb6e28700adc32dc7229622e2afa618f1#diff-09a66c4298fd443b5dd467e6e8eac16c86a80c41ca9948b227c3c03ce707f8a9L180). 

`AxiRdBlenDcache` -> `AxiRdBlenIcache`