### PR TITLE
fix: mstatus.SXL/UXL should be 0 when S/U modes are not implemented

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1938,8 +1938,10 @@ module csr_regfile
       endcase
     end
     if (CVA6Cfg.IS_XLEN64) begin
-      mstatus_d.sxl = riscv::XLEN_64;
-      mstatus_d.uxl = riscv::XLEN_64;
+      if (CVA6Cfg.RVS) mstatus_d.sxl = riscv::XLEN_64;
+      else mstatus_d.sxl = riscv::XLEN_NA;
+      if (CVA6Cfg.RVU) mstatus_d.uxl = riscv::XLEN_64;
+      else mstatus_d.uxl = riscv::XLEN_NA;
     end
     if (!CVA6Cfg.RVU) begin
       mstatus_d.mpp = riscv::PRIV_LVL_M;

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -37,6 +37,7 @@ package riscv;
 
   // type which holds xlen
   typedef enum logic [1:0] {
+    XLEN_NA  = 2'b00,  // Used for mstatus.{S/U}XL when {S/U} not implemented
     XLEN_32  = 2'b01,
     XLEN_64  = 2'b10,
     XLEN_128 = 2'b11


### PR DESCRIPTION
This PR fixes #3182 by ensuring the SXL and UXL fields in mstatus are tied to 0 when S-mode or U-mode is not implemented, as required by the RISC-V Privileged Spec.