### PR TITLE
Enable gdb on toolchain builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Info : Listening on port 4444 for telnet connections
 Then you will be able to either connect through `telnet` or with `gdb`:
 
 ```
-riscv64-unknown-elf-gdb /path/to/elf
+risc-none-elf-gdb /path/to/elf
 
 (gdb) target remote localhost:3333
 (gdb) load

--- a/util/toolchain-builder/config/global.sh
+++ b/util/toolchain-builder/config/global.sh
@@ -60,11 +60,7 @@ BINUTILS_CONFIGURE_OPTS() {
         --target=$1
         --prefix=${INSTALL_DIR}
         --disable-werror
-        --disable-gdb
         --disable-nls
-        --disable-sim
-        --disable-libdecnumber
-        --disable-readline
     )
     echo "${OPTS[@]}"
 }


### PR DESCRIPTION
As discussed in https://github.com/openhwgroup/cva6/issues/2775#issuecomment-2676320205 , this pr enables gdb back on the toolchain build scripts. It also updates the README to use the current toolchain name for the gdb section.