### PR TITLE
update GitHub's actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       NUM_JOBS: 8
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -25,7 +25,7 @@ jobs:
 
     - name: Cache toolchain
       id: cache-toolchain
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-toolchain
       with:
@@ -34,7 +34,7 @@ jobs:
 
     - name: Cache verilator
       id: cache-verilator
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-verilator
       with:
@@ -43,7 +43,7 @@ jobs:
 
     - name: Cache Spike
       id: cache-spike
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-spike
       with:
@@ -75,7 +75,7 @@ jobs:
     needs:
       build-riscv-tests
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -87,7 +87,7 @@ jobs:
 
     - name: Cache toolchain
       id: cache-toolchain
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-toolchain
       with:
@@ -96,7 +96,7 @@ jobs:
 
     - name: Cache verilator
       id: cache-verilator
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-verilator
       with:
@@ -105,7 +105,7 @@ jobs:
 
     - name: Cache Spike
       id: cache-spike
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-spike
       with:
@@ -141,7 +141,7 @@ jobs:
     needs:
       build-riscv-tests
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -153,7 +153,7 @@ jobs:
 
     - name: Cache toolchain
       id: cache-toolchain
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-toolchain
       with:
@@ -162,7 +162,7 @@ jobs:
 
     - name: Cache verilator
       id: cache-verilator
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-verilator
       with:
@@ -171,7 +171,7 @@ jobs:
 
     - name: Cache Spike
       id: cache-spike
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
           cache-name: cache-spike
       with:


### PR DESCRIPTION
GitHub indicates this warning:

Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v3, actions/ checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting
ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

So I ran this nu command:

ls .github/**/*.yml | get name | each {
  sed -i s=actions/cache@v3=actions/cache@v5= $in
  sed -i s=actions/checkout@v4=actions/checkout@v6= $in
}