### PR TITLE
Improve Code Coverage by simplifying resolved_branch condition

### DIFF
--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -323,7 +323,7 @@ module frontend
     for (int i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++)
     bp_valid |= ((cf_type[i] != NoCF & cf_type[i] != Return) | ((cf_type[i] == Return) & ras_predict.valid));
   end
-  assign is_mispredict = resolved_branch_i.valid & resolved_branch_i.is_mispredict;
+  assign is_mispredict = resolved_branch_i.is_mispredict;
 
   logic spec_req_non_idempot;
 
@@ -632,8 +632,7 @@ module frontend
   assign bht_update.pc = resolved_branch_i.pc;
   assign bht_update.taken = resolved_branch_i.is_taken;
   // only update mispredicted branches e.g. no returns from the RAS
-  assign btb_update.valid = resolved_branch_i.valid
-                                & resolved_branch_i.is_mispredict
+  assign btb_update.valid = resolved_branch_i.is_mispredict
                                 & (resolved_branch_i.cf_type == ariane_pkg::JumpR);
   assign btb_update.pc = resolved_branch_i.pc;
   assign btb_update.target_address = resolved_branch_i.target_address;

--- a/core/perf_counters.sv
+++ b/core/perf_counters.sv
@@ -126,8 +126,7 @@ module perf_counters
         5'b00111: events[i] = ex_i.valid;  //Exceptions
         5'b01000: events[i] = eret_i;  //Exception handler returns
         5'b01001: events[i] = |branch_event;  // Branch instructions
-        5'b01010:
-        events[i] = resolved_branch_i.valid && resolved_branch_i.is_mispredict;//Branch mispredicts
+        5'b01010: events[i] = resolved_branch_i.is_mispredict;  //Branch mispredicts
         5'b01011: events[i] = branch_exceptions_i.valid;  //Branch exceptions
         // The standard software calling convention uses register x1 to hold the return address on a call
         // the unconditional jump is decoded as ADD op

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -262,7 +262,7 @@ module scoreboard #(
     end
   end
 
-  assign bmiss = resolved_branch_i.valid && resolved_branch_i.is_mispredict;
+  assign bmiss = resolved_branch_i.is_mispredict;
   assign after_flu_wb = trans_id_i[ariane_pkg::FLU_WB] + 'd1;
 
   // FIFO counter updates


### PR DESCRIPTION
When resolved_branch_i.is_mispredict is 1, resolved_branch_i.valid is 1 (see branch_unit.sv code).
Simplify code to increase code coverage