### PR TITLE
Proposed CI fix: remove edatools repository from prerequisites

### DIFF
--- a/ci/install-prereq.sh
+++ b/ci/install-prereq.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-echo 'deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:phiwag:edatools.list
-curl -fsSL https://download.opensuse.org/repositories/home:phiwag:edatools/Debian_Unstable/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_phiwag_edatools.gpg > /dev/null
-
 sudo apt update
 sudo apt install device-tree-compiler libfl-dev help2man
-


### PR DESCRIPTION
The CI is currently broken due to an expired GPG key for the `edatools` repository. However, it seems like there is no real need for it in the current CI.

Removing it fixes the CI. I could not observe anything breaking due to this change. However, someone more knowledgeable about the CI could double check the proposed change. 