### PR TITLE
TB UVM : don't instanciate obi_amo_agent without amo extension enabled

### DIFF
--- a/verif/env/uvme/uvme_cva6_cfg.sv
+++ b/verif/env/uvme/uvme_cva6_cfg.sv
@@ -394,7 +394,11 @@ class uvme_cva6_cfg_c extends uvma_core_cntrl_cfg_c;
          axi_cfg.cov_model_enabled       == 1;
          obi_memory_instr_cfg.cov_model_enabled == 1;
          obi_memory_store_cfg.cov_model_enabled == 1;
-         obi_memory_amo_cfg.cov_model_enabled == 1;
+         if (ext_a_supported) {
+            obi_memory_amo_cfg.cov_model_enabled == 1;
+         } else {
+            obi_memory_amo_cfg.cov_model_enabled == 0;
+         }
          obi_memory_load_cfg.cov_model_enabled == 1;
          //obi_memory_mmu_ptw_cfg.cov_model_enabled == 1;
          interrupt_cfg.cov_model_enabled == 1;

--- a/verif/env/uvme/uvme_cva6_cntxt.sv
+++ b/verif/env/uvme/uvme_cva6_cntxt.sv
@@ -95,13 +95,17 @@ function uvme_cva6_cntxt_c::new(string name="uvme_cva6_cntxt");
 
    clknrst_cntxt      = uvma_clknrst_cntxt_c::type_id::create("clknrst_cntxt");
    core_cntrl_cntxt   = uvma_cva6_core_cntrl_cntxt_c::type_id::create("core_cntrl_cntxt");
-   axi_cntxt          = uvma_axi_cntxt_c::type_id::create("axi_cntxt");
-
-   obi_memory_instr_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_instr_cntxt");
-   obi_memory_store_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_store_cntxt");
-   obi_memory_amo_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_amo_cntxt");
-   obi_memory_load_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_load_cntxt");
-   //obi_memory_mmu_ptw_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_mmu_ptw_cntxt");
+   if (!RTLCVA6Cfg.PipelineOnly || config_pkg::OBI_NOT_COMPLIANT) begin
+      axi_cntxt          = uvma_axi_cntxt_c::type_id::create("axi_cntxt");
+   end else begin
+      obi_memory_instr_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_instr_cntxt");
+      obi_memory_store_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_store_cntxt");
+      obi_memory_load_cntxt        = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_load_cntxt");
+      if (RTLCVA6Cfg.RVA) begin
+         obi_memory_amo_cntxt         = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_amo_cntxt");
+      end
+      //obi_memory_mmu_ptw_cntxt       = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_mmu_ptw_cntxt");
+   end
 
    mem = uvml_mem_cva6::type_id::create("mem");
    mem_obi = uvml_mem_c::type_id::create("mem_obi");

--- a/verif/env/uvme/uvme_cva6_env.sv
+++ b/verif/env/uvme/uvme_cva6_env.sv
@@ -187,8 +187,10 @@ function void uvme_cva6_env_c::build_phase(uvm_phase phase);
       end else begin
          cntxt.obi_memory_instr_cntxt.mem = cntxt.mem_obi;
          cntxt.obi_memory_store_cntxt.mem = cntxt.mem_obi;
-         cntxt.obi_memory_amo_cntxt.mem   = cntxt.mem_obi;
          cntxt.obi_memory_load_cntxt.mem  = cntxt.mem_obi;
