### PR TITLE
docs/requirements.txt: add missing packages for RTD

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,9 @@ sphinx-rtd-theme
 recommonmark
 sphinxcontrib-svg2pdfconverter
 sphinx_github_changelog
+
+# for gen_from_riscv_config
+mako
+mdutils
+pyyaml
+rstcloth


### PR DESCRIPTION
this should fix build of design documents

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>