### PR TITLE
Indicate dirty in mstatus.FS correctly

### DIFF
--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -113,8 +113,9 @@ module commit_stage
   always_comb begin : dirty_fp_state
     dirty_fp_state_o = 1'b0;
     for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
-      dirty_fp_state_o |= commit_ack_o[i] & ((commit_instr_i[i].fu inside {FPU, FPU_VEC} & CVA6Cfg.FpPresent & ariane_pkg::fd_changes_rd_state(commit_instr_i[i].op))
-        || (CVA6Cfg.FpPresent && ariane_pkg::is_rd_fpr(
+      dirty_fp_state_o |= commit_ack_o[i] & ((commit_instr_i[i].fu inside {FPU, FPU_VEC} & CVA6Cfg.FpPresent & ariane_pkg::fd_changes_rd_state(
+          commit_instr_i[i].op
+      )) || (CVA6Cfg.FpPresent && ariane_pkg::is_rd_fpr(
           commit_instr_i[i].op
           // Check if we issued a vector floating-point instruction to the accellerator
       ))) | (commit_instr_i[i].fu == ACCEL && commit_instr_i[i].vfp);

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -113,10 +113,11 @@ module commit_stage
   always_comb begin : dirty_fp_state
     dirty_fp_state_o = 1'b0;
     for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
-      dirty_fp_state_o |= commit_ack_o[i] & (commit_instr_i[i].fu inside {FPU, FPU_VEC} || (CVA6Cfg.FpPresent && ariane_pkg::is_rd_fpr(
+      dirty_fp_state_o |= commit_ack_o[i] & ((commit_instr_i[i].fu inside {FPU, FPU_VEC} & CVA6Cfg.FpPresent & ariane_pkg::fd_changes_rd_state(commit_instr_i[i].op))
+        || (CVA6Cfg.FpPresent && ariane_pkg::is_rd_fpr(
           commit_instr_i[i].op
           // Check if we issued a vector floating-point instruction to the accellerator
-      ))) | commit_instr_i[i].fu == ACCEL && commit_instr_i[i].vfp;
+      ))) | (commit_instr_i[i].fu == ACCEL && commit_instr_i[i].vfp);
     end
   end
 

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -608,13 +608,13 @@ package ariane_pkg;
   endfunction
 
   function automatic logic fd_changes_rd_state(input fu_op op);
-    unique case(op) inside
-      [FSD:FSB],  // stores
-      FCVT_F2I,   // conversion to int
-      FMV_F2X,    // move as-is to int
-      FCLASS:     // classification (writes output to integer register)
-        return 1'b0; // floating-point registers are only read
-      default: return 1'b1; // other ops - floating-point registers are written as well
+    unique case (op) inside
+      [FSD : FSB],  // stores
+      FCVT_F2I,  // conversion to int
+      FMV_F2X,  // move as-is to int
+      FCLASS:  // classification (writes output to integer register)
+      return 1'b0;  // floating-point registers are only read
+      default: return 1'b1;  // other ops - floating-point registers are written as well
     endcase
   endfunction
 

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -607,6 +607,17 @@ package ariane_pkg;
     endcase
   endfunction
 
+  function automatic logic fd_changes_rd_state(input fu_op op);
+    unique case(op) inside
+      [FSD:FSB],  // stores
+      FCVT_F2I,   // conversion to int
+      FMV_F2X,    // move as-is to int
+      FCLASS:     // classification (writes output to integer register)
+        return 1'b0; // floating-point registers are only read
+      default: return 1'b1; // other ops - floating-point registers are written as well
+    endcase
+  endfunction
+
   function automatic logic is_amo(fu_op op);
     case (op) inside
       [AMO_LRW : AMO_MINDU]: begin

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -609,7 +609,7 @@ package ariane_pkg;
 
   function automatic logic fd_changes_rd_state(input fu_op op);
     unique case (op) inside
-      [FSD : FSB],  // stores
+      FSD, FSW, FSH, FSB,  // stores
       FCVT_F2I,  // conversion to int
       FMV_F2X,  // move as-is to int
       FCLASS:  // classification (writes output to integer register)


### PR DESCRIPTION
This commit makes two changes to the commit stage:
- It fixes incorrect parenthesis, causing dirty_fp_state_o not to be set on floating point instructions such as fld.
- It adds a condition for dirty_fp_state_o that only asserts the flag for floating point instructions that change any FPU registers.

This PR fixes #2934 