### PR TITLE
csr_regfile.sv: use better signal name (CSR_MTVEC)

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1472,12 +1472,13 @@ module csr_regfile
         end
 
         riscv::CSR_MTVEC: begin
-          logic DirVecOnly;
-          DirVecOnly = CVA6Cfg.DirectVecOnly ? 1'b0 : csr_wdata[0];
-          mtvec_d = {csr_wdata[CVA6Cfg.XLEN-1:2], 1'b0, DirVecOnly};
+          logic Vectored;
+          Vectored = CVA6Cfg.DirectVecOnly ? 1'b0 : csr_wdata[0];
+          if (!Vectored) mtvec_d = {csr_wdata[CVA6Cfg.XLEN-1:2], 1'b0, Vectored};
           // we are in vector mode, this implementation requires the additional
           // alignment constraint of 64 * 4 bytes
-          if (DirVecOnly) mtvec_d = {csr_wdata[CVA6Cfg.XLEN-1:8], 7'b0, DirVecOnly};
+          else
+            mtvec_d = {csr_wdata[CVA6Cfg.XLEN-1:8], 7'b0, Vectored};
         end
         riscv::CSR_MCOUNTEREN: begin
           if (CVA6Cfg.RVU) mcounteren_d = {{CVA6Cfg.XLEN - 32{1'b0}}, csr_wdata[31:0]};


### PR DESCRIPTION
Vectored instead of misleading DirVecOnly