### PR TITLE
[DO NOT MERGE] docs: Review of the current cv32a60x documentation

### DIFF
--- a/docs/design/design-manual/source/Traps_Interrupts_Exceptions.adoc
+++ b/docs/design/design-manual/source/Traps_Interrupts_Exceptions.adoc
@@ -103,7 +103,7 @@ endif::[]
 ** unimplemented CSRs
 ** unsupported extensions
 
-* breakpoint (`EBREAK`)
+* breakpoint (EBREAK)
 
 * load address misaligned:
 ** `LH` at 2n+1 address
@@ -124,14 +124,14 @@ ifeval::[{NrPMPEntries} != 0]
 endif::[]
 
 ifeval::[{RVU} == true]
-* environment call (`ECALL`) from U-mode
+* environment call (ECALL) from U-mode
 endif::[]
 
 ifeval::[{RVS} == true]
-* environment call (`ECALL`) from S-mode
+* environment call (ECALL) from S-mode
 endif::[]
 
-* environment call (`ECALL`) from M-mode
+* environment call (ECALL) from M-mode
 
 ifeval::[{MmuPresent} == true]
 * instruction page fault
@@ -157,7 +157,7 @@ Trap return
 
 Trap handler ends with trap return instruction (`MRET`
 ifeval::[{RVS} == true]
-, `SRET`
+, SRET
 endif::[]
 ). The behaviour of the {ohg-config} core depends on several CSRs.
 

--- a/docs/riscv-isa/src/colophon.adoc
+++ b/docs/riscv-isa/src/colophon.adoc
@@ -276,15 +276,15 @@ and this and future versions of this document will be released under the
 same license.
 * Rearranged chapters to put all extensions first in canonical order.
 * Improvements to the description and commentary.
-* Modified implicit hinting suggestion on `JALR` to support more efficient
-macro-op fusion of `LUI/JALR` and `AUIPC/JALR` pairs.
+* Modified implicit hinting suggestion on JALR to support more efficient
+macro-op fusion of LUI/JALR and AUIPC/JALR pairs.
 * Clarification of constraints on load-reserved/store-conditional
 sequences.
 * A new table of control and status register (CSR) mappings.
 * Clarified purpose and behavior of high-order bits of `fcsr`.
-* Corrected the description of the `FNMADD`._fmt_ and `FNMSUB`._fmt_
+* Corrected the description of the FNMADD._fmt_ and FNMSUB._fmt_
 instructions, which had suggested the incorrect sign of a zero result.
-* Instructions `FMV.S.X` and `FMV.X.S` were renamed to `FMV.W.X` and `FMV.X.W`
+* Instructions FMV.S.X and FMV.X.S were renamed to `FMV.W.X` and `FMV.X.W`
 respectively to be more consistent with their semantics, which did not
 change. The old names will continue to be supported in the tools.
 * Specified behavior of narrower (latexmath:[$<$]FLEN) floating-point
@@ -317,20 +317,20 @@ avoid moving the _rd_ specifier in very long instruction formats.
 the counter registers are introduced, as opposed to only being
 introduced later in the floating-point section (and the companion
 privileged architecture manual).
-* The SCALL and SBREAK instructions have been renamed to `ECALL` and
-`EBREAK`, respectively. Their encoding and functionality are unchanged.
+* The SCALL and SBREAK instructions have been renamed to ECALL and
+EBREAK, respectively. Their encoding and functionality are unchanged.
 * Clarification of floating-point NaN handling, and a new canonical NaN
 value.
 * Clarification of values returned by floating-point to integer
 conversions that overflow.
-* Clarification of `LR/SC` allowed successes and required failures,
+* Clarification of LR/SC allowed successes and required failures,
 including use of compressed instructions in the sequence.
 * A new `RV32E` base ISA proposal for reduced integer register counts,
 supports `MAC` extensions.
 * A revised calling convention.
 * Relaxed stack alignment for soft-float calling convention, and
 description of the RV32E calling convention.
