### PR TITLE
Hotfix 2885: Condition on RVU

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -2570,7 +2570,7 @@ module csr_regfile
                                priv_lvl_o != riscv::PRIV_LVL_M && v_q)
                               ? 1'b1
                               : 1'b0;
-  end else if (CVA6Cfg.RVS) begin
+  end else if (CVA6Cfg.RVU) begin
     assign en_translation_o   = (satp_mode_is_sv && priv_lvl_o != riscv::PRIV_LVL_M) ? 1'b1 : 1'b0;
     assign en_g_translation_o = 1'b0;
   end else begin


### PR DESCRIPTION
Condition on RVU because you can have RVU with M mode but not RVS without RVU