### PR TITLE
When using HPDCache, kill cache request from CVA6 PTW in case of flush to prevent spurious rvalid

### DIFF
--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -408,9 +408,9 @@ module cva6_ptw
       end
 
       KILL_REQ: begin
-          kill_req_n = 1'b0;
-          // even when killed, the request sends a response
-          state_d = WAIT_RVALID;
+        kill_req_n = 1'b0;
+        // even when killed, the request sends a response
+        state_d = WAIT_RVALID;
       end
 
       PTE_LOOKUP: begin
@@ -636,10 +636,8 @@ module cva6_ptw
       // 1. in the PTE Lookup check whether we still need to wait for an rvalid
       // 2. waiting for a grant, if so: wait for it
       // if not, go back to idle
-      if ((state_q inside {PTE_LOOKUP, WAIT_RVALID}) && !data_rvalid_q)
-        state_d = WAIT_RVALID;
-      else if (state_q != WAIT_GRANT)
-        state_d = LATENCY;
+      if ((state_q inside {PTE_LOOKUP, WAIT_RVALID}) && !data_rvalid_q) state_d = WAIT_RVALID;
+      else if (state_q != WAIT_GRANT) state_d = LATENCY;
 
       kill_req_n = (state_q == WAIT_GRANT);
     end


### PR DESCRIPTION
I encountered an issue where the page table walker would request a PTE, then encounter a flush and request a new PTE. This caused an issue in conjunction with the HPDcache in which rvalid was first signaled for the old PTE and then for the new PTE, causing the PTW to use the incorrect PTE for a translation.

I did not fully investigate the cause of this issue. I assume that the root cause is first raising and then lowering the `data_req` flag without sending `tag_valid` or `kill_req` accordingly.

This PR makes the PTW send a kill request in that scenario, preventing the spurious `rvalid`.