+         if (RTLCVA6Cfg.RVA) begin
+            cntxt.obi_memory_amo_cntxt.mem   = cntxt.mem_obi;
+         end
          //cntxt.obi_memory_mmu_ptw_cntxt.mem = cntxt.mem_obi;
          cntxt.interrupt_cntxt.mem_obi    = cntxt.mem_obi;
          `uvm_info("UVMECVA6ENV", "OBI interface is active", UVM_NONE)
@@ -268,8 +270,10 @@ function void uvme_cva6_env_c::assign_cfg();
    else begin
       uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_instr_agent", "cfg", cfg.obi_memory_instr_cfg);
       uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_store_agent", "cfg", cfg.obi_memory_store_cfg);
-      uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_amo_agent", "cfg", cfg.obi_memory_amo_cfg);
       uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_load_agent", "cfg", cfg.obi_memory_load_cfg);
+      if (RTLCVA6Cfg.RVA) begin
+         uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_amo_agent", "cfg", cfg.obi_memory_amo_cfg);
+      end
       //uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_mmu_ptw_agent", "cfg", cfg.obi_memory_mmu_ptw_cfg);
    end
 
@@ -298,8 +302,10 @@ function void uvme_cva6_env_c::assign_cntxt();
    end else begin
      uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_instr_agent", "cntxt", cntxt.obi_memory_instr_cntxt);
      uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_store_agent", "cntxt", cntxt.obi_memory_store_cntxt);
-     uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_amo_agent", "cntxt", cntxt.obi_memory_amo_cntxt);
      uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_load_agent", "cntxt", cntxt.obi_memory_load_cntxt);
+     if (RTLCVA6Cfg.RVA) begin
+        uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_amo_agent", "cntxt", cntxt.obi_memory_amo_cntxt);
+     end
      //uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_mmu_ptw_agent", "cntxt", cntxt.obi_memory_mmu_ptw_cntxt);
    end
 
@@ -318,8 +324,10 @@ function void uvme_cva6_env_c::create_agents();
    end else begin
       obi_memory_instr_agent      = uvma_obi_memory_agent_c::type_id::create("obi_memory_instr_agent", this);
       obi_memory_store_agent      = uvma_obi_memory_agent_c::type_id::create("obi_memory_store_agent", this);
-      obi_memory_amo_agent        = uvma_obi_memory_agent_c::type_id::create("obi_memory_amo_agent", this);
-      obi_memory_load_agent     = uvma_obi_memory_agent_c::type_id::create("obi_memory_load_agent", this);
+      obi_memory_load_agent       = uvma_obi_memory_agent_c::type_id::create("obi_memory_load_agent", this);
+      if (RTLCVA6Cfg.RVA) begin
+         obi_memory_amo_agent        = uvma_obi_memory_agent_c::type_id::create("obi_memory_amo_agent", this);
+      end
       //obi_memory_mmu_ptw_agent  = uvma_obi_memory_agent_c::type_id::create("obi_memory_mmu_ptw_agent", this);
    end
 
@@ -421,8 +429,10 @@ function void uvme_cva6_env_c::assemble_vsequencer();
    end else begin
      vsequencer.obi_memory_instr_sequencer     = obi_memory_instr_agent.sequencer;
      vsequencer.obi_memory_store_sequencer     = obi_memory_store_agent.sequencer;
-     vsequencer.obi_memory_amo_sequencer       = obi_memory_amo_agent.sequencer;
      vsequencer.obi_memory_load_sequencer      = obi_memory_load_agent.sequencer;
+     if (RTLCVA6Cfg.RVA) begin
+        vsequencer.obi_memory_amo_sequencer       = obi_memory_amo_agent.sequencer;
+     end
      //vsequencer.obi_memory_mmu_ptw_sequencer   = obi_memory_mmu_ptw_agent.sequencer;
    end
    vsequencer.interrupt_sequencer  = interrupt_agent.sequencer;
@@ -495,7 +505,7 @@ task uvme_cva6_env_c::run_phase(uvm_phase phase);
          end
       end
       begin : obi_amo_slv_thread
-         if(cfg.obi_memory_amo_cfg.is_active == UVM_ACTIVE && !config_pkg::OBI_NOT_COMPLIANT) begin
+         if(cfg.obi_memory_amo_cfg.is_active == UVM_ACTIVE && !config_pkg::OBI_NOT_COMPLIANT && RTLCVA6Cfg.RVA) begin
             amo_slv_seq = uvma_obi_memory_slv_seq_c::type_id::create("amo_slv_seq");
             if (!amo_slv_seq.randomize()) begin
                `uvm_fatal("AMOSLVSEQ", "Randomize failed");

--- a/verif/tb/uvmt/cva6_tb_wrapper.sv
+++ b/verif/tb/uvmt/cva6_tb_wrapper.sv
@@ -289,33 +289,35 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
          assign obi_store_slave.exokay     = i_cva6.obi_store_rsp.r.r_optional.exokay;
          assign obi_store_slave.rvalidpar  = i_cva6.obi_store_rsp.rvalidpar;
          assign obi_store_slave.rchk       = i_cva6.obi_store_rsp.r.r_optional.rchk;
