### PR TITLE
Add parameter type to define which coprocessor is instantiated on CVXIF

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ build_tools:
   stage: light tests
   rules: *on_dev
   before_script:
-    - git -C verif/core-v-verif fetch --unshallow
+    - git -C verif/core-v-verif fetch --unshallow || git -C verif/core-v-verif fetch --all
     - !reference [.copy_spike_artifacts]
     - rm -rf artifacts/
     - mkdir -p artifacts/{reports,logs}
@@ -543,7 +543,7 @@ simu-gate:
     PERIOD: "15"  # 66 Mhz
   script:
     - mkdir -p artifacts/{reports,logs}
-    - git -C verif/core-v-verif fetch --unshallow
+    - git -C verif/core-v-verif fetch --unshallow || git -C verif/core-v-verif fetch --all
     - !reference [.copy_spike_artifacts]
     - echo $PERIOD
     - source ./verif/sim/setup-env.sh

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -74,6 +74,7 @@ package build_config_pkg;
     cfg.RVZCMP = CVA6Cfg.RVZCMP;
     cfg.XFVec = CVA6Cfg.XFVec;
     cfg.CvxifEn = CVA6Cfg.CvxifEn;
+    cfg.CoproType = CVA6Cfg.CoproType;
     cfg.RVZiCond = CVA6Cfg.RVZiCond;
     cfg.RVZicntr = CVA6Cfg.RVZicntr;
     cfg.RVZihpm = CVA6Cfg.RVZihpm;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -46,7 +46,7 @@ package config_pkg;
   } vm_mode_t;
 
   /// Coprocessor type parameter
-  typedef enum logic [0:0] {
+  typedef enum {
     COPRO_NONE,
     COPRO_EXAMPLE
   } copro_type_t;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -47,8 +47,8 @@ package config_pkg;
 
   /// Coprocessor type parameter
   typedef enum logic [0:0] {
-    NO_COPRO = 0,
-    COPRO_EXAMPLE = 1
+    COPRO_NONE,
+    COPRO_EXAMPLE
   } copro_type_t;
 
   localparam NrMaxRules = 16;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -45,6 +45,12 @@ package config_pkg;
     ModeSv64 = 11
   } vm_mode_t;
 
+  /// Coprocessor type parameter
+  typedef enum logic [0:0] {
+    NO_COPRO = 0,
+    COPRO_EXAMPLE = 1
+  } copro_type_t;
+
   localparam NrMaxRules = 16;
 
   typedef struct packed {
@@ -140,6 +146,8 @@ package config_pkg;
     logic [NrMaxRules-1:0][63:0] CachedRegionLength;
     // CV-X-IF coprocessor interface enable
     bit                          CvxifEn;
+    // Coprocessor type
+    copro_type_t                 CoproType;
     // NOC bus type
     noc_type_e                   NOCType;
     // AXI address width
@@ -263,6 +271,7 @@ package config_pkg;
     bit          RVZCMT;
     bit          XFVec;
     bit          CvxifEn;
+    copro_type_t CoproType;
     bit          RVZiCond;
     bit          RVZicntr;
     bit          RVZihpm;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -48,6 +48,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(0),
       XFVec: bit'(0),
       CvxifEn: bit'(1),
+      CoproType: config_pkg::COPRO_EXAMPLE,
       RVZiCond: bit'(0),
       RVZicntr: bit'(0),
       RVZihpm: bit'(0),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -48,6 +48,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(0),
       XFVec: bit'(0),
       CvxifEn: bit'(1),
+      CoproType: config_pkg::COPRO_EXAMPLE,
       RVZiCond: bit'(0),
       RVZicntr: bit'(0),
       RVZihpm: bit'(0),

--- a/core/include/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/cv32a6_embedded_config_pkg_deprecated.sv
@@ -102,6 +102,7 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       RVZCMT: bit'(0),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/cv32a6_embedded_config_pkg_deprecated.sv
@@ -102,7 +102,7 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       RVZCMT: bit'(0),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -100,6 +100,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -100,7 +100,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -100,6 +100,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -100,7 +100,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -99,7 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -99,6 +99,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -100,7 +100,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -100,6 +100,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -103,7 +103,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -103,6 +103,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -103,6 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -103,7 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -110,6 +110,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -110,7 +110,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -110,6 +110,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -110,7 +110,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -103,6 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -103,7 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -103,6 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -103,7 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -103,6 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -103,7 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -103,6 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -103,7 +103,7 @@ package cva6_config_pkg;
       RVZCMP: bit'(CVA6ConfigZcmpExtEn),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -105,6 +105,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -105,7 +105,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -55,6 +55,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(0),
       CvxifEn: bit'(1),
+      CoproType: config_pkg::NO_COPRO,
       RVZiCond: bit'(0),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -55,7 +55,7 @@ package cva6_config_pkg;
       RVZCMT: bit'(0),
       XFVec: bit'(0),
       CvxifEn: bit'(1),
-      CoproType: config_pkg::NO_COPRO,
+      CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(0),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -109,7 +109,7 @@ module ariane import ariane_pkg::*; #(
   );
 
   if (CVA6Cfg.CvxifEn) begin: gen_cvxif
