### PR TITLE
.readthedocs.yaml: clone submodule recursively

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 submodules:
   include:
     - docs/riscv-isa/riscv-isa-manual
+  recursive: true
 
 build:
   os: "ubuntu-20.04"


### PR DESCRIPTION
as riscv-isa-manual has a submodule, clone it