### PR TITLE
Improve Code Coverage in Frontend

### DIFF
--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -212,7 +212,7 @@ module frontend
   // function return -> RAS
   assign is_return = instruction_valid & (rvi_return | rvc_return);
   // unconditional jumps with known target -> immediately resolved
-  assign is_jump = instruction_valid & (rvi_jump | rvc_jump);
+  assign is_jump   = instruction_valid & (rvi_jump | rvc_jump);
   // unconditional jumps with unknown target -> BTB
   assign is_jalr   = instruction_valid & ~is_return & (rvi_jalr | rvc_jalr | rvc_jr);
 

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -208,7 +208,7 @@ module frontend
   // branch history table -> BHT
   assign is_branch = instruction_valid & (rvi_branch | rvc_branch);
   // function calls -> RAS
-  assign is_call = instruction_valid & (rvi_call | rvc_call);
+  assign is_call   = instruction_valid & (rvi_call | rvc_call);
   // function return -> RAS
   assign is_return = instruction_valid & (rvi_return | rvc_return);
   // unconditional jumps with known target -> immediately resolved

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -205,18 +205,16 @@ module frontend
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] is_return;
   logic [CVA6Cfg.INSTR_PER_FETCH-1:0] is_jalr;
 
-  for (genvar i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++) begin
-    // branch history table -> BHT
-    assign is_branch[i] = instruction_valid[i] & (rvi_branch[i] | rvc_branch[i]);
-    // function calls -> RAS
-    assign is_call[i] = instruction_valid[i] & (rvi_call[i] | rvc_call[i]);
-    // function return -> RAS
-    assign is_return[i] = instruction_valid[i] & (rvi_return[i] | rvc_return[i]);
-    // unconditional jumps with known target -> immediately resolved
-    assign is_jump[i] = instruction_valid[i] & (rvi_jump[i] | rvc_jump[i]);
-    // unconditional jumps with unknown target -> BTB
-    assign is_jalr[i] = instruction_valid[i] & ~is_return[i] & (rvi_jalr[i] | rvc_jalr[i] | rvc_jr[i]);
-  end
+  // branch history table -> BHT
+  assign is_branch = instruction_valid & (rvi_branch | rvc_branch);
+  // function calls -> RAS
+  assign is_call = instruction_valid & (rvi_call | rvc_call);
+  // function return -> RAS
+  assign is_return = instruction_valid & (rvi_return | rvc_return);
+  // unconditional jumps with known target -> immediately resolved
+  assign is_jump = instruction_valid & (rvi_jump | rvc_jump);
+  // unconditional jumps with unknown target -> BTB
+  assign is_jalr = instruction_valid & ~is_return & (rvi_jalr | rvc_jalr | rvc_jr);
 
   // taken/not taken
   always_comb begin

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -214,7 +214,7 @@ module frontend
   // unconditional jumps with known target -> immediately resolved
   assign is_jump = instruction_valid & (rvi_jump | rvc_jump);
   // unconditional jumps with unknown target -> BTB
-  assign is_jalr = instruction_valid & ~is_return & (rvi_jalr | rvc_jalr | rvc_jr);
+  assign is_jalr   = instruction_valid & ~is_return & (rvi_jalr | rvc_jalr | rvc_jr);
 
   // taken/not taken
   always_comb begin


### PR DESCRIPTION
The last instruction cannot be a 32 bit instruction when this instruction is not word aligned (in single or dual issue mode).
This cannot be (easily) conditioned. One solution was to exclude the lines, but as it is not so user friendly, Côme proposed to rewrite the code to hide the uncovered case.