### PR TITLE
Introduce operand_a and operand_b temps in ALU

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -39,8 +39,10 @@ module alu
     output logic alu_branch_res_o
 );
 
+  logic [CVA6Cfg.XLEN-1:0] operand_a;
   logic [CVA6Cfg.XLEN-1:0] operand_a_rev;
   logic [            31:0] operand_a_rev32;
+  logic [CVA6Cfg.XLEN-1:0] operand_b;
   logic [  CVA6Cfg.XLEN:0] operand_b_neg;
   logic [CVA6Cfg.XLEN+1:0] adder_result_ext_o;
   logic                    less;  // handles both signed and unsigned forms
@@ -59,13 +61,15 @@ module alu
   logic [CVA6Cfg.XLEN-1:0] xperm8_result;
   logic [CVA6Cfg.XLEN-1:0] xperm4_result;
 
+  assign operand_a = fu_data_i.operand_a;
+  assign operand_b = fu_data_i.operand_b;
+
   // bit reverse operand_a for left shifts and bit counting
   generate
     genvar k;
-    for (k = 0; k < CVA6Cfg.XLEN; k++)
-      assign operand_a_rev[k] = fu_data_i.operand_a[CVA6Cfg.XLEN-1-k];
+    for (k = 0; k < CVA6Cfg.XLEN; k++) assign operand_a_rev[k] = operand_a[CVA6Cfg.XLEN-1-k];
 
-    for (k = 0; k < 32; k++) assign operand_a_rev32[k] = fu_data_i.operand_a[31-k];
+    for (k = 0; k < 32; k++) assign operand_a_rev32[k] = operand_a[31-k];
   endgenerate
 
   // ------
@@ -81,25 +85,25 @@ module alu
   assign adder_op_b_negate = fu_data_i.operation inside {EQ, NE, SUB, SUBW, ANDN, ORN, XNOR};
 
   always_comb begin
-    operand_a_bitmanip = fu_data_i.operand_a;
+    operand_a_bitmanip = operand_a;
     operand_a_cpop     = fu_data_cpop_i.operand_a;
 
     if (CVA6Cfg.RVB) begin
       if (CVA6Cfg.IS_XLEN64) begin
         unique case (fu_data_i.operation)
-          SH1ADDUW:    operand_a_bitmanip = fu_data_i.operand_a[31:0] << 1;
-          SH2ADDUW:    operand_a_bitmanip = fu_data_i.operand_a[31:0] << 2;
-          SH3ADDUW:    operand_a_bitmanip = fu_data_i.operand_a[31:0] << 3;
+          SH1ADDUW:    operand_a_bitmanip = operand_a[31:0] << 1;
+          SH2ADDUW:    operand_a_bitmanip = operand_a[31:0] << 2;
+          SH3ADDUW:    operand_a_bitmanip = operand_a[31:0] << 3;
           CTZW:        operand_a_bitmanip = operand_a_rev32;
-          ADDUW, CLZW: operand_a_bitmanip = fu_data_i.operand_a[31:0];
+          ADDUW, CLZW: operand_a_bitmanip = operand_a[31:0];
           CPOPW:       operand_a_cpop = fu_data_cpop_i.operand_a[31:0];
           default:     ;
         endcase
       end
       unique case (fu_data_i.operation)
-        SH1ADD:  operand_a_bitmanip = fu_data_i.operand_a << 1;
-        SH2ADD:  operand_a_bitmanip = fu_data_i.operand_a << 2;
-        SH3ADD:  operand_a_bitmanip = fu_data_i.operand_a << 3;
+        SH1ADD:  operand_a_bitmanip = operand_a << 1;
+        SH2ADD:  operand_a_bitmanip = operand_a << 2;
+        SH3ADD:  operand_a_bitmanip = operand_a << 3;
         CTZ:     operand_a_bitmanip = operand_a_rev;
         default: ;
       endcase
