### PR TITLE
Remove nested comment block

### DIFF
--- a/corev_apu/instr_tracing/rv_tracer-main/rtl/te_packet_emitter.sv
+++ b/corev_apu/instr_tracing/rv_tracer-main/rtl/te_packet_emitter.sv
@@ -1031,10 +1031,9 @@ module te_packet_emitter
                 /* requires non mandatory support for jtc and branch prediction
                 case(packet_f_opt_ext_subformat_i)
                 SF_PBC: begin // subformat 0
-                /*  There can be two type of payloads for this subformat:
-                    1. no address, branch count
-                    2. address, branch count
-                * /    
+                    // There can be two type of payloads for this subformat:
+                    // 1. no address, branch count
+                    // 2. address, branch count
                 
                     // only for F0SF0 payload w/address
                     // updating latest address sent in a packet


### PR DESCRIPTION
The systemverilog standard disallows nested comment blocks. Some tools highlight this as an issue, e.g., slang:

corev_apu/instr_tracing/rv_tracer-main/rtl/te_packet_emitter.sv:1034:17: error: nested block comments are disallowed by SystemVerilog

                /*  There can be two type of payloads for this subformat:

                ^