### PR TITLE
Improve Code Coverage

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -899,7 +899,9 @@ module csr_regfile
     instret_d       = instret_q;
     if (!(CVA6Cfg.DebugEn && debug_mode_q)) begin
       // increase instruction retired counter
-      for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
+      if (commit_ack_i[0] && !(ex_i.valid && CVA6Cfg.SpeculativeSb) && (!CVA6Cfg.PerfCounterEn || (CVA6Cfg.PerfCounterEn && !mcountinhibit_q[2])))
+        instret++;
+      for (int i = 1; i < CVA6Cfg.NrCommitPorts; i++) begin
         if (commit_ack_i[i] && !ex_i.valid && (!CVA6Cfg.PerfCounterEn || (CVA6Cfg.PerfCounterEn && !mcountinhibit_q[2])))
           instret++;
       end
@@ -2233,7 +2235,7 @@ module csr_regfile
       // interrupts are enabled during single step or we are not stepping
       // No need to check interrupts during single step if we don't support DEBUG mode
       & (~CVA6Cfg.DebugEn | (~dcsr_q.step | dcsr_q.stepie))
-                                    & ((mstatus_q.mie & (priv_lvl_o == riscv::PRIV_LVL_M))
+                                    & ((mstatus_q.mie & (priv_lvl_o == riscv::PRIV_LVL_M | !CVA6Cfg.RVU))
                                     | (CVA6Cfg.RVU & priv_lvl_o != riscv::PRIV_LVL_M));
 
   always_comb begin : privilege_check

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -715,7 +715,7 @@ module frontend
   logic fetch_valid_d;
 
   // re-align the cache line
-  assign fetch_data = ex_rvalid ? '0 : obi_fetch_rsp_i.r.rdata >> {shamt, 4'b0};
+  assign fetch_data = ex_rvalid && CVA6Cfg.MmuPresent ? '0 : obi_fetch_rsp_i.r.rdata >> {shamt, 4'b0};
   assign fetch_valid_d = rvalid;
   assign fetch_vaddr_d = vaddr_rvalid;
 
@@ -756,7 +756,7 @@ module frontend
           fetch_ex_valid_q <= ariane_pkg::FE_INSTR_GUEST_PAGE_FAULT;
         end else if (CVA6Cfg.MmuPresent && arsp_i.fetch_exception.cause == riscv::INSTR_PAGE_FAULT) begin
           fetch_ex_valid_q <= ariane_pkg::FE_INSTR_PAGE_FAULT;
-        end else if (arsp_i.fetch_exception.cause == riscv::INSTR_ACCESS_FAULT) begin
+        end else if (CVA6Cfg.NrPMPEntries != 0 && arsp_i.fetch_exception.cause == riscv::INSTR_ACCESS_FAULT) begin
           fetch_ex_valid_q <= ariane_pkg::FE_INSTR_ACCESS_FAULT;
         end else begin
           fetch_ex_valid_q <= ariane_pkg::FE_NONE;

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -338,7 +338,7 @@ module instr_queue
       for (int unsigned i = 0; i < CVA6Cfg.INSTR_PER_FETCH; i++) begin
         // TODO handle fetch_entry_o[1] if superscalar
         if (idx_ds[0][i]) begin
-          if (instr_data_out[i].ex == ariane_pkg::FE_INSTR_ACCESS_FAULT) begin
+          if (CVA6Cfg.NrPMPEntries != 0 && instr_data_out[i].ex == ariane_pkg::FE_INSTR_ACCESS_FAULT) begin
             fetch_entry_o[0].ex.cause = riscv::INSTR_ACCESS_FAULT;
           end else if (CVA6Cfg.RVH && instr_data_out[i].ex == ariane_pkg::FE_INSTR_GUEST_PAGE_FAULT) begin
             fetch_entry_o[0].ex.cause = riscv::INSTR_GUEST_PAGE_FAULT;
@@ -346,7 +346,7 @@ module instr_queue
             fetch_entry_o[0].ex.cause = riscv::INSTR_PAGE_FAULT;
           end
           fetch_entry_o[0].instruction = instr_data_out[i].instr;
-          fetch_entry_o[0].ex.valid = instr_data_out[i].ex != ariane_pkg::FE_NONE;
+          fetch_entry_o[0].ex.valid = ((CVA6Cfg.MmuPresent || CVA6Cfg.NrPMPEntries !=0) && instr_data_out[i].ex != ariane_pkg::FE_NONE);
           if (CVA6Cfg.TvalEn)
             fetch_entry_o[0].ex.tval = {
               {(CVA6Cfg.XLEN - CVA6Cfg.VLEN) {1'b0}}, instr_data_out[i].ex_vaddr


### PR DESCRIPTION
Improve code condition knowing that:
- ex_rvalid is always 0 in cv32a60x : MMU and PMP are not present
- PRIV_LVL_M is always 1 in cv32a60x
- commi_ack and exception can be both at 1 if and only if CVA6Cfg.SpeculativeSb is 1
- Frontend generates exception only if MMU or PMP is present