### PR TITLE
wt_axi_adapter: Fix addr width parametrisation

### DIFF
--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -142,7 +142,7 @@ module wt_axi_adapter
     axi_wr_data[0]  = {(CVA6Cfg.AxiDataWidth/CVA6Cfg.XLEN){dcache_data.data}};
     axi_wr_user[0]  = dcache_data.user;
     // Cast to AXI address width
-    axi_wr_addr  = {{CVA6Cfg.AxiAddrWidth-CVA6Cfg.PLEN{1'b0}}, dcache_data.paddr};
+    axi_wr_addr  = CVA6Cfg.AxiAddrWidth'(dcache_data.paddr);
     axi_wr_size  = dcache_data.size;
     axi_wr_req   = 1'b0;
     axi_wr_blen  = '0;// single word writes
@@ -167,7 +167,7 @@ module wt_axi_adapter
     // arbiter mux
     if (arb_idx) begin
       // Cast to AXI address width
-      axi_rd_addr = {{CVA6Cfg.AxiAddrWidth - CVA6Cfg.PLEN{1'b0}}, dcache_data.paddr};
+      axi_rd_addr = CVA6Cfg.AxiAddrWidth'(dcache_data.paddr);
       // If dcache_data.size MSB is set, we want to read as much as possible
       axi_rd_size = dcache_data.size[2] ? MaxNumWords[2:0] : dcache_data.size;
       if (dcache_data.size[2]) begin
@@ -175,7 +175,7 @@ module wt_axi_adapter
       end
     end else begin
       // Cast to AXI address width
-      axi_rd_addr = {{CVA6Cfg.AxiAddrWidth - CVA6Cfg.PLEN{1'b0}}, icache_data.paddr};
+      axi_rd_addr = CVA6Cfg.AxiAddrWidth'(icache_data.paddr);
       axi_rd_size = MaxNumWords[2:0];  // always request max number of words in case of ifill
       if (!icache_data.nc) begin
         axi_rd_blen = AxiRdBlenIcache[AxiBlenWidth-1:0];


### PR DESCRIPTION
#1571 zero-extended the `paddr`s to match the `axi_addr` width and thus fix lint warnings. However, this breaks elaboration  if `AxiAddrWidth <= PLEN`. To fix lint warnings without breaking parametrisation, use explicit casts to pad/truncate as required.