### PR TITLE
Implement Svpbmt extension support (parameter, PTE, PTW, CSRs)

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -140,6 +140,8 @@ module csr_regfile
     output logic scbcfe_o,
     // hypervisor-mode clean/flush cache block invalidate enable - ID_STAGE
     output logic hcbcfe_o,
+    // page-based memory type enable - EX_STAGE
+    output logic pbmte_o,
     // external interrupt in - SUBSYSTEM
     input logic [1:0] irq_i,
     // inter processor interrupt -> connected to machine mode sw - SUBSYSTEM
@@ -267,6 +269,8 @@ module csr_regfile
   logic [CVA6Cfg.XLEN-1:0] mtinst_q, mtinst_d;
   logic [CVA6Cfg.XLEN-1:0] mtval2_q, mtval2_d;
   logic fiom_d, fiom_q;
+  logic pbmte_d, pbmte_q;
+  logic hpbmte_d, hpbmte_q;
 
   logic [CVA6Cfg.XLEN-1:0] stvec_q, stvec_d;
   logic [CVA6Cfg.XLEN-1:0] scounteren_q, scounteren_d;
@@ -580,6 +584,9 @@ module csr_regfile
               csr_rdata[5:4] = hcbie_q;
               csr_rdata[6]   = hcbcfe_q;
             end
+            if (CVA6Cfg.SvpbmtEn && CVA6Cfg.IS_XLEN64) begin
+              csr_rdata[62] = hpbmte_q;
+            end
           end else begin
             read_access_exception = 1'b1;
           end
@@ -636,7 +643,10 @@ module csr_regfile
             csr_rdata[5:4] = mcbie_q;
             csr_rdata[6]   = mcbcfe_q;
           end
-          if (!CVA6Cfg.RVU && !CVA6Cfg.RVZiCbom) begin
+          if (CVA6Cfg.SvpbmtEn && CVA6Cfg.IS_XLEN64) begin
+            csr_rdata[62] = pbmte_q;
+          end
+          if (!CVA6Cfg.RVU && !CVA6Cfg.RVZiCbom && !CVA6Cfg.SvpbmtEn) begin
             read_access_exception = 1'b1;
           end
         end
@@ -1059,6 +1069,8 @@ module csr_regfile
     end
 
     fiom_d     = fiom_q;
+    pbmte_d    = pbmte_q;
+    hpbmte_d   = hpbmte_q;
     dcache_d   = dcache_q;
     icache_d   = icache_q;
     acc_cons_d = acc_cons_q;
@@ -1523,6 +1535,7 @@ module csr_regfile
               endcase
               hcbcfe_d = csr_wdata[6];
             end
+            if (CVA6Cfg.SvpbmtEn && CVA6Cfg.IS_XLEN64) hpbmte_d = csr_wdata[62] & pbmte_q;
           end else begin
             update_access_exception = 1'b1;
           end
@@ -1705,6 +1718,7 @@ module csr_regfile
             endcase
             mcbcfe_d = csr_wdata[6];
           end
+          if (CVA6Cfg.SvpbmtEn && CVA6Cfg.IS_XLEN64) pbmte_d = csr_wdata[62];
         end
         riscv::CSR_MENVCFGH: begin
           if (!CVA6Cfg.RVU || CVA6Cfg.XLEN != 32) update_access_exception = 1'b1;
@@ -2702,6 +2716,13 @@ module csr_regfile
   assign mcbcfe_o = CVA6Cfg.RVZiCbom ? mcbcfe_q : 1'b0;
   assign scbcfe_o = CVA6Cfg.RVZiCbom ? scbcfe_q : 1'b0;
   assign hcbcfe_o = CVA6Cfg.RVZiCbom ? hcbcfe_q : 1'b0;
