### PR TITLE
fix dhrystone for GCC 15

### DIFF
--- a/verif/tests/custom/dhrystone/dhrystone_main.c
+++ b/verif/tests/custom/dhrystone/dhrystone_main.c
@@ -28,7 +28,7 @@ char            Ch_1_Glob,
 int             Arr_1_Glob [50];
 int             Arr_2_Glob [50] [50];
 
-Enumeration     Func_1 ();
+Enumeration Func_1 (Capital_Letter, Capital_Letter);
   /* forward declaration necessary since Enumeration may not simply be int */
 
 #ifndef REG


### PR DESCRIPTION
I was not able to run Dhrystone using GCC 15.1 because of compile-time errors.

This patch fixes the errors.

<details><summary>Trivia</summary>

By the way I discovered that the ugly parameter late declaration that I sometimes see in SystemVerilog code came from old versions of C.

```c
int foo(bar)
int bar;
{
    return bar;
}
```

instead of

```c
int foo(int bar)
{
    return bar;
}
```

is like

```sv
component foo (bar, baz);
    input logic bar;
    output logic baz;
    assign baz = bar;
endcomponent
```

instead of 

```sv
component foo (
    input logic bar,
    output logic baz
);
    assign baz = bar;
endcomponent
```

</details>