### PR TITLE
config_pkg: fix HPDCache related parameter

### DIFF
--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -56,7 +56,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigDcacheIdWidth = 3;
   localparam CVA6ConfigMemTidWidth = CVA6ConfigAxiIdWidth;
 
-  localparam CVA6ConfigWtDcacheWbufDepth = 8;
+  localparam CVA6ConfigWtDcacheWbufDepth = 7;
 
   localparam CVA6ConfigNrScoreboardEntries = 8;
 


### PR DESCRIPTION
The AXI AW channel in the HPDcache is shared by three components:

- Write Buffer
- Flush Controller
- Uncached Controller

The ID for each transaction is generated based on its source as follows:

- Write Buffer: `{1'b0, write_buffer_entry_index}`
- Flush Controller: `{1'b1, flush_controller_index}`
- Uncached Controller: `'1`

To distinguish between flush transactions and uncached transactions, the flush transaction ID must include at least one 0.

Currently, the AXI ID is limited to 4 bits, while the flush controller supports 8 entries. As a result, when a transaction is sent from the 8th entry of the flush controller, all bits of the ID are set to 1. This causes the HPDcache to misroute the response to the uncached controller instead of the flush controller.

The parameter `CVA6ConfigWtDcacheWbufDepth` is used in the WB cache to set the number of flush entries. To avoid modifying the ID width, the number of flush entries must be less than 8. Non-power-of-two values are supported.