### PR TITLE
Add parameter to disable software interrupt. Fix issue #2500

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1435,9 +1435,14 @@ module csr_regfile
                       | CVA6Cfg.XLEN'(riscv::MIP_MTIP)
                       | CVA6Cfg.XLEN'(riscv::MIP_MEIP);
             end else begin
-              mask = CVA6Cfg.XLEN'(riscv::MIP_MSIP)
-                      | CVA6Cfg.XLEN'(riscv::MIP_MTIP)
-                      | CVA6Cfg.XLEN'(riscv::MIP_MEIP);
+              if (CVA6Cfg.SoftwareInterruptEn) begin
+                mask = CVA6Cfg.XLEN'(riscv::MIP_MSIP) // same shift as MSIE
+                        | CVA6Cfg.XLEN'(riscv::MIP_MTIP) // same shift as MTIE
+                        | CVA6Cfg.XLEN'(riscv::MIP_MEIP); // same shift as MEIE
+              end else begin
+                mask = CVA6Cfg.XLEN'(riscv::MIP_MTIP) // same shift as MTIE
+                        | CVA6Cfg.XLEN'(riscv::MIP_MEIP); // same shift as MEIE
+              end
             end
           end
           mie_d = (mie_q & ~mask) | (csr_wdata & mask); // we only support supervisor and M-mode interrupts
@@ -1771,7 +1776,7 @@ module csr_regfile
     // Machine Mode External Interrupt Pending
     mip_d[riscv::IRQ_M_EXT] = irq_i[0];
     // Machine software interrupt
-    mip_d[riscv::IRQ_M_SOFT] = ipi_i;
+    mip_d[riscv::IRQ_M_SOFT] = CVA6Cfg.SoftwareInterruptEn && ipi_i;
     // Timer interrupt pending, coming from platform timer
     mip_d[riscv::IRQ_M_TIMER] = time_irq_i;
 

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -95,6 +95,7 @@ package build_config_pkg;
     cfg.MmuPresent = CVA6Cfg.MmuPresent;
     cfg.RVS = CVA6Cfg.RVS;
     cfg.RVU = CVA6Cfg.RVU;
+    cfg.SoftwareInterruptEn = CVA6Cfg.SoftwareInterruptEn;
 
     cfg.HaltAddress = CVA6Cfg.HaltAddress;
     cfg.ExceptionAddress = CVA6Cfg.ExceptionAddress;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -94,6 +94,8 @@ package config_pkg;
     bit                          RVS;
     // User mode
     bit                          RVU;
+    // Software interrupts are enabled
+    bit                          SoftwareInterruptEn;
     // Debug support
     bit                          DebugEn;
     // Base address of the debug module
@@ -279,6 +281,7 @@ package config_pkg;
     bit          MmuPresent;
     bit          RVS;                //Supervisor mode
     bit          RVU;                //User mode
+    bit          SoftwareInterruptEn;
 
     logic [63:0] HaltAddress;
     logic [63:0] ExceptionAddress;
@@ -388,6 +391,10 @@ package config_pkg;
     assert (!(Cfg.SuperscalarEn && Cfg.RVF));
     assert (!(Cfg.SuperscalarEn && Cfg.RVZCMP));
     assert (Cfg.FETCH_WIDTH == 32 || Cfg.FETCH_WIDTH == 64)
+    // Support for disabling MIP.MSIP and MIE.MSIE in Hypervisor and Supervisor mode is not supported
+    // Software Interrupt can be disabled when there is only M machine mode in CVA6.
+    assert (!(Cfg.RVS && !Cfg.SoftwareInterruptEn))
+    assert (!(Cfg.RVH && !Cfg.SoftwareInterruptEn))
     else $fatal(1, "[frontend] fetch width != not supported");
     // pragma translate_on
   endfunction

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -55,6 +55,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(0),
       RVS: bit'(0),
       RVU: bit'(0),
+      SoftwareInterruptEn: bit'(0),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(2),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -55,6 +55,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(0),
       RVS: bit'(0),
       RVU: bit'(0),
+      SoftwareInterruptEn: bit'(0),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(2),

--- a/core/include/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/cv32a6_embedded_config_pkg_deprecated.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(0),
       RVU: bit'(0),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -106,6 +106,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -110,6 +110,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -117,6 +117,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -117,6 +117,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -110,6 +110,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -107,6 +107,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(CVA6ConfigMmuPresent),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(CVA6ConfigRASDepth),

--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -62,6 +62,7 @@ package cva6_config_pkg;
       MmuPresent: bit'(1),
       RVS: bit'(1),
       RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
       HaltAddress: 64'h800,
       ExceptionAddress: 64'h808,
       RASDepth: unsigned'(2),

--- a/verif/env/uvme/uvme_cva6_cfg.sv
+++ b/verif/env/uvme/uvme_cva6_cfg.sv
@@ -131,8 +131,7 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
       HPDCache_supported      == (RTLCVA6Cfg.DCacheType == 2);
 
       MmuPresent              == RTLCVA6Cfg.MmuPresent;
-      // TODO : add RTL paramater related to this field fix issue#2500
-      sw_int_supported        == 0;
+      sw_int_supported        == RTLCVA6Cfg.SoftwareInterruptEn;
    }
 
    constraint ext_const {


### PR DESCRIPTION
Fix issue #2500

Add parameter to disable software interrupt.
MIP.MSIP and MIE.MSIE are now read only  when this parameter is disabled.