### PR TITLE
Refactor toolchain-builder and add better LLVM support

### DIFF
--- a/util/toolchain-builder/build-toolchain.sh
+++ b/util/toolchain-builder/build-toolchain.sh
@@ -149,6 +149,10 @@ build_llvm() {
         ln -sv clang riscv32-unknown-elf-$TOOL
         ln -sv clang riscv64-unknown-elf-$TOOL
     done
+    for TOOL in ar nm objcopy objdump ranlib size strings strip; do
+        ln -sv llvm-$TOOL riscv32-unknown-elf-$TOOL
+    done
+    ln -sv lld riscv32-unknown-elf-ld
 }
 
 
@@ -171,7 +175,7 @@ build_compiler_rt() {
     cd "$BUILD_DIR/compiler-rt-$1"
 
     COMPILER_RT_CONFIGURE_OPTS $1
-    [ -f Makefile ] || cmake $SRC_DIR/$LLVM_DIR/compiler-rt $(COMPILER_RT_CONFIGURE_OPTS $1)
+    [ -f Makefile ] || cmake $SRC_DIR/$LLVM_DIR/compiler-rt $(COMPILER_RT_CONFIGURE_OPTS $1) -DCMAKE_C_FLAGS="-fuse-ld=lld" -DCMAKE_CXX_FLAGS="-fuse-ld=lld"
     make -j$NUM_JOBS
     make install
 }