+
+  // Svpbmt: effective PBMTE depends on virtualization mode.
+  // In HS-mode (v=0): effective = menvcfg.PBMTE
+  // In VS/VU-mode (v=1): effective = menvcfg.PBMTE AND henvcfg.PBMTE
+  assign pbmte_o = CVA6Cfg.SvpbmtEn ?
+                   (CVA6Cfg.RVH ? (pbmte_q & (v_q ? hpbmte_q : 1'b1)) : pbmte_q) :
+                   1'b0;
   // we support bare memory addressing and SV39
   if (CVA6Cfg.RVH) begin
     assign en_translation_o = (((config_pkg::vm_mode_t'(satp_q.mode) == CVA6Cfg.MODE_SV && !v_q) || (config_pkg::vm_mode_t'(vsatp_q.mode) == CVA6Cfg.MODE_SV && v_q)) &&
@@ -2780,6 +2801,8 @@ module csr_regfile
       mscratch_q       <= {CVA6Cfg.XLEN{1'b0}};
       if (CVA6Cfg.TvalEn) mtval_q <= {CVA6Cfg.XLEN{1'b0}};
       fiom_q          <= '0;
+      pbmte_q         <= '0;
+      hpbmte_q        <= '0;
       dcache_q        <= {{CVA6Cfg.XLEN - 1{1'b0}}, 1'b1};
       icache_q        <= {{CVA6Cfg.XLEN - 1{1'b0}}, 1'b1};
       mcountinhibit_q <= '0;
@@ -2878,6 +2901,8 @@ module csr_regfile
       mscratch_q       <= mscratch_d;
       if (CVA6Cfg.TvalEn) mtval_q <= mtval_d;
       fiom_q          <= fiom_d;
+      pbmte_q         <= pbmte_d;
+      hpbmte_q        <= hpbmte_d;
       dcache_q        <= dcache_d;
       icache_q        <= icache_d;
       mcountinhibit_q <= mcountinhibit_d;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -570,6 +570,7 @@ module cva6
   logic vs_sum_csr_ex;
   logic mxr_csr_ex;
   logic vmxr_csr_ex;
+  logic pbmte_csr_ex;
   logic [CVA6Cfg.PPNW-1:0] satp_ppn_csr_ex;
   logic [CVA6Cfg.ASID_WIDTH-1:0] asid_csr_ex;
   logic [CVA6Cfg.PPNW-1:0] vsatp_ppn_csr_ex;
@@ -1085,6 +1086,7 @@ module cva6
       .vs_sum_i                (vs_sum_csr_ex),                  // from CSR
       .mxr_i                   (mxr_csr_ex),                     // from CSR
       .vmxr_i                  (vmxr_csr_ex),                    // from CSR
+      .pbmte_i                 (pbmte_csr_ex),                   // from CSR
       .satp_ppn_i              (satp_ppn_csr_ex),                // from CSR
       .asid_i                  (asid_csr_ex),                    // from CSR
       .vsatp_ppn_i             (vsatp_ppn_csr_ex),               // from CSR
@@ -1215,6 +1217,7 @@ module cva6
       .vs_sum_o                (vs_sum_csr_ex),
       .mxr_o                   (mxr_csr_ex),
       .vmxr_o                  (vmxr_csr_ex),
+      .pbmte_o                 (pbmte_csr_ex),
       .satp_ppn_o              (satp_ppn_csr_ex),
       .asid_o                  (asid_csr_ex),
       .vsatp_ppn_o             (vsatp_ppn_csr_ex),

--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -63,6 +63,8 @@ module cva6_mmu
     output logic lsu_valid_o,  // translation is valid
     output logic [CVA6Cfg.PLEN-1:0] lsu_paddr_o,  // translated address
     output exception_t lsu_exception_o,  // address translation threw an exception
+    // Svpbmt: page-based memory type for data accesses - EX_STAGE
+    output logic [1:0] lsu_pbmt_o,
     // General control signals
     input riscv::priv_lvl_t priv_lvl_i,
     input logic v_i,
@@ -72,6 +74,7 @@ module cva6_mmu
     input logic vs_sum_i,
     input logic mxr_i,
     input logic vmxr_i,
+    input logic pbmte_i,
     input logic mbe_i,
     input logic hlvx_inst_i,
     input logic hs_ld_st_inst_i,
@@ -108,7 +111,8 @@ module cva6_mmu
   // memory management, pte for cva6
   localparam type pte_cva6_t = struct packed {
     logic n;
-    logic [8:0] reserved;
+    logic [1:0] pbmt;  // bits [62:61] -- PBMT field (Svpbmt, currently unused)
+    logic [6:0] reserved;  // bits [60:54] -- truly reserved, must be zero
     logic [CVA6Cfg.PPNW-1:0] ppn;  // PPN length for
     logic [1:0] rsw;
     logic d;
@@ -124,6 +128,7 @@ module cva6_mmu
   localparam type tlb_update_cva6_t = struct packed {
     logic valid;
     logic is_napot_64k;  // Svnapot: Flag indicating a 64KiB NAPOT page
+    logic [1:0] pbmt;  // Svpbmt: Page-based memory type (bits [62:61] of PTE)
     logic [CVA6Cfg.PtLevels-2:0][HYP_EXT:0] is_page;
     logic [CVA6Cfg.VpnLen-1:0] vpn;
     logic [CVA6Cfg.ASID_WIDTH-1:0] asid;
@@ -168,6 +173,10 @@ module cva6_mmu
   logic                               dtlb_lu_hit;
   logic      [     CVA6Cfg.GPLEN-1:0] dtlb_gpaddr;
 
+  // Svpbmt: PBMT value from TLB lookup
+  logic      [                   1:0] itlb_pbmt;
+  logic      [                   1:0] dtlb_pbmt;
+
   logic shared_tlb_access, shared_tlb_miss;
   logic shared_tlb_hit, itlb_req;
 
@@ -207,6 +216,7 @@ module cva6_mmu
       .vaddr_to_be_flushed_i,
       .gpaddr_to_be_flushed_i,
       .lu_is_page_o  (itlb_is_page),
+      .lu_pbmt_o     (itlb_pbmt),
       .lu_hit_o      (itlb_lu_hit)
   );
 
@@ -238,6 +248,7 @@ module cva6_mmu
       .vaddr_to_be_flushed_i,
       .gpaddr_to_be_flushed_i,
       .lu_is_page_o  (dtlb_is_page),
+      .lu_pbmt_o     (dtlb_pbmt),
       .lu_hit_o      (dtlb_lu_hit)
   );
 
@@ -345,6 +356,7 @@ module cva6_mmu
       .hgatp_ppn_i,
       .mxr_i,
       .vmxr_i,
+      .pbmte_i,
       .mbe_i(mbe_i),
       // Performance counters
       .shared_tlb_miss_o(shared_tlb_miss),  //open for now
@@ -499,6 +511,7 @@ module cva6_mmu
   logic lsu_is_store_n, lsu_is_store_q;
   logic dtlb_hit_n, dtlb_hit_q;
   logic [CVA6Cfg.PtLevels-2:0] dtlb_is_page_n, dtlb_is_page_q;
+  logic [1:0] dtlb_pbmt_n, dtlb_pbmt_q;  // Svpbmt: registered PBMT from DTLB
   exception_t misaligned_ex_n, misaligned_ex_q;
 
   // check if we need to do translation or if we are always ready (e.g.: we are not translating anything)
@@ -514,10 +527,12 @@ module cva6_mmu
     dtlb_hit_n = dtlb_lu_hit;
     lsu_is_store_n = lsu_is_store_i;
     dtlb_is_page_n = dtlb_is_page;
+    dtlb_pbmt_n = dtlb_pbmt;
     misaligned_ex_n = misaligned_ex_i;
 
     lsu_valid_o = lsu_req_q;
     lsu_exception_o = misaligned_ex_q;
+    lsu_pbmt_o = 2'b00;  // Svpbmt: default to PMA (no override)
 
     // mute misaligned exceptions if there is no request otherwise they will throw accidental exceptions
     misaligned_ex_n.valid = misaligned_ex_i.valid & lsu_req_i;
@@ -547,6 +562,7 @@ module cva6_mmu
     // translation is enabled and no misaligned exception occurred
     if ((en_ld_st_translation_i || en_ld_st_g_translation_i) && !misaligned_ex_q.valid) begin
       lsu_valid_o = 1'b0;
+      lsu_pbmt_o = CVA6Cfg.SvpbmtEn ? dtlb_pbmt_q : 2'b00;
 
       lsu_dtlb_ppn_o = (en_ld_st_g_translation_i && CVA6Cfg.RVH) ? dtlb_g_content.ppn : dtlb_content.ppn;
       lsu_paddr_o = {
@@ -745,6 +761,7 @@ module cva6_mmu
       dtlb_hit_q      <= '0;
       lsu_is_store_q  <= '0;
       dtlb_is_page_q  <= '0;
+      dtlb_pbmt_q     <= '0;
       lsu_tinst_q     <= '0;
       hs_ld_st_inst_q <= '0;
       misaligned_ex_q <= '0;
@@ -755,6 +772,7 @@ module cva6_mmu
       dtlb_hit_q      <= dtlb_hit_n;
       lsu_is_store_q  <= lsu_is_store_n;
       dtlb_is_page_q  <= dtlb_is_page_n;
+      dtlb_pbmt_q     <= dtlb_pbmt_n;
       misaligned_ex_q <= misaligned_ex_n;
 
       if (CVA6Cfg.RVH) begin

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -78,6 +78,7 @@ module cva6_ptw
     input logic [CVA6Cfg.PPNW-1:0] hgatp_ppn_i,  // ppn from hgatp
     input logic                    mxr_i,
     input logic                    vmxr_i,
+    input logic                    pbmte_i,
     input logic                    mbe_i,
 
     // Performance counters
@@ -204,6 +205,7 @@ module cva6_ptw
   always_comb begin : tlb_update
     shared_tlb_update_o.valid = shared_tlb_update_valid;
     shared_tlb_update_o.is_napot_64k = is_napot_64k;
+    shared_tlb_update_o.pbmt = CVA6Cfg.SvpbmtEn ? pte.pbmt : 2'b00;
 
     // update the correct page table level
     for (int unsigned y = 0; y < HYP_EXT + 1; y++) begin
@@ -426,8 +428,11 @@ module cva6_ptw
           // -------------
           // Invalid PTE
           // -------------
-          // If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if pte.reserved !=0 in sv39 and sv39x4, stop and raise a page-fault exception.
-          if (!pte.v || (!pte.r && pte.w) || (|pte.reserved && CVA6Cfg.XLEN == 64) || (!CVA6Cfg.SvnapotEn && pte.n) || (CVA6Cfg.SvnapotEn && !(pte.r || pte.x) && pte.n))
+          // If pte.v = 0, or if pte.r = 0 and pte.w = 1, or if pte.reserved != 0
+          // (bits [60:54] in sv39/sv39x4), stop and raise a page-fault exception.
+          // Note: pte.pbmt (bits [62:61]) is intentionally excluded from this
+          // check per the Svpbmt extension (RISC-V Priv. Spec v1.12, 12.3).
+          if (!pte.v || (!pte.r && pte.w) || (|pte.reserved && CVA6Cfg.XLEN == 64) || (!CVA6Cfg.SvpbmtEn && |pte.pbmt && CVA6Cfg.XLEN == 64) || (!CVA6Cfg.SvnapotEn && pte.n) || (CVA6Cfg.SvnapotEn && !(pte.r || pte.x) && pte.n))
             state_d = PROPAGATE_ERROR;
           // -----------
           // Valid PTE
@@ -443,6 +448,15 @@ module cva6_ptw
                 // Svnapot: Any other encoding with the N-bit set is a reserved format and must cause a page fault
                 // Additionally, fault if N is set on a megapage or gigapage
                 if (!is_napot_64k) begin
+                  state_d = PROPAGATE_ERROR;
+                end
+              end
+
+              // Validate PBMT encoding on leaf PTEs
+              if (CVA6Cfg.SvpbmtEn) begin
+                if (pte.pbmt == 2'b11) begin
+                  state_d = PROPAGATE_ERROR;
+                end else if (!pbmte_i && (pte.pbmt != 2'b00)) begin
                   state_d = PROPAGATE_ERROR;
                 end
               end
@@ -576,6 +590,14 @@ module cva6_ptw
                     default: ;
                   endcase
                 end else ptw_pptr_n = {pte.ppn, vaddr_lvl[0][ptw_lvl_q[0]], (CVA6Cfg.PtLevels)'(0)};
+
+                // Svpbmt: non-leaf PTEs must have pbmt == 0 (reserved per spec).
+                // Placed after the RVH case block so ptw_stage_d is correctly
+                // preserved when both a stage transition and PBMT error apply.
+                if (CVA6Cfg.SvpbmtEn && pte.pbmt != 2'b00) begin
+                  state_d = PROPAGATE_ERROR;
+                  if (CVA6Cfg.RVH) ptw_stage_d = ptw_stage_q;
+                end
 
                 if (CVA6Cfg.RVH && (pte.a || pte.d || pte.u)) begin
                   state_d = PROPAGATE_ERROR;

--- a/core/cva6_mmu/cva6_shared_tlb.sv
+++ b/core/cva6_mmu/cva6_shared_tlb.sv
@@ -295,6 +295,7 @@ module cva6_shared_tlb #(
           itlb_update_o.asid = shared_tlb_update_i.asid;
           itlb_update_o.vmid = shared_tlb_update_i.vmid;
           itlb_update_o.is_napot_64k = shared_tlb_update_i.is_napot_64k;
+          itlb_update_o.pbmt = shared_tlb_update_i.pbmt;
 
         end else if (dtlb_req_q) begin
           dtlb_update_o.valid = 1'b1;
@@ -306,6 +307,7 @@ module cva6_shared_tlb #(
           dtlb_update_o.asid = shared_tlb_update_i.asid;
           dtlb_update_o.vmid = shared_tlb_update_i.vmid;
           dtlb_update_o.is_napot_64k = shared_tlb_update_i.is_napot_64k;
+          dtlb_update_o.pbmt = shared_tlb_update_i.pbmt;
         end
       end
     end else begin
@@ -342,6 +344,7 @@ module cva6_shared_tlb #(
               itlb_update_o.asid = tlb_update_asid_q;
               itlb_update_o.vmid = tlb_update_vmid_q;
               itlb_update_o.is_napot_64k = CVA6Cfg.SvnapotEn ? shared_tag_rd[i].is_napot_64k : 1'b0;
+              itlb_update_o.pbmt = CVA6Cfg.SvpbmtEn ? pte[i][0].pbmt : 2'b00;
             end else if (dtlb_req_q) begin
               dtlb_update_o.valid = 1'b1;
               dtlb_update_o.vpn = dtlb_vpn_q;
@@ -352,6 +355,7 @@ module cva6_shared_tlb #(
               dtlb_update_o.asid = tlb_update_asid_q;
               dtlb_update_o.vmid = tlb_update_vmid_q;
               dtlb_update_o.is_napot_64k = CVA6Cfg.SvnapotEn ? shared_tag_rd[i].is_napot_64k : 1'b0;
+              dtlb_update_o.pbmt = CVA6Cfg.SvpbmtEn ? pte[i][0].pbmt : 2'b00;
             end
           end
         end

--- a/core/cva6_mmu/cva6_tlb.sv
+++ b/core/cva6_mmu/cva6_tlb.sv
@@ -53,6 +53,7 @@ module cva6_tlb
     input logic [CVA6Cfg.VLEN-1:0] vaddr_to_be_flushed_i,
     input logic [CVA6Cfg.GPLEN-1:0] gpaddr_to_be_flushed_i,
     output logic [CVA6Cfg.PtLevels-2:0] lu_is_page_o,
+    output logic [1:0] lu_pbmt_o,  // Svpbmt: page-based memory type from TLB hit
     output logic lu_hit_o
 );
   localparam GPPN2 = (CVA6Cfg.XLEN == 32) ? CVA6Cfg.VLEN - 33 : 10;
@@ -70,6 +71,7 @@ module cva6_tlb
     logic [HYP_EXT*2:0] v_st_enbl;  // v_i, g-stage enabled, s-stage enabled
     logic valid;
     logic is_napot_64k;  // Svnapot: Flag indicating a 64KiB NAPOT page
+    logic [1:0] pbmt;  // Svpbmt: page-based memory type (bits [62:61] of PTE)
   } [TLB_ENTRIES-1:0]
       tags_q, tags_n;
 
@@ -190,6 +192,7 @@ module cva6_tlb
     lu_content_o   = '{default: 0};
     lu_g_content_o = '{default: 0};
     lu_is_page_o   = '{default: 0};
+    lu_pbmt_o      = 2'b00;
     match_asid     = '{default: 0};
     match_vmid     = CVA6Cfg.RVH ? '{default: 0} : '{default: 1};
     match_stage    = '{default: 0};
@@ -253,6 +256,7 @@ module cva6_tlb
         end
         if (|level_match[i] || napot_tag_match[i]) begin
           lu_is_page_o = is_page_o[i];
+          lu_pbmt_o    = CVA6Cfg.SvpbmtEn ? tags_q[i].pbmt : 2'b00;
           lu_hit_o     = 1'b1;
           lu_hit[i]    = 1'b1;
           // Patch the PPN on every TLB hit if this entry is a 64 KiB Svnapot page
@@ -392,7 +396,8 @@ module cva6_tlb
           update_i.is_page,
           update_i.v_st_enbl,
           1'b1,
-          CVA6Cfg.SvnapotEn ? update_i.is_napot_64k : 1'b0  // Svnapot: Propagate the NAPOT flag into the TLB entry
+          CVA6Cfg.SvnapotEn ? update_i.is_napot_64k : 1'b0,  // Svnapot: Propagate the NAPOT flag
+          CVA6Cfg.SvpbmtEn ? update_i.pbmt : 2'b00  // Svpbmt: Propagate the PBMT field
         };
         // update content as well
         content_n[i].pte = update_i.content;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -205,6 +205,7 @@ module ex_stage
     input logic mxr_i,
     // Make executable readable Virtual Supervisor - CSR_REGFILE
     input logic vmxr_i,
+    input logic pbmte_i,
     // TO_BE_COMPLETED - CSR_REGFILE
     input logic [CVA6Cfg.PPNW-1:0] satp_ppn_i,
     // TO_BE_COMPLETED - CSR_REGFILE
@@ -586,6 +587,7 @@ module ex_stage
       .vs_sum_i,
       .mxr_i,
       .vmxr_i,
+      .pbmte_i,
       .satp_ppn_i,
       .vsatp_ppn_i,
       .hgatp_ppn_i,

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -187,6 +187,7 @@ package build_config_pkg;
     cfg.DataTlbEntries = CVA6Cfg.DataTlbEntries;
     cfg.UseSharedTlb = CVA6Cfg.UseSharedTlb;
     cfg.SvnapotEn = CVA6Cfg.SvnapotEn;
+    cfg.SvpbmtEn = CVA6Cfg.SvpbmtEn;
     cfg.SharedTlbDepth = CVA6Cfg.SharedTlbDepth;
     cfg.VpnLen = VpnLen;
     cfg.PtLevels = PtLevels;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -263,6 +263,8 @@ package config_pkg;
     int unsigned SharedTlbDepth;
     // Option to enable Svnapot extension
     bit          SvnapotEn;
+    // Option to enable Svpbmt extension (page-based memory types)
+    bit          SvpbmtEn;
   } cva6_user_cfg_t;
 
   typedef struct packed {
@@ -349,6 +351,7 @@ package config_pkg;
     int unsigned DataTlbEntries;
     bit unsigned UseSharedTlb;
     bit SvnapotEn;
+    bit SvpbmtEn;
     int unsigned SharedTlbDepth;
     int unsigned VpnLen;
     int unsigned PtLevels;

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -111,6 +111,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(0),
       NrStorePipeRegs: int'(0),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -111,6 +111,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(0),
       NrStorePipeRegs: int'(0),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -164,6 +164,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -163,6 +163,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a60ax_config_pkg.sv
+++ b/core/include/cv64a60ax_config_pkg.sv
@@ -140,6 +140,7 @@ localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
    DataTlbEntries: int'(16),
    UseSharedTlb: bit'(0),
    SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
    SharedTlbDepth: int'(64),
    NrLoadPipeRegs: int'(0),
    NrStorePipeRegs: int'(0),

--- a/core/include/cv64a60ax_config_pkg_cvfpu-uvm.sv
+++ b/core/include/cv64a60ax_config_pkg_cvfpu-uvm.sv
@@ -129,6 +129,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(0),
       NrStorePipeRegs: int'(0),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -168,6 +168,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(1),
+      SvpbmtEn: bit'(1),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -175,6 +175,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -177,6 +177,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -168,6 +168,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -168,6 +168,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -168,6 +168,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -168,6 +168,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -170,6 +170,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/deprecated_packages/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/deprecated_packages/cv32a6_embedded_config_pkg_deprecated.sv
@@ -166,6 +166,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/deprecated_packages/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/deprecated_packages/cv32a6_imac_sv0_config_pkg.sv
@@ -164,6 +164,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/deprecated_packages/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/deprecated_packages/cv32a6_imafc_sv32_config_pkg.sv
@@ -164,6 +164,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/deprecated_packages/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/deprecated_packages/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -168,6 +168,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(16),
       UseSharedTlb: bit'(0),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(CVA6ConfigNrLoadPipeRegs),
       NrStorePipeRegs: int'(CVA6ConfigNrStorePipeRegs),

--- a/core/include/deprecated_packages/cv64a6_mmu_config_pkg.sv
+++ b/core/include/deprecated_packages/cv64a6_mmu_config_pkg.sv
@@ -118,6 +118,7 @@ package cva6_config_pkg;
       DataTlbEntries: int'(2),
       UseSharedTlb: bit'(1),
       SvnapotEn: bit'(0),
+      SvpbmtEn: bit'(0),
       SharedTlbDepth: int'(64),
       NrLoadPipeRegs: int'(0),
       NrStorePipeRegs: int'(0),

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -118,6 +118,7 @@ module load_store_unit
     input  logic                                      mxr_i,
     // Make Executable Readable Virtual Supervisor - CSR_REGFILE
     input  logic                                      vmxr_i,
+    input  logic                                      pbmte_i,
     // TO_BE_COMPLETED - TO_BE_COMPLETED
     input  logic             [      CVA6Cfg.PPNW-1:0] satp_ppn_i,
     // TO_BE_COMPLETED - TO_BE_COMPLETED
@@ -299,6 +300,7 @@ module load_store_unit
         .vs_sum_i,
         .mxr_i,
         .vmxr_i,
+        .pbmte_i,
         .mbe_i           (mbe_i),
 
         .hlvx_inst_i    (mmu_hlvx_inst),


### PR DESCRIPTION
## Description

This PR implements the RISC-V **Svpbmt** (Supervisor Page-Based Memory Types) extension for CVA6, as specified in the RISC-V Privileged Specification v1.12, Section 12.3.

All functionality is introduced behind a new `SvpbmtEn` configuration parameter. Existing configurations remain functionally unchanged (`SvpbmtEn=0` by default).

This PR is submitted as a complete **parameter + functionality** unit, following feedback from @JeanRochCoulon on the earlier incremental PRs (#3254, #3269, #3283).

---

### Changes

#### 1. Parameter Declaration
- `SvpbmtEn` added to `cva6_user_cfg_t` and `cva6_cfg_t` in `config_pkg.sv`
- Propagated through `build_config_pkg.sv`
- Added to all 19 target config packages (`bit'(0)` by default; `bit'(1)` in `cv64a6_imafdc_sv39` only)

#### 2. PTE Field Restructuring (`cva6_mmu.sv`)
- Split `pte_cva6_t.reserved[8:0]` into `pbmt[1:0]` (bits [62:61]) and `reserved[6:0]` (bits [60:54])
- Added `pbmt` field to `tlb_update_cva6_t` for the TLB refill path

#### 3. CSR Control Bits (`csr_regfile.sv`)
- Added `menvcfg.PBMTE` (bit 62): controls Svpbmt enable at M-mode
- Added `henvcfg.PBMTE` (bit 62): AND-masked with `menvcfg.PBMTE` on write, ensuring hypervisor isolation
- `pbmte_o` output accounts for virtualization mode (`v_q`):
  - HS-mode: `menvcfg.PBMTE`
  - VS/VU-mode: `menvcfg.PBMTE AND henvcfg.PBMTE`
- Both reset to 0 (extension disabled at boot)

#### 4. Signal Threading
- `pbmte` threaded from CSR regfile through `cva6.sv` -> `ex_stage.sv` -> `load_store_unit.sv` -> `cva6_mmu.sv` -> `cva6_ptw.sv`

#### 5. PTW Validation (`cva6_ptw.sv`)
- **Leaf PTEs**: Fault on reserved encoding (`pbmt==2'b11`); fault on non-zero `pbmt` when PBMTE disabled
- **Non-leaf PTEs**: Fault on any non-zero `pbmt` (spec requires `pbmt==0` for pointer PTEs)
- When `SvpbmtEn=0`: non-zero `pbmt` bits are treated as reserved fields and cause page faults

#### 6. TLB Storage and MMU Output
- `cva6_tlb.sv`: PBMT stored in TLB tag struct; `lu_pbmt_o` output on hit
- `cva6_shared_tlb.sv`: PBMT propagated through bypass and SRAM-backed update paths
- `cva6_mmu.sv`: `lsu_pbmt_o` output with registered pipeline (`dtlb_pbmt_n/q`)

---

### Limitations (deferred to future PRs)
- `lsu_pbmt_o` is not yet wired to the cache subsystem (HPDcache backend support)
- I-cache PBMT wiring is not included
- The PBMT value is surfaced at the MMU output but not yet consumed by downstream hardware

### Testing
- All existing tests are expected to pass since `SvpbmtEn=0` for most configurations
- `cv64a6_imafdc_sv39` config with `SvpbmtEn=1` exercises the gated paths via CI

### Related
- Closes the scope of #3254, #3269, #3283 (all previously closed per reviewer request to consolidate)
