### PR TITLE
Add RTL configuration RVZifencei

### DIFF
--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -267,11 +267,13 @@ module commit_stage
         // from interrupt service routine
         // Fence synchronizes data and instruction streams. That means that we need to flush the private icache
         // and the private dcache. This is the most expensive instruction.
-        if (commit_instr_i[0].op == FENCE_I || (flush_dcache_i && CVA6Cfg.DCacheType == config_pkg::WB && commit_instr_i[0].fu != STORE)) begin
-          if (!commit_drop_i[0]) begin
-            commit_ack_o[0] = no_st_pending_i;
-            // tell the controller to flush the I$
-            fence_i_o = no_st_pending_i;
+        if (CVA6Cfg.RVZifencei) begin
+          if (commit_instr_i[0].op == FENCE_I || (flush_dcache_i && CVA6Cfg.DCacheType == config_pkg::WB && commit_instr_i[0].fu != STORE)) begin /* FIXME */ //confirm that flush_dcache_i & not STORE is only related to  RVZifencei
+            if (!commit_drop_i[0]) begin
+              commit_ack_o[0] = no_st_pending_i;
+              // tell the controller to flush the I$
+              fence_i_o = no_st_pending_i;
+            end
           end
         end
         // ------------------

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -133,7 +133,7 @@ module controller
     // ---------------------------------
     // FENCE.I
     // ---------------------------------
-    if (fence_i_i) begin
+    if (CVA6Cfg.RVZifencei && fence_i_i) begin
       set_pc_commit_o        = 1'b1;
       flush_if_o             = 1'b1;
       flush_unissued_instr_o = 1'b1;

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -451,10 +451,14 @@ module decoder
           case (instr.stype.funct3)
             // FENCE
             // Currently implemented as a whole DCache flush boldly ignoring other things
-            3'b000: instruction_o.op = ariane_pkg::FENCE;
+            3'b000:  instruction_o.op = ariane_pkg::FENCE;
             // FENCE.I
-            3'b001: instruction_o.op = ariane_pkg::FENCE_I;
-
+            3'b001:
+            if (CVA6Cfg.RVZifencei) begin
+              instruction_o.op = ariane_pkg::FENCE_I;
+            end else begin
+              illegal_instr = 1'b1;
+            end
             default: illegal_instr = 1'b1;
           endcase
         end

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -76,6 +76,7 @@ package build_config_pkg;
     cfg.CvxifEn = CVA6Cfg.CvxifEn;
     cfg.RVZiCond = CVA6Cfg.RVZiCond;
     cfg.RVZicntr = CVA6Cfg.RVZicntr;
+    cfg.RVZifencei = CVA6Cfg.RVZifencei;
     cfg.RVZihpm = CVA6Cfg.RVZihpm;
     cfg.NR_SB_ENTRIES = CVA6Cfg.NrScoreboardEntries;
     cfg.TRANS_ID_BITS = $clog2(CVA6Cfg.NrScoreboardEntries);

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -74,6 +74,8 @@ package config_pkg;
     bit                          RVZiCond;
     // Zicntr RISC-V extension
     bit                          RVZicntr;
+    // Zifencei RISC-V extension
+    bit                          RVZifencei;
     // Zihpm RISC-V extension
     bit                          RVZihpm;
     // Floating Point
@@ -265,6 +267,7 @@ package config_pkg;
     bit          CvxifEn;
     bit          RVZiCond;
     bit          RVZicntr;
+    bit          RVZifencei;
     bit          RVZihpm;
 
     int unsigned NR_SB_ENTRIES;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -50,6 +50,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(1),
       RVZiCond: bit'(0),
       RVZicntr: bit'(0),
+      RVZifencei: bit'(0),
       RVZihpm: bit'(0),
       NrScoreboardEntries: unsigned'(4),
       PerfCounterEn: bit'(0),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -50,6 +50,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(1),
       RVZiCond: bit'(0),
       RVZicntr: bit'(0),
+      RVZifencei: bit'(0),
       RVZihpm: bit'(0),
       NrScoreboardEntries: unsigned'(8),
       PerfCounterEn: bit'(0),

--- a/core/include/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/cv32a6_embedded_config_pkg_deprecated.sv
@@ -104,6 +104,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -102,6 +102,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -102,6 +102,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -101,6 +101,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -102,6 +102,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -112,6 +112,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -112,6 +112,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(CVA6ConfigPerfCounterEn),

--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -57,6 +57,7 @@ package cva6_config_pkg;
       CvxifEn: bit'(1),
       RVZiCond: bit'(0),
       RVZicntr: bit'(1),
+      RVZifencei: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),
       PerfCounterEn: bit'(0),


### PR DESCRIPTION
Add RTL configuration RVZifencei


I have a doubt about this line in the "commit stage"
I don't know if the RVZifencei configuration should block the continuation of this logic (via fence_i_o). 
Is this a special case of the WB reusing the fence_i_o logic or is this linked to the only case of a fence_i instruction?

``` if (commit_instr_i[0].op == FENCE_I || (flush_dcache_i && CVA6Cfg.DCacheType == config_pkg::WB && commit_instr_i[0].fu != STORE)) begin ```