### PR TITLE
fix 8e5872c03 (add missing smctr.adoc file)

### DIFF
--- a/docs/riscv-isa/src/smctr.adoc
+++ b/docs/riscv-isa/src/smctr.adoc
@@ -1,0 +1,7 @@
+[[smctr]]
+
+== "Smctr" Control Transfer Records Extension, Version 1.0
+
+ifeval::[{RVZsmctr} == false]
+{ohg-config}: This extension is not supported.
+endif::[]


### PR DESCRIPTION
smctr.adoc is a new file in riscv-isa-manual to be overwritten

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>