-* A revised proposal for the `C` compressed extension, version 1.9 .
+* A revised proposal for the `C` compressed extension, version 1.9.
 
 [.big]*_Preface to Version 2.0_*
 
@@ -345,37 +345,37 @@ extensions.
 encoding more efficient.
 * The base ISA has been defined to have a little-endian memory system,
 with big-endian or bi-endian as non-standard variants.
-* Load-Reserved/Store-Conditional (`LR/SC`) instructions have been added
+* Load-Reserved/Store-Conditional (LR/SC) instructions have been added
 in the atomic instruction extension.
-* `AMOs` and `LR/SC` can support the release consistency model.
-* The `FENCE` instruction provides finer-grain memory and I/O orderings.
-* An `AMO` for fetch-and-`XOR` (`AMOXOR`) has been added, and the encoding for
-`AMOSWAP` has been changed to make room.
-* The `AUIPC` instruction, which adds a 20-bit upper immediate to the `PC`,
-replaces the `RDNPC` instruction, which only read the current `PC` value.
+* AMOs and LR/SC can support the release consistency model.
+* The FENCE instruction provides finer-grain memory and I/O orderings.
+* An AMO for fetch-and-XOR (AMOXOR) has been added, and the encoding for
+AMOSWAP has been changed to make room.
+* The AUIPC instruction, which adds a 20-bit upper immediate to the `PC`,
+replaces the RDNPC instruction, which only read the current `PC` value.
 This results in significant savings for position-independent code.
-* The `JAL` instruction has now moved to the `U-Type` format with an
-explicit destination register, and the `J` instruction has been dropped
-being replaced by `JAL` with _rd_=`x0`. This removes the only instruction
-with an implicit destination register and removes the `J-Type` instruction
-format from the base ISA. There is an accompanying reduction in `JAL`
+* The JAL instruction has now moved to the U-Type format with an
+explicit destination register, and the J instruction has been dropped
+being replaced by JAL with _rd_=`x0`. This removes the only instruction
+with an implicit destination register and removes the J-Type instruction
+format from the base ISA. There is an accompanying reduction in JAL
 reach, but a significant reduction in base ISA complexity.
-* The static hints on the `JALR` instruction have been dropped. The hints
+* The static hints on the JALR instruction have been dropped. The hints
 are redundant with the _rd_ and _rs1_ register specifiers for code
 compliant with the standard calling convention.
-* The `JALR` instruction now clears the lowest bit of the calculated
+* The JALR instruction now clears the lowest bit of the calculated
 target address, to simplify hardware and to allow auxiliary information
 to be stored in function pointers.