@@ -110,7 +114,7 @@ module alu
   assign adder_in_a         = {operand_a_bitmanip, 1'b1};
 
   // prepare operand b
-  assign operand_b_neg      = {fu_data_i.operand_b, 1'b0} ^ {CVA6Cfg.XLEN + 1{adder_op_b_negate}};
+  assign operand_b_neg      = {operand_b, 1'b0} ^ {CVA6Cfg.XLEN + 1{adder_op_b_negate}};
   assign adder_in_b         = operand_b_neg;
 
   // actual adder
@@ -155,7 +159,7 @@ module alu
   logic [CVA6Cfg.XLEN-1:0] shift_left_result;
   logic [            31:0] shift_left_result32;
 
-  assign shift_amt = fu_data_i.operand_b;
+  assign shift_amt = operand_b;
 
   assign shift_left = (fu_data_i.operation == SLL) | (CVA6Cfg.IS_XLEN64 && fu_data_i.operation == SLLW);
 
@@ -166,8 +170,8 @@ module alu
   logic [32:0] shift_op_a_32;
 
   // choose the bit reversed or the normal input for shift operand a
-  assign shift_op_a           = shift_left ? operand_a_rev : fu_data_i.operand_a;
-  assign shift_op_a32         = shift_left ? operand_a_rev32 : fu_data_i.operand_a[31:0];
+  assign shift_op_a           = shift_left ? operand_a_rev : operand_a;
+  assign shift_op_a32         = shift_left ? operand_a_rev32 : operand_a[31:0];
 
   assign shift_op_a_64        = {shift_arithmetic & shift_op_a[CVA6Cfg.XLEN-1], shift_op_a};
   assign shift_op_a_32        = {shift_arithmetic & shift_op_a[31], shift_op_a32};
@@ -203,8 +207,8 @@ module alu
             (fu_data_i.operation == MIN))
       sgn = 1'b1;
 
-    less = ($signed({sgn & fu_data_i.operand_a[CVA6Cfg.XLEN-1], fu_data_i.operand_a}) <
-            $signed({sgn & fu_data_i.operand_b[CVA6Cfg.XLEN-1], fu_data_i.operand_b}));
+    less = ($signed({sgn & operand_a[CVA6Cfg.XLEN-1], operand_a}) <
+            $signed({sgn & operand_b[CVA6Cfg.XLEN-1], operand_b}));
   end
 
   if (CVA6Cfg.RVB) begin : gen_bitmanip
@@ -242,31 +246,19 @@ module alu
 
   if (CVA6Cfg.RVB) begin : gen_orcbw_rev8w_results
     assign orcbw = {
-      {8{|fu_data_i.operand_a[31:24]}},
-      {8{|fu_data_i.operand_a[23:16]}},
-      {8{|fu_data_i.operand_a[15:8]}},
-      {8{|fu_data_i.operand_a[7:0]}}
+      {8{|operand_a[31:24]}}, {8{|operand_a[23:16]}}, {8{|operand_a[15:8]}}, {8{|operand_a[7:0]}}
     };
-    assign rev8w = {
-      {fu_data_i.operand_a[7:0]},
-      {fu_data_i.operand_a[15:8]},
-      {fu_data_i.operand_a[23:16]},
-      {fu_data_i.operand_a[31:24]}
-    };
+    assign rev8w = {{operand_a[7:0]}, {operand_a[15:8]}, {operand_a[23:16]}, {operand_a[31:24]}};
     if (CVA6Cfg.IS_XLEN64) begin : gen_64b
       assign orcbw_result = {
-        {8{|fu_data_i.operand_a[63:56]}},
-        {8{|fu_data_i.operand_a[55:48]}},
-        {8{|fu_data_i.operand_a[47:40]}},
-        {8{|fu_data_i.operand_a[39:32]}},
+        {8{|operand_a[63:56]}},
+        {8{|operand_a[55:48]}},
+        {8{|operand_a[47:40]}},
+        {8{|operand_a[39:32]}},
         orcbw
       };
       assign rev8w_result = {
-        rev8w,
-        {fu_data_i.operand_a[39:32]},
-        {fu_data_i.operand_a[47:40]},
-        {fu_data_i.operand_a[55:48]},
-        {fu_data_i.operand_a[63:56]}
+        rev8w, {operand_a[39:32]}, {operand_a[47:40]}, {operand_a[55:48]}, {operand_a[63:56]}
       };
     end else begin : gen_32b
       assign orcbw_result = orcbw;
@@ -279,26 +271,26 @@ module alu
     genvar i, m, n, q;
     for (i = 0; i < (CVA6Cfg.XLEN / 8); i++) begin : brev8_xperm8_gen
       // Generating xperm8_result by extracting bytes from operand a based on indices from operand b
-      assign xperm8_result[i << 3 +: 8] = (fu_data_i.operand_b[i << 3 +: 8] < (CVA6Cfg.XLEN / 8)) ? fu_data_i.operand_a[fu_data_i.operand_b[i << 3 +: 8] << 3 +: 8] : 8'b0;
+      assign xperm8_result[i << 3 +: 8] = (operand_b[i << 3 +: 8] < (CVA6Cfg.XLEN / 8)) ? operand_a[operand_b[i << 3 +: 8] << 3 +: 8] : 8'b0;
       // Generate brev8_reversed by reversing bits within each byte
       for (m = 0; m < 8; m++) begin : reverse_bits
         // Reversing the order of bits within a single byte
-        assign brev8_reversed[(i<<3)+m] = fu_data_i.operand_a[(i<<3)+(7-m)];
+        assign brev8_reversed[(i<<3)+m] = operand_a[(i<<3)+(7-m)];
       end
     end
     for (q = 0; q < (CVA6Cfg.XLEN / 4); q++) begin : xperm4_gen
       // Generating xperm4_result by extracting nibbles from operand a based on indices from operand b
-      assign xperm4_result[q << 2 +: 4] = (fu_data_i.operand_b[q << 2 +: 4] < (CVA6Cfg.XLEN / 4)) ? fu_data_i.operand_a[{2'b0, fu_data_i.operand_b[q << 2 +: 4]} << 2 +: 4] : 4'b0;
+      assign xperm4_result[q << 2 +: 4] = (operand_b[q << 2 +: 4] < (CVA6Cfg.XLEN / 4)) ? operand_a[{2'b0, operand_b[q << 2 +: 4]} << 2 +: 4] : 4'b0;
     end
     if (CVA6Cfg.IS_XLEN32) begin
       // Generate zip and unzip results
       for (n = 0; n < 16; n++) begin : zip_unzip_gen
         // Assigning lower and upper half of operand into the even and odd positions of result
-        assign zip_gen[n<<1] = fu_data_i.operand_a[n];
-        assign zip_gen[(n<<1)+1] = fu_data_i.operand_a[n+16];
+        assign zip_gen[n<<1] = operand_a[n];
+        assign zip_gen[(n<<1)+1] = operand_a[n+16];
         // Assigning even and odd bits of operand into lower and upper halves of result
-        assign unzip_gen[n] = fu_data_i.operand_a[n<<1];
-        assign unzip_gen[n+16] = fu_data_i.operand_a[(n<<1)+1];
+        assign unzip_gen[n] = operand_a[n<<1];
+        assign unzip_gen[n+16] = operand_a[(n<<1)+1];
       end
     end
   end
@@ -321,9 +313,9 @@ module alu
     end
     unique case (fu_data_i.operation)
       // Standard Operations
-      ANDL, ANDN: result_o = fu_data_i.operand_a & operand_b_neg[CVA6Cfg.XLEN:1];
-      ORL, ORN: result_o = fu_data_i.operand_a | operand_b_neg[CVA6Cfg.XLEN:1];
-      XORL, XNOR: result_o = fu_data_i.operand_a ^ operand_b_neg[CVA6Cfg.XLEN:1];
+      ANDL, ANDN: result_o = operand_a & operand_b_neg[CVA6Cfg.XLEN:1];
+      ORL, ORN: result_o = operand_a | operand_b_neg[CVA6Cfg.XLEN:1];
+      XORL, XNOR: result_o = operand_a ^ operand_b_neg[CVA6Cfg.XLEN:1];
       // Adder Operations
       ADD, SUB, ADDUW, SH1ADD, SH2ADD, SH3ADD: result_o = adder_result;
       // Shift Operations
@@ -335,11 +327,11 @@ module alu
 
     if (CVA6Cfg.RVB) begin
       // Index for Bitwise Rotation
-      bit_indx = 1 << (fu_data_i.operand_b & (CVA6Cfg.XLEN - 1));
+      bit_indx = 1 << (operand_b & (CVA6Cfg.XLEN - 1));
       if (CVA6Cfg.IS_XLEN64) begin
         // rolw, roriw, rorw
-        rolw = ({{CVA6Cfg.XLEN-32{1'b0}},fu_data_i.operand_a[31:0]} << fu_data_i.operand_b[4:0]) | ({{CVA6Cfg.XLEN-32{1'b0}},fu_data_i.operand_a[31:0]} >> (CVA6Cfg.XLEN-32-fu_data_i.operand_b[4:0]));
-        rorw = ({{CVA6Cfg.XLEN-32{1'b0}},fu_data_i.operand_a[31:0]} >> fu_data_i.operand_b[4:0]) | ({{CVA6Cfg.XLEN-32{1'b0}},fu_data_i.operand_a[31:0]} << (CVA6Cfg.XLEN-32-fu_data_i.operand_b[4:0]));
+        rolw = ({{CVA6Cfg.XLEN-32{1'b0}},operand_a[31:0]} << operand_b[4:0]) | ({{CVA6Cfg.XLEN-32{1'b0}},operand_a[31:0]} >> (CVA6Cfg.XLEN-32-operand_b[4:0]));
+        rorw = ({{CVA6Cfg.XLEN-32{1'b0}},operand_a[31:0]} >> operand_b[4:0]) | ({{CVA6Cfg.XLEN-32{1'b0}},operand_a[31:0]} << (CVA6Cfg.XLEN-32-operand_b[4:0]));
         unique case (fu_data_i.operation)
           CLZW, CTZW:
           result_o = (lz_tz_wempty) ? 32 : {{CVA6Cfg.XLEN - 5{1'b0}}, lz_tz_wcount};  // change
@@ -350,16 +342,16 @@ module alu
       end
       unique case (fu_data_i.operation)
         // Integer minimum/maximum
-        MAX:  result_o = less ? fu_data_i.operand_b : fu_data_i.operand_a;
-        MAXU: result_o = less ? fu_data_i.operand_b : fu_data_i.operand_a;
-        MIN:  result_o = ~less ? fu_data_i.operand_b : fu_data_i.operand_a;
-        MINU: result_o = ~less ? fu_data_i.operand_b : fu_data_i.operand_a;
+        MAX:  result_o = less ? operand_b : operand_a;
+        MAXU: result_o = less ? operand_b : operand_a;
+        MIN:  result_o = ~less ? operand_b : operand_a;
+        MINU: result_o = ~less ? operand_b : operand_a;
 
         // Single bit instructions operations
-        BCLR, BCLRI: result_o = fu_data_i.operand_a & ~bit_indx;
-        BEXT, BEXTI: result_o = {{CVA6Cfg.XLEN - 1{1'b0}}, |(fu_data_i.operand_a & bit_indx)};
-        BINV, BINVI: result_o = fu_data_i.operand_a ^ bit_indx;
-        BSET, BSETI: result_o = fu_data_i.operand_a | bit_indx;
+        BCLR, BCLRI: result_o = operand_a & ~bit_indx;
+        BEXT, BEXTI: result_o = {{CVA6Cfg.XLEN - 1{1'b0}}, |(operand_a & bit_indx)};
+        BINV, BINVI: result_o = operand_a ^ bit_indx;
+        BSET, BSETI: result_o = operand_a | bit_indx;
 
         // Count Leading/Trailing Zeros
         CLZ, CTZ:
@@ -370,31 +362,31 @@ module alu
         CPOP, CPOPW: result_o = {{(CVA6Cfg.XLEN - ($clog2(CVA6Cfg.XLEN) + 1)) {1'b0}}, cpop};
 
         // Sign and Zero Extend
-        SEXTB: result_o = {{CVA6Cfg.XLEN - 8{fu_data_i.operand_a[7]}}, fu_data_i.operand_a[7:0]};
-        SEXTH: result_o = {{CVA6Cfg.XLEN - 16{fu_data_i.operand_a[15]}}, fu_data_i.operand_a[15:0]};
-        ZEXTH: result_o = {{CVA6Cfg.XLEN - 16{1'b0}}, fu_data_i.operand_a[15:0]};
+        SEXTB: result_o = {{CVA6Cfg.XLEN - 8{operand_a[7]}}, operand_a[7:0]};
+        SEXTH: result_o = {{CVA6Cfg.XLEN - 16{operand_a[15]}}, operand_a[15:0]};
+        ZEXTH: result_o = {{CVA6Cfg.XLEN - 16{1'b0}}, operand_a[15:0]};
 
         // Bitwise Rotation
         ROL:
-        result_o = (CVA6Cfg.IS_XLEN64) ? ((fu_data_i.operand_a << fu_data_i.operand_b[5:0]) | (fu_data_i.operand_a >> (CVA6Cfg.XLEN-fu_data_i.operand_b[5:0]))) : ((fu_data_i.operand_a << fu_data_i.operand_b[4:0]) | (fu_data_i.operand_a >> (CVA6Cfg.XLEN-fu_data_i.operand_b[4:0])));
+        result_o = (CVA6Cfg.IS_XLEN64) ? ((operand_a << operand_b[5:0]) | (operand_a >> (CVA6Cfg.XLEN-operand_b[5:0]))) : ((operand_a << operand_b[4:0]) | (operand_a >> (CVA6Cfg.XLEN-operand_b[4:0])));
 
         ROR, RORI:
-        result_o = (CVA6Cfg.IS_XLEN64) ? ((fu_data_i.operand_a >> fu_data_i.operand_b[5:0]) | (fu_data_i.operand_a << (CVA6Cfg.XLEN-fu_data_i.operand_b[5:0]))) : ((fu_data_i.operand_a >> fu_data_i.operand_b[4:0]) | (fu_data_i.operand_a << (CVA6Cfg.XLEN-fu_data_i.operand_b[4:0])));
+        result_o = (CVA6Cfg.IS_XLEN64) ? ((operand_a >> operand_b[5:0]) | (operand_a << (CVA6Cfg.XLEN-operand_b[5:0]))) : ((operand_a >> operand_b[4:0]) | (operand_a << (CVA6Cfg.XLEN-operand_b[4:0])));
 
         ORCB: result_o = orcbw_result;
         REV8: result_o = rev8w_result;
 
         default:
         if (fu_data_i.operation == SLLIUW && CVA6Cfg.IS_XLEN64)
-          result_o = {{CVA6Cfg.XLEN-32{1'b0}}, fu_data_i.operand_a[31:0]} << fu_data_i.operand_b[5:0];  // Left Shift 32 bit unsigned
+          result_o = {{CVA6Cfg.XLEN-32{1'b0}}, operand_a[31:0]} << operand_b[5:0];  // Left Shift 32 bit unsigned
       endcase
     end
     if (CVA6Cfg.RVZiCond) begin
       unique case (fu_data_i.operation)
         CZERO_EQZ:
-        result_o = (|fu_data_i.operand_b) ? fu_data_i.operand_a : '0;  // move zero to rd if rs2 is equal to zero else rs1
+        result_o = (|operand_b) ? operand_a : '0;  // move zero to rd if rs2 is equal to zero else rs1
         CZERO_NEZ:
-        result_o = (|fu_data_i.operand_b) ? '0 : fu_data_i.operand_a; // move zero to rd if rs2 is nonzero else rs1
+        result_o = (|operand_b) ? '0 : operand_a;  // move zero to rd if rs2 is nonzero else rs1
         default: ;  // default case to suppress unique warning
       endcase
     end
@@ -402,18 +394,16 @@ module alu
     if (CVA6Cfg.ZKN && CVA6Cfg.RVB) begin
       unique case (fu_data_i.operation)
         PACK:
-        result_o = (CVA6Cfg.IS_XLEN32) ? ({fu_data_i.operand_b[15:0], fu_data_i.operand_a[15:0]}) : ({fu_data_i.operand_b[31:0], fu_data_i.operand_a[31:0]});
+        result_o = (CVA6Cfg.IS_XLEN32) ? ({operand_b[15:0], operand_a[15:0]}) : ({operand_b[31:0], operand_a[31:0]});
         PACK_H:
-        result_o = (CVA6Cfg.IS_XLEN32) ? ({16'b0, fu_data_i.operand_b[7:0], fu_data_i.operand_a[7:0]}) : ({48'b0, fu_data_i.operand_b[7:0], fu_data_i.operand_a[7:0]});
+        result_o = (CVA6Cfg.IS_XLEN32) ? ({16'b0, operand_b[7:0], operand_a[7:0]}) : ({48'b0, operand_b[7:0], operand_a[7:0]});
         BREV8: result_o = brev8_reversed;
         XPERM8: result_o = xperm8_result;
         XPERM4: result_o = xperm4_result;
         default: ;
       endcase
       if (fu_data_i.operation == PACK_W && CVA6Cfg.IS_XLEN64)
-        result_o = {
-          {32{fu_data_i.operand_b[15]}}, {fu_data_i.operand_b[15:0]}, {fu_data_i.operand_a[15:0]}
-        };
+        result_o = {{32{operand_b[15]}}, {operand_b[15:0]}, {operand_a[15:0]}};
       if (CVA6Cfg.IS_XLEN32) begin
         if (fu_data_i.operation == UNZIP) result_o = unzip_gen;
         if (fu_data_i.operation == ZIP) result_o = zip_gen;


### PR DESCRIPTION
As suggested by Jean Roch, this reduces the diff to CHERI. It also reduces the length of many lines in the ALU, making them clearer to read.