### PR TITLE
scoreboard.sv: improve code coverage

### DIFF
--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -115,7 +115,7 @@ module scoreboard #(
   logic [$clog2(CVA6Cfg.NrCommitPorts):0] num_commit;
 
   for (genvar i = 0; i < CVA6Cfg.NR_SB_ENTRIES; i++) begin
-    assign still_issued[i] = mem_q[i].issued & ~mem_q[i].cancelled;
+    assign still_issued[i] = mem_q[i].issued & ~(CVA6Cfg.SpeculativeSb & mem_q[i].cancelled);
   end
 
   for (genvar i = 0; i < CVA6Cfg.NR_SB_ENTRIES; i++) begin
@@ -196,7 +196,7 @@ module scoreboard #(
       // check if this instruction was issued (e.g.: it could happen after a flush that there is still
       // something in the pipeline e.g. an incomplete memory operation)
       if (wt_valid_i[i] && mem_q[trans_id_i[i]].issued) begin
-        if (mem_q[trans_id_i[i]].sbe.is_double_rd_macro_instr && mem_q[trans_id_i[i]].sbe.is_macro_instr) begin
+        if (CVA6Cfg.RVZCMP && mem_q[trans_id_i[i]].sbe.is_double_rd_macro_instr && mem_q[trans_id_i[i]].sbe.is_macro_instr) begin
           if (mem_q[trans_id_i[i]].sbe.is_last_macro_instr) begin
             mem_n[trans_id_i[i]].sbe.valid = 1'b1;
             mem_n[8'(trans_id_i[i])-1].sbe.valid = 1'b1;


### PR DESCRIPTION
- no speculative scoreboard
- no Zcmp