### PR TITLE
Reduce Coremark execution time to alleviate the CI

### DIFF
--- a/.gitlab-ci/scripts/report_benchmark.py
+++ b/.gitlab-ci/scripts/report_benchmark.py
@@ -21,8 +21,8 @@ iterations = None
 valid_cycles = {
     "dhrystone_dual": 16282,
     "dhrystone_single": 22256,
-    "coremark_dual": 865167,
-    "coremark_single": 1294524,
+    "coremark_dual": 215642,
+    "coremark_single": 322997,
     "dhrystone_cv32a65x": 27329,
     "dhrystone_cv32a60x": 36629,
 }
@@ -33,7 +33,7 @@ for arg in sys.argv[1:]:
             iterations = 50
         else:
             if "--coremark" in arg:
-                iterations = 4
+                iterations = 1
         mode = arg.replace("-", "")
     else:
         path = arg

--- a/verif/regress/coremark.sh
+++ b/verif/regress/coremark.sh
@@ -76,7 +76,7 @@ cflags_opt=(
 cflags=(
         "${cflags_opt[@]}"
         "-DCOMPILER_FLAGS='\"${cflags_opt[*]}\"'"
-        -DITERATIONS=4
+        -DITERATIONS=1
         -DPERFORMANCE_RUN
         -DSKIP_TIME_CHECK
         -I../tests/custom/env

--- a/verif/tests/custom/coremark/coremark_main.c
+++ b/verif/tests/custom/coremark/coremark_main.c
@@ -281,6 +281,7 @@ for (i = 0; i < MULTITHREAD; i++)
             divisor = 1;
         results[0].iterations *= 1 + 10 / divisor;
     }
+    iterate(&results[0]);
     /* perform actual benchmark */
     start_time();
 #if (MULTITHREAD > 1)


### PR DESCRIPTION
Run one iteration before starting cycle counter, then run 1 iteration