### PR TITLE
Add Spike-specific extension option in cva6.py for issue #3249

### DIFF
--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -128,8 +128,6 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spi
   Returns:
     cmd         : ISS run command
   """
-
-
   logging.info("Processing ISS setup file: %s" % iss_yaml)
   yaml_data = read_yaml(iss_yaml)
   # Search for matched ISS

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -804,8 +804,7 @@ def parse_args(cwd):
                       help="Spike command line parameters, run spike --help and spike --print-params to see more")
   parser.add_argument("--spike_extension", type=str, default="",
                       help="Additional ISA extensions enabled only for Spike simulation. "
-                         "Use this for extensions not yet supported by the GCC toolchain (e.g., svadu).")
-  
+                           "Use this for extensions not yet supported by the GCC toolchain (e.g., svadu).")
   rsg = parser.add_argument_group('Random seeds',
                                   'To control random seeds, use at most one '
                                   'of the --start_seed, --seed or --seed_yaml '

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -128,6 +128,8 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spi
   Returns:
     cmd         : ISS run command
   """
+
+
   logging.info("Processing ISS setup file: %s" % iss_yaml)
   yaml_data = read_yaml(iss_yaml)
   # Search for matched ISS
@@ -150,6 +152,15 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spi
       if m: cmd = re.sub(r"\<xlen\>", m.group('xlen'), cmd)
       if iss == "ovpsim":
         cmd = re.sub(r"\<cfg_path\>", setting_dir, cmd)
+      elif iss == "spike":
+        spike_isa = isa
+        if spike_extension_list !=['']:
+          for i in spike_extension_list:
+            if i!= "":
+              spike_isa += (f"_{i}")
+        cmd = re.sub(r"\<variant\>", spike_isa, cmd)
+        cmd = re.sub(r"\<priv\>", priv, cmd)
+        cmd = re.sub(r"\<target\>", target, cmd)
       elif iss == "whisper":
         if m:
           # TODO: Support u/s mode
@@ -793,6 +804,10 @@ def parse_args(cwd):
                       help="Choose additional z, s, x extensions")
   parser.add_argument("--spike_params", type=str, default="",
                       help="Spike command line parameters, run spike --help and spike --print-params to see more")
+  parser.add_argument("--spike_extension", type=str, default="",
+                      help="Additional ISA extensions enabled only for Spike simulation. "
+                         "Use this for extensions not yet supported by the GCC toolchain (e.g., svadu).")
+  
   rsg = parser.add_argument_group('Random seeds',
                                   'To control random seeds, use at most one '
                                   'of the --start_seed, --seed or --seed_yaml '
@@ -966,6 +981,9 @@ def load_config(args, cwd):
   if not "g" in args.isa: # LLVM complains if we add zicsr and zifencei when g is set.
     isa_extension_list.append("zicsr")
     isa_extension_list.append("zifencei")
+
+  global spike_extension_list
+  spike_extension_list = args.spike_extension.split(",")
 
   args.spike_params = get_full_spike_param_args(args.spike_params) if args.spike_params else ""
 

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -152,7 +152,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spi
         cmd = re.sub(r"\<cfg_path\>", setting_dir, cmd)
       elif iss == "spike":
         spike_isa = isa
-        if spike_extension_list !=['']:
+        if spike_extension_list != ['']:
           for i in spike_extension_list:
             if i!= "":
               spike_isa += (f"_{i}")

--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -154,7 +154,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, target, setting_dir, debug_cmd, priv, spi
         spike_isa = isa
         if spike_extension_list != ['']:
           for i in spike_extension_list:
-            if i!= "":
+            if i != "":
               spike_isa += (f"_{i}")
         cmd = re.sub(r"\<variant\>", spike_isa, cmd)
         cmd = re.sub(r"\<priv\>", priv, cmd)


### PR DESCRIPTION
This PR adds support for Spike-specific extension options in `cva6.py`, based on Issue #3249.

## Current state
In `cva6.py`, the `isa` argument is currently shared across all ISS configurations and is also passed to the riscv-compiler (`risc-gcc`).
Because of this, when I try to compare traces between Spike and Verilator while working on Svadu, the current argument handling causes problems.

<img width="1205" height="40" alt="image" src="https://github.com/user-attachments/assets/0d682481-d5ac-49a0-988f-a1c2a0a008d1" />

- Using `--isa_extension` applies the extension to both Spike and GCC, which leads to errors because the ISA string is shared.

<img width="1417" height="69" alt="image" src="https://github.com/user-attachments/assets/943481ef-56f5-4c57-af20-99a7ba98d6f4" />

- Using `--spike_params` is not sufficient either, because it does not update the Spike ISA/variant.



In my opinion, for robust verification of extensions to RVA23/RVB23, it is useful to configure Spike-specific ISA extensions independently from the compiler ISA.

--
## What this PR changes
This PR updates the simulation framework in `cva6.py` by:
- adding a new argument, `--spike_extension`
- applying the provided extension only to the Spike ISA setup


<img width="1412" height="51" alt="image" src="https://github.com/user-attachments/assets/9260424d-f1a5-4a38-95a1-a69b30ed645f" />
- Using `--spike_extension` (what I modified), it accurately reflects the spike-specfici extensions to `variant` for Spike.


--
## Why PR?
I'm working on Svadu extension to the CVA6 core in my local environment, but it is hard to verify my changes with this `cva6.py` framework for using Spike as a golden reference against Verilator.
It keeps triggering errors by sharing ISA between the compiler and Spike, making executing each step independently.
(It can be my fault, which I'm not familar with this CVA6 verification framework, but I tried my best....)

So I believe this makes it easier to use Spike as a golden reference for verification without affecting the GCC ISA configuration or other ISS settings.
And it is helpful to separate ISA for compiler (i.e., toolchain) and ISA for Spike for future RVA23/RVB23 extensions.


--
This modification may not be necessary for extensions that mainly affect the core pipeline, but it can be useful for extensions that affect architectural/MMU behavior than normal compiler-visible core extensions.

Thank you for reviewing this PR. If any concerns about the approach or the naming, please feel free to let me know :)