### PR TITLE
cva6_iti: fix iret value and itype type

### DIFF
--- a/.gitlab-ci/iti_reference.trace
+++ b/.gitlab-ci/iti_reference.trace
@@ -1,10 +1,10 @@
 i :          1 , val = 1 , iret =         12, ilast = 0x1 , itype = 6 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x00010000 
-i :          0 , val = 1 , iret =         39, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80000000 
+i :          0 , val = 1 , iret =         38, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80000000 
 i :          0 , val = 1 , iret =         19, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80000058 
-i :          0 , val = 1 , iret =         76, ilast = 0x0 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000007e 
+i :          0 , val = 1 , iret =         77, ilast = 0x0 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000007e 
 i :          0 , val = 1 , iret =         18, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003f12 
 i :          0 , val = 1 , iret =          7, ilast = 0x0 , itype = 6 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003f52 
-i :          0 , val = 1 , iret =         35, ilast = 0x0 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003602 
+i :          0 , val = 1 , iret =         36, ilast = 0x0 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003602 
 i :          0 , val = 1 , iret =         36, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003fc4 
 i :          0 , val = 1 , iret =         18, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003ffa 
 i :          0 , val = 1 , iret =         18, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003ffa 
@@ -37,9 +37,9 @@ i :          0 , val = 1 , iret =         18, ilast = 0x1 , itype = 5 , cause = 
 i :          0 , val = 1 , iret =         18, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003ffa 
 i :          0 , val = 1 , iret =          7, ilast = 0x0 , itype = 6 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000401e 
 i :          0 , val = 1 , iret =          5, ilast = 0x0 , itype = 6 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000362a 
-i :          0 , val = 1 , iret =         15, ilast = 0x0 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003662 
+i :          0 , val = 1 , iret =         16, ilast = 0x0 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003662 
 i :          0 , val = 1 , iret =          5, ilast = 0x0 , itype = 6 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000359e 
-i :          1 , val = 1 , iret =         17, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000366c 
+i :          1 , val = 1 , iret =         16, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000366c 
 i :          0 , val = 1 , iret =          2, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80004266 
 i :          0 , val = 1 , iret =          2, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000426a 
 i :          0 , val = 1 , iret =          2, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x8000426e 
@@ -152,8 +152,8 @@ i :          0 , val = 1 , iret =          2, ilast = 0x0 , itype = 4 , cause = 
 i :          0 , val = 1 , iret =          1, ilast = 0x0 , itype = 6 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80004298 
 i :          0 , val = 1 , iret =          6, ilast = 0x0 , itype = 6 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003014 
 i :          0 , val = 1 , iret =         12, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003672 
-i :          0 , val = 1 , iret =          9, ilast = 0x0 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003680 
+i :          0 , val = 1 , iret =         10, ilast = 0x0 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003680 
 i :          0 , val = 1 , iret =         10, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x800036d8 
-i :          0 , val = 1 , iret =          9, ilast = 0x0 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003680 
+i :          0 , val = 1 , iret =         10, ilast = 0x0 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x80003680 
 i :          0 , val = 1 , iret =         10, ilast = 0x1 , itype = 4 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x800036d8 
 i :          0 , val = 1 , iret =          4, ilast = 0x1 , itype = 5 , cause = 0x00 , tval= 0x00000000 , priv = 0x3 , iadd= 0x800036ec 

--- a/core/cva6_iti/instr_to_trace.sv
+++ b/core/cva6_iti/instr_to_trace.sv
@@ -44,7 +44,6 @@ module instr_to_trace #(
     itt_out_o = '0;
 
     if (uop_entry_i.valid) begin
-      counter_o = uop_entry_i.compressed ? counter_i + 1 : counter_i + 2;
 
       if (was_special_i) begin
         counter_o = 0;
@@ -52,9 +51,11 @@ module instr_to_trace #(
         is_special_o = 1'b0;
       end
 
+      counter_o = uop_entry_i.compressed ? counter_o + 1 : counter_o + 2;
+
       if (special_inst) begin
         itt_out_o.valid = 1'b1;
-        itt_out_o.iretire = uop_entry_i.compressed ? counter_o + 1 : counter_o + 2;
+        itt_out_o.iretire = counter_o;
         itt_out_o.itype = uop_entry_i.itype;
         itt_out_o.ilastsize = ~uop_entry_i.compressed;
         itt_out_o.iaddr = iaddr_o;

--- a/core/cva6_iti/iti.sv
+++ b/core/cva6_iti/iti.sv
@@ -124,8 +124,10 @@ module cva6_iti #(
 
 
   always_comb begin
-    iti_to_encoder_o.cause = '0;
-    iti_to_encoder_o.tval  = '0;
+    iti_to_encoder_o.cause  = '0;
+    iti_to_encoder_o.tval   = '0;
+    iti_to_encoder_o.priv   = riscv::PRIV_LVL_U;
+    iti_to_encoder_o.cycles = '0;
     for (int i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
       uop_entry[i].valid = valid_i[i];
       uop_entry[i].pc = rvfi_to_iti_i.pc[i];
@@ -137,8 +139,9 @@ module cva6_iti #(
       iti_to_encoder_o.valid[i] = 1'b0;
       iti_to_encoder_o.iretire[i] = '0;
       iti_to_encoder_o.ilastsize[i] = '0;
-      iti_to_encoder_o.itype[i] = '0;
+      iti_to_encoder_o.itype[i] = iti_pkg::STANDARD;
       iti_to_encoder_o.iaddr[i] = '0;
+      valid_o[i] = '0;
       if (itt_out[i].valid) begin
         valid_o[i] = itt_out[i].valid;
         iti_to_encoder_o.valid[i] = itt_out[i].valid;

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -164,7 +164,7 @@ module cva6_rvfi
   assign branch_valid_iti = instr.branch_valid;
   assign is_taken_iti = instr.is_taken;
   assign tval_iti = instr.tval;
-  assign time_iti = rvfi_probes_i.csr.cycle_q;
+  assign time_iti = csr.cycle_q;
 
   assign priv_lvl = instr.priv_lvl;
 

--- a/core/include/iti_types.svh
+++ b/core/include/iti_types.svh
@@ -13,7 +13,7 @@
      logic [Cfg.NrCommitPorts-1:0] valid; \
      logic [Cfg.NrCommitPorts-1:0][iti_pkg::IRETIRE_LEN-1:0] iretire; \
      logic [Cfg.NrCommitPorts-1:0] ilastsize; \
-     iti_pkg::itype_t [Cfg.NrCommitPorts-1:0][iti_pkg::ITYPE_LEN-1:0] itype; \
+     iti_pkg::itype_t [Cfg.NrCommitPorts-1:0] itype; \
      logic [iti_pkg::CAUSE_LEN-1:0] cause; \
      logic [Cfg.XLEN-1:0] tval; \
      riscv::priv_lvl_t  priv; \


### PR DESCRIPTION
More testing in real conditions pinpointed some bugs:

* `iretire` value was sometimes off by 1 because `counter_o` was not
  cleared correctly in instr_to_trace
* A dimension was redundant in the `itype` field of iti_to_encoder
* `valid_o` in cva6_iti was not being cleared when the output was not
  valid