### PR TITLE
CODEOWNERS: remove `zarubaf` from global owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global Owners
-*  @JeanRochCoulon @zarubaf
+*  @JeanRochCoulon
 
 # Core
 


### PR DESCRIPTION
I haven't reviewed anything in quite a while so I believe its best for me to depart the `CODEOWNER`s file. I'll still be watching the repo and any mentions, and of course,e we are using CVA6 heavily internally so still supporting the project!