-* The `MFTX.S` and `MFTX.D` instructions have been renamed to `FMV.X.S` and
-`FMV.X.D`, respectively. Similarly, `MXTF.S` and `MXTF.D` instructions have
-been renamed to `FMV.S.X` and `FMV.D.X`, respectively.
-* The `MFFSR` and `MTFSR` instructions have been renamed to `FRCSR` and `FSCSR`,
-respectively. `FRRM`, `FSRM`, `FRFLAGS`, and `FSFLAGS` instructions have been
+* The MFTX.S and MFTX.D instructions have been renamed to FMV.X.S and
+FMV.X.D, respectively. Similarly, MXTF.S and MXTF.D instructions have
+been renamed to FMV.S.X and FMV.D.X, respectively.
+* The MFFSR and MTFSR instructions have been renamed to FRCSR and FSCSR,
+respectively. FRRM, FSRM, FRFLAGS, and FSFLAGS` instructions have been
 added to individually access the rounding mode and exception flags
 subfields of the `fcsr`.
-* The `FMV.X.S` and `FMV.X.D` instructions now source their operands from
+* The FMV.X.S and FMV.X.D instructions now source their operands from
 _rs1_, instead of _rs2_. This change simplifies datapath design.
-* `FCLASS.S` and `FCLASS.D` floating-point classify instructions have been
+* FCLASS.S and FCLASS.D floating-point classify instructions have been
 added.
 * A simpler NaN generation and propagation scheme has been adopted.
 * For `RV32I`, the system performance counters have been extended to

--- a/docs/riscv-isa/src/machine.adoc
+++ b/docs/riscv-isa/src/machine.adoc
@@ -94,10 +94,10 @@ endif::[]
 ifdef::archi-CVA6[]
 [CVA6] The Extensions field encodes the presence of the standard extensions,
 with a single bit per letter of the alphabet (bit 0 encodes presence of
-extension "A" , bit 1 encodes presence of extension "B", through to
+extension "A", bit 1 encodes presence of extension "B", through to
 bit 25 which encodes "Z"). The "I" bit will be set for RV32I, RV64I,
 and RV128I base ISAs, and the "E" bit will be set for RV32E and RV64E.
-In CVA6, the Extensions field is not writeable, the presence of standard
+In CVA6, the Extensions field is not writable, the presence of standard
 extensions corresponds to the hardware reset value and cannot be modified
 by writing in the register.
 endif::[]
@@ -348,9 +348,16 @@ implemented.
 endif::[]
 
 ifdef::archi-CVA6[]
-[CVA6] The `marchid` CSR is an MXLEN-bit read-only register encoding the base
+The `marchid` CSR is an MXLEN-bit read-only register encoding the base
 microarchitecture of the hart.
-In CVA6, `marchid` is implemented and returns the base microarchitecture
+
+Open-source project architecture IDs are allocated globally by RISC-V
+International, and have non-zero architecture IDs with a zero
+most-significant-bit (MSB). The combination of `mvendorid` and `marchid` should
+uniquely identify the type of hart microarchitecture that is
+implemented.
+
+[CVA6] In CVA6, `marchid` is implemented and returns the base microarchitecture
 of the hart supplied to CVA6, 0x3.
 endif::[]
 
@@ -400,7 +407,8 @@ endif::[]
 
 ifdef::archi-CV32A60X,archi-CV32A65X[]
 The `mimpid` CSR provides a unique encoding of the version of the
-processor implementation.
+processor implementation. The Implementation value should reflect the
+design of the RISC-V processor itself and not any surrounding system.
 
 [CVA6] This register is readable,
 but a value of 0 is returned to indicate that the
@@ -409,10 +417,10 @@ endif::[]
 
 ifeval::["{ohg-config}" == "CV64A6_MMU"]
 The `mimpid` CSR provides a unique encoding of the version of the
-processor implementation.
+processor implementation. The Implementation value should reflect the
+design of the RISC-V processor itself and not any surrounding system.
 
-[CVA6] This register is readable,
-but a value of 0 is returned to indicate that the
+[CVA6] This register is readable, but a value of 0 is returned to indicate that the
 field is not implemented.
 endif::[]
 
@@ -515,7 +523,7 @@ endif::[]
 
 ifdef::archi-default,XLEN-32[]
 [[mstatushreg]]
-.Additional machine-mode status (`mstatush`) register  for RV32.
+.Additional machine-mode status (`mstatush`) register for RV32.
 include::images/wavedrom/mstatushreg.edn[]
 endif::[]
 
@@ -563,7 +571,7 @@ ifeval::[{note} == true]
 [NOTE]
 ====
 A higher-privilege mode _y_ could disable all of its interrupts before
-ceding control to a lower-privilege mode but this would be unusual as it
+ceding control to a lower-privilege mode, but this would be unusual as it
 would leave only a synchronous trap, non-maskable interrupt, or reset as
 means to regain control of the hart.
 ====
@@ -730,7 +738,7 @@ the affected hart or restarting the entire platform, among others.
 endif::[]
 
 ifdef::archi-default,RVZsmdbltrp-true[]
-The `MRET` and `SRET` instructions, when executed in M-mode, set the `MDT` bit
+The MRET and SRET instructions, when executed in M-mode, set the `MDT` bit
 to 0. If the new privilege mode is U, VS, or VU, then `sstatus.SDT` is also set
 to 0. Additionally, if it is VU, then `vsstatus.SDT` is also set to 0.
 
@@ -1297,7 +1305,7 @@ read-only zero, then SD is also always zero.
 endif::[]
 
 ifdef::archi-CVA6[]
-[{ohg-config}] The SD bit is a read-only bit that summarizes whether either the FS, VS,
+The SD bit is a read-only bit that summarizes whether either the FS, VS,
 or XS fields signal the presence of some dirty state that will require
 saving extended user context to memory.
 
@@ -1638,7 +1646,7 @@ endif::[]
 ifdef::archi-CVA6[]
 [{ohg-config}] The `mtvec` register is writable. The value in the BASE field must
 always be aligned on a 4-byte boundary. `mtvec` is always accessed in
-Mode=Direct.
+MODE=Direct.
 endif::[]
 
 [[mtvec-mode]]
@@ -2196,7 +2204,7 @@ counters, `mhpmcounter3`-`mhpmcounter31`. The event selector CSRs,
 `mhpmevent3`-`mhpmevent31`, are 64-bit *WARL* registers that control which
 event causes the corresponding counter to increment. The meaning of
 these events is defined by the platform, but event 0 is defined to mean
-"no event." In {ohg-config} all counters are implemented, but  both the counter and its corresponding event
+"no event." In {ohg-config} all counters are implemented, but both the counter and its corresponding event
 selector are read-only 0.
 
 .Hardware performance monitor counters.
@@ -2221,7 +2229,7 @@ do not exist.
 endif::[]
 
 ifdef::archi-CV32A60X,archi-CV32A65X[]
-As the Sscofpmf extension is not implemented, the `mhpmevent__n__h` CSRs
+[{ohg-config}] As the Sscofpmf extension is not implemented, the `mhpmevent__n__h` CSRs
 are not provided.
 endif::[]
 
@@ -3030,7 +3038,7 @@ enabled in S-mode, and the following rules apply to S-mode. If the `LPE` field
 is 0 and S-mode is not implemented, then the same rules apply to U-mode.
 
 * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
-* The `LPAD` instruction operates as a no-op.
+* The LPAD instruction operates as a no-op.
 endif::[]
 
 ifdef::archi-CVA6+RVU-true[]
@@ -3103,7 +3111,7 @@ Zicfilp extension is not enabled in M-mode and the following rules apply to
 M-mode.
 
 * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
-* The `LPAD` instruction operates as a no-op.
+* The LPAD instruction operates as a no-op.
 
 When XLEN=32 only, `mseccfgh` is a 32-bit read/write register that
 aliases bits 63:32 of `mseccfg`.
@@ -3743,10 +3751,10 @@ endif::[]
 ifdef::archi-default,RVA-true[]
 Within AMOs, there are four levels of support: _AMONone_, _AMOSwap_,
 _AMOLogical_, and _AMOArithmetic_. AMONone indicates that no AMO
-operations are supported. AMOSwap indicates that only `amoswap`
+operations are supported. AMOSwap indicates that only AMOSWAP
 instructions are supported in this address range. AMOLogical indicates
 that swap instructions plus all the logical AMOs (`amoand`, `amoor`,
-`amoxor`) are supported. AMOArithmetic indicates that all RISC-V AMOs
+AMOXOR) are supported. AMOArithmetic indicates that all RISC-V AMOs
 are supported. For each level of support, naturally aligned AMOs of a
 given width are supported if the underlying memory region supports reads
 and writes of that width. Main memory and I/O regions may only support a
@@ -3761,8 +3769,8 @@ AMOSwap +
 AMOLogical +
 AMOArithmetic
 |_None_ +
-`amoswap` +
-above + `amoand`, `amoor`, `amoxor` +
+AMOSWAP +
+above + `amoand`, `amoor`, AMOXOR +
 above + `amoadd`, `amomin`, `amomax`, `amominu`,
 `amomaxu`
 |===

--- a/docs/riscv-isa/src/supervisor.adoc
+++ b/docs/riscv-isa/src/supervisor.adoc
@@ -320,7 +320,7 @@ taken into M-mode. The `mtval2` register is then set to what would be otherwise
 written into the `mcause` register by the _unexpected trap_. The `mcause`
 register is set to 16, the double-trap exception code.
 
-An `SRET` instruction sets the `SDT` bit to 0.
+An SRET instruction sets the `SDT` bit to 0.
 
 [NOTE]
 ====
@@ -328,7 +328,7 @@ After a trap handler has saved the state, such as `scause`, `sepc`,
 and `stval`, needed for resuming from the trap and is reentrant, it
 should clear the `SDT` bit.
 
-Resetting the `SDT` by an `SRET` enables the trap handler to detect a double
+Resetting the `SDT` by an SRET enables the trap handler to detect a double
 trap that may occur during the tail phase, where it restores critical state
 to return from a trap.
 
@@ -343,7 +343,7 @@ the GPA is considered benign because, if required, it can still be obtained
 
 For a double trap that originates in VS-mode, M-mode should redirect the exception
 to HS-mode by copying the values of M-mode CSRs updated by the trap to HS-mode
-CSRs and should use an `MRET` to resume execution at the address in `stvec`.
+CSRs and should use an MRET to resume execution at the address in `stvec`.
 
 Supervisor Software Events (SSE), an extension to the SBI, provide a
 mechanism for supervisor software to register and service system events
@@ -923,7 +923,7 @@ set to 1, the Zicfilp extension is enabled in VU/U-mode. When the `LPE` field is
 apply to VU/U-mode:
 
 * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
-* The `LPAD` instruction operates as a no-op.
+* The LPAD instruction operates as a no-op.
 
 The Zicfiss extension adds the `SSE` field in `senvcfg`. When the `SSE` field is
 set to 1, the Zicfiss extension is activated in VU/U-mode. When the `SSE` field


### PR DESCRIPTION
DO NOT MERGE!

Hi @ASintzoff and @MikeOpenHWGroup ,

I analysed the docs under https://cva6-cv32a60x.readthedocs.io/en/latest/07_cv32a60x/, the parts that are specific to the CV32A60X, I would like to point out some questions and suggestions:

* Line 1345 of [machine.adoc](https://github.com/openhwgroup/cva6/compare/cv32a60x...cairo-caplan:cva6:cv32a60x?expand=1#diff-696b2e33a1189641c377671cf26cf7eebce4587a2ba0aa33dd7dfa0b40fc006e) , on section "3.1.6.7. Extension Context Status in `mstatus` Register", the paragraph "[CV32A60X] When an extension’s status is set to Off, any instruction that attempts to read or write the corresponding state will cause an illegal-instruction exception.". It starts with the "[CV32A60X]" ([{ohg-config}]), but I don't see this paragraph specific to the [CV32A60X].
* Line 1649 of [machine.adoc](https://github.com/openhwgroup/cva6/compare/cv32a60x...cairo-caplan:cva6:cv32a60x?expand=1#diff-696b2e33a1189641c377671cf26cf7eebce4587a2ba0aa33dd7dfa0b40fc006e): Mode => MODE, as this is what is used on other parts of the text and on Figure 9.
* Many times an instruction is listed with a \`\` syntax, others they are formatted as plain text. I am setting them as plain text (without \`\`). Feel free to completely ignore this though.
* In section 3.1.10. Hardware Performance Monitor, on the part "[CV32A60X] The hardware performance monitor includes 29 additional 64-bit event counters". I see the standard amount of Performance counters is 6, as in `/core/csr_regfile.sv` line 589: `localparam int unsigned MHPMCounterNum = 6;`. Should it be mentioned here that the amount of performance counters is configurable, with a maximum amount of 29?
* On section "3.1.19. Machine Security Configuration (mseccfg) Register", it is written that "As XLEN=32, mseccfgh is a 32-bit read/write register that aliases bits 63:32 of mseccfg". At the same time, the next paragraph affirms that "[CV32A60X] As Zkr, Smepmp, and Smmpm extensions are not implemented, mseccfg and mseccfgh do not exist.". Only the last one should exist in my opinion.