@@ -194,25 +198,15 @@ build_gcc_toolchain() {
 build_llvm_toolchain() {
     [ $FORCE_REBUILD = "yes" ] && rm -rf $BUILD_DIR/{llvm,*-unknown-elf}
 
-    echo "### Building Binutils ..."
-    build_binutils riscv32-unknown-elf
-
     echo "### Building LLVM ..."
     build_llvm
 
     echo "### Building Newlib 32 bits ..."
     build_newlib riscv32-unknown-elf
 
-    echo "### Building Newlib 64 bits ..."
-    build_newlib riscv64-unknown-elf
-
     echo "### Building Compiler-RT 32 bits ..."
     build_compiler_rt riscv32-unknown-elf
-
-    echo "### Building Compiler-RT 64 bits ..."
-    build_compiler_rt riscv64-unknown-elf
 }
-
 
 
 # Absolute path of the toolchain-builder directory

--- a/util/toolchain-builder/build-toolchain.sh
+++ b/util/toolchain-builder/build-toolchain.sh
@@ -136,6 +136,11 @@ build_gcc() {
     $SRC_DIR/$GCC_DIR/configure $(GCC_CONFIGURE_OPTS $1)
     make -j$NUM_JOBS
     make install
+
+    # Write version
+    BRANCH_NAME=$(git -C "$SRC_DIR/$GCC_DIR" branch --show-current)
+    COMMIT_HASH=$(git -C "$SRC_DIR/$GCC_DIR" rev-parse HEAD)
+    echo "GCC $BRANCH_NAME $COMMIT_HASH" >> "$INSTALL_DIR/VERSION"
 }
 
 
@@ -164,6 +169,11 @@ build_llvm() {
 EOF
     chmod +x $1-readelf
     chmod +x llvm-readelf
+
+    # Write version
+    BRANCH_NAME=$(git -C "$SRC_DIR/$LLVM_DIR" branch --show-current)
+    COMMIT_HASH=$(git -C "$SRC_DIR/$LLVM_DIR" rev-parse HEAD)
+    echo "LLVM $BRANCH_NAME $COMMIT_HASH" >> "$INSTALL_DIR/VERSION"
 }
 
 
@@ -183,6 +193,11 @@ build_newlib() {
     [ -f Makefile ] || CFLAGS_FOR_TARGET="$cflags" $SRC_DIR/$NEWLIB_DIR/configure $(NEWLIB_CONFIGURE_OPTS $1) $MULTILIB
     make -j$NUM_JOBS
     make install
+
+    # Write version
+    BRANCH_NAME=$(git -C "$SRC_DIR/$NEWLIB_DIR" branch --show-current)
+    COMMIT_HASH=$(git -C "$SRC_DIR/$NEWLIB_DIR" rev-parse HEAD)
+    echo "Newlib $BRANCH_NAME $COMMIT_HASH" >> "$INSTALL_DIR/VERSION"
 }
 
 
@@ -252,6 +267,9 @@ if [ -n "$(ls -A $INSTALL_DIR 2>/dev/null)" ]; then
         echo "Install directory $INSTALL_DIR is not empty!"
         echo "Use -y or --force-install if you want to skip this check"
         exit 1
+    else
+        rm -f $INSTALL_DIR/VERSION
+        echo "WARNING: Toolchain created with --force-install; may contain oudated files!" > $INSTALL_DIR/VERSION
     fi
 else
     mkdir -p "$INSTALL_DIR"

--- a/util/toolchain-builder/build-toolchain.sh
+++ b/util/toolchain-builder/build-toolchain.sh
@@ -44,7 +44,7 @@ print_usage() {
     echo "  -h, --help           Print this help message and exit."
     echo "  -f, --force-rebuild  Rebuild toolchain from scratch (remove build dirs,"
     echo "                         configure and build again.)"
-    echo "  -y, --force-install  Don't exit if install dir ins't empty."
+    echo "  -y, --force-install  Don't exit if install dir isn't empty."
     echo "  CONFIG_NAME          Use configuration from file config/CONFIG_NAME.sh"
     echo "                         (default: '$CONFIG_NAME')"
     echo "  INSTALL_DIR          Path where the toolchain should be installed"
@@ -269,7 +269,7 @@ if [ -n "$(ls -A $INSTALL_DIR 2>/dev/null)" ]; then
         exit 1
     else
         rm -f $INSTALL_DIR/VERSION
-        echo "WARNING: Toolchain created with --force-install; may contain oudated files!" > $INSTALL_DIR/VERSION
+        echo "WARNING: Toolchain created with --force-install; may contain outdated files!" > $INSTALL_DIR/VERSION
     fi
 else
     mkdir -p "$INSTALL_DIR"

--- a/util/toolchain-builder/config/global.sh
+++ b/util/toolchain-builder/config/global.sh
@@ -60,11 +60,7 @@ BINUTILS_CONFIGURE_OPTS() {
         --target=$1
         --prefix=${INSTALL_DIR}
         --disable-werror
-        --disable-gdb
         --disable-nls
-        --disable-sim
-        --disable-libdecnumber
-        --disable-readline
     )
     echo "${OPTS[@]}"
 }

--- a/util/toolchain-builder/config/global.sh
+++ b/util/toolchain-builder/config/global.sh
@@ -86,7 +86,6 @@ LLVM_CONFIGURE_OPTS() {
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
         -DLLVM_ENABLE_PROJECTS='clang;lld'
-        -DLLVM_BINUTILS_INCDIR=${SRC_DIR}/${BINUTILS_DIR}/include
         -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;llvm-ar;llvm-cov;llvm-cxxfilt;llvm-dwp;llvm-nm;llvm-objcopy;llvm-objdump;llvm-ranlib;llvm-readobj;llvm-size;llvm-strings;llvm-strip;llvm-profdata;llvm-symbolizer'
         -DLLVM_TARGETS_TO_BUILD='RISCV'
         -DLLVM_OPTIMIZED_TABLEGEN=ON

--- a/util/toolchain-builder/config/global.sh
+++ b/util/toolchain-builder/config/global.sh
@@ -72,7 +72,7 @@ BINUTILS_CONFIGURE_OPTS() {
 GCC_CONFIGURE_OPTS() {
     OPTS=(
         --prefix=${INSTALL_DIR}
-        --target=riscv-none-elf
+        --target=$1
         --enable-languages=c
         --disable-libssp
         --disable-libgomp
@@ -85,12 +85,18 @@ LLVM_CONFIGURE_OPTS() {
     OPTS=(
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
-        -DLLVM_ENABLE_PROJECTS='clang;lld'
-        -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;llvm-ar;llvm-cov;llvm-cxxfilt;llvm-dwp;llvm-nm;llvm-objcopy;llvm-objdump;llvm-ranlib;llvm-readobj;llvm-size;llvm-strings;llvm-strip;llvm-profdata;llvm-symbolizer'
+        -DLLVM_ENABLE_PROJECTS='clang;lld;lldb'
+        -DLLVM_DISTRIBUTION_COMPONENTS='clang;clang-resource-headers;lld;lldb;llvm-ar;llvm-cov;llvm-cxxfilt;llvm-dwp;llvm-nm;llvm-objcopy;llvm-objdump;llvm-ranlib;llvm-readobj;llvm-size;llvm-strings;llvm-strip;llvm-profdata;llvm-symbolizer'
         -DLLVM_TARGETS_TO_BUILD='RISCV'
+        -DLLVM_DEFAULT_TARGET_TRIPLE=$1
         -DLLVM_OPTIMIZED_TABLEGEN=ON
         -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
         -DLLVM_INSTALL_BINUTILS_SYMLINKS=ON
+        -DLLVM_ENABLE_BINDINGS=OFF
+        -DLLVM_ENABLE_UNWIND_TABLES=OFF
+        -DLLVM_INCLUDE_BENCHMARKS=OFF
+        -DLLVM_INCLUDE_EXAMPLES=OFF
+        -DLLVM_INCLUDE_DOCS=OFF
     )
     echo "${OPTS[@]}"
 }
@@ -99,7 +105,6 @@ NEWLIB_CONFIGURE_OPTS() {
     OPTS=(
         --target=$1
         --prefix=${INSTALL_DIR}
-        --enable-multilib
         --enable-newlib-io-long-double
         --enable-newlib-io-long-long
         --enable-newlib-io-c99-formats

--- a/util/toolchain-builder/config/llvm-19-baremetal.sh
+++ b/util/toolchain-builder/config/llvm-19-baremetal.sh
@@ -27,7 +27,7 @@
 # typically a tag, a commit or the output of "git describe" of a Git tree.
 
 # LLVM
-LLVM_COMMIT=release/18.x
+LLVM_COMMIT=release/19.x
 
 # newlib
 NEWLIB_COMMIT=newlib-4.4.0

--- a/util/toolchain-builder/config/llvm-20-baremetal.sh
+++ b/util/toolchain-builder/config/llvm-20-baremetal.sh
@@ -27,8 +27,8 @@
 # typically a tag, a commit or the output of "git describe" of a Git tree.
 
 # LLVM
-LLVM_COMMIT=release/18.x
+LLVM_COMMIT=release/20.x
 
 # newlib
-NEWLIB_COMMIT=newlib-4.4.0
+NEWLIB_COMMIT=newlib-4.5.0
 

--- a/util/toolchain-builder/config/llvm-master-baremetal.sh
+++ b/util/toolchain-builder/config/llvm-master-baremetal.sh
@@ -26,9 +26,6 @@
 # Each *_COMMIT variable can designate any valid 'commit-ish' entity:
 # typically a tag, a commit or the output of "git describe" of a Git tree.
 
-# Binutils
-BINUTILS_COMMIT=master
-
 # LLVM
 LLVM_COMMIT=main
 

--- a/util/toolchain-builder/get-toolchain.sh
+++ b/util/toolchain-builder/get-toolchain.sh
@@ -130,7 +130,6 @@ setup_sources_from_git()
     cd -
 }
 
-
 if [[ $CONFIG_NAME == "gcc"* ]]; then
     # Get Binutils sources
     echo "# Step 1: Obtaining sources of binutils..."

--- a/util/toolchain-builder/get-toolchain.sh
+++ b/util/toolchain-builder/get-toolchain.sh
@@ -131,23 +131,29 @@ setup_sources_from_git()
     cd -
 }
 
-# Get Binutils sources
-echo "# Step 1: Obtaining sources of binutils..."
-setup_sources_from_git $BINUTILS_REPO $BINUTILS_DIR $BINUTILS_COMMIT
 
 if [[ $CONFIG_NAME == "gcc"* ]]; then
+    # Get Binutils sources
+    echo "# Step 1: Obtaining sources of binutils..."
+    setup_sources_from_git $BINUTILS_REPO $BINUTILS_DIR $BINUTILS_COMMIT
+
     # Get GCC sources
     echo "# Step 2: Obtaining sources of GCC..."
     setup_sources_from_git $GCC_REPO $GCC_DIR $GCC_COMMIT
+
+    # Get Newlib sources
+    echo "# Step 3: Obtaining sources of newlib..."
+    setup_sources_from_git $NEWLIB_REPO $NEWLIB_DIR $NEWLIB_COMMIT
 else
     # Get LLVM sources
-    echo "# Step 2: Obtaining sources of LLVM..."
+    echo "# Step 1: Obtaining sources of LLVM..."
     setup_sources_from_git $LLVM_REPO $LLVM_DIR $LLVM_COMMIT
+
+    # Get Newlib sources
+    echo "# Step 2: Obtaining sources of newlib..."
+    setup_sources_from_git $NEWLIB_REPO $NEWLIB_DIR $NEWLIB_COMMIT
 fi
 
-# Get Newlib sources
-echo "# Step 3: Obtaining sources of newlib..."
-setup_sources_from_git $NEWLIB_REPO $NEWLIB_DIR $NEWLIB_COMMIT
 
 # Exit happily.
 exit 0

--- a/util/toolchain-builder/get-toolchain.sh
+++ b/util/toolchain-builder/get-toolchain.sh
@@ -123,9 +123,8 @@ setup_sources_from_git()
     # Check out the required revision as local branch (the shallow clone
     # leaves a "detached HEAD" state.)
     cd $SRC_DIR/$2
-    LOCAL_BRANCH="${3}-local"
-    { git branch | grep -q "$LOCAL_BRANCH" ; } || git checkout -b "$LOCAL_BRANCH"
-    git checkout "$LOCAL_BRANCH"
+    { git branch | grep -q "$3" ; } || git checkout -b "$3"
+    git checkout "$3"
     # Pull any updates available upstream (useful for 'master' branches).
     git pull origin "$3"
     cd -


### PR DESCRIPTION
This commit does the following :
- Refactor some code to be more readable
- Enable GDB when compiling a GCC toolchain
- Add tools branch name and commit hash to a VERSION file
- Build LLVM without Binutils