### PR TITLE
riscv-isa-manual: ignore mm-formal.adoc

### DIFF
--- a/docs/riscv-isa/src/mm-formal.adoc
+++ b/docs/riscv-isa/src/mm-formal.adoc
@@ -1,0 +1,7 @@
+[appendix]
+== Formal Memory Model Specifications, Version 0.1
+[[mm-formal]]
+
+ifeval::["{ohg-config}" == "CV32A65X"]
+{ohg-config}: No RVWMO memory model.
+endif::[]


### PR DESCRIPTION
as this appendix requires Java and as it is not relevant for CV32A65X

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>