### PR TITLE
fix: add elf_file and tohost_addr to verilog_plusargs in ariane_tb.cpp

### DIFF
--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -53,7 +53,7 @@
 // allow modulus.  You can also use a double, if you wish.
 static vluint64_t main_time = 0;
 
-static const char *verilog_plusargs[] = {"jtag_rbb_enable", "time_out", "debug_disable"};
+static const char *verilog_plusargs[] = {"jtag_rbb_enable", "time_out", "debug_disable", "elf_file", "tohost_addr"};
 
 extern dtm_t* dtm;
 extern remote_bitbang_t * jtag;


### PR DESCRIPTION
## Problem
When running Verilator simulation directly with `Variane_testharness`, the simulation never exits and times out because `tohost_addr` stays `0x0`.
`rvfi_tracer.sv` already supports `+elf_file` and `+tohost_addr` plusargs as fallback to find the tohost symbol address. However `ariane_tb.cpp` has a whitelist `verilog_plusargs[]` that blocks all plusargs not in the list before Verilator sees them. Since `elf_file` and `tohost_addr` were missing from this list, they were rejected with:
        **`invalid plus-arg (Verilog or HTIF) "+elf_file=test.elf"`**
## Fix
Add `elf_file` and `tohost_addr` to `verilog_plusargs[]` in `ariane_tb.cpp`.
## Evidence

- Without fix: `+elf_file` rejected, simulation hangs until timeout
- With fix: `rvfi_tracer.sv` finds tohost, simulation exits correctly
## Note
`verif/sim/Makefile` already passes both `+elf_file` and `+tohost_addr` in its simulation flow (lines 193-196 and 324-327). This fix makes direct Verilator usage consistent with the official verification flow.