-	     
-         assign obi_amo_slave.req        = i_cva6.obi_amo_req.req;
-         assign obi_amo_slave.addr       = i_cva6.obi_amo_req.a.addr;
-         assign obi_amo_slave.we         = i_cva6.obi_amo_req.a.we;
-         assign obi_amo_slave.be         = i_cva6.obi_amo_req.a.be;
-         assign obi_amo_slave.wdata      = i_cva6.obi_amo_req.a.wdata;
-         assign obi_amo_slave.auser      = i_cva6.obi_amo_req.a.a_optional.auser;
-         assign obi_amo_slave.wuser      = i_cva6.obi_amo_req.a.a_optional.wuser;
-         assign obi_amo_slave.aid        = i_cva6.obi_amo_req.a.aid;
-         assign obi_amo_slave.atop       = i_cva6.obi_amo_req.a.a_optional.atop;
-         assign obi_amo_slave.memtype    = i_cva6.obi_amo_req.a.a_optional.memtype;
-         assign obi_amo_slave.prot       = i_cva6.obi_amo_req.a.a_optional.prot;
-         assign obi_amo_slave.reqpar     = i_cva6.obi_amo_req.reqpar;
-         assign obi_amo_slave.achk       = i_cva6.obi_amo_req.a.a_optional.achk;
-         assign obi_amo_slave.rready     = i_cva6.obi_amo_req.rready;
-         assign obi_amo_slave.rreadypar  = i_cva6.obi_amo_req.rreadypar;
-         assign obi_amo_slave.gnt        = i_cva6.obi_amo_rsp.gnt;
-         assign obi_amo_slave.gntpar     = i_cva6.obi_amo_rsp.gntpar;
-         assign obi_amo_slave.rvalid     = i_cva6.obi_amo_rsp.rvalid;
-         assign obi_amo_slave.rdata      = i_cva6.obi_amo_rsp.r.rdata;
-         assign obi_amo_slave.err        = i_cva6.obi_amo_rsp.r.err;
-         assign obi_amo_slave.ruser      = i_cva6.obi_amo_rsp.r.r_optional.ruser;
-         assign obi_amo_slave.rid        = i_cva6.obi_amo_rsp.r.rid;
-         assign obi_amo_slave.exokay     = i_cva6.obi_amo_rsp.r.r_optional.exokay;
-         assign obi_amo_slave.rvalidpar  = i_cva6.obi_amo_rsp.rvalidpar;
-         assign obi_amo_slave.rchk       = i_cva6.obi_amo_rsp.r.r_optional.rchk;
-	     
+
+         if (CVA6Cfg.RVA) begin
+            assign obi_amo_slave.req        = i_cva6.obi_amo_req.req;
+            assign obi_amo_slave.addr       = i_cva6.obi_amo_req.a.addr;
+            assign obi_amo_slave.we         = i_cva6.obi_amo_req.a.we;
+            assign obi_amo_slave.be         = i_cva6.obi_amo_req.a.be;
+            assign obi_amo_slave.wdata      = i_cva6.obi_amo_req.a.wdata;
+            assign obi_amo_slave.auser      = i_cva6.obi_amo_req.a.a_optional.auser;
+            assign obi_amo_slave.wuser      = i_cva6.obi_amo_req.a.a_optional.wuser;
+            assign obi_amo_slave.aid        = i_cva6.obi_amo_req.a.aid;
+            assign obi_amo_slave.atop       = i_cva6.obi_amo_req.a.a_optional.atop;
+            assign obi_amo_slave.memtype    = i_cva6.obi_amo_req.a.a_optional.memtype;
+            assign obi_amo_slave.prot       = i_cva6.obi_amo_req.a.a_optional.prot;
+            assign obi_amo_slave.reqpar     = i_cva6.obi_amo_req.reqpar;
+            assign obi_amo_slave.achk       = i_cva6.obi_amo_req.a.a_optional.achk;
+            assign obi_amo_slave.rready     = i_cva6.obi_amo_req.rready;
+            assign obi_amo_slave.rreadypar  = i_cva6.obi_amo_req.rreadypar;
+            assign obi_amo_slave.gnt        = i_cva6.obi_amo_rsp.gnt;
+            assign obi_amo_slave.gntpar     = i_cva6.obi_amo_rsp.gntpar;
+            assign obi_amo_slave.rvalid     = i_cva6.obi_amo_rsp.rvalid;
+            assign obi_amo_slave.rdata      = i_cva6.obi_amo_rsp.r.rdata;
+            assign obi_amo_slave.err        = i_cva6.obi_amo_rsp.r.err;
+            assign obi_amo_slave.ruser      = i_cva6.obi_amo_rsp.r.r_optional.ruser;
+            assign obi_amo_slave.rid        = i_cva6.obi_amo_rsp.r.rid;
+            assign obi_amo_slave.exokay     = i_cva6.obi_amo_rsp.r.r_optional.exokay;
+            assign obi_amo_slave.rvalidpar  = i_cva6.obi_amo_rsp.rvalidpar;
+            assign obi_amo_slave.rchk       = i_cva6.obi_amo_rsp.r.r_optional.rchk;
+         end
+
          assign obi_load_slave.req        = i_cva6.obi_load_req.req;
          assign obi_load_slave.addr       = i_cva6.obi_load_req.a.addr;
          assign obi_load_slave.we         = i_cva6.obi_load_req.a.we;
@@ -515,31 +517,33 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
       assign obi_store_rsp.rvalidpar            = obi_store_slave.rvalidpar;
       assign obi_store_rsp.r.r_optional.rchk    = obi_store_slave.rchk;
 
