### PR TITLE
wt_dcache_buffer: Avoid out-of-range user signal access

### DIFF
--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -594,8 +594,6 @@ module wt_dcache_wbuffer
             wbuffer_d[wr_ptr].data[k*8+:8] = req_port_i.data_wdata[k*8+:8];
             if (CVA6Cfg.DATA_USER_EN) begin
               wbuffer_d[wr_ptr].user[k*8+:8] = req_port_i.data_wuser[k*8+:8];
-            end else begin
-              wbuffer_d[wr_ptr].user[k*8+:8] = '0;
             end
           end
         end


### PR DESCRIPTION
If the data user signal is disabled and the user bus width is reduced, the slice operator into the user field will cause elaboration errors. Since the faulty else block is anyways without effect, just remove it.