### PR TITLE
[DRAFT] Remove unsupported config from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,12 @@ jobs:
       SPIKE_TANDEM: 1
     strategy:
       matrix:
-        testcase:  [ cv64a6_imafdc_tests ]
-        config:    [ cv64a6_imafdc_sv39_hpdcache, cv64a6_imafdc_sv39_hpdcache_wb, cv64a6_imafdc_sv39_wb, cv64a6_imafdc_sv39 ]
+        testcase:  [ cv64a60ax_tests ]
+        config:    [ cv64a60ax, cv64a6_imafdc_sv39_hpdcache_wb ]
         simulator: [ veri-testharness ]
         include:
           - testcase: dv-riscv-arch-test
-            config: cv64a6_imafdc_sv39_hpdcache
+            config: cv64a60ax
             simulator: veri-testharness
           - testcase: dv-riscv-arch-test
             config: cv64a6_imafdc_sv39_hpdcache_wb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,7 @@ smoke-tests:
   parallel:
     matrix:
       - DV_SIMULATORS: ["vcs-testharness", "questa-testharness"]
-        DV_TARGET: ["cv32a6_imac_sv32", "cv64a6_imafdc_sv39"]
+        DV_TARGET: ["cv32a6_imac_sv32", "cv64a60ax"]
       - DV_SIMULATORS: "vcs-uvm"
         DV_TARGET: "cv32a65x"
   script:
@@ -419,7 +419,7 @@ riscv-tests-v:
     DASHBOARD_SORT_INDEX: 3
     DASHBOARD_JOB_CATEGORY: "Test suites"
     DV_SIMULATORS: "veri-testharness,spike"
-    DV_TARGET: cv64a6_imafdc_sv39
+    DV_TARGET: cv64a60x
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
   script: source verif/regress/dv-riscv-tests.sh
   after_script: *simu_after_script


### PR DESCRIPTION
Following discussion on the CVA6 configuration, this PR start the discussion on how to update both the gitlab and the github CI. cv32a60x and cv32a65x are kept, the 64bits configuration  are switched to cv64a60ax and cv64a6_imafdc_sv39_hpdcache_wb (to also check the writeback version of hpdcache).
List of open points (so far) :

- What to do with config cv32a6_imac_sv32 ? Could it be simply removed ? Are we at risk of letting bugs go unnoticed on the sv32 mode of the MMU ?
- Cache selection : if only the HPD/Icache is kept, is it better to check static WT and WB configuration or a single config that can configure the cache in either mode ? @cfuguet  what is your opinion on this ?
- Any config that should get added to the CI ? Openpiton ? a configuration with hypervisor enabled ?

All inputs are welcome