### PR TITLE
Fix cvxif_off_instr_n in issue_read_operands

### DIFF
--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -764,7 +764,7 @@ module issue_read_operands
           case (issue_instr_i[i].fu)
             CVXIF: begin
               cvxif_valid_n[i]  = 1'b1;
-              cvxif_off_instr_n = orig_instr[i];
+              cvxif_off_instr_n = orig_instr_i[i];
             end
             default: ;
           endcase


### PR DESCRIPTION
Currently, cvxif_off_instr_n is assigned to orig_instr[i], with i being 0 or 1 depending on the issue port.

This assigns the original instruction value (which will be propagated, e.g., into tval in an exception) to the last bit of the instruction on issue port 0.

This commit assigns it to the full instruction on the corresponding issue port instead.

Fixes https://github.com/openhwgroup/cva6/issues/2935.