### PR TITLE
Fix tval reported values in some exception cases

### DIFF
--- a/core/branch_unit.sv
+++ b/core/branch_unit.sv
@@ -120,7 +120,9 @@ module branch_unit #(
     branch_exception_o.cause = riscv::INSTR_ADDR_MISALIGNED;
     branch_exception_o.valid = 1'b0;
     if (CVA6Cfg.TvalEn)
-      branch_exception_o.tval = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
+      branch_exception_o.tval = {
+        {CVA6Cfg.XLEN - CVA6Cfg.VLEN{target_address[CVA6Cfg.VLEN-1]}}, target_address
+      };
     else branch_exception_o.tval = '0;
     branch_exception_o.tval2 = {CVA6Cfg.GPLEN{1'b0}};
     branch_exception_o.tinst = '0;

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -1886,6 +1886,7 @@ module decoder
         // set gva bit
         if (CVA6Cfg.RVH) instruction_o.ex.gva = v_i;
         else instruction_o.ex.gva = 1'b0;
+        if (CVA6Cfg.TvalEn) instruction_o.ex.tval = pc_i;
       end
       // -----------------
       // Interrupt Control

--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -1877,6 +1877,7 @@ module decoder
         end else if (priv_lvl_i == riscv::PRIV_LVL_M) begin
           instruction_o.ex.cause = riscv::ENV_CALL_MMODE;
         end
+        if (CVA6Cfg.TvalEn) instruction_o.ex.tval = '0;
       end else if (ebreak) begin
         // this exception is valid
         instruction_o.ex.valid = 1'b1;


### PR DESCRIPTION
I think this should fix: https://github.com/openhwgroup/cva6/issues/2451, https://github.com/openhwgroup/cva6/issues/898, https://github.com/openhwgroup/cva6/issues/3018, and https://github.com/openhwgroup/cva6/issues/3019