### PR TITLE
Quick fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.ya
 
 # COREV-APU FPGA Emulation
 
-We currently provide support for the [Genesys 2 board](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual) and the [Agilex 7 Development Kit](https://www.intel.la/content/www/xl/es/products/details/fpga/development-kits/agilex/agf014.html).
+We currently provide support for the [Genesys 2 board](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual) and the [Agilex 7 Development Kit](https://www.intel.la/content/www/xl/es/products/details/fpga/development-kits/agilex/agf014.html). In order the run the FPGA build scripts you will need to use Xilinx 2018.2.
 
 - **Genesys 2**
     

--- a/ci/install-verilator.sh
+++ b/ci/install-verilator.sh
@@ -10,7 +10,7 @@ fi
 VERILATOR_REPO="https://github.com/verilator/verilator.git"
 VERILATOR_BRANCH="master"
 # Use the release tag instead of a full SHA1 hash.
-VERILATOR_HASH="v5.008"
+VERILATOR_HASH="v5.028"
 VERILATOR_PATCH="$ROOT/verif/regress/verilator-v5.patch"
 
 VERILATOR_BUILD_DIR=$PWD/verilator-$VERILATOR_HASH/verilator

--- a/docs/scripts/classes.py
+++ b/docs/scripts/classes.py
@@ -7,7 +7,7 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 
 class Parameter:

--- a/docs/scripts/define_blacklist.py
+++ b/docs/scripts/define_blacklist.py
@@ -7,7 +7,7 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 
 def define_blacklist(parameters):

--- a/docs/scripts/parameters_extractor.py
+++ b/docs/scripts/parameters_extractor.py
@@ -7,7 +7,7 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/docs/scripts/spec_builder.py
+++ b/docs/scripts/spec_builder.py
@@ -7,7 +7,7 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/verif/regress/install-verilator.sh
+++ b/verif/regress/install-verilator.sh
@@ -18,7 +18,7 @@ fi
 VERILATOR_REPO="https://github.com/verilator/verilator.git"
 VERILATOR_BRANCH="master"
 # Use the release tag instead of a full SHA1 hash.
-VERILATOR_HASH="v5.008"
+VERILATOR_HASH="v5.028"
 VERILATOR_PATCH="$ROOT_PROJECT/verif/regress/verilator-v5.patch"
 
 # Unset historical variable VERILATOR_ROOT as it collides with the build process.

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1004,7 +1004,7 @@ def check_spike_version():
     logging.info(f"- stderr:\n\n{user_spike_stderr_string}")
     # Run 'ldd' on Spike binary and print contents of stdout and stderr.
     spike_ldd = subprocess.run(
-        "/bin/ldd $SPIKE_PATH/spike", capture_output=True, text=True, shell=True
+        "ldd $SPIKE_PATH/spike", capture_output=True, text=True, shell=True
     )
     spike_ldd_stdout = spike_ldd.stdout.strip()
     spike_ldd_stderr = spike_ldd.stderr.strip()

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1030,7 +1030,7 @@ def check_spike_version():
 
 
 def check_verilator_version():
-  REQUIRED_VERILATOR_VERSION = "5.008"
+  REQUIRED_VERILATOR_VERSION = "5.028"
 
   verilator_version_string = run_cmd("verilator --version")
   logging.info(f"Verilator Version: {verilator_version_string.strip()}")


### PR DESCRIPTION
- Adds a caveat to the README for #2535 where Vivado 2018.2 is needed
- Bumps verilator version to 5.028
- Removes some hard coded paths