-    if (CVA6Cfg.CoproType == config_pkg::NO_COPRO) begin: gen_no_copro
+    if (CVA6Cfg.CoproType == config_pkg::COPRO_NONE) begin: gen_COPRO_NONE
       assign cvxif_resp = '{compressed_ready: 1'b1, issue_ready: 1'b1, register_ready: 1'b1, default: '0}; 
     end else if (CVA6Cfg.CoproType == config_pkg::COPRO_EXAMPLE) begin: gen_copro_example
       cvxif_example_coprocessor #(

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -109,9 +109,7 @@ module ariane import ariane_pkg::*; #(
   );
 
   if (CVA6Cfg.CvxifEn) begin: gen_cvxif
-    if (CVA6Cfg.CoproType == config_pkg::COPRO_NONE) begin: gen_COPRO_NONE
-      assign cvxif_resp = '{compressed_ready: 1'b1, issue_ready: 1'b1, register_ready: 1'b1, default: '0}; 
-    end else if (CVA6Cfg.CoproType == config_pkg::COPRO_EXAMPLE) begin: gen_copro_example
+    if (CVA6Cfg.CoproType == config_pkg::COPRO_EXAMPLE) begin: gen_COPRO_EXAMPLE
       cvxif_example_coprocessor #(
         .NrRgprPorts (CVA6Cfg.NrRgprPorts),
         .XLEN (CVA6Cfg.XLEN),
@@ -134,6 +132,8 @@ module ariane import ariane_pkg::*; #(
         .cvxif_req_i          ( cvxif_req                      ),
         .cvxif_resp_o         ( cvxif_resp                     )
       );
+    end else begin: gen_COPRO_NONE
+      assign cvxif_resp = '{compressed_ready: 1'b1, issue_ready: 1'b1, register_ready: 1'b1, default: '0};
     end
   end else begin: gen_no_cvxif
     assign cvxif_resp = '0;

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -108,38 +108,36 @@ module ariane import ariane_pkg::*; #(
     .noc_resp_i           ( noc_resp_i                )
   );
 
-  if (CVA6Cfg.CvxifEn) begin : gen_example_coprocessor
-    cvxif_example_coprocessor #(
-      .NrRgprPorts (CVA6Cfg.NrRgprPorts),
-      .XLEN (CVA6Cfg.XLEN),
-      .readregflags_t (readregflags_t),
-      .writeregflags_t (writeregflags_t),
-      .id_t (id_t),
-      .hartid_t (hartid_t),
-      .x_compressed_req_t (x_compressed_req_t),
-      .x_compressed_resp_t (x_compressed_resp_t),
-      .x_issue_req_t (x_issue_req_t),
-      .x_issue_resp_t (x_issue_resp_t),
-      .x_register_t (x_register_t),
-      .x_commit_t (x_commit_t),
-      .x_result_t (x_result_t),
-      .cvxif_req_t (cvxif_req_t),
-      .cvxif_resp_t (cvxif_resp_t)
-    ) i_cvxif_coprocessor (
-      .clk_i                ( clk_i                          ),
-      .rst_ni               ( rst_ni                         ),
-      .cvxif_req_i          ( cvxif_req                      ),
-      .cvxif_resp_o         ( cvxif_resp                     )
-    );
-  end else begin
-    always_comb begin
-      cvxif_resp = '0;
-      cvxif_resp.compressed_ready = 1'b1;
-      cvxif_resp.issue_ready = 1'b1;
-      cvxif_resp.register_ready = 1'b1;
+  if (CVA6Cfg.CvxifEn) begin: gen_cvxif
+    if (CVA6Cfg.CoproType == config_pkg::NO_COPRO) begin: gen_no_copro
+      assign cvxif_resp = '{compressed_ready: 1'b1, issue_ready: 1'b1, register_ready: 1'b1, default: '0}; 
+    end else if (CVA6Cfg.CoproType == config_pkg::COPRO_EXAMPLE) begin: gen_copro_example
+      cvxif_example_coprocessor #(
+        .NrRgprPorts (CVA6Cfg.NrRgprPorts),
+        .XLEN (CVA6Cfg.XLEN),
+        .readregflags_t (readregflags_t),
+        .writeregflags_t (writeregflags_t),
+        .id_t (id_t),
+        .hartid_t (hartid_t),
+        .x_compressed_req_t (x_compressed_req_t),
+        .x_compressed_resp_t (x_compressed_resp_t),
+        .x_issue_req_t (x_issue_req_t),
+        .x_issue_resp_t (x_issue_resp_t),
+        .x_register_t (x_register_t),
+        .x_commit_t (x_commit_t),
+        .x_result_t (x_result_t),
+        .cvxif_req_t (cvxif_req_t),
+        .cvxif_resp_t (cvxif_resp_t)
+      ) i_cvxif_coprocessor (
+        .clk_i                ( clk_i                          ),
+        .rst_ni               ( rst_ni                         ),
+        .cvxif_req_i          ( cvxif_req                      ),
+        .cvxif_resp_o         ( cvxif_resp                     )
+      );
     end
+  end else begin: gen_no_cvxif
+    assign cvxif_resp = '0;
   end
-
 
 
 endmodule // ariane


### PR DESCRIPTION
Add parameter `CoproType` to select which coprocessor to instantiate when `CvxifEn == 1`