### PR TITLE
Assign a default value to tinst in decoder

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -186,6 +186,7 @@ module decoder
     ecall                                  = 1'b0;
     ebreak                                 = 1'b0;
     check_fprm                             = 1'b0;
+    tinst                                  = 32'h0;
 
     if (~ex_i.valid) begin
       case (instr.rtype.opcode)


### PR DESCRIPTION
This PR assigns 0 to tinst by default. 
Even though tinst is only used when CVA6Cfg.RVH is enabled, I chose to assign it a default value in all configurations, since the signal is defined for all configurations.

Fixes #2803 