### PR TITLE
pulp-actions: bump version

### DIFF
--- a/.github/workflows/bender-up-to-date.yml
+++ b/.github/workflows/bender-up-to-date.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Bender up-to-date
-        uses: pulp-platform/pulp-actions/bender-up-to-date@v2
+        uses: pulp-platform/pulp-actions/bender-up-to-date@v2.4.4


### PR DESCRIPTION
Adopt latest version of ```pulp-actions``` to ensure compatibility with ```bender``` versions >= 0.30.0