### PR TITLE
Misaligned Load/Store Exceptions Ignored When MMU Is Enabled (Breaks rv32mi-ma_addr & I-MISALIGN_LDST_01)

### DIFF
--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -743,19 +743,19 @@ module cva6_mmu
       hs_ld_st_inst_q <= '0;
       misaligned_ex_q <= '0;
     end else begin
-      lsu_vaddr_q    <= lsu_vaddr_n;
-      lsu_req_q      <= lsu_req_n;
-      dtlb_pte_q     <= dtlb_pte_n;
-      dtlb_hit_q     <= dtlb_hit_n;
-      lsu_is_store_q <= lsu_is_store_n;
-      dtlb_is_page_q <= dtlb_is_page_n;
+      lsu_vaddr_q     <= lsu_vaddr_n;
+      lsu_req_q       <= lsu_req_n;
+      dtlb_pte_q      <= dtlb_pte_n;
+      dtlb_hit_q      <= dtlb_hit_n;
+      lsu_is_store_q  <= lsu_is_store_n;
+      dtlb_is_page_q  <= dtlb_is_page_n;
+      misaligned_ex_q <= misaligned_ex_n;
 
       if (CVA6Cfg.RVH) begin
         lsu_tinst_q     <= lsu_tinst_n;
         hs_ld_st_inst_q <= hs_ld_st_inst_n;
         dtlb_gpte_q     <= dtlb_gpte_n;
         lsu_gpaddr_q    <= lsu_gpaddr_n;
-        misaligned_ex_q <= misaligned_ex_n;
       end
     end
   end


### PR DESCRIPTION
## Description
With the MMU enabled (`MmuPresent = 1`), load/store operations to unaligned addresses silently complete instead of raising the required `LOAD_ADDR_MISALIGNED` or `STORE_ADDR_MISALIGNED` exceptions. When `MmuPresent = 0`, behavior is correct and matches Spike.

## Root Cause
The MMU’s internal register that latches LSU misalignment errors `misaligned_ex_q` was only updated when Hypervisor support was enabled (`CVA6Cfg.RVH = 1`). If Hypervisor support is disabled (`RVH = 0`), misaligned_ex_q never captures the pending misalignment exception, and translation proceeds without triggering the exception.
https://github.com/openhwgroup/cva6/blob/c39333bdacf6e2a1d544b6cf264ad160a7b03f14/core/cva6_mmu/cva6_mmu.sv#L753-L759

## Solution
Unconditionally update `misaligned_ex_q` on every cycle (or reset) so that misaligned exceptions are always latched regardless of Hypervisor support and thus take precedence over translation:
```DIFF
--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -749,13 +749,13 @@ module cva6_mmu
       dtlb_hit_q     <= dtlb_hit_n;
       lsu_is_store_q <= lsu_is_store_n;
       dtlb_is_page_q <= dtlb_is_page_n;
+      misaligned_ex_q <= misaligned_ex_n;
 
       if (CVA6Cfg.RVH) begin
         lsu_tinst_q     <= lsu_tinst_n;
         hs_ld_st_inst_q <= hs_ld_st_inst_n;
         dtlb_gpte_q     <= dtlb_gpte_n;
         lsu_gpaddr_q    <= lsu_gpaddr_n;
-        misaligned_ex_q <= misaligned_ex_n;
       end
     end
   end
```

## Verification
### Test Suites: 
- rv32mi-ma_addr
- rv32i-I-MISALIGN_LDST_01

### Before Fix:
#### Veilator.log
```LOG
core   0: 0x000000008000010a (0x0001a203) lw      tp, 0(gp)
3 0x000000008000010a (0x0001a203) x 4 0xffffffff91a1b1c1 mem 0x0000000080003000               # aligned → OK
core   0: 0x000000008000010e (0x0000c012) c.swsp  tp, 0(sp)
3 0x000000008000010e (0xc012) mem 0x0000000080003010 0xffffffff91a1b1c1
core   0: 0x0000000080000110 (0x0011a203) lw      tp, 1(gp)
3 0x0000000080000110 (0x0011a203) x 4 0x000000000291a1b1 mem 0x0000000080003001       # misaligned, but no exception
core   0: 0x0000000080000114 (0x0000c212) c.swsp  tp, 4(sp)
3 0x0000000080000114 (0xc212) mem 0x0000000080003014 0x000000000291a1b1                      
```
#### Waves
![beforFixP](https://github.com/user-attachments/assets/ef789668-ccb0-4a06-9444-b524004c2006)

### After Fix:
#### Veilator.log
```LOG
core   0: 0x000000008000010a (0x0001a203) lw      tp, 0(gp)
3 0x000000008000010a (0x0001a203) x 4 0xffffffff91a1b1c1 mem 0x0000000080003000               # aligned → OK
core   0: 0x000000008000010e (0x0000c012) c.swsp  tp, 0(sp)
3 0x000000008000010e (0xc012) mem 0x0000000080003010 0xffffffff91a1b1c1                       # misaligned  → exception
LD_ADDR_MISALIGNED exception @ 0x0000000080000110 (0x0011a203)
core   0: 0x00000000800001f0 (0x34102f73) csrrs   t5, mepc, zero
3 0x00000000800001f0 (0x34102f73) x30 0x0000000080000110
core   0: 0x00000000800001f4 (0x00000f11) c.addi  t5, 4
3 0x00000000800001f4 (0x0f11) x30 0x0000000080000114
core   0: 0x00000000800001f6 (0x341f1073) csrrw   zero, mepc, t5
3 0x00000000800001f6 (0x341f1073)
core   0: 0x00000000800001fa (0x34302f73) csrrs   t5, mtval, zero
3 0x00000000800001fa (0x34302f73) x30 0x0000000080003001
core   0: 0x00000000800001fe (0x003f7f13) andi    t5, t5, 3
3 0x00000000800001fe (0x003f7f13) x30 0x0000000000000001
core   0: 0x0000000080000202 (0x01e0a023) sw      t5, 0(ra)
3 0x0000000080000202 (0x01e0a023) mem 0x0000000080003020 0x0000000000000001
core   0: 0x0000000080000206 (0x34202f73) csrrs   t5, mcause, zero
3 0x0000000080000206 (0x34202f73) x30 0x0000000000000004
core   0: 0x000000008000020a (0x01e0a223) sw      t5, 4(ra)
3 0x000000008000020a (0x01e0a223) mem 0x0000000080003024 0x0000000000000004
core   0: 0x000000008000020e (0x000000a1) c.addi  ra, 8
3 0x000000008000020e (0x00a1) x 1 0x0000000080003028
core   0: 0x0000000080000210 (0x30200073) mret
3 0x0000000080000210 (0x30200073)
core   0: 0x0000000080000114 (0x0000c212) c.swsp  tp, 4(sp)
3 0x0000000080000114 (0xc212) mem 0x0000000080003014 0xffffffff91a1b1c1
```
#### Waves
![afterFixP](https://github.com/user-attachments/assets/9e940af9-ad1a-4eda-8f10-0dd070b0ad62)
