### PR TITLE
Fix URLs to point to CV32A60X-specific files on RTDs.

### DIFF
--- a/docs/07_cv32a60x/index.rst
+++ b/docs/07_cv32a60x/index.rst
@@ -8,11 +8,10 @@ CV32A60X documentation
    riscv/unpriv.rst
    riscv/priv.rst
 
-Below are links to RISC-V ISA documents tailored for OpenHW Group CV32A60X
-and to design documentation.
-Only those CSRs and Instruction Sets that are supported by the CV32A60X are documented here.
+Below are links to RISC-V ISA documents tailored for the CV32A60X and to CV32A60X-specific design documentation.
+Only those CSRs and Instructions that are supported by the CV32A60X are documented here.
 
 | `Unprivileged RISC-V ISA <https://cva6-cv32a60x.readthedocs.io/en/latest/07_cv32a60x/riscv/unpriv.html>`_
 | `Privileged RISC-V ISA <https://cva6-cv32a60x.readthedocs.io/en/latest/07_cv32a60x/riscv/priv.html>`_
-| `Design Documentation for CV32A60X architecture <https://cva6-cv32a60x.readthedocs.io/en/latest/07_cv32a60x/design/design-cv32a60x.html>`_
+| `Design Documentation for CV32A60X <https://cva6-cv32a60x.readthedocs.io/en/latest/07_cv32a60x/design/design.html>`_
 


### PR DESCRIPTION
This fixes the paths for the CV32A60X-specific documentation (from the `cv32a60x` branch).  Whenever the `cv32a60x` branch is updated, the documentation will be regenerated by RTD.