### PR TITLE
Fix #1625: Allow unmapped memory accesses in Spike for cv32a60x/cv32a65x.

### DIFF
--- a/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a60x/spike/spike.yaml
@@ -58,3 +58,4 @@ spike_param_tree:
       mcycleh_implemented: false
       mhpmevent31_implemented: false
       cvxif_x_num_rs: 2
+      allow_unmapped_mem_access: true

--- a/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
+++ b/config/gen_from_riscv_config/cv32a65x/spike/spike.yaml
@@ -58,3 +58,4 @@ spike_param_tree:
       mcycleh_implemented: false
       mhpmevent31_implemented: false
       cvxif_x_num_rs: 2
+      allow_unmapped_mem_access: true


### PR DESCRIPTION
Enable silent fetch/load of zeroes when accessing unmapped memory locations in Spike:
- Bump CVV to use Spike supporting unmapped accesses when core-specific parameter `allow_unmapped_mem_access` is set to `True`.
- Add `allow_unmapped_mem_access: True` field to core-specific section of CV32A60X and CV32A65X Spike Yaml files.