### PR TITLE
push reports to cv32a60x pipelines when applicable

### DIFF
--- a/.github/workflows/dashboard-done.yml
+++ b/.github/workflows/dashboard-done.yml
@@ -9,6 +9,10 @@ on:
         description: 'Is the workflow successful?'
         required: true
         type: boolean
+      source_branch:
+        description: "To know which dashboard should be used in url"
+        required: false
+        type: string
 
 permissions:
   pull-requests: write
@@ -22,9 +26,10 @@ jobs:
           script: |
             const inputs = context.payload.inputs
             const pr = inputs.pr_number
+            const dashboardBranch = inputs.source_branch ? inputs.source_branch : cva6
             const success = inputs.success == 'true'
             const status_text = success ? ":heavy_check_mark: successful" : ":x: failed"
-            const url = `https://riscv-ci.pages.thales-invia.fr/dashboard/dashboard_cva6_${pr}.html`
+            const url = `https://riscv-ci.pages.thales-invia.fr/dashboard/dashboard_${dashboardBranch}_${pr}.html`
             await github.rest.issues.createComment({
               issue_number: pr,
               owner: context.repo.owner,

--- a/.gitlab-ci/scripts/github_integration.py
+++ b/.gitlab-ci/scripts/github_integration.py
@@ -47,11 +47,12 @@ class DashboardDone(Workflow):
         workflow_id = 'dashboard-done.yml'
         Workflow.__init__(self, owner, repo, workflow_id, ref)
 
-    def send(self, pr, success):
+    def send(self, pr, success, source_branch):
         "Send success or failure message"
         inputs = {
             'pr_number': str(pr),
             'success': success,
+            "source_branch": source_branch
         }
         time.sleep(120) # wait for dashboard generation
         return self._trigger(inputs)

--- a/.gitlab-ci/scripts/github_integration.py
+++ b/.gitlab-ci/scripts/github_integration.py
@@ -4,6 +4,7 @@ This module makes it possible to trigger GitHub workflows.
 
 from os import environ as env
 import requests
+import time
 
 def api_url(owner, repo):
     "Build API url for a given repository"
@@ -52,6 +53,7 @@ class DashboardDone(Workflow):
             'pr_number': str(pr),
             'success': success,
         }
+        time.sleep(120) # wait for dashboard generation
         return self._trigger(inputs)
 
     def send_success(self, pr):

--- a/.gitlab-ci/scripts/merge_job_reports.py
+++ b/.gitlab-ci/scripts/merge_job_reports.py
@@ -154,5 +154,5 @@ pr = find_pr(workflow_commit_ref_name, pulls)
 if pr is not None:
     ref_branch = pr['base']['ref']
     wf = gh.DashboardDone('openhwgroup', workflow_repo, ref_branch)
-    response = wf.send(pr['number'], success)
+    response = wf.send(pr['number'], success, source_branch)
     print(response.text)

--- a/.gitlab-ci/scripts/merge_job_reports.py
+++ b/.gitlab-ci/scripts/merge_job_reports.py
@@ -15,6 +15,7 @@ import datetime
 import sys
 import subprocess
 import github_integration as gh
+import source_branch_finder as source_branch
 
 # arguments: inputdir outputfile
 
@@ -39,7 +40,7 @@ if workflow_type == 'github':  # (from wrapper)
     
     workflow_uid = os.environ['WORKFLOW_RUN_ID'].strip('\'\"')
     workflow_repo_owner = os.environ['WORKFLOW_REPO_OWNER'].strip('\'\"')
-    workflow_repo = os.environ['WORKFLOW_REPO'].strip('\'\"')  # cvv or cva6
+    workflow_repo = "cva6" if os.environ["CI_COMMIT_REF_NAME"] == "master" else os.environ["CI_COMMIT_REF_NAME"]  # cvv or cva6
     workflow_commit_subject = os.environ['WORKFLOW_COMMIT_MESSAGE'].strip('\'\"')
     workflow_commit_author = os.environ['WORKFLOW_COMMIT_AUTHOR'].strip('\'\"')
     cvv_branch = os.environ['CORE_V_VERIF_BRANCH'].strip('\'\"')
@@ -48,13 +49,15 @@ if workflow_type == 'github':  # (from wrapper)
     cva6_sha = os.environ['CVA6_HASH'].strip('\'\"')
 else:  # gitlab
     workflow_uid = os.environ['CI_PIPELINE_ID'].strip('\'\"')
-    workflow_repo = 'cva6'
     cvv_branch = 'none'
     cvv_sha = '0000000'
     cva6_branch = os.environ['CI_COMMIT_REF_NAME'].strip('\'\"')
+    workflow_repo = 'cva6'
     cva6_sha = os.environ['CI_COMMIT_SHA'].strip('\'\"')
     workflow_commit_subject = os.environ['CI_COMMIT_MESSAGE'].strip('\'\"')
     workflow_commit_author = os.environ['CI_COMMIT_AUTHOR'].strip('\'\"')
+
+source_branch = source_branch.find(cva6_branch)
 
 if len(workflow_commit_subject) > 60:
     title = workflow_commit_subject[0:60] + '...'
@@ -123,14 +126,14 @@ try:
   print(subprocess.check_output(f'''
 rm -r .gitlab-ci/dashboard_tmp || echo "nothing to do"
 git clone {dashboard_url} .gitlab-ci/dashboard_tmp
-mkdir -p .gitlab-ci/dashboard_tmp/pipelines_{workflow_repo}
+mkdir -p .gitlab-ci/dashboard_tmp/pipelines_{source_branch}
 ls -al {sys.argv[1]}
-cp {sys.argv[1]}/{filename} .gitlab-ci/dashboard_tmp/pipelines_{workflow_repo}/
+cp {sys.argv[1]}/{filename} .gitlab-ci/dashboard_tmp/pipelines_{source_branch}/
 cd .gitlab-ci/dashboard_tmp
 git config user.email {git_email}
 git config user.name {git_name}
-git add pipelines_{workflow_repo}/{filename}
-git commit -m  '{workflow_repo}: '{quoted_title} || echo "commit fail"
+git add pipelines_{source_branch}/{filename}
+git commit -m  '{source_branch}: '{quoted_title} || echo "commit fail"
 git push
 cd -
 ''', shell=True))

--- a/.gitlab-ci/scripts/source_branch_finder.py
+++ b/.gitlab-ci/scripts/source_branch_finder.py
@@ -1,0 +1,23 @@
+import gitlab
+import os
+
+GITLAB_URL = "https://gitlab.thales-invia.fr"
+CVA6_PROJECT_ID = os.environ["CVA6_PROJECT_ID"]
+CVA6_PROJECT = gitlab.Gitlab(GITLAB_URL, private_token=os.environ["CVA6_TOKEN"]).projects.get(CVA6_PROJECT_ID, lazy=True)
+
+def find(branch):
+    MONITORED_BRANCHES = ["master", "cv32a60x"]
+    monitored_branches_commit_ids = []
+
+    for monitored_branch in MONITORED_BRANCHES:
+        monitored_branches_commit_ids.append(get_branch_commits_ids(monitored_branch))
+    branch_commits_ids = get_branch_commits_ids(branch)
+
+    for commit_id in branch_commits_ids:
+        for i in range(len(MONITORED_BRANCHES)):
+            if commit_id in monitored_branches_commit_ids[i]:
+                return MONITORED_BRANCHES[i]
+    return "master"
+
+def get_branch_commits_ids(branch):
+    return set(commit.id for commit in CVA6_PROJECT.commits.list(ref_name=branch, get_all=False, per_page=100))


### PR DESCRIPTION
Pipeline triggered by commits coming from cv32a60x branch will be pushed to the cv32a60x dashboard.
Also adds a wait time before commenting the pr to wait for the dashboard generation.