### PR TITLE
fix 023e67e9 (define PATH variable and make in one command)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,8 +27,7 @@ build:
       - npm install docs/riscv-isa/riscv-isa-manual/dependencies
       - gem install -g docs/riscv-isa/riscv-isa-manual/dependencies/Gemfile
     pre_build:
-      - export PATH=$PWD/node_modules/.bin:$PATH
-      - make -C docs prepare
+      - PATH=$PWD/node_modules/.bin:$PATH make -C docs prepare
 
 # Build from the docs directory with Sphinx
 sphinx:


### PR DESCRIPTION
to avoid PATH export, define it in the same command with make

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>