-      assign obi_amo_slave.req                  = obi_amo_req.req;
-      assign obi_amo_slave.addr                 = obi_amo_req.a.addr;
-      assign obi_amo_slave.we                   = obi_amo_req.a.we;
-      assign obi_amo_slave.be                   = obi_amo_req.a.be;
-      assign obi_amo_slave.wdata                = obi_amo_req.a.wdata;
-      assign obi_amo_slave.auser                = obi_amo_req.a.a_optional.auser;
-      assign obi_amo_slave.wuser                = obi_amo_req.a.a_optional.wuser;
-      assign obi_amo_slave.aid                  = obi_amo_req.a.aid;
-      assign obi_amo_slave.atop                 = obi_amo_req.a.a_optional.atop;
-      assign obi_amo_slave.memtype              = obi_amo_req.a.a_optional.memtype;
-      assign obi_amo_slave.prot                 = obi_amo_req.a.a_optional.prot;
-      assign obi_amo_slave.reqpar               = obi_amo_req.reqpar;
-      assign obi_amo_slave.achk                 = obi_amo_req.a.a_optional.achk;
-      assign obi_amo_slave.rready               = obi_amo_req.rready;
-      assign obi_amo_slave.rreadypar            = obi_amo_req.rreadypar;
-      assign obi_amo_rsp.gnt                    = obi_amo_slave.gnt;
-      assign obi_amo_rsp.gntpar                 = obi_amo_slave.gntpar;
-      assign obi_amo_rsp.rvalid                 = obi_amo_slave.rvalid;
-      assign obi_amo_rsp.r.rdata                = obi_amo_slave.rdata;
-      assign obi_amo_rsp.r.err                  = obi_amo_slave.err;
-      assign obi_amo_rsp.r.r_optional.ruser     = obi_amo_slave.ruser;
-      assign obi_amo_rsp.r.rid                  = obi_amo_slave.rid;
-      assign obi_amo_rsp.r.r_optional.exokay    = obi_amo_slave.exokay;
-      assign obi_amo_rsp.rvalidpar              = obi_amo_slave.rvalidpar;
-      assign obi_amo_rsp.r.r_optional.rchk      = obi_amo_slave.rchk;
+      if (CVA6Cfg.RVA) begin
+         assign obi_amo_slave.req                  = obi_amo_req.req;
+         assign obi_amo_slave.addr                 = obi_amo_req.a.addr;
+         assign obi_amo_slave.we                   = obi_amo_req.a.we;
+         assign obi_amo_slave.be                   = obi_amo_req.a.be;
+         assign obi_amo_slave.wdata                = obi_amo_req.a.wdata;
+         assign obi_amo_slave.auser                = obi_amo_req.a.a_optional.auser;
+         assign obi_amo_slave.wuser                = obi_amo_req.a.a_optional.wuser;
+         assign obi_amo_slave.aid                  = obi_amo_req.a.aid;
+         assign obi_amo_slave.atop                 = obi_amo_req.a.a_optional.atop;
+         assign obi_amo_slave.memtype              = obi_amo_req.a.a_optional.memtype;
+         assign obi_amo_slave.prot                 = obi_amo_req.a.a_optional.prot;
+         assign obi_amo_slave.reqpar               = obi_amo_req.reqpar;
+         assign obi_amo_slave.achk                 = obi_amo_req.a.a_optional.achk;
+         assign obi_amo_slave.rready               = obi_amo_req.rready;
+         assign obi_amo_slave.rreadypar            = obi_amo_req.rreadypar;
+         assign obi_amo_rsp.gnt                    = obi_amo_slave.gnt;
+         assign obi_amo_rsp.gntpar                 = obi_amo_slave.gntpar;
+         assign obi_amo_rsp.rvalid                 = obi_amo_slave.rvalid;
+         assign obi_amo_rsp.r.rdata                = obi_amo_slave.rdata;
+         assign obi_amo_rsp.r.err                  = obi_amo_slave.err;
+         assign obi_amo_rsp.r.r_optional.ruser     = obi_amo_slave.ruser;
+         assign obi_amo_rsp.r.rid                  = obi_amo_slave.rid;
+         assign obi_amo_rsp.r.r_optional.exokay    = obi_amo_slave.exokay;
+         assign obi_amo_rsp.rvalidpar              = obi_amo_slave.rvalidpar;
+         assign obi_amo_rsp.r.r_optional.rchk      = obi_amo_slave.rchk;
+      end
 
       assign obi_load_slave.req                = obi_load_req.req;
       assign obi_load_slave.addr               = obi_load_req.a.addr;


### PR DESCRIPTION
To improve the UVM tb, I condition instantiation of obi_amo_agent in the uvm env only when amo extension is enbaled, that's gonna gain more time in simulation also disabling coverage of amo_obi_agent