### PR TITLE
Fix rvfi exception decoding

### DIFF
--- a/corev_apu/tb/rvfi_tracer.sv
+++ b/corev_apu/tb/rvfi_tracer.sv
@@ -179,6 +179,11 @@ module rvfi_tracer #(
             32'h6: cause = "ST_ADDR_MISALIGNED";
             32'h7: cause = "ST_ACCESS_FAULT";
             32'hb: cause = "ENV_CALL_MMODE";
+            32'h8: cause = "ENV_CALL_UMODE";
+            32'h9: cause = "ENV_CALL_SMODE";
+            32'hc: cause = "INSTR_PAGE_FAULT";
+            32'hd: cause = "LOAD_PAGE_FAULT";
+            32'hf: cause = "STORE_PAGE_FAULT";
           endcase;
           if (rvfi_i[i].insn[1:0] != 2'b11) begin
             $fwrite(f, "%s exception @ 0x%h (0x%h)\n", cause, pc64, rvfi_i[i].insn[15:0]);


### PR DESCRIPTION
This PR addresses the missing Sv39 page-fault cause decodings in the RVFI tracer reported in #3239. 

While implementing the fix, I audited the `case` statement against the RISC-V Privileged Architecture Specification and noticed that the U-mode and S-mode Environment Calls were also missing. I have added them alongside the page faults to ensure the tracer's logging is comprehensive.

### Changes Made in `corev_apu/tb/rvfi_tracer.sv`:
* Added Sv39 Page Faults: `INSTR_PAGE_FAULT` (0xc), `LOAD_PAGE_FAULT` (0xd), and `STORE_PAGE_FAULT` (0xf).
* Added Environment Calls: `ENV_CALL_UMODE` (0x8) and `ENV_CALL_SMODE` (0x9).
* Ensured strict alignment and formatting parity with the existing codebase.

### Related Issue
Fixes #3239 (Thanks to @sjo99-kr for the catch!)