### PR TITLE
Spike.yaml : cv32a60x doesn't support vectored mode

### DIFF
--- a/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
@@ -37,6 +37,7 @@ spike_param_tree:
       mip_override_mask: 0xfffff77f
       mip_override_value: 0x00000000
       mtval_write_mask: 0
+      mtvec_write_mask: 0xFFFFFFFE
       tinfo_accessible: 0
       mscontext_accessible: 0
       mcontext_accessible: 0


### PR DESCRIPTION
This is a fix in spike.yaml, I added a mask as the cv32a60x doesn't support vectored mode