### PR TITLE
Bugfix/conflicting declaration read elf

### DIFF
--- a/corev_apu/tb/ariane_gate_tb.sv
+++ b/corev_apu/tb/ariane_gate_tb.sv
@@ -24,10 +24,13 @@ import uvm_pkg::*;
 
 `timescale 1ns/1ns
 
+`ifndef READ_ELF_T
+`define READ_ELF_T
 import "DPI-C" function void read_elf(input string filename);
 import "DPI-C" function byte get_section(output longint address, output longint len);
 import "DPI-C" context function void read_section_sv(input longint address, inout byte buffer[]);
 import "DPI-C" function string getenv(input string env_name);
+`endif
 
 module ariane_gate_tb;
 

--- a/verif/tb/uvmt/cva6_tb_wrapper.sv
+++ b/verif/tb/uvmt/cva6_tb_wrapper.sv
@@ -34,10 +34,13 @@ import uvm_pkg::*;
 
 `ifndef DPI_FESVR_SPIKE_UTILS
 `define DPI_FESVR_SPIKE_UTILS
+`ifndef READ_ELF_T
+`define READ_ELF_T
 import "DPI-C" function void read_elf(input string filename);
 import "DPI-C" function byte read_symbol(input string symbol_name, inout longint unsigned address);
 import "DPI-C" function byte get_section(output longint address, output longint len);
 import "DPI-C" context function read_section_sv(input longint address, inout byte buffer[]);
+`endif
 `endif
 
 module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(


### PR DESCRIPTION
Use define to constraint function declaration from DPI-C. This was already done in ariane_tb.sv and rvfi_tracer.sv
This prevent an error with xcelium reporting that functions such as read_elf have multiple definitions