### PR TITLE
cv32a60x_config_pkg.sv: set NrPMPEntries to 0

### DIFF
--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -68,7 +68,7 @@ package cva6_config_pkg;
       DmBaseAddress: 64'h0,
       TvalEn: bit'(0),
       DirectVecOnly: bit'(1),
-      NrPMPEntries: unsigned'(8),
+      NrPMPEntries: unsigned'(0),
       PMPCfgRstVal: {64{64'h0}},
       PMPAddrRstVal: {64{64'h0}},
       PMPEntryReadOnly: 64'd0,


### PR DESCRIPTION
to build correct RISC-V ISA privilege manual