### PR TITLE
[riscv-config] Mark all PMP registers as RO const zero.

### DIFF
--- a/config/riscv-config/cv32a60x/generated/isa_gen.yaml
+++ b/config/riscv-config/cv32a60x/generated/isa_gen.yaml
@@ -2238,12 +2238,7 @@ hart0:
             pmp0cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp0cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2252,12 +2247,7 @@ hart0:
             pmp1cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp1cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2266,12 +2256,7 @@ hart0:
             pmp2cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp2cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2280,12 +2265,7 @@ hart0:
             pmp3cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp3cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2308,12 +2288,7 @@ hart0:
             pmp4cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp4cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2322,12 +2297,7 @@ hart0:
             pmp5cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp5cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2336,12 +2306,7 @@ hart0:
             pmp6cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp6cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2350,12 +2315,7 @@ hart0:
             pmp7cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp7cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -3162,12 +3122,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr0[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3183,12 +3138,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr1[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3204,12 +3154,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr2[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3225,12 +3170,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr3[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3246,12 +3186,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr4[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3267,12 +3202,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr5[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3288,12 +3218,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr6[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3309,12 +3234,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr7[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw

--- a/config/riscv-config/cv32a60x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a60x/spec/isa_spec.yaml
@@ -995,39 +995,19 @@ hart0: &hart0
             pmp0cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp0cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp1cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp1cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp2cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp2cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp3cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp3cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1037,39 +1017,19 @@ hart0: &hart0
             pmp4cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp4cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp5cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp5cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp6cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp6cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp7cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp7cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1437,12 +1397,7 @@ hart0: &hart0
         rv32:
             accessible: true            
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr0[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1450,12 +1405,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr1[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1463,12 +1413,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr2[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1476,12 +1421,7 @@ hart0: &hart0
         rv32:
             accessible: true            
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr3[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1489,12 +1429,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr4[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1502,12 +1437,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr5[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1515,12 +1445,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr6[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+               ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1528,12 +1453,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr7[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0

--- a/config/riscv-config/cv32a65x/generated/isa_gen.yaml
+++ b/config/riscv-config/cv32a65x/generated/isa_gen.yaml
@@ -2238,12 +2238,7 @@ hart0:
             pmp0cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp0cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2252,12 +2247,7 @@ hart0:
             pmp1cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp1cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2266,12 +2256,7 @@ hart0:
             pmp2cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp2cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2280,12 +2265,7 @@ hart0:
             pmp3cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp3cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2308,12 +2288,7 @@ hart0:
             pmp4cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp4cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2322,12 +2297,7 @@ hart0:
             pmp5cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp5cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2336,12 +2306,7 @@ hart0:
             pmp6cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp6cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -2350,12 +2315,7 @@ hart0:
             pmp7cfg:
                 implemented: true
                 type:
-                    warl:
-                        dependency_fields: []
-                        legal:
-                          - pmp7cfg[7:0] bitmask [0x8f, 0x0]
-                        wr_illegal:
-                          - unchanged
+                    ro_constant: 0x0
                 description: pmp configuration bits
                 shadow:
                 shadow_type: rw
@@ -3162,12 +3122,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr0[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3183,12 +3138,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr1[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3204,12 +3154,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr2[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3225,12 +3170,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr3[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3246,12 +3186,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr4[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3267,12 +3202,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr5[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3288,12 +3218,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr6[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw
@@ -3309,12 +3234,7 @@ hart0:
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr7[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
             fields: []
             shadow:
             shadow_type: rw

--- a/config/riscv-config/cv32a65x/spec/isa_spec.yaml
+++ b/config/riscv-config/cv32a65x/spec/isa_spec.yaml
@@ -995,39 +995,19 @@ hart0: &hart0
             pmp0cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp0cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp1cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp1cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp2cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp2cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp3cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp3cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1037,39 +1017,19 @@ hart0: &hart0
             pmp4cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp4cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp5cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp5cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp6cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp6cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
             pmp7cfg:
                 implemented: true
                 type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp7cfg[7:0] bitmask [0x8f, 0x0]
-                       wr_illegal:
-                         - unchanged 
+                    ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1437,12 +1397,7 @@ hart0: &hart0
         rv32:
             accessible: true            
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr0[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1450,12 +1405,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr1[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1463,12 +1413,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr2[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1476,12 +1421,7 @@ hart0: &hart0
         rv32:
             accessible: true            
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr3[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1489,12 +1429,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr4[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1502,12 +1437,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr5[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1515,12 +1445,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr6[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+               ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0
@@ -1528,12 +1453,7 @@ hart0: &hart0
         rv32:
             accessible: true
             type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr7[31:0] bitmask [0xFFFFFFFE, 0x00000000]
-                    wr_illegal:
-                      - unchanged
+                ro_constant: 0x0
         rv64:
             accessible: false
         reset-val: 0


### PR DESCRIPTION
Since the CV32A60X and CV32A65X do not have a PMP unit, specify all PMP registers as read-only constant zero in riscv-config 'ISA' files.