### PR TITLE
Spike.yaml : disable pmp regions in cv32a60x

### DIFF
--- a/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
@@ -22,7 +22,7 @@ spike_param_tree:
       pmpaddr0: 0
       pmpcfg0: 0
       pmpregions_max: 64
-      pmpregions_writable: 8
+      pmpregions_writable: 0
       priv: M
       status_fs_field_we: false
       status_fs_field_we_enable: false


### PR DESCRIPTION
Disable cv32a60x pmp writeable regions