### PR TITLE
frontend.sv: fix obi fetch align

### DIFF
--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -542,7 +542,10 @@ module frontend
 
   //default obi state registred
   assign obi_fetch_req_o.reqpar = !obi_fetch_req_o.req;
-  assign obi_fetch_req_o.a.addr = obi_a_state_q == TRANSPARENT ? paddr : paddr_q;
+  assign obi_fetch_req_o.a.addr = {
+    obi_a_state_q == TRANSPARENT ? paddr[CVA6Cfg.PLEN-1:CVA6Cfg.FETCH_ALIGN_BITS] : paddr_q[CVA6Cfg.PLEN-1:CVA6Cfg.FETCH_ALIGN_BITS],
+    {CVA6Cfg.FETCH_ALIGN_BITS{1'b0}}
+  };
   assign obi_fetch_req_o.a.we = '0;
   assign obi_fetch_req_o.a.be = '1;
   assign obi_fetch_req_o.a.wdata = '0;


### PR DESCRIPTION
OBI protocol requires that addr field is align with BE field, Fetch bus performs only full BE access, and until now provides next PC in addr field, next pc is not necessary align so in that case we are not compliant to OBI protocol.

This PR fixes by force to zero LSB of addr obi.