### PR TITLE
Fix RVFI rs1/rs2 len from VLEN to XLEN

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -418,6 +418,8 @@ module cva6
   // --------------
   logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs1_forwarding_id_ex;  // unregistered version of fu_data_o.operanda
   logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs2_forwarding_id_ex;  // unregistered version of fu_data_o.operandb
+  logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs1;
+  logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs2;
 
   fu_data_t [CVA6Cfg.NrIssuePorts-1:0] fu_data_id_ex;
   logic [CVA6Cfg.VLEN-1:0] pc_id_ex;
@@ -898,7 +900,9 @@ module cva6
       .stall_issue_o        (stall_issue),
       //RVFI
       .rvfi_issue_pointer_o (rvfi_issue_pointer),
-      .rvfi_commit_pointer_o(rvfi_commit_pointer)
+      .rvfi_commit_pointer_o(rvfi_commit_pointer),
+      .rvfi_rs1_o           (rvfi_rs1),
+      .rvfi_rs2_o           (rvfi_rs2)
   );
 
   // ---------
@@ -1751,8 +1755,8 @@ module cva6
       .decoded_instr_valid_i (issue_entry_valid_id_issue),
       .decoded_instr_ack_i   (issue_instr_issue_id),
 
-      .rs1_forwarding_i(rs1_forwarding_id_ex),
-      .rs2_forwarding_i(rs2_forwarding_id_ex),
+      .rs1_i(rvfi_rs1),
+      .rs2_i(rvfi_rs2),
 
       .commit_instr_i(commit_instr_id_commit),
       .commit_drop_i (commit_drop_id_commit),

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -64,8 +64,8 @@ module cva6_rvfi
   logic [CVA6Cfg.NrIssuePorts-1:0] decoded_instr_valid;
   logic [CVA6Cfg.NrIssuePorts-1:0] decoded_instr_ack;
 
-  logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs1_forwarding;
-  logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs2_forwarding;
+  logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs1;
+  logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs2;
 
   logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_intr;
 
@@ -132,8 +132,8 @@ module cva6_rvfi
   assign decoded_instr_valid = instr.decoded_instr_valid;
   assign decoded_instr_ack = instr.decoded_instr_ack;
 
-  assign rs1_forwarding = instr.rs1_forwarding;
-  assign rs2_forwarding = instr.rs2_forwarding;
+  assign rs1 = instr.rs1;
+  assign rs2 = instr.rs2;
 
   assign commit_instr_pc = instr.commit_instr_pc;
   assign commit_instr_op = instr.commit_instr_op;
@@ -240,8 +240,8 @@ module cva6_rvfi
     for (int unsigned i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
       if (decoded_instr_valid[i] && decoded_instr_ack[i] && !flush_unissued_instr) begin
         mem_n[issue_pointer[i]] = '{
-            rs1_rdata: rs1_forwarding[i],
-            rs2_rdata: rs2_forwarding[i],
+            rs1_rdata: rs1[i],
+            rs2_rdata: rs2[i],
             lsu_addr: '0,
             lsu_rmask: '0,
             lsu_wmask: '0,

--- a/core/cva6_rvfi_probes.sv
+++ b/core/cva6_rvfi_probes.sv
@@ -35,8 +35,8 @@ module cva6_rvfi_probes
     input logic [CVA6Cfg.NrIssuePorts-1:0] decoded_instr_valid_i,
     input logic [CVA6Cfg.NrIssuePorts-1:0] decoded_instr_ack_i,
 
-    input logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs1_forwarding_i,
-    input logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs2_forwarding_i,
+    input logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs1_i,
+    input logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs2_i,
 
     input scoreboard_entry_t [CVA6Cfg.NrCommitPorts-1:0] commit_instr_i,
     input logic [CVA6Cfg.NrCommitPorts-1:0] commit_drop_i,
@@ -76,8 +76,8 @@ module cva6_rvfi_probes
     instr.decoded_instr_valid = decoded_instr_valid_i;
     instr.decoded_instr_ack = decoded_instr_ack_i;
 
-    instr.rs1_forwarding = rs1_forwarding_i;
-    instr.rs2_forwarding = rs2_forwarding_i;
+    instr.rs1 = rs1_i;
+    instr.rs2 = rs2_i;
 
     instr.ex_commit_cause = ex_commit_i.cause;
     instr.ex_commit_valid = ex_commit_i.valid;

--- a/core/include/rvfi_types.svh
+++ b/core/include/rvfi_types.svh
@@ -104,8 +104,8 @@
   logic [Cfg.NrIssuePorts-1:0] fetch_entry_valid; \
   logic [Cfg.NrIssuePorts-1:0][31:0] instruction; \
   logic [Cfg.NrIssuePorts-1:0] is_compressed; \
-  logic [Cfg.NrIssuePorts-1:0][Cfg.VLEN-1:0] rs1_forwarding; \
-  logic [Cfg.NrIssuePorts-1:0][Cfg.VLEN-1:0] rs2_forwarding; \
+  logic [Cfg.NrIssuePorts-1:0][Cfg.XLEN-1:0] rs1; \
+  logic [Cfg.NrIssuePorts-1:0][Cfg.XLEN-1:0] rs2; \
   logic [Cfg.NrCommitPorts-1:0][Cfg.VLEN-1:0] commit_instr_pc; \
   ariane_pkg::fu_op [Cfg.NrCommitPorts-1:0] commit_instr_op; \
   logic [Cfg.NrCommitPorts-1:0][ariane_pkg::REG_ADDR_SIZE-1:0] commit_instr_rs1; \

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -51,9 +51,9 @@ module issue_read_operands
     // FU data useful to execute instruction - EX_STAGE
     output fu_data_t [CVA6Cfg.NrIssuePorts-1:0] fu_data_o,
     // Unregistered version of fu_data_o.operanda - EX_STAGE
-    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs1_forwarding_o,
+    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs1_forwarding_o,
     // Unregistered version of fu_data_o.operandb - EX_STAGE
-    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs2_forwarding_o,
+    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.VLEN-1:0] rs2_forwarding_o,
     // Program Counter - EX_STAGE
     output logic [CVA6Cfg.VLEN-1:0] pc_o,
     // Is zcmt - EX_STAGE
