### PR TITLE
instr_tracer.sv: Fix double sampling

### DIFF
--- a/common/local/util/instr_tracer.sv
+++ b/common/local/util/instr_tracer.sv
@@ -94,7 +94,7 @@ module instr_tracer #(
     forever begin
       automatic bp_resolve_t bp_instruction = '0;
       // new cycle, we are only interested if reset is de-asserted
-      @(pck) if (rstn !== 1'b1) begin
+      @(posedge pck) if (rstn !== 1'b1) begin
         flush();
         continue;
       end


### PR DESCRIPTION
Currently, the instruction trace update logic is triggered on both clock edges, leading to double entries in the instruction trace and a wrong cycle count. Fix this by updating the trace only on positive clock edges.

Note that this was previously done through the interface: https://github.com/openhwgroup/cva6/blob/f886713754c9916df7ae23eab2a73959b58312d2/common/local/util/instr_tracer_if.sv#L63

But since [`38e8c059b`](https://github.com/openhwgroup/cva6/commit/38e8c059b#diff-86f1f47bb1bcb5af0e128339306dbcc972c80a4e7fdca22d6d5d819949cc9d96L1558), `clk_i` is directly assigned to `pck`.