### PR TITLE
Improve CC

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -863,7 +863,7 @@ module csr_regfile
           // -> last bit of pmpaddr must be set 0/1 based on the mode:
           // NA4, NAPOT: 1
           // TOR, OFF:   0
-          if (pmpcfg_q[index].addr_mode[1] == 1'b1)
+          if (CVA6Cfg.PMPNapotEn && pmpcfg_q[index].addr_mode[1] == 1'b1)
             csr_rdata = {pmpaddr_q[index][CVA6Cfg.PLEN-3:1], 1'b1};
           else csr_rdata = {pmpaddr_q[index][CVA6Cfg.PLEN-3:1], 1'b0};
         end


### PR DESCRIPTION
addr_mode[1] = 1 for NATOP and NA4. As cv32a60x supports only TOR and OFF, the line can be conditioned by CVA6Cfg.PMPNapotEn