@@ -122,7 +122,12 @@ module issue_read_operands
     // FPR write enable - COMMIT_STAGE
     input logic [CVA6Cfg.NrCommitPorts-1:0] we_fpr_i,
     // Issue stall - PERF_COUNTERS
-    output logic stall_issue_o
+    output logic stall_issue_o,
+    // Information dedicated to RVFI - RVFI
+    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs1_o,
+    // Information dedicated to RVFI - RVFI
+    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs2_o
+
 );
 
   localparam OPERANDS_PER_INSTR = CVA6Cfg.NrRgprPorts / CVA6Cfg.NrIssuePorts;
@@ -253,6 +258,8 @@ module issue_read_operands
   for (genvar i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
     assign rs1_forwarding_o[i] = fu_data_n[i].operand_a[CVA6Cfg.VLEN-1:0];  //forwarding or unregistered rs1 value
     assign rs2_forwarding_o[i] = fu_data_n[i].operand_b[CVA6Cfg.VLEN-1:0];  //forwarding or unregistered rs2 value
+    assign rvfi_rs1_o[i] = fu_data_n[i].operand_a;
+    assign rvfi_rs2_o[i] = fu_data_n[i].operand_b;
   end
 
   assign fu_data_o = fu_data_q;

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -159,7 +159,11 @@ module issue_stage
     // Information dedicated to RVFI - RVFI
     output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.TRANS_ID_BITS-1:0] rvfi_issue_pointer_o,
     // Information dedicated to RVFI - RVFI
-    output logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.TRANS_ID_BITS-1:0] rvfi_commit_pointer_o
+    output logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.TRANS_ID_BITS-1:0] rvfi_commit_pointer_o,
+    // Information dedicated to RVFI - RVFI
+    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs1_o,
+    // Information dedicated to RVFI - RVFI
+    output logic [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rvfi_rs2_o
 );
   // ---------------------------------------------------
   // Scoreboard (SB) <-> Issue and Read Operands (IRO)
@@ -177,14 +181,6 @@ module issue_stage
   logic              [CVA6Cfg.NrIssuePorts-1:0][            31:0] orig_instr_sb_iro;
   logic              [CVA6Cfg.NrIssuePorts-1:0]                   issue_instr_valid_sb_iro;
   logic              [CVA6Cfg.NrIssuePorts-1:0]                   issue_ack_iro_sb;
-
-  logic              [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs1_forwarding_xlen;
-  logic              [CVA6Cfg.NrIssuePorts-1:0][CVA6Cfg.XLEN-1:0] rs2_forwarding_xlen;
-
-  for (genvar i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
-    assign rs1_forwarding_o[i] = rs1_forwarding_xlen[i][CVA6Cfg.VLEN-1:0];
-    assign rs2_forwarding_o[i] = rs2_forwarding_xlen[i][CVA6Cfg.VLEN-1:0];
-  end
 
   assign issue_instr_o    = issue_instr_sb_iro[0];
   assign issue_instr_hs_o = issue_instr_valid_sb_iro[0] & issue_ack_iro_sb[0];
@@ -262,8 +258,8 @@ module issue_stage
       .issue_ack_o             (issue_ack_iro_sb),
       .fwd_i                   (fwd),
       .fu_data_o               (fu_data_o),
-      .rs1_forwarding_o        (rs1_forwarding_xlen),
-      .rs2_forwarding_o        (rs2_forwarding_xlen),
+      .rs1_forwarding_o        (rs1_forwarding_o),
+      .rs2_forwarding_o        (rs2_forwarding_o),
       .pc_o,
       .is_zcmt_o,
       .is_compressed_instr_o,
@@ -302,7 +298,9 @@ module issue_stage
       .wdata_i,
       .we_gpr_i,
       .we_fpr_i,
-      .stall_issue_o
+      .stall_issue_o,
+      .rvfi_rs1_o              (rvfi_rs1_o),
+      .rvfi_rs2_o              (rvfi_rs2_o)
   );
 
 endmodule


### PR DESCRIPTION
RVFI rs1 and rs2 operands were VLEN, it has been fixed to be XLEN.