### PR TITLE
docs: clarify WLRL CSR fields on CVA6 (fix #1053)

### DIFF
--- a/docs/riscv-isa/src/priv-csrs.adoc
+++ b/docs/riscv-isa/src/priv-csrs.adoc
@@ -1,0 +1,1039 @@
+[[priv-csrs]]
+== Control and Status Registers (CSRs)
+
+The SYSTEM major opcode is used to encode all privileged instructions in
+the RISC-V ISA. These can be divided into two main classes: those that
+atomically read-modify-write control and status registers (CSRs), which
+are defined in the Zicsr extension, and all other privileged
+instructions. The privileged architecture requires the Zicsr extension;
+which other privileged instructions are required depends on the
+privileged-architecture feature set.
+
+In addition to the unprivileged state described in Volume I of this
+manual, an implementation may contain additional CSRs, accessible by
+some subset of the privilege levels using the CSR instructions described
+in Volume I. In this chapter, we map out the CSR address space. The
+following chapters describe the function of each of the CSRs according
+to privilege level, as well as the other privileged instructions which
+are generally closely associated with a particular privilege level. Note
+that although CSRs and instructions are associated with one privilege
+level, they are also accessible at all higher privilege levels.
+
+Standard CSRs do not have side effects on reads but may have side
+effects on writes.
+
+=== CSR Address Mapping Conventions
+
+The standard RISC-V ISA sets aside a 12-bit encoding space (csr[11:0])
+for up to 4,096 CSRs. By convention, the upper 4 bits of the CSR address
+(csr[11:8]) are used to encode the read and write accessibility of the
+CSRs according to privilege level as shown in <<csrrwpriv>>. The top two bits (csr[11:10]) indicate whether the register is read/write (`00`,`01`, or `10`) or read-only (`11`). The next two bits (csr[9:8]) encode the lowest privilege level that can access the CSR.
+
+[NOTE]
+====
+The CSR address convention uses the upper bits of the CSR address to
+encode default access privileges. This simplifies error checking in the
+hardware and provides a larger CSR space, but does constrain the mapping
+of CSRs into the address space.
+
+Implementations might allow a more-privileged level to trap otherwise
+permitted CSR accesses by a less-privileged level to allow these
+accesses to be intercepted. This change should be transparent to the
+less-privileged software.
+====
+
+Instructions that access a non-existent CSR are reserved.
+Attempts to access a CSR without appropriate privilege level
+raise illegal-instruction exceptions or, as described in
+<<sec:hcauses>>, virtual-instruction exceptions.
+Attempts to write a read-only register raise illegal-instruction exceptions.
+A read/write register might also contain some bits that are
+read-only, in which case writes to the read-only bits are ignored.
+
+<<csrrwpriv>> also indicates the convention to
+allocate CSR addresses between standard and custom uses. The CSR
+addresses designated for custom uses will not be redefined by future
+standard extensions.
+
+Machine-mode standard read-write CSRs `0x7A0`-`0x7BF` are reserved for
+use by the debug system. Of these CSRs, `0x7A0`-`0x7AF` are accessible
+to machine mode, whereas `0x7B0`-`0x7BF` are only visible to debug mode.
+Implementations should raise illegal-instruction exceptions on
+machine-mode access to the latter set of registers.
+
+[NOTE]
+====
+Effective virtualization requires that as many instructions run natively
+as possible inside a virtualized environment, while any privileged
+accesses trap to the virtual machine monitor. cite:[goldbergvm] CSRs that are read-only
+at some lower privilege level are shadowed into separate CSR addresses
+if they are made read-write at a higher privilege level. This avoids
+trapping permitted lower-privilege accesses while still causing traps on
+illegal accesses. Currently, the counters are the only shadowed CSRs.
+====
+
+=== CSR Listing
+
+<<ucsrnames>>-<<mcsrnames1>> list the CSRs that
+have currently been allocated CSR addresses. The timers, counters, and
+floating-point CSRs are standard unprivileged CSRs. The other registers
+are used by privileged code, as described in the following chapters.
+Note that not all registers are required on all implementations.
+
+[[csrrwpriv]]
+.Allocation of RISC-V CSR address ranges.
+[%autowidth,float="center",align="center",cols="^,^,^,^,<,<,<,<"]
+[.monofont]
+|===
+3+^|CSR Address 2.2+|Hex 3.2+|Use and Accessibility
+|[11:10] |[9:8] |[7:4]
+8+|Unprivileged and User-Level CSRs
+m|00 m|00 m|XXXX 2+m| 0x000-0x0FF 3+|Standard read/write
+|`01` |`00` |`XXXX` 2+| `0x400-0x4FF` 3+|Standard read/write
+|`10` |`00` |`XXXX` 2+| `0x800-0x8FF` 3+|Custom read/write
+|`11` |`00` |`0XXX` 2+| `0xC00-0xC7F` 3+|Standard read-only
+|`11` |`00` |`10XX` 2+| `0xC80-0xCBF` 3+|Standard read-only
+|`11` |`00` |`11XX` 2+| `0xCC0-0xCFF` 3+|Custom read-only
+8+|Supervisor-Level CSRs
+|`00` |`01` |`XXXX` 2+| `0x100-0x1FF` 3+|Standard read/write
+|`01` |`01` |`0XXX` 2+| `0x500-0x57F` 3+|Standard read/write
+|`01` |`01` |`10XX` 2+| `0x580-0x5BF` 3+|Standard read/write
+|`01` |`01` |`11XX` 2+| `0x5C0-0x5FF` 3+|Custom read/write
+|`10` |`01` |`0XXX` 2+| `0x900-0x97F` 3+|Standard read/write
+|`10` |`01` |`10XX` 2+| `0x980-0x9BF` 3+|Standard read/write
+|`10` |`01` |`11XX` 2+| `0x9C0-0x9FF` 3+|Custom read/write
+|`11` |`01` |`0XXX` 2+| `0xD00-0xD7F` 3+|Standard read-only
+|`11` |`01` |`10XX` 2+| `0xD80-0xDBF` 3+|Standard read-only
+|`11` |`01` |`11XX` 2+| `0xDC0-0xDFF` 3+|Custom read-only
+8+|Hypervisor and VS CSRs
+|`00` |`10` |`XXXX` 2+| `0x200-0x2FF` 3+|Standard read/write
+|`01` |`10` |`0XXX` 2+| `0x600-0x67F` 3+|Standard read/write
+|`01` |`10` |`10XX` 2+| `0x680-0x6BF` 3+|Standard read/write
+|`01` |`10` |`11XX` 2+| `0x6C0-0x6FF` 3+|Custom read/write
+|`10` |`10` |`0XXX` 2+| `0xA00-0xA7F` 3+|Standard read/write
+|`10` |`10` |`10XX` 2+| `0xA80-0xABF` 3+|Standard read/write
+|`10` |`10` |`11XX` 2+| `0xAC0-0xAFF` 3+|Custom read/write
+|`11` |`10` |`0XXX` 2+| `0xE00-0xE7F` 3+|Standard read-only
+|`11` |`10` |`10XX` 2+| `0xE80-0xEBF` 3+|Standard read-only
+|`11` |`10` |`11XX` 2+| `0xEC0-0xEFF` 3+|Custom read-only
+8+|Machine-Level CSRs
+|`00` |`11` |`XXXX` 2+|`0x300-0x3FF` 3+|Standard read/write
+|`01` |`11` |`0XXX` 2+|`0x700-0x77F` 3+|Standard read/write
+|`01` |`11` |`100X` 2+|`0x780-0x79F` 3+|Standard read/write
+|`01` |`11` |`1010` 2+|`0x7A0-0x7AF` 3+|Standard read/write debug CSRs
+|`01` |`11` |`1011` 2+|`0x7B0-0x7BF` 3+|Debug-mode-only CSRs
+|`01` |`11` |`11XX` 2+|`0x7C0-0x7FF` 3+|Custom read/write
+|`10` |`11` |`0XXX` 2+|`0xB00-0xB7F` 3+|Standard read/write
+|`10` |`11` |`10XX` 2+|`0xB80-0xBBF` 3+|Standard read/write
+|`10` |`11` |`11XX` 2+|`0xBC0-0xBFF` 3+|Custom read/write
+|`11` |`11` |`0XXX` 2+|`0xF00-0xF7F` 3+|Standard read-only
+|`11` |`11` |`10XX` 2+|`0xF80-0xFBF` 3+|Standard read-only
+|`11` |`11` |`11XX` 2+|`0xFC0-0xFFF` 3+|Custom read-only
+|===
+
+<<<
+
+[[ucsrnames]]
+.Currently allocated RISC-V unprivileged CSR addresses.
+[float="center",align="center",cols="<10%,<10%,<20%,<60%",options="header"]
+|===
+|Number |Privilege |Name |Description
+4+^|Unprivileged Floating-Point CSRs
+
+|`0x001` +
+`0x002` +
+`0x003`
+|URW +
+URW +
+URW
+|`fflags` +
+`frm` +
+`fcsr`
+|Floating-Point Accrued Exceptions. +
+Floating-Point Dynamic Rounding Mode. +
+Floating-Point Control and Status Register (`frm` +`fflags`).
+
+4+^|Unprivileged Vector CSRs
+
+|`0x008` +
+`0x009` +
+`0x00A` +
+`0x00F` +
+`0xC20` +
+`0xC21` +
+`0xC22`
+|URW +
+URW +
+URW +
+URW +
+URO +
+URO +
+URO
+|`vstart` +
+`vxsat` +
+`vxrm` +
+`vcsr` +
+`vl` +
+`vtype` +
+`vlenb`
+|Vector start position. +
+Fixed-point accrued saturation flag. +
+Fixed-point rounding mode. +
+Vector control and status register. +
+Vector length. +
+Vector data type register. +
+Vector register length in bytes.
+
+4+^|Unprivileged Zicfiss extension CSR
+|`0x011` +
+|URW +
+|`ssp` +
+|Shadow Stack Pointer. +
+
+4+^|Unprivileged Entropy Source Extension CSR
+|`0x015` +
+|URW +
+|`seed` +
+|Seed for cryptographic random bit generators. +
+
+4+^|Unprivileged Zcmt Extension CSR
+|`0x017` +
+|URW +
+|`jvt` +
+|Table jump base vector and control register. +
+
+4+^|Unprivileged Counter/Timers
+
+|`0xC00` +
+`0xC01` +
+`0xC02` +
+`0xC03` +
+`0xC04` +
+ &#160; +
+`0xC1F` +
+`0xC80` +
+`0xC81` +
+`0xC82` +
+`0xC83` +
+`0xC84` +
+&#160; +
+`0xC9F`
+|URO +
+URO +
+URO +
+URO +
+URO +
+&#160; +
+URO +
+URO +
+URO +
+URO +
+URO +
+URO +
+&#160; +
+URO
+|`cycle` +
+`time` +
+`instret` +
+`hpmcounter3` +
+`hpmcounter4` +
+&#8942; +
+`hpmcounter31` +
+`cycleh` +
+`timeh` +
+`instreth` +
+`hpmcounter3h` +
+`hpmcounter4h` +
+&#8942; +
+`hpmcounter31h`
+|Cycle counter for RDCYCLE instruction. +
+Timer for RDTIME instruction. +
+Instructions-retired counter for RDINSTRET instruction. +
+Performance-monitoring counter. +
+Performance-monitoring counter. +
+&#160; +
+Performance-monitoring counter. +
+Upper 32 bits of `cycle`, RV32 only. +
+Upper 32 bits of `time`, RV32 only. +
+Upper 32 bits of `instret`, RV32 only. +
+Upper 32 bits of `hpmcounter3`, RV32 only. +
+Upper 32 bits of `hpmcounter4`, RV32 only. +
+&#160; +
+Upper 32 bits of `hpmcounter31`, RV32 only.
+|===
+
+<<<
+
+[[scsrnames]]
+.Currently allocated RISC-V supervisor-level CSR addresses.
+[%autowidth,float="center",align="center",cols="<,<,<,<",options="header"]
+|===
+|Number |Privilege |Name |Description
+4+^|Supervisor Trap Setup
+
+|`0x100` +
+`0x104` +
+`0x105` +
+`0x106`
+|SRW +
+SRW +
+SRW +
+SRW
+|`sstatus` +
+`sie` +
+`stvec` +
+`scounteren`
+|Supervisor status register. +
+Supervisor interrupt-enable register. +
+Supervisor trap handler base address. +
+Supervisor counter enable.
+
+4+^|Supervisor Configuration
+
+|`0x10A` |SRW |`senvcfg` |Supervisor environment configuration register.
+
+4+^|Supervisor Counter Setup
+
+|`0x120` |SRW |`scountinhibit` |Supervisor counter-inhibit register.
+
+4+^|Supervisor Trap Handling
+
+|`0x140` +
+`0x141` +
+`0x142` +
+`0x143` +
+`0x144` +
+`0xDA0`
+|SRW +
+SRW +
+SRW +
+SRW +
+SRW +
+SRO
+|`sscratch` +
+`sepc` +
+`scause` +
+`stval` +
+`sip` +
+`scountovf`
+|Supervisor scratch register. +
+Supervisor exception program counter. +
+Supervisor trap cause. +
+Supervisor trap value. +
+Supervisor interrupt pending. +
+Supervisor count overflow.
+
+4+^|Supervisor Protection and Translation
+
+|`0x180` |SRW |`satp` |Supervisor address translation and protection.
+
+4+^|Debug/Trace Registers
+
+|`0x5A8` |SRW |`scontext` |Supervisor-mode context register.
+
+//4+^|Supervisor Resource Management Configuration
+//|`0x181` |SRW |`srmcfg` |Supervisor Resource Management Configuration.
+
+4+^|Supervisor State Enable Registers
+|`0x10C` +
+ `0x10D` +
+ `0x10E` +
+ `0x10F`
+|SRW +
+ SRW +
+ SRW +
+ SRW
+|`sstateen0` +
+ `sstateen1` +
+ `sstateen2` +
+ `sstateen3`
+|Supervisor State Enable 0 Register. +
+ Supervisor State Enable 1 Register. +
+ Supervisor State Enable 2 Register. +
+ Supervisor State Enable 3 Register.
+
+|===
+
+<<<
+
+[[hcsrnames]]
+.Currently allocated RISC-V hypervisor and VS CSR addresses.
+[%autowidth,float="center",align="center",cols="<,<,<,<",options="header"]
+|===
+|Number |Privilege |Name |Description
+4+^|Hypervisor Trap Setup
+
+|`0x600` +
+`0x602` +
+`0x603` +
+`0x604` +
+`0x606` +
+`0x607` +
+`0x612`
+|HRW +
+HRW +
+HRW +
+HRW +
+HRW +
+HRW +
+HRW
+|`hstatus` +
+`hedeleg` +
+`hideleg` +
+`hie` +
+`hcounteren` +
+`hgeie` +
+`hedelegh`
+|Hypervisor status register. +
+Hypervisor exception delegation register. +
+Hypervisor interrupt delegation register. +
+Hypervisor interrupt-enable register. +
+Hypervisor counter enable. +
+Hypervisor guest external interrupt-enable register. +
+Upper 32 bits of `hedeleg`, RV32 only.
+
+4+^|Hypervisor Trap Handling
+
+|`0x643` +
+`0x644` +
+`0x645` +
+`0x64A` +
+`0xE12`
+|HRW +
+HRW +
+HRW +
+HRW +
+HRO
+|`htval` +
+`hip` +
+`hvip` +
+`htinst` +
+`hgeip`
+|Hypervisor trap value. +
+Hypervisor interrupt pending. +
+Hypervisor virtual interrupt pending. +
+Hypervisor trap instruction (transformed). +
+Hypervisor guest external interrupt pending.
+
+4+^|Hypervisor Configuration
+
+|`0x60A` +
+`0x61A`
+|HRW +
+HRM
+|`henvcfg` +
+`henvcfgh`
+|Hypervisor environment configuration register. +
+Upper 32 bits of `henvcfg`, RV32 only.
+
+4+^|Hypervisor Protection and Translation
+
+|`0x680` |HRW |`hgatp` |Hypervisor guest address translation and protection.
+
+4+^|Debug/Trace Registers
+
+|`0x6A8` |HRW |`hcontext` |Hypervisor-mode context register.
+
+4+^|Hypervisor Counter/Timer Virtualization Registers
+
+|`0x605` +
+`0x615`
+|HRW +
+HRW
+|`htimedelta` +
+`htimedeltah`
+|Delta for VS/VU-mode timer. +
+Upper 32 bits of `htimedelta`, RV32 only.
+
+4+^|Hypervisor State Enable Registers
+|`0x60C` +
+ `0x60D` +
+ `0x60E` +
+ `0x60F` +
+ `0x61C` +
+ `0x61D` +
+ `0x61E` +
+ `0x61F`
+|HRW +
+ HRW +
+ HRW +
+ HRW +
+ HRW +
+ HRW +
+ HRW +
+ HRW
+|`hstateen0`  +
+ `hstateen1`  +
+ `hstateen2`  +
+ `hstateen3`  +
+ `hstateen0h` +
+ `hstateen1h` +
+ `hstateen2h` +
+ `hstateen3h`
+|Hypervisor State Enable 0 Register. +
+ Hypervisor State Enable 1 Register. +
+ Hypervisor State Enable 2 Register. +
+ Hypervisor State Enable 3 Register. +
+ Upper 32 bits of Hypervisor State Enable 0 Register, RV32 only. +
+ Upper 32 bits of Hypervisor State Enable 1 Register, RV32 only. +
+ Upper 32 bits of Hypervisor State Enable 2 Register, RV32 only. +
+ Upper 32 bits of Hypervisor State Enable 3 Register, RV32 only.
+
+4+^|Virtual Supervisor Registers
+
+|`0x200` +
+`0x204` +
+`0x205` +
+`0x240` +
+`0x241` +
+`0x242` +
+`0x243` +
+`0x244` +
+`0x280`
+|HRW +
+HRW +
+HRW +
+HRW +
+HRW +
+HRW +
+HRW +
+HRW +
+HRW
+|`vsstatus` +
+`vsie` +
+`vstvec` +
+`vsscratch` +
+`vsepc` +
+`vscause` +
+`vstval` +
+`vsip` +
+`vsatp`
+|Virtual supervisor status register. +
+Virtual supervisor interrupt-enable register. +
+Virtual supervisor trap handler base address. +
+Virtual supervisor scratch register. +
+Virtual supervisor exception program counter. +
+Virtual supervisor trap cause. +
+Virtual supervisor trap value. +
+Virtual supervisor interrupt pending. +
+Virtual supervisor address translation and protection.
+
+|===
+
+<<<
+
+[[mcsrnames0]]
+[.monocell]
+.Currently allocated RISC-V machine-level CSR addresses.
+[%autowidth,float="center",align="center",cols="<,<,<,<",options="header"]
+|===
+|Number |Privilege |Name |Description
+4+^|Machine Information Registers
+
+|`0xF11` +
+`0xF12` +
+`0xF13` +
+`0xF14` +
+`0xF15`
+|MRO +
+MRO +
+MRO +
+MRO +
+MRO
+|`mvendorid` +
+`marchid` +
+`mimpid` +
+`mhartid` +
+`mconfigptr`
+|Vendor ID. +
+Architecture ID. +
+Implementation ID. +
+Hardware thread ID. +
+Pointer to configuration data structure.
+
+4+^|Machine Trap Setup
+
+|`0x300` +
+`0x301` +
+`0x302` +
+`0x303` +
+`0x304` +
+`0x305` +
+`0x306` +
+`0x310` +
+`0x312`
+|MRW +
+MRW +
+MRW +
+MRW +
+MRW +
+MRW +
+MRW +
+MRW +
+MRW
+|`mstatus` +
+`misa` +
+`medeleg` +
+`mideleg` +
+`mie` +
+`mtvec` +
+`mcounteren` +
+`mstatush` +
+`medelegh`
+|Machine status register. +
+ISA and extensions +
+Machine exception delegation register. +
+Machine interrupt delegation register. +
+Machine interrupt-enable register. +
+Machine trap-handler base address. +
+Machine counter enable. +
+Additional machine status register, RV32 only. +
+Upper 32 bits of `medeleg`, RV32 only.
+
+4+^|Machine Trap Handling
+
+|`0x340` +
+`0x341` +
+`0x342` +
+`0x343` +
+`0x344` +
+`0x34A` +
+`0x34B`
+|MRW +
+MRW +
+MRW +
+MRW +
+MRW +
+MRW +
+MRW
+|`mscratch` +
+`mepc` +
+`mcause` +
+`mtval` +
+`mip` +
+`mtinst` +
+`mtval2`
+|Machine scratch register. +
+Machine exception program counter. +
+Machine trap cause. +
+Machine trap value. +
+Machine interrupt pending. +
+Machine trap instruction (transformed). +
+Machine second trap value.
+
+4+^|Machine Configuration
+
+|`0x30A` +
+`0x31A` +
+`0x747` +
+`0x757`
+|MRW +
+MRW +
+MRW +
+MRW
+|`menvcfg` +
+`menvcfgh` +
+`mseccfg` +
+`mseccfgh`
+|Machine environment configuration register. +
+Upper 32 bits of `menvcfg`, RV32 only. +
+Machine security configuration register. +
+Upper 32 bits of `mseccfg`, RV32 only.
+
+4+^|Machine Memory Protection
+
+|`0x3A0` +
+`0x3A1` +
+`0x3A2` +
+`0x3A3` +
+&#160; +
+`0x3AE` +
+`0x3AF` +
+`0x3B0` +
+`0x3B1` +
+&#160; +
+`0x3EF`
+|MRW +
+MRW +
+MRW +
+MRW +
+&#160; +
+MRW +
+MRW +
+MRW +
+MRW +
+&#160; +
+MRW
+|`pmpcfg0` +
+`pmpcfg1` +
+`pmpcfg2` +
+`pmpcfg3` +
+&#8943; +
+`pmpcfg14` +
+`pmpcfg15` +
+`pmpaddr0` +
+`pmpaddr1` +
+&#8943; +
+`pmpaddr63`
+|Physical memory protection configuration. +
+Physical memory protection configuration, RV32 only. +
+Physical memory protection configuration. +
+Physical memory protection configuration, RV32 only. +
+&#160; +
+Physical memory protection configuration. +
+Physical memory protection configuration, RV32 only. +
+Physical memory protection address register. +
+Physical memory protection address register. +
+&#160; +
+Physical memory protection address register.
+
+4+^|Machine State Enable Registers
+|`0x30C` +
+ `0x30D` +
+ `0x30E` +
+ `0x30F` +
+ `0x31C` +
+ `0x31D` +
+ `0x31E` +
+ `0x31F`
+|MRW +
+ MRW +
+ MRW +
+ MRW +
+ MRW +
+ MRW +
+ MRW +
+ MRW
+|`mstateen0`  +
+ `mstateen1`  +
+ `mstateen2`  +
+ `mstateen3`  +
+ `mstateen0h` +
+ `mstateen1h` +
+ `mstateen2h` +
+ `mstateen3h`
+|Machine State Enable 0 Register. +
+ Machine State Enable 1 Register. +
+ Machine State Enable 2 Register. +
+ Machine State Enable 3 Register. +
+ Upper 32 bits of Machine State Enable 0 Register, RV32 only. +
+ Upper 32 bits of Machine State Enable 1 Register, RV32 only. +
+ Upper 32 bits of Machine State Enable 2 Register, RV32 only. +
+ Upper 32 bits of Machine State Enable 3 Register, RV32 only.
+|===
+
+<<<
+
+[[mcsrnames1]]
+.Currently allocated RISC-V machine-level CSR addresses.
+[%autowidth,float="center",align="center",cols="<,<,<,<",options="header"]
+|===
+|Number |Privilege |Name |Description
+4+^|Machine Non-Maskable Interrupt Handling
+
+|`0x740` +
+`0x741` +
+`0x742` +
+`0x744`
+|MRW +
+MRW +
+MRW +
+MRW
+|`mnscratch` +
+`mnepc` +
+`mncause` +
+`mnstatus`
+|Resumable NMI scratch register. +
+Resumable NMI program counter. +
+Resumable NMI cause. +
+Resumable NMI status.
+
+4+^|Machine Counter/Timers
+
+|`0xB00` +
+`0xB02` +
+`0xB03` +
+`0xB04` +
+&#160; +
+`0xB1F` +
+`0xB80` +
+`0xB82` +
+`0xB83` +
+`0xB84` +
+&#160; +
+`0xB9F`
+|MRW +
+MRW +
+MRW +
+MRW +
+&#160; +
+MRW +
+MRW +
+MRW +
+MRW +
+MRW +
+&#160; +
+MRW +
+|`mcycle` +
+`minstret` +
+`mhpmcounter3` +
+`mhpmcounter4` +
+&#8942; +
+`mhpmcounter31` +
+`mcycleh` +
+`minstreth` +
+`mhpmcounter3h` +
+`mhpmcounter4h` +
+&#8942;
+`mhpmcounter31h`
+|Machine cycle counter. +
+Machine instructions-retired counter. +
+Machine performance-monitoring counter. +
+Machine performance-monitoring counter. +
+&#160; +
+Machine performance-monitoring counter. +
+Upper 32 bits of `mcycle`, RV32 only. +
+Upper 32 bits of `minstret`, RV32 only. +
+Upper 32 bits of `mhpmcounter3`, RV32 only. +
+Upper 32 bits of `mhpmcounter4`, RV32 only. +
+&#160; +
+Upper 32 bits of `mhpmcounter31`, RV32 only.
+
+4+^|Machine Counter Setup
+
+|`0x320` +
+`0x323` +
+`0x324` +
+&#160; +
+`0x33F` +
+`0x723` +
+`0x724` +
+&#160; +
+`0x73F`
+|MRW +
+MRW +
+MRW +
+&#160; +
+MRW +
+MRW +
+MRW +
+&#160; +
+MRW
+|`mcountinhibit` +
+`mhpmevent3` +
+`mhpmevent4` +
+&#8942; +
+`mhpmevent31` +
+`mhpmevent3h` +
+`mhpmevent4h` +
+&#8942; +
+`mhpmevent31h`
+|Machine counter-inhibit register. +
+Machine performance-monitoring event selector. +
+Machine performance-monitoring event selector. +
+&#160; +
+Machine performance-monitoring event selector. +
+Upper 32 bits of `mhpmevent3`, RV32 only. +
+Upper 32 bits of `mhpmevent4`, RV32 only. +
+&#160; +
+Upper 32 bits of `mhpmevent31`, RV32 only.
+
+
+4+^|Debug/Trace Registers (shared with Debug Mode)
+
+|`0x7A0` +
+`0x7A1`  +
+`0x7A2`  +
+`0x7A3` +
+`0x7A8`
+|MRW +
+MRW +
+MRW +
+MRW +
+MRW
+|`tselect` +
+`tdata1` +
+`tdata2` +
+`tdata3` +
+`mcontext`
+
+|Debug/Trace trigger register select. +
+First Debug/Trace trigger data register. +
+Second Debug/Trace trigger data register. +
+Third Debug/Trace trigger data register. +
+Machine-mode context register.
+
+4+^|Debug Mode Registers
+
+|`0x7B0` +
+`0x7B1` +
+`0x7B2` +
+`0x7B3`
+|DRW +
+DRW +
+DRW +
+DRW +
+|`dcsr` +
+`dpc` +
+`dscratch0` +
+`dscratch1`
+|Debug control and status register. +
+Debug program counter. +
+Debug scratch register 0. +
+Debug scratch register 1.
+|===
+
+=== CSR Field Specifications
+
+The following definitions and abbreviations are used in specifying the
+behavior of fields within the CSRs.
+
+==== Reserved Writes Preserve Values, Reads Ignore Values (WPRI)
+
+Some whole read/write fields are reserved for future use. Software
+should ignore the values read from these fields, and should preserve the
+values held in these fields when writing values to other fields of the
+same register. For forward compatibility, implementations that do not
+furnish these fields must make them read-only zero. These fields are
+labeled *WPRI* in the register descriptions.
+
+[NOTE]
+====
+To simplify the software model, any backward-compatible future
+definition of previously reserved fields within a CSR must cope with the
+possibility that a non-atomic read/modify/write sequence is used to
+update other fields in the CSR. Alternatively, the original CSR
+definition must specify that subfields can only be updated atomically,
+which may require a two-instruction clear bit/set bit sequence in
+general that can be problematic if intermediate values are not legal.
+====
+
+==== Write/Read Only Legal Values (WLRL)
+
+Some read/write CSR fields specify behavior for only a subset of
+possible bit encodings, with other bit encodings reserved. Software
+should not write anything other than legal values to such a field, and
+should not assume a read will return a legal value unless the last write
+was of a legal value, or the register has not been written since another
+operation (e.g., reset) set the register to a legal value. These fields
+are labeled *WLRL* in the register descriptions.
+
+[NOTE]
+====
+Hardware implementations need only implement enough state bits to
+differentiate between the supported values, but must always return the
+complete specified bit-encoding of any supported value when read.
+====
+
+ifdef::archi-default[]
+Implementations are permitted but not required to raise an
+illegal-instruction exception if an instruction attempts to write a
+non-supported value to a *WLRL* field. Implementations can return arbitrary
+bit patterns on the read of a *WLRL* field when the last write was of an
+illegal value, but the value returned should deterministically depend on
+the illegal written value and the value of the field prior to the write.
+endif::[]
+
+ifdef::archi-CVA6[]
+[CVA6] CVA6 does not raise an
+illegal-instruction exception if an instruction attempts to write a
+non-supported value to a *WLRL* field. CVA6 returns the last written
+legal value on the read of a *WLRL* filed.
+endif::[]
+
+==== Write Any Values, Reads Legal Values (WARL)
+
+Some read/write CSR fields are only defined for a subset of bit
+encodings, but allow any value to be written while guaranteeing to
+return a legal value whenever read. Assuming that writing the CSR has no
+other side effects, the range of supported values can be determined by
+attempting to write a desired setting then reading to see if the value
+was retained. These fields are labeled *WARL* in the register descriptions.
+
+Implementations will not raise an exception on writes of unsupported
+values to a *WARL* field. Implementations can return any legal value on the
+read of a *WARL* field when the last write was of an illegal value, but the
+legal value returned should deterministically depend on the illegal
+written value and the architectural state of the hart.
+
+=== CSR Field Modulation
+
+If a write to one CSR changes the set of legal values allowed for a
+field of a second CSR, then unless specified otherwise, the second CSR's
+field immediately gets an `UNSPECIFIED` value from among its new legal values. This
+is true even if the field's value before the write remains legal after
+the write; the value of the field may be changed in consequence of the
+write to the controlling CSR.
+
+[NOTE]
+====
+As a special case of this rule, the value written to one CSR may control
+whether a field of a second CSR is writable (with multiple legal values)
+or is read-only. When a write to the controlling CSR causes the second
+CSR's field to change from previously read-only to now writable, that
+field immediately gets an `UNSPECIFIED` but legal value, unless specified otherwise.
+
+***
+Some CSR fields are, when writable, defined as aliases of other CSR
+fields. Let _x_ be such a CSR field, and let _y_ be the CSR field it aliases when writable. If a write to a controlling CSR causes field _x_ to change from previously read-only to now writable, the new value of _x_ is not `UNSPECIFIED` but instead immediately reflects the existing value of its alias _y_, as required.
+====
+
+A change to the value of a CSR for this reason is not a write to the
+affected CSR and thus does not trigger any side effects specified for
+that CSR.
+
+=== Implicit Reads of CSRs
+
+Implementations sometimes perform _implicit_ reads of CSRs. (For
+example, all S-mode instruction fetches implicitly read the `satp` CSR.)
+Unless otherwise specified, the value returned by an implicit read of a
+CSR is the same value that would have been returned by an explicit read
+of the CSR, using a CSR-access instruction in a sufficient privilege
+mode.
+
+[[csrwidthmodulation]]
+=== CSR Width Modulation
+
+If the width of a CSR is changed (for example, by changing SXLEN or
+UXLEN, as described in <<xlen-control>>), the
+values of the _writable_ fields and bits of the new-width CSR are,
+unless specified otherwise, determined from the previous-width CSR as
+though by this algorithm:
+
+. The value of the previous-width CSR is copied to a temporary register
+of the same width.
+. For the read-only bits of the previous-width CSR, the bits at the same
+positions in the temporary register are set to zeros.
+. The width of the temporary register is changed to the new width. If
+the new width _W_ is narrower than the previous width, the
+least-significant _W_ bits of the temporary register are
+retained and the more-significant bits are discarded. If the new width
+is wider than the previous width, the temporary register is
+zero-extended to the wider width.
+. Each writable field of the new-width CSR takes the value of the bits
+at the same positions in the temporary register.
+
+Changing the width of a CSR is not a read or write of the CSR and thus
+does not trigger any side effects.
+
+=== Explicit Accesses to CSRs Wider than XLEN
+
+If a standard CSR is wider than XLEN bits, then an explicit read
+of the CSR returns the register's least-significant XLEN bits,
+and an explicit write to the CSR modifies only the register's
+least-significant XLEN bits, leaving the upper bits unchanged.
+
+Some standard CSRs, such as the counter CSRs of extension
+Zicntr, are always 64 bits, even when XLEN=32 (RV32).
+For each such 64-bit CSR (for example, counter `time`),
+a corresponding 32-bit _high-half CSR_ is usually defined with
+the same name but with the letter '`h`' appended at the end (`timeh`).
+The high-half CSR aliases bits 63:32 of its namesake
+64-bit CSR, thus providing a way for RV32 software
+to read and modify the otherwise-unreachable 32 bits.
+
+Standard high-half CSRs are accessible only when
+the base RISC-V instruction set is RV32 (XLEN=32).
+For RV64 (when XLEN=64), the addresses of all standard high-half CSRs
+are reserved, so an attempt to access a high-half CSR
+typically raises an illegal-instruction exception.


### PR DESCRIPTION
as priv-csrs.adoc was not yet tailored for CVA6, the file is copied
and tailored

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>