### PR TITLE
mmu: Fix pmpcfg, pmpaddr width

### DIFF
--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -100,8 +100,8 @@ module cva6_mmu
 
     // PMP
 
-    input riscv::pmpcfg_t [CVA6Cfg.NrPMPEntries-1:0]                   pmpcfg_i,
-    input logic           [CVA6Cfg.NrPMPEntries-1:0][CVA6Cfg.PLEN-3:0] pmpaddr_i
+    input riscv::pmpcfg_t [(CVA6Cfg.NrPMPEntries > 0 ? CVA6Cfg.NrPMPEntries-1 : 0):0] pmpcfg_i,
+    input logic           [(CVA6Cfg.NrPMPEntries > 0 ? CVA6Cfg.NrPMPEntries-1 : 0):0][CVA6Cfg.PLEN-3:0] pmpaddr_i
 );
 
   // memory management, pte for cva6

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -83,8 +83,8 @@ module cva6_ptw
     output logic shared_tlb_miss_o,
 
     // PMP
-    input riscv::pmpcfg_t [CVA6Cfg.NrPMPEntries-1:0] pmpcfg_i,
-    input logic [CVA6Cfg.NrPMPEntries-1:0][CVA6Cfg.PLEN-3:0] pmpaddr_i,
+    input riscv::pmpcfg_t [(CVA6Cfg.NrPMPEntries > 0 ? CVA6Cfg.NrPMPEntries-1 : 0):0] pmpcfg_i,
+    input logic [(CVA6Cfg.NrPMPEntries > 0 ? CVA6Cfg.NrPMPEntries-1 : 0):0][CVA6Cfg.PLEN-3:0] pmpaddr_i,
     output logic [CVA6Cfg.PLEN-1:0] bad_paddr_o,
     output logic [CVA6Cfg.GPLEN-1:0] bad_gpaddr_o
 );


### PR DESCRIPTION
#2692 changed the bus width for `pmpcfg` and `pmpaddr` in most modules. Do the same in `cva6_mmu` and `cva6_ptw` to fix port width mismatches.