### PR TITLE
FENCE_i : Remove fence_i from HVP and core-dv

### DIFF
--- a/verif/env/corev-dv/target/rv32imcb/riscv_core_setting.sv
+++ b/verif/env/corev-dv/target/rv32imcb/riscv_core_setting.sv
@@ -27,7 +27,8 @@ parameter satp_mode_t SATP_MODE = BARE;
 privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE};
 
 // Unsupported instructions
-riscv_instr_name_t unsupported_instr[];
+// Disable generating fence.i instruction as we don't support it
+riscv_instr_name_t unsupported_instr[] = {FENCE_I};
 
 // ISA supported by the processor
 riscv_instr_group_t supported_isa[$] = {RV32I,

--- a/verif/sim/cva6.hvp
+++ b/verif/sim/cva6.hvp
@@ -456,12 +456,6 @@ plan "CVA6 Verification Master Plan";
                     endmeasure
                 endfeature
             endfeature
-            feature RV32ZIFENCEI;
-                description = "ZIFENCE.I extension";
-                measure Group FEINCE_I;
-                    source = "group instance: uvma_isacov_pkg.uvma_isacov_pkg.rv32zifencei_fence_i_cg";
-                endmeasure
-            endfeature
             feature RV32ZCB;
                 weight = 1;
                 description = "ZCB extension";
@@ -714,11 +708,6 @@ plan "CVA6 Verification Master Plan";
                 feature ZICSR_EXT;
                     measure Group ZICSR_EXT;
                         source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.illegal_zicsr_cg";
-                    endmeasure
-                endfeature
-                feature ZIFENCEI_EXT;
-                    measure Group ZIFENCEI_EXT;
-                        source = "group instance: uvme_cva6_pkg.uvme_cva6_pkg.illegal_zifencei_cg";
                     endmeasure
                 endfeature
             endfeature


### PR DESCRIPTION
This MR relative to disabling fence_i from UVM TB

waiting disabling fence_i in RTL cv32a60x configue