### PR TITLE
cva6_tlb: fix wrong indexing of `vaddr_vpn_match` when `RVH` is set

### DIFF
--- a/core/cva6_mmu/cva6_tlb.sv
+++ b/core/cva6_mmu/cva6_tlb.sv
@@ -106,7 +106,7 @@ module cva6_tlb
         // Identify if virtual address at level `x` matches the vaddr / gpaddr to be flushed
         assign vaddr_vpn_match[i][0][x] = vaddr_to_be_flushed_i[12+((CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*(x+1))-1:12+((CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*x)] == tags_q[i].vpn[x];
         if (CVA6Cfg.RVH) begin
-          assign vaddr_vpn_match[i][HYP_EXT][0] =  gpaddr_to_be_flushed_i[12+((CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*(x+1))-1:12+((CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*x)] ==
+          assign vaddr_vpn_match[i][HYP_EXT][x] =  gpaddr_to_be_flushed_i[12+((CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*(x+1))-1:12+((CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*x)] ==
                                                                   gppn[i][    (CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*(x+1)-1 :    (CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)*x];
         end
       end


### PR DESCRIPTION
I tried using the CVA6 configuration `cv64a6_imafdch_sv39_wb` with QuestaSim. The following error is returned.

```
'vaddr_vpn_match[i][1][0]' is driven by more than one continuous assignment
```
where i ranges on all the values of the following loop.

https://github.com/openhwgroup/cva6/blob/301d11ceb88c1169f75e9dea415e4bff4eb29888/core/cva6_mmu/cva6_tlb.sv#L102-L112

My educated guess for the fix is the following:
https://github.com/ricted98/cva6/blob/ef6cc993c8b45b3402587c715ab65facc2a06f24/core/cva6_mmu/cva6_tlb.sv#L102-L112

Where the last index is not tied to `0` but rather it varies with `x`, however I would like someone more knowledgeable to review this change.