### PR TITLE
Prevent verif/regress scripts from failing silently

### DIFF
--- a/verif/regress/benchmark.sh
+++ b/verif/regress/benchmark.sh
@@ -74,6 +74,4 @@ python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/vvadd/vvadd_main.c         --sv_seed
 make clean
 make -C verif/sim clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/benchmark.sh
+++ b/verif/regress/benchmark.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Guillaume Chauvon (guillaume.chauvon@thalesgroup.com)
 
+set -exo pipefail
+
 # where are the tools
 if [ -z "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -55,21 +57,23 @@ GCC_CFLAGS=(
 
 GCC_OPTS="${GCC_COMMON_SRC[*]} ${GCC_CFLAGS[*]}"
 
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/dhrystone/dhrystone_main.c --sv_seed 1 --gcc_opts "$BDIR/dhrystone/dhrystone.c $GCC_OPTS -I$BDIR/dhrystone/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/median/median_main.c       --sv_seed 1 --gcc_opts "$BDIR/median/median.c       $GCC_OPTS -I$BDIR/median/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/mm/mm.c                    --sv_seed 1 --gcc_opts "$BDIR/mm/mm_main.c          $GCC_OPTS -I$BDIR/mm/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/mt-matmul/mt-matmul.c      --sv_seed 1 --gcc_opts "$BDIR/mt-matmul/matmul.c    $GCC_OPTS -I$BDIR/mt-matmul/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/mt-vvadd/mt-vvadd.c        --sv_seed 1 --gcc_opts "$BDIR/mt-vvadd/vvadd.c      $GCC_OPTS -I$BDIR/mt-vvadd/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/multiply/multiply_main.c   --sv_seed 1 --gcc_opts "$BDIR/multiply/multiply.c   $GCC_OPTS -I$BDIR/multiply/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/pmp/pmp.c                  --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/pmp/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/qsort/qsort_main.c         --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/qsort/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/rsort/rsort.c              --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/rsort/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/spmv/spmv_main.c           --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/spmv/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/towers/towers_main.c       --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/towers/"
-python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/vvadd/vvadd_main.c         --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/vvadd/"
+error=0
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/dhrystone/dhrystone_main.c --sv_seed 1 --gcc_opts "$BDIR/dhrystone/dhrystone.c $GCC_OPTS -I$BDIR/dhrystone/"  || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/median/median_main.c       --sv_seed 1 --gcc_opts "$BDIR/median/median.c       $GCC_OPTS -I$BDIR/median/"     || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/mm/mm.c                    --sv_seed 1 --gcc_opts "$BDIR/mm/mm_main.c          $GCC_OPTS -I$BDIR/mm/"         || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/mt-matmul/mt-matmul.c      --sv_seed 1 --gcc_opts "$BDIR/mt-matmul/matmul.c    $GCC_OPTS -I$BDIR/mt-matmul/"  || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/mt-vvadd/mt-vvadd.c        --sv_seed 1 --gcc_opts "$BDIR/mt-vvadd/vvadd.c      $GCC_OPTS -I$BDIR/mt-vvadd/"   || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/multiply/multiply_main.c   --sv_seed 1 --gcc_opts "$BDIR/multiply/multiply.c   $GCC_OPTS -I$BDIR/multiply/"   || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/pmp/pmp.c                  --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/pmp/"        || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/qsort/qsort_main.c         --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/qsort/"      || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/rsort/rsort.c              --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/rsort/"      || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/spmv/spmv_main.c           --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/spmv/"       || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/towers/towers_main.c       --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/towers/"     || error=$?
+python3 cva6.py $CVA6_FLAGS --c_tests $BDIR/vvadd/vvadd_main.c         --sv_seed 1 --gcc_opts "                            $GCC_OPTS -I$BDIR/vvadd/"      || error=$?
 
 make clean
 make -C verif/sim clean_all
 
 cd -
 
+exit $error

--- a/verif/regress/coremark.sh
+++ b/verif/regress/coremark.sh
@@ -100,6 +100,4 @@ python3 cva6.py \
         --iss_timeout=2000 \
         $DV_OPTS || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/coremark.sh
+++ b/verif/regress/coremark.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
 
+set -exo pipefail
+
 noprint=""
 if [ "$1" == "--no-print" ]; then
         noprint="-DHAS_PRINTF=0"
@@ -86,6 +88,7 @@ cflags=(
 
 isa="rv32imc_zba_zbb_zbc_zbs"
 
+error=0
 python3 cva6.py \
         --target hwconfig \
         --hwconfig_opts="$DV_HWCONFIG_OPTS" \
@@ -95,4 +98,8 @@ python3 cva6.py \
         --sv_seed 1 \
         --gcc_opts "${srcA[*]} ${cflags[*]}" \
         --iss_timeout=2000 \
-        $DV_OPTS
+        $DV_OPTS || error=$?
+
+cd -
+
+exit $error

--- a/verif/regress/cv32a6_tests.sh
+++ b/verif/regress/cv32a6_tests.sh
@@ -8,6 +8,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -54,6 +56,9 @@ riscv_tests_list=(
   rv32ui-p-beq
   rv32ui-p-jal
 )
+
+set +exo pipefail
+
 for t in ${riscv_tests_list[@]} ; do
   python3 cva6.py --testlist=../tests/testlist_riscv-tests-${DV_TARGET}-p.yaml --test $t --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
   [[ $? > 0 ]] && ((errors++))
@@ -62,6 +67,8 @@ done
 python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c --linker=../../config/gen_from_riscv_config/linker/link.ld\
   --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common" $DV_OPTS
 [[ $? > 0 ]] && ((errors++))
+
+set -exo pipefail
 
 make -C ../.. clean
 make clean_all

--- a/verif/regress/cv64a6_imafdc_tests.sh
+++ b/verif/regress/cv64a6_imafdc_tests.sh
@@ -11,6 +11,8 @@
 # Contributor: Cesar Fuguet, CEA List
 # RISC-V tests for 64-bit configurations implementing MMU
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -57,6 +59,9 @@ riscv_tests_list=(
   rv64ui-v-beq
   rv64ui-v-jal
 )
+
+set +exo pipefail
+
 for t in ${riscv_tests_list[@]} ; do
   python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test $t --iss_yaml cva6.yaml --target ${DV_TARGET} --iss=$DV_SIMULATORS $DV_OPTS
   [[ $? > 0 ]] && ((errors++))
@@ -65,6 +70,8 @@ done
 python3 cva6.py --target ${DV_TARGET} --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c \
   --gcc_opts="-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../../config/gen_from_riscv_config/linker/link.ld" $DV_OPTS
 [[ $? > 0 ]] && ((errors++))
+
+set -exo pipefail
 
 make -C ../.. clean
 make clean_all

--- a/verif/regress/cvxif_verif_regression.sh
+++ b/verif/regress/cvxif_verif_regression.sh
@@ -49,6 +49,4 @@ python3 cva6.py --testlist=../tests/testlist_cvxif.yaml --test cvxif_add_nop --i
 make -C ../.. clean
 make clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/cvxif_verif_regression.sh
+++ b/verif/regress/cvxif_verif_regression.sh
@@ -7,6 +7,7 @@
 #
 # Original Author: Guillaume Chauvon
 
+set -exo pipefail
 
 # where are the tools
 if ! [ -n "$RISCV" ]; then
@@ -40,11 +41,14 @@ export DV_OPTS="$DV_OPTS --issrun_opts=+debug_disable=1+UVM_VERBOSITY=$UVM_VERBO
 cd verif/sim/
 make -C ../.. clean
 make clean_all
-python3 cva6.py --testlist=../tests/testlist_cvxif.yaml --test cvxif_add_nop --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=vcs-testharness,spike $DV_OPTS --linker=../../config/gen_from_riscv_config/linker/link.ld
+error=0
+python3 cva6.py --testlist=../tests/testlist_cvxif.yaml --test cvxif_add_nop --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=vcs-testharness,spike $DV_OPTS --linker=../../config/gen_from_riscv_config/linker/link.ld || error=$?
 make -C ../.. clean
 make clean_all
-python3 cva6.py --testlist=../tests/testlist_cvxif.yaml --test cvxif_add_nop --iss_yaml cva6.yaml --target cv32a65x --iss=vcs-uvm,spike --issrun_opts="+enabled_cvxif" --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld
+python3 cva6.py --testlist=../tests/testlist_cvxif.yaml --test cvxif_add_nop --iss_yaml cva6.yaml --target cv32a65x --iss=vcs-uvm,spike --issrun_opts="+enabled_cvxif" --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld || error=$?
 make -C ../.. clean
 make clean_all
 
 cd -
+
+exit $error

--- a/verif/regress/debug_test.sh
+++ b/verif/regress/debug_test.sh
@@ -77,6 +77,4 @@ python3 cva6.py \
         --linker "$link_ld" \
         $DV_OPTS -v || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/debug_test.sh
+++ b/verif/regress/debug_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 # You may obtain a copy of the License at https://solderpad.org/licenses/
 
+set -exo pipefail
+
 noprint=""
 if [ "$1" == "--no-print" ]; then
         noprint="-DHAS_PRINTF=0"
@@ -65,6 +67,7 @@ default_target="cv32a6_imac_sv0"
 link_ld="../tests/custom/debug_test/bsp/link.ld"
 
 set -x
+error=0
 python3 cva6.py \
         --target "$default_target" \
         --iss="$DV_SIMULATORS" \
@@ -72,4 +75,8 @@ python3 cva6.py \
         --c_tests "$src0" \
         --gcc_opts "${srcA[*]} ${cflags[*]}" \
         --linker "$link_ld" \
-        $DV_OPTS -v
+        $DV_OPTS -v || error=$?
+
+cd -
+
+exit $error

--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -76,6 +76,4 @@ python3 cva6.py \
         --gcc_opts "${srcA[*]} ${cflags[*]}" \
         $DV_OPTS || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/dhrystone.sh
+++ b/verif/regress/dhrystone.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -63,6 +65,7 @@ cflags=(
         -DNOPRINT
 )
 
+error=0
 python3 cva6.py \
         --target hwconfig \
         --hwconfig_opts="$DV_HWCONFIG_OPTS" \
@@ -71,4 +74,8 @@ python3 cva6.py \
         --c_tests "$src0" \
         --sv_seed 1 \
         --gcc_opts "${srcA[*]} ${cflags[*]}" \
-        $DV_OPTS
+        $DV_OPTS || error=$?
+
+cd -
+
+exit $error

--- a/verif/regress/dhrystone_smoke.sh
+++ b/verif/regress/dhrystone_smoke.sh
@@ -68,6 +68,4 @@ python3 cva6.py \
         --sv_seed 1 \
         --gcc_opts "${srcA[*]} ${cflags[*]}" || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/dhrystone_smoke.sh
+++ b/verif/regress/dhrystone_smoke.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -57,10 +59,15 @@ cflags=(
         -DNOPRINT
 )
 
+error=0
 python3 cva6.py \
         --target $DV_TARGET \
         --iss="$DV_SIMULATORS" \
         --iss_yaml=cva6.yaml \
         --c_tests "$src0" \
         --sv_seed 1 \
-        --gcc_opts "${srcA[*]} ${cflags[*]}"
+        --gcc_opts "${srcA[*]} ${cflags[*]}" || error=$?
+
+cd -
+
+exit $error

--- a/verif/regress/dv-csr-embedded-tests.sh
+++ b/verif/regress/dv-csr-embedded-tests.sh
@@ -38,6 +38,4 @@ cd verif/sim/
 error=0
 python3 cva6.py --testlist=../tests/testlist_csr_embedded.yaml --iss_yaml cva6.yaml --target $DV_TARGET --iss=$DV_SIMULATORS $DV_OPTS --priv=m --iss_timeout 600 --linker=../../config/gen_from_riscv_config/$DV_TARGET/linker/link.ld || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/dv-csr-embedded-tests.sh
+++ b/verif/regress/dv-csr-embedded-tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Ayoub JALALI - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -33,6 +35,9 @@ if ! [ -n "$DV_TARGET" ]; then
 fi
 
 cd verif/sim/
-python3 cva6.py --testlist=../tests/testlist_csr_embedded.yaml --iss_yaml cva6.yaml --target $DV_TARGET --iss=$DV_SIMULATORS $DV_OPTS --priv=m --iss_timeout 600 --linker=../../config/gen_from_riscv_config/$DV_TARGET/linker/link.ld
+error=0
+python3 cva6.py --testlist=../tests/testlist_csr_embedded.yaml --iss_yaml cva6.yaml --target $DV_TARGET --iss=$DV_SIMULATORS $DV_OPTS --priv=m --iss_timeout 600 --linker=../../config/gen_from_riscv_config/$DV_TARGET/linker/link.ld || error=$?
 
 cd -
+
+exit $error

--- a/verif/regress/dv-generated-tests.sh
+++ b/verif/regress/dv-generated-tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Ayoub JALALI (ayoub.jalali@external.thalesgroup.com)
 
+set -exo pipefail
+
 if [ -n "$RISCV_ZCB" ]; then
   echo "Using RISCV_ZCB to support Zcb extension"
   RISCV=$RISCV_ZCB
@@ -92,7 +94,7 @@ if [[ ${#TEST_NAME[@]} != ${#I[@]} ]];then
   echo "***********ERROR***************"
   echo "The length of TEST_NAME and Iteration should be equal !!!!"
   echo "Fix the length of one of the arrays"
-  exit 
+  exit
 fi
 printf "+====================================================================================+"
 header="\n %-50s %-20s %s\n"
@@ -109,7 +111,7 @@ printf "+=======================================================================
 j=0
 while [[ $j -lt ${#TEST_NAME[@]} ]];do
   cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
-  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike --priv=m -i ${I[j]} -bz 1 --iss_timeout 300
+  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike --priv=m -i ${I[j]} -bz 1 --iss_timeout 300 || error=$?
   n=0
   echo "Generate the test: ${TEST_NAME[j]}"
 #this while loop detects the failed tests from the log file and remove them
@@ -132,6 +134,8 @@ done
 j=0
 elif [[ "$list_num" = 0 ]];then
    printf "==== Execute Directed tests to improve functional coverage of isa, by hitting corners !!! ====\n\n"
-   python3 cva6.py --testlist=$DIRECTED_TESTLIST --iss_yaml cva6.yaml --isa_extension="zcb" --target $DV_TARGET --iss=vcs-uvm,spike --priv=m --linker=../../config/gen_from_riscv_config/$DV_TARGET/linker/link.ld
+   python3 cva6.py --testlist=$DIRECTED_TESTLIST --iss_yaml cva6.yaml --isa_extension="zcb" --target $DV_TARGET --iss=vcs-uvm,spike --priv=m --linker=../../config/gen_from_riscv_config/$DV_TARGET/linker/link.ld || error=$?
 fi
 cd -
+
+exit $error

--- a/verif/regress/dv-generated-tests.sh
+++ b/verif/regress/dv-generated-tests.sh
@@ -136,6 +136,5 @@ elif [[ "$list_num" = 0 ]];then
    printf "==== Execute Directed tests to improve functional coverage of isa, by hitting corners !!! ====\n\n"
    python3 cva6.py --testlist=$DIRECTED_TESTLIST --iss_yaml cva6.yaml --isa_extension="zcb" --target $DV_TARGET --iss=vcs-uvm,spike --priv=m --linker=../../config/gen_from_riscv_config/$DV_TARGET/linker/link.ld || error=$?
 fi
-cd -
 
 exit $error

--- a/verif/regress/dv-generated-xif-tests.sh
+++ b/verif/regress/dv-generated-xif-tests.sh
@@ -103,6 +103,5 @@ elif [[ "$list_num" = 0 ]];then
    printf "==== Execute Directed tests to improve functional coverage of isa, by hitting corners !!! ====\n\n"
    python3 cva6.py --testlist=$DIRECTED_TESTLIST --iss_yaml cva6.yaml --target $DV_TARGET --iss=vcs-uvm,spike --priv=m --linker=../../config/gen_from_riscv_config/$DV_TARGET/linker/link.ld || error=$?
 fi
-cd -
 
 exit $error

--- a/verif/regress/dv-interrupt-test.sh
+++ b/verif/regress/dv-interrupt-test.sh
@@ -41,6 +41,4 @@ error=0
 python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_interrupt_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS --priv=m --issrun_opts="+enable_interrupt" -i 5 -bz 1 --iss_timeout 300 || error=$?
 python3 cva6.py --testlist=../tests/testlist_interrupt.yaml --test jump_to_zero --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS --priv=m --issrun_opts="+enable_interrupt" || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/dv-interrupt-test.sh
+++ b/verif/regress/dv-interrupt-test.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Ayoub JALALI - Thales
 
+set -exo pipefail
+
 if [ -n "$RISCV_ZCB" ]; then
   echo "Using RISCV_ZCB to support Zcb extension"
   RISCV=$RISCV_ZCB
@@ -35,8 +37,10 @@ fi
 
 cd verif/sim/
 cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
-
-python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_interrupt_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS --priv=m --issrun_opts="+enable_interrupt" -i 5 -bz 1 --iss_timeout 300
-python3 cva6.py --testlist=../tests/testlist_interrupt.yaml --test jump_to_zero --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS --priv=m --issrun_opts="+enable_interrupt"
+error=0
+python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_interrupt_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS --priv=m --issrun_opts="+enable_interrupt" -i 5 -bz 1 --iss_timeout 300 || error=$?
+python3 cva6.py --testlist=../tests/testlist_interrupt.yaml --test jump_to_zero --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS --priv=m --issrun_opts="+enable_interrupt" || error=$?
 
 cd -
+
+exit $error

--- a/verif/regress/dv-riscv-arch-test.sh
+++ b/verif/regress/dv-riscv-arch-test.sh
@@ -47,6 +47,4 @@ cd verif/sim
 error=0
 python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/dv-riscv-arch-test.sh
+++ b/verif/regress/dv-riscv-arch-test.sh
@@ -8,6 +8,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -42,4 +44,9 @@ fi
 export DV_OPTS="$DV_OPTS --issrun_opts=+tb_performance_mode+debug_disable=1+UVM_VERBOSITY=$UVM_VERBOSITY"
 
 cd verif/sim
-python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
+error=0
+python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld || error=$?
+
+cd -
+
+exit $error

--- a/verif/regress/dv-riscv-compliance.sh
+++ b/verif/regress/dv-riscv-compliance.sh
@@ -39,6 +39,5 @@ export DV_OPTS="$DV_OPTS --issrun_opts=+tb_performance_mode+debug_disable=1+UVM_
 cd verif/sim
 error=0
 python3 cva6.py --testlist=../tests/testlist_riscv-compliance-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS || error=$?
-cd -
 
 exit $error

--- a/verif/regress/dv-riscv-compliance.sh
+++ b/verif/regress/dv-riscv-compliance.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -35,5 +37,8 @@ fi
 export DV_OPTS="$DV_OPTS --issrun_opts=+tb_performance_mode+debug_disable=1+UVM_VERBOSITY=$UVM_VERBOSITY"
 
 cd verif/sim
-python3 cva6.py --testlist=../tests/testlist_riscv-compliance-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS
+error=0
+python3 cva6.py --testlist=../tests/testlist_riscv-compliance-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS || error=$?
 cd -
+
+exit $error

--- a/verif/regress/dv-riscv-csr-access-test.sh
+++ b/verif/regress/dv-riscv-csr-access-test.sh
@@ -34,6 +34,4 @@ cd verif/sim
 error=0
 python3 cva6.py --testlist=../tests/testlist_riscv-csr-access-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../sim/link.ld || error=$?
 
-cd -
-
 exit $error

--- a/verif/regress/dv-riscv-csr-access-test.sh
+++ b/verif/regress/dv-riscv-csr-access-test.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -29,7 +31,9 @@ if ! [ -n "$DV_SIMULATORS" ]; then
 fi
 
 cd verif/sim
-python3 cva6.py --testlist=../tests/testlist_riscv-csr-access-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../sim/link.ld
+error=0
+python3 cva6.py --testlist=../tests/testlist_riscv-csr-access-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../sim/link.ld || error=$?
 
 cd -
 
+exit $error

--- a/verif/regress/dv-riscv-mmu-sv32-test.sh
+++ b/verif/regress/dv-riscv-mmu-sv32-test.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -29,5 +31,8 @@ if ! [ -n "$DV_SIMULATORS" ]; then
 fi
 
 cd verif/sim
-python3 cva6.py --testlist=../tests/testlist_riscv-mmu-sv32-arch-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
+error=0
+python3 cva6.py --testlist=../tests/testlist_riscv-mmu-sv32-arch-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld || error=$?
 cd -
+
+exit $error

--- a/verif/regress/dv-riscv-mmu-sv32-test.sh
+++ b/verif/regress/dv-riscv-mmu-sv32-test.sh
@@ -33,6 +33,5 @@ fi
 cd verif/sim
 error=0
 python3 cva6.py --testlist=../tests/testlist_riscv-mmu-sv32-arch-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld || error=$?
-cd -
 
 exit $error

--- a/verif/regress/dv-riscv-tests.sh
+++ b/verif/regress/dv-riscv-tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -42,8 +44,11 @@ fi
 export DV_OPTS="$DV_OPTS --issrun_opts=+tb_performance_mode+debug_disable=1+UVM_VERBOSITY=$UVM_VERBOSITY"
 
 cd verif/sim
+error=0
 for TESTLIST in $DV_TESTLISTS
 do
-  python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml $DV_OPTS
+  python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml $DV_OPTS || error=$?
 done
 cd -
+
+exit $error

--- a/verif/regress/dv-riscv-tests.sh
+++ b/verif/regress/dv-riscv-tests.sh
@@ -49,6 +49,5 @@ for TESTLIST in $DV_TESTLISTS
 do
   python3 cva6.py --testlist=$TESTLIST --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml $DV_OPTS || error=$?
 done
-cd -
 
 exit $error

--- a/verif/regress/hwconfig_tests.sh
+++ b/verif/regress/hwconfig_tests.sh
@@ -61,5 +61,3 @@ python3 cva6.py \
         --iss_yaml=cva6.yaml \
         --c_tests "../tests/custom/return0/return0.c" \
         --gcc_opts "${srcA[*]} ${cflags[*]}"
-
-cd -

--- a/verif/regress/hwconfig_tests.sh
+++ b/verif/regress/hwconfig_tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Guillaume Chauvon (guillaume.chauvon@thalesgroup.com)
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"

--- a/verif/regress/install-riscv-arch-test.sh
+++ b/verif/regress/install-riscv-arch-test.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # riscv-arch-tests uses definition of RVMODEL_HALT provided by Spike.
 . verif/regress/install-spike.sh
 if [ ! -d $SPIKE_SRC_DIR/arch_test_target ]; then
@@ -32,4 +34,3 @@ if ! [ -d verif/tests/riscv-arch-test ]; then
   cp -rpa $SPIKE_SRC_DIR/arch_test_target riscv-target
   cd -
 fi
-

--- a/verif/regress/install-riscv-compliance.sh
+++ b/verif/regress/install-riscv-compliance.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 if ! [ -n "$COMPLIANCE_REPO" ]; then
   COMPLIANCE_REPO="https://github.com/riscv-non-isa/riscv-arch-test.git"
   COMPLIANCE_BRANCH="main"

--- a/verif/regress/install-riscv-tests.sh
+++ b/verif/regress/install-riscv-tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 if ! [ -n "$TESTS_REPO" ]; then
   TESTS_REPO="https://github.com/riscv/riscv-tests.git"
   TESTS_BRANCH="master"

--- a/verif/regress/install-spike.sh
+++ b/verif/regress/install-spike.sh
@@ -8,6 +8,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 if [ -z ${NUM_JOBS} ]; then
   NUM_JOBS=1
 fi

--- a/verif/regress/install-verilator.sh
+++ b/verif/regress/install-verilator.sh
@@ -8,6 +8,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # Customise this to a fast local disk
 ROOT_PROJECT=$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../../)
 

--- a/verif/regress/iss-tests.sh
+++ b/verif/regress/iss-tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Guillaume CHAUVON (guillaume.chauvon@thalesgroup.fr)
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -28,8 +30,11 @@ if ! [ -n "$DV_TARGET" ]; then
 fi
 
 cd verif/sim/
-python3 cva6.py --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --testlist=../tests/testlist_riscv-compliance-$DV_TARGET.yaml --test rv32ui-addi
+error=0
+python3 cva6.py --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --testlist=../tests/testlist_riscv-compliance-$DV_TARGET.yaml --test rv32ui-addi || error=$?
 make clean
 make -C verif/sim clean_all
 
 cd -
+
+exit $error

--- a/verif/regress/iss-tests.sh
+++ b/verif/regress/iss-tests.sh
@@ -35,6 +35,4 @@ python3 cva6.py --target $DV_TARGET --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --
 make clean
 make -C verif/sim clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/issue-tests.sh
+++ b/verif/regress/issue-tests.sh
@@ -36,6 +36,4 @@ python3 cva6.py --testlist=../tests/testlist_issues.yaml --test compressed-fpreg
 make clean
 make -C verif/sim clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/issue-tests.sh
+++ b/verif/regress/issue-tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -26,11 +28,14 @@ if ! [ -n "$DV_SIMULATORS" ]; then
 fi
 
 cd verif/sim/
-python3 cva6.py --testlist=../tests/testlist_issues.yaml --test compressed-fpreg-commits-rv64 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
+error=0
+python3 cva6.py --testlist=../tests/testlist_issues.yaml --test compressed-fpreg-commits-rv64 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
 make clean
 make -C verif/sim clean_all
-python3 cva6.py --testlist=../tests/testlist_issues.yaml --test compressed-fpreg-commits-rv32 --iss_yaml cva6.yaml --target cv32a6_imafc_sv32 --iss=$DV_SIMULATORS $DV_OPTS
+python3 cva6.py --testlist=../tests/testlist_issues.yaml --test compressed-fpreg-commits-rv32 --iss_yaml cva6.yaml --target cv32a6_imafc_sv32 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
 make clean
 make -C verif/sim clean_all
 
 cd -
+
+exit $error

--- a/verif/regress/iti_test.sh
+++ b/verif/regress/iti_test.sh
@@ -49,6 +49,4 @@ cp iti.trace ../../.gitlab-ci
 make -C ../.. clean
 make clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/iti_test.sh
+++ b/verif/regress/iti_test.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -40,10 +42,13 @@ cd verif/sim/
 
 make -C ../.. clean
 make clean_all
-python3 cva6.py --elf_tests ../tests/custom/ITI/test_iti_asm.o --target cv32a65x --iss_yaml cva6.yaml --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld $DV_OPTS
-#python3 cva6.py --c_tests ../tests/custom/ITI/test_iti_asm.c --iss_yaml cva6.yaml --target cv32a65x --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld --gcc_opts="$CC_OPTS" $DV_OPTS
+error=0
+python3 cva6.py --elf_tests ../tests/custom/ITI/test_iti_asm.o --target cv32a65x --iss_yaml cva6.yaml --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld $DV_OPTS || error=$?
+#python3 cva6.py --c_tests ../tests/custom/ITI/test_iti_asm.c --iss_yaml cva6.yaml --target cv32a65x --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld --gcc_opts="$CC_OPTS" $DV_OPTS || error=$?
 cp iti.trace ../../.gitlab-ci
 make -C ../.. clean
 make clean_all
 
 cd -
+
+exit $error

--- a/verif/regress/linux.sh
+++ b/verif/regress/linux.sh
@@ -34,6 +34,5 @@ cp $BBL_ROOT/bbl bbl.o
 error=0
 python3 cva6.py --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --elf_tests bbl.o\
   --issrun_opts="+time_out=40000000 +debug_disable=1" --isspostrun_opts="ffffffe0005e5cd4" || error=$?
-cd -
 
 exit $error

--- a/verif/regress/linux.sh
+++ b/verif/regress/linux.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -exo pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -29,6 +31,9 @@ fi
 
 cd verif/sim
 cp $BBL_ROOT/bbl bbl.o
+error=0
 python3 cva6.py --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --elf_tests bbl.o\
-  --issrun_opts="+time_out=40000000 +debug_disable=1" --isspostrun_opts="ffffffe0005e5cd4"
+  --issrun_opts="+time_out=40000000 +debug_disable=1" --isspostrun_opts="ffffffe0005e5cd4" || error=$?
 cd -
+
+exit $error

--- a/verif/regress/pmp_cv32a65x_tests.sh
+++ b/verif/regress/pmp_cv32a65x_tests.sh
@@ -6,6 +6,8 @@
 ## Original Author: Konstantinos Leventos - Robert Bosch France SAS
 ##-----------------------------------------------------------------------------
 
+set -exo pipefail
+
 # Where the tools are
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -34,8 +36,11 @@ make clean
 cd verif/sim/
 make clean_all
 
-python3 cva6.py --testlist=../tests/testlist_pmp-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../../config/gen_from_riscv_config/cv32a60x/linker/link.ld
+error=0
+python3 cva6.py --testlist=../tests/testlist_pmp-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../../config/gen_from_riscv_config/cv32a60x/linker/link.ld || error=$?
 
 make clean_all
 cd -
 make clean
+
+exit $error

--- a/verif/regress/smoke-gen_tests.sh
+++ b/verif/regress/smoke-gen_tests.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Ayoub JALALI - Thales
 
+set -exo pipefail
+
 if [ -n "$RISCV_ZCB" ]; then
   echo "Using RISCV_ZCB to support Zcb extension"
   RISCV=$RISCV_ZCB
@@ -41,9 +43,12 @@ export DV_OPTS="$DV_OPTS --issrun_opts=+debug_disable=1+UVM_VERBOSITY=$UVM_VERBO
 
 cd verif/sim/
 cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
-python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_arithmetic_basic_test_comp --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300
-python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300
-python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_unaligned_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300
+error=0
+python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_arithmetic_basic_test_comp --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300 || error=$?
+python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300 || error=$?
+python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_unaligned_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300 || error=$?
 make clean_all
 
 cd -
+
+exit $error

--- a/verif/regress/smoke-gen_tests.sh
+++ b/verif/regress/smoke-gen_tests.sh
@@ -49,6 +49,4 @@ python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_load_store_test 
 python3 cva6.py --testlist=cva6_base_testlist.yaml --test riscv_unaligned_load_store_test --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imcb/ --mabi ilp32 --isa rv32imc --isa_extension="zba,zbb,zbc,zbs,zcb" --simulator_yaml ../env/corev-dv/simulator.yaml --iss=$DV_SIMULATORS $DV_OPTS --priv=m -i 1 --iss_timeout 300 || error=$?
 make clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/smoke-tests-cv32a65x.sh
+++ b/verif/regress/smoke-tests-cv32a65x.sh
@@ -48,6 +48,4 @@ python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml c
 make -C ../.. clean
 make clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/smoke-tests-cv32a65x.sh
+++ b/verif/regress/smoke-tests-cv32a65x.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -eox pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -41,8 +43,11 @@ cd verif/sim/
 
 make -C ../.. clean
 make clean_all
-python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv32a65x --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld --gcc_opts="$CC_OPTS" $DV_OPTS
+error=0
+python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv32a65x --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/cv32a65x/linker/link.ld --gcc_opts="$CC_OPTS" $DV_OPTS || error=$?
 make -C ../.. clean
 make clean_all
 
 cd -
+
+exit $error

--- a/verif/regress/smoke-tests-cv32a6_imac_sv32.sh
+++ b/verif/regress/smoke-tests-cv32a6_imac_sv32.sh
@@ -56,6 +56,4 @@ python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml c
 make -C ../.. clean
 make clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/smoke-tests-cv32a6_imac_sv32.sh
+++ b/verif/regress/smoke-tests-cv32a6_imac_sv32.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -eox pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -46,11 +48,14 @@ cd verif/sim/
 
 make -C ../.. clean
 make clean_all
-python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv32a60x.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv32a60x.yaml --test rv32im-cadd-01 --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS  --linker=../../config/gen_from_riscv_config/linker/link.ld
-python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/linker/link.ld --gcc_opts="$CC_OPTS -nostdlib -lgcc" $DV_OPTS
+error=0
+python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv32a60x.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
+python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv32a60x.yaml --test rv32im-cadd-01 --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS $DV_OPTS  --linker=../../config/gen_from_riscv_config/linker/link.ld || error=$?
+python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv32a6_imac_sv32 --iss=$DV_SIMULATORS --linker=../../config/gen_from_riscv_config/linker/link.ld --gcc_opts="$CC_OPTS -nostdlib -lgcc" $DV_OPTS || error=$?
 make -C ../.. clean
 make clean_all
 
 cd -
+
+exit $error

--- a/verif/regress/smoke-tests-cv64a6_imafdc_sv39.sh
+++ b/verif/regress/smoke-tests-cv64a6_imafdc_sv39.sh
@@ -58,6 +58,4 @@ python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml c
 make -C ../.. clean
 make clean_all
 
-cd -
-
 exit $error

--- a/verif/regress/smoke-tests-cv64a6_imafdc_sv39.sh
+++ b/verif/regress/smoke-tests-cv64a6_imafdc_sv39.sh
@@ -7,6 +7,8 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+set -eox pipefail
+
 # where are the tools
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -46,13 +48,16 @@ cd verif/sim/
 
 make -C ../.. clean
 make clean_all
-python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-add --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64ui-p-add --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml --test rv64i_m-add-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS  --linker=../../config/gen_from_riscv_config/linker/link.ld
-python3 cva6.py --testlist=../tests/testlist_custom.yaml --test custom_test_template --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --gcc_opts="$CC_OPTS -nostdlib -lgcc" $DV_OPTS --linker=../../config/gen_from_riscv_config/linker/link.ld
+error=0
+python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.yaml --test rv64ui-v-add --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
+python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64ui-p-add --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
+python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml --test rv64i_m-add-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS  --linker=../../config/gen_from_riscv_config/linker/link.ld || error=$?
+python3 cva6.py --testlist=../tests/testlist_custom.yaml --test custom_test_template --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS || error=$?
+python3 cva6.py --c_tests ../tests/custom/hello_world/hello_world.c --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --gcc_opts="$CC_OPTS -nostdlib -lgcc" $DV_OPTS --linker=../../config/gen_from_riscv_config/linker/link.ld || error=$?
 make -C ../.. clean
 make clean_all
 
 cd -
+
+exit $error


### PR DESCRIPTION
Simple addition to prevent errors in the smoke test scripts not being reported.