### PR TITLE
Initialize compressed related signals in id_stage when RVC is disabled

### DIFF
--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -269,6 +269,13 @@ module id_stage #(
     end else begin
       assign stall_instr_fetch[0] = stall_macro_deco;
     end
+  end else begin
+    for (genvar i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
+        assign is_illegal_rvc[i] = 1'b0;
+        assign instruction_rvc[i] = fetch_entry_i[i].instruction;
+        assign is_compressed_rvc[i] = 1'b0;
+        assign stall_instr_fetch[i] = 1'b0;
+      end
   end
 
   // ---------------------------------------------------------

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -271,11 +271,11 @@ module id_stage #(
     end
   end else begin
     for (genvar i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
-        assign is_illegal_rvc[i] = 1'b0;
-        assign instruction_rvc[i] = fetch_entry_i[i].instruction;
-        assign is_compressed_rvc[i] = 1'b0;
-        assign stall_instr_fetch[i] = 1'b0;
-      end
+      assign is_illegal_rvc[i] = 1'b0;
+      assign instruction_rvc[i] = fetch_entry_i[i].instruction;
+      assign is_compressed_rvc[i] = 1'b0;
+      assign stall_instr_fetch[i] = 1'b0;
+    end
   end
 
   // ---------------------------------------------------------


### PR DESCRIPTION
Add `else` case to initialize signals going into decoder.
Should fix #2819