### PR TITLE
Add Alveo U200 board support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ else ifeq ($(BOARD), nexys_video)
 	XILINX_PART              := xc7a200tsbg484-1
 	XILINX_BOARD             := digilentinc.com:nexys_video:part0:1.1
 	CLK_PERIOD_NS            := 40
+else ifeq ($(BOARD), u200)
+	XILINX_PART              := xcu200-fsgd2104-2-e
+	XILINX_BOARD             := xilinx.com:au200:part0:1.3
+	CLK_PERIOD_NS            := 20
 else
 $(error Unknown board - please specify a supported FPGA board)
 endif

--- a/corev_apu/fpga/Makefile
+++ b/corev_apu/fpga/Makefile
@@ -5,6 +5,19 @@ work-dir := work-fpga
 bit := $(work-dir)/ariane_xilinx.bit
 mcs := $(work-dir)/ariane_xilinx.mcs
 ip-dir := xilinx
+ifeq ($(BOARD), u200)
+ips := xlnx_axi_clock_converter.xci  \
+       xlnx_axi_dwidth_converter.xci \
+       xlnx_axi_dwidth_converter_dm_master.xci \
+       xlnx_axi_dwidth_converter_dm_slave.xci \
+       xlnx_axi_512_64_dwidth_converter.xci \
+       xlnx_axi_512_64_dwidth_converter_pcie.xci \
+       xlnx_axi_quad_spi.xci         \
+       xlnx_axi_gpio.xci             \
+       xlnx_clk_gen.xci              \
+       xlnx_xdma.xci                 \
+       xlnx_ddr4.xci
+else
 ips := xlnx_axi_clock_converter.xci  \
        xlnx_axi_dwidth_converter.xci \
        xlnx_axi_dwidth_converter_dm_master.xci \
@@ -14,6 +27,7 @@ ips := xlnx_axi_clock_converter.xci  \
        xlnx_clk_gen.xci              \
 	   xlnx_dpti_clk.xci             \
        xlnx_mig_7_ddr3.xci
+endif
 
 ips := $(addprefix $(work-dir)/, $(ips))
 ips-target := $(join $(addsuffix /ip/, $(addprefix $(ip-dir)/, $(basename $(ips)))), $(ips))

--- a/corev_apu/fpga/constraints/u200.xdc
+++ b/corev_apu/fpga/constraints/u200.xdc
@@ -1,0 +1,84 @@
+############################################################################
+### Alveo U200 (xcu200-fsgd2104-2-e) XDC for CVA6
+### Derived from VCU118 CVA6 XDC with U200-specific pin locations.
+###
+### NOTE: DDR4 and PCIe lane pin constraints are NOT included here.
+### They are generated automatically by the MIG (xlnx_ddr4) and XDMA
+### (xlnx_xdma) Vivado IPs respectively via board-file automation.
+### Only non-IP-managed user I/O and reference clocks appear below.
+############################################################################
+
+# Buttons / Reset
+# U200 CPU_RESET_FPGA is directly from the satellite controller (active-low).
+set_property -dict {PACKAGE_PIN AL20 IOSTANDARD LVCMOS12} [get_ports cpu_resetn] ;# Bank 64 VCCO - VCC1V2 - CPU_RESET_FPGA
+
+# 300 MHz System Reference Clock (SYSCLK1_300, Bank 64)
+# Independent board oscillator output for the CPU system PLL.
+# SYSCLK1_300 is in Bank 64 (LVDS, near all user I/O), leaving SYSCLK0_300
+# (Bank 42) free for the DDR4 MIG.  Decoupling the system PLL from the MIG
+# eliminates cascaded-MMCM jitter and cross-domain over-constraining.
+set_property -dict {PACKAGE_PIN AW20 IOSTANDARD LVDS} [get_ports ref_clk_p]
+set_property -dict {PACKAGE_PIN AW19 IOSTANDARD LVDS} [get_ports ref_clk_n]
+create_clock -name ref_clk -period 3.333 [get_ports ref_clk_p]
+
+# PCIe
+set_property -dict {PACKAGE_PIN BD21 IOSTANDARD LVCMOS12} [get_ports sys_rst_n];
+set_property PACKAGE_PIN AM11 [get_ports sys_clk_p]
+set_property PACKAGE_PIN AM10 [get_ports sys_clk_n]
+create_clock -name sys_clk -period 10 [get_ports sys_clk_p]
+
+# UART (FTDI FT4232 Port 3, exposed via microUSB on Alveo U200)
+# Bank 64 VCCO = 1.2V (LVCMOS12), unlike VCU118's 1.8V (LVCMOS18).
+set_property -dict {PACKAGE_PIN BF18 IOSTANDARD LVCMOS12} [get_ports rx]
+set_property -dict {PACKAGE_PIN BB20 IOSTANDARD LVCMOS12} [get_ports tx]
+
+# SD Card / SPI — not present on Alveo U200.
+# InclSPI is already 0 in the U200 ifdef, but the ports are still on the
+# top-level module (common section). Assign them to unused Bank 64 pins
+# so Vivado can place them without error.  They will be inactive.
+set_property -dict {PACKAGE_PIN AM19 IOSTANDARD LVCMOS12} [get_ports spi_clk_o] ;# SW_DP1 (unused)
+set_property -dict {PACKAGE_PIN AL19 IOSTANDARD LVCMOS12} [get_ports spi_ss]    ;# SW_DP2 (unused)
+set_property -dict {PACKAGE_PIN AP20 IOSTANDARD LVCMOS12} [get_ports spi_miso]  ;# SW_DP3 (unused)
+set_property -dict {PACKAGE_PIN AL21 IOSTANDARD LVCMOS12} [get_ports spi_mosi]  ;# SW_SET1_FPGA (unused)
+
+# JTAG and DPTI: the consumers (dmi_jtag, dpti_ctrl, slicer_DPTI) are gated
+# out under `ifdef U200`, so the input/inout ports (tck, tms, tdi, prog_clko,
+# prog_rxen, prog_txen, prog_spien, prog_d) are unread and Vivado trims them
+# automatically — no PACKAGE_PIN needed for those.
+#
+# The 5 output ports (tdo, prog_oen, prog_rdn, prog_wrn, prog_siwun) cannot
+# be optimized away — Vivado preserves any port declared on the top-level
+# interface — so we tie them to constants under `ifdef U200` in
+# ariane_xilinx.sv and park them on harmless Bank 64 GPIO_MSP / SW_DP test
+# pins below (verified against the U200 board file / reference XDC).
+set_property -dict {PACKAGE_PIN AR20 IOSTANDARD LVCMOS12} [get_ports tdo]        ;# GPIO_MSP[0]
+set_property -dict {PACKAGE_PIN AM20 IOSTANDARD LVCMOS12} [get_ports prog_oen]   ;# GPIO_MSP[1]
+set_property -dict {PACKAGE_PIN AM21 IOSTANDARD LVCMOS12} [get_ports prog_rdn]   ;# GPIO_MSP[2]
+set_property -dict {PACKAGE_PIN AN21 IOSTANDARD LVCMOS12} [get_ports prog_wrn]   ;# GPIO_MSP[3]
+set_property -dict {PACKAGE_PIN AN22 IOSTANDARD LVCMOS12} [get_ports prog_siwun] ;# SW_DP[0]
+
+# U200 has a quad SPI flash
+set_property CONFIG_VOLTAGE 1.8                        [current_design]
+set_property CONFIG_MODE {SPIx4}                       [current_design]
+set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable    [current_design]; # Golden image is the fall back image if  new …
+set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN disable [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 63.8          [current_design]
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4           [current_design]
+set_property BITSTREAM.GENERAL.COMPRESS TRUE           [current_design]
+set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES        [current_design]
+set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR Yes       [current_design]
+set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup         [current_design]
+
+
+#############################################
+# Asynchronous Clock Domain Crossings
+#############################################
+# Three independent clock trees exist in this design:
+#   1. ref_clk       (SYSCLK1_300 → xlnx_clk_gen MMCM → CPU 50 MHz, etc.)
+#   2. c0_sys_clk_p  (SYSCLK1_300 → DDR4 MIG → mmcm_clkout0 UI clock)
+#   3. sys_clk       (PCIe ref 100 MHz → XDMA → pcie_axi_clk, etc.)
+
+ set_clock_groups -asynchronous \
+  -group [get_clocks -include_generated_clocks ref_clk] \
+  -group [get_clocks -include_generated_clocks {c0_sys_clk_p mmcm_clkout0}] \
+  -group [get_clocks -include_generated_clocks sys_clk]

--- a/corev_apu/fpga/scripts/pcie_hot_reset.sh
+++ b/corev_apu/fpga/scripts/pcie_hot_reset.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+###############################################################################
+# pcie_hot_reset.sh — Re-enumerate an Alveo U200 after JTAG bitstream load.
+#
+# After Vivado hw_manager programs a new bitstream, the FPGA's PCIe hard block
+# resets.  The host must:
+#   1. Remove the stale device,
+#   2. Wait for the FPGA to finish configuration,
+#   3. Tell the upstream PCIe bridge to retrain the link,
+#   4. Rescan the bus.
+#
+# Usage:
+#   sudo ./pcie_hot_reset.sh            # uses defaults (10ee:903f)
+#   sudo ./pcie_hot_reset.sh 10ee:903f  # explicit vendor:device
+#
+# Run this AFTER Vivado finishes programming. The script handles the rest.
+###############################################################################
+set -euo pipefail
+
+VDID="${1:-10ee:903f}"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+echo "=== PCIe hot-reset for Alveo U200 (${VDID}) ==="
+
+###########################################################################
+# Step 1: Locate endpoint and its upstream bridge
+###########################################################################
+# lspci -D includes domain (e.g. 0000:02:00.0); strip it for setpci/lspci -s
+# but keep the full path for sysfs.
+EP_LINE=$(lspci -Dd "$VDID" 2>/dev/null | head -1)
+EP_BDF_FULL=$(echo "$EP_LINE" | awk '{print $1}')     # 0000:02:00.0
+EP_BDF=$(echo "$EP_BDF_FULL" | sed 's/^[0-9a-f]*://')  # 02:00.0
+BRIDGE_BDF=""
+
+if [[ -n "$EP_BDF" ]]; then
+    echo "[1] Endpoint found at $EP_BDF_FULL"
+
+    # The bridge is the parent directory in sysfs
+    EP_SYSFS="/sys/bus/pci/devices/${EP_BDF_FULL}"
+    if [[ -L "$EP_SYSFS" ]]; then
+        BRIDGE_SYSFS=$(dirname "$(readlink -f "$EP_SYSFS")")
+        BRIDGE_BDF=$(basename "$BRIDGE_SYSFS")
+        echo "    Upstream bridge: $BRIDGE_BDF"
+    fi
+
+    # Save the bridge's full config space (256 bytes) as a defensive
+    # snapshot.  In normal operation we only touch the PCIe Capability
+    # registers below, but if anything else gets disturbed during
+    # rescan we can restore the memory windows from this copy.
+    if [[ -n "$BRIDGE_BDF" ]]; then
+        BRIDGE_CFG_FILE="/tmp/bridge_${BRIDGE_BDF}_cfg.bin"
+        echo "    Saving bridge config → $BRIDGE_CFG_FILE"
+        cp "/sys/bus/pci/devices/${BRIDGE_BDF}/config" "$BRIDGE_CFG_FILE" 2>/dev/null || true
+    fi
+
+    # Remove the stale endpoint from the kernel
+    echo "[2] Removing stale endpoint $EP_BDF_FULL ..."
+    echo 1 > "/sys/bus/pci/devices/${EP_BDF_FULL}/remove"
+    sleep 1
+else
+    echo "[1] Device $VDID not currently visible."
+    echo "    Cannot auto-detect the upstream bridge without an endpoint."
+    echo "    After the rescan below brings the device back, re-run this"
+    echo "    script if you also need to retrain the link."
+    echo "[2] (skip — device already absent)"
+fi
+
+###########################################################################
+# Step 2: Wait for FPGA configuration + initial link training
+###########################################################################
+echo "[3] Waiting 5 s for FPGA configuration & link training ..."
+sleep 5
+
+###########################################################################
+# Step 3: Retrain the PCIe link via the upstream bridge
+###########################################################################
+if [[ -n "$BRIDGE_BDF" ]]; then
+    echo "[4] Retraining PCIe link on bridge $BRIDGE_BDF ..."
+
+    # setpci's "CAP_EXP+offset" syntax resolves the PCIe Express Capability
+    # base in the bridge's config space automatically — no manual cap-chain
+    # walking required. The PCIe spec layout inside the cap is:
+    #   +0x00  Capability ID / Next Pointer
+    #   +0x10  Link Control register (16-bit)
+    #   +0x12  Link Status  register (16-bit)
+
+    # Quick sanity check: is there an Express capability at all?
+    if setpci -s "$BRIDGE_BDF" CAP_EXP+0.b >/dev/null 2>&1; then
+        # Read current Link Control
+        LINK_CTL=$(setpci -s "$BRIDGE_BDF" CAP_EXP+0x10.w)
+        echo "    Current Link Control: 0x${LINK_CTL}"
+
+        # Set bit 5 = Retrain Link, write back
+        NEW_LINK_CTL=$(printf "%04x" $(( 16#${LINK_CTL} | 0x0020 )))
+        echo "    Setting Retrain Link bit → 0x${NEW_LINK_CTL}"
+        setpci -s "$BRIDGE_BDF" CAP_EXP+0x10.w=${NEW_LINK_CTL}
+
+        # Poll Link Status (bit 11 = Link Training, clears when done)
+        echo "    Waiting for link training ..."
+        for i in $(seq 1 20); do
+            sleep 0.5
+            LINK_STS=$(setpci -s "$BRIDGE_BDF" CAP_EXP+0x12.w)
+            LINK_TRAINING=$(( 16#${LINK_STS} & 0x0800 ))
+            if [[ $LINK_TRAINING -eq 0 ]]; then
+                LINK_SPEED=$(( 16#${LINK_STS} & 0x000F ))
+                LINK_WIDTH=$(( (16#${LINK_STS} >> 4) & 0x003F ))
+                echo "    Link trained! Speed: Gen${LINK_SPEED}, Width: x${LINK_WIDTH}"
+                break
+            fi
+            if [[ $i -eq 20 ]]; then
+                echo "    WARNING: Link training did not complete in 10 s!"
+            fi
+        done
+    else
+        echo "    WARNING: Bridge $BRIDGE_BDF has no PCIe Express capability."
+        echo "    Falling back to Secondary Bus Reset ..."
+        setpci -s "$BRIDGE_BDF" BRIDGE_CONTROL.w=0040:0040
+        sleep 1
+        setpci -s "$BRIDGE_BDF" BRIDGE_CONTROL.w=0000:0040
+        sleep 3
+    fi
+
+    # Restore the bridge's memory windows from the snapshot we saved
+    # earlier. With the link-retrain step above using only CAP_EXP-relative
+    # writes this is just defence-in-depth, but it's cheap insurance against
+    # anything else (BIOS/SMM, kernel quirks) disturbing the windows during
+    # rescan.
+    if [[ -f "${BRIDGE_CFG_FILE:-}" ]]; then
+        echo "    Restoring bridge memory windows from $BRIDGE_CFG_FILE ..."
+        # Bytes 0x20-0x2F: memory base/limit + prefetch base/limit
+        dd if="$BRIDGE_CFG_FILE" of="/sys/bus/pci/devices/${BRIDGE_BDF}/config" \
+           bs=1 skip=32 seek=32 count=16 conv=notrunc 2>/dev/null || true
+    fi
+else
+    echo "[4] (skip — no bridge BDF known)"
+fi
+
+###########################################################################
+# Step 4: Rescan the PCI bus
+###########################################################################
+echo "[5] Rescanning PCI bus ..."
+echo 1 > /sys/bus/pci/rescan
+sleep 2
+
+###########################################################################
+# Step 5: Verify and enable - if needed
+###########################################################################
+echo ""
+echo "=== Verification ==="
+
+NEW_BDF_FULL=$(lspci -Dd "$VDID" 2>/dev/null | head -1 | awk '{print $1}')
+NEW_BDF=$(echo "$NEW_BDF_FULL" | sed 's/^[0-9a-f]*://')
+
+if [[ -z "$NEW_BDF" ]]; then
+    echo "FAIL: Device $VDID not found after rescan."
+    echo ""
+    echo "Troubleshooting:"
+    echo "  dmesg | tail -40"
+    echo "  lspci -tv    # check if bridge still exists"
+    echo ""
+    echo "If the bridge itself vanished, you need a cold reboot."
+    exit 1
+fi
+
+echo "Device found at $NEW_BDF_FULL"
+
+# Check if memory space is enabled
+CMD=$(setpci -s "$NEW_BDF" COMMAND.w)
+MEM_EN=$(( 16#${CMD} & 0x0002 ))
+BM_EN=$((  16#${CMD} & 0x0004 ))
+
+if [[ $MEM_EN -eq 0 ]] || [[ $BM_EN -eq 0 ]]; then
+    echo "Enabling Memory Space + Bus Master on $NEW_BDF ..."
+    setpci -s "$NEW_BDF" COMMAND.w=0006:0006
+    sleep 0.5
+fi
+
+# Show BAR info
+echo ""
+lspci -vvs "$NEW_BDF" 2>/dev/null | grep -E "Region|LnkSta:|Memory" || true
+echo ""
+
+# Check for [disabled] or [virtual]
+BAR_LINE=$(lspci -vvs "$NEW_BDF" 2>/dev/null | grep "Region 0:" || true)
+if echo "$BAR_LINE" | grep -qE '\[disabled\]|\[virtual\]'; then
+    echo "WARNING: BAR0 is disabled/virtual. The bridge memory window may not cover it."
+    echo ""
+    echo "Bridge memory windows:"
+    lspci -vvs "${BRIDGE_BDF:-unknown}" 2>/dev/null | grep -E "Memory behind|Prefetchable" || true
+    echo ""
+    echo "This usually means the bridge windows (set at cold boot) don't include"
+    echo "the address Linux wants to assign to the BAR. Solutions:"
+    echo "  1. Add 'pci=realloc' to kernel cmdline and reboot once"
+    echo "  2. Cold reboot with the MCS programmed into SPI flash"
+    exit 1
+else
+    echo "BAR0 appears OK."
+fi
+
+# Quick read test
+RESOURCE="/sys/bus/pci/devices/${NEW_BDF_FULL}/resource0"
+if [[ -e "$RESOURCE" ]]; then
+    echo ""
+    echo "resource0: $(ls -la "$RESOURCE" 2>/dev/null)"
+    echo ""
+    echo "Ready to load:"
+    echo "  sudo ./pcie_load $RESOURCE 0x0 boot.bin"
+fi
+
+echo ""
+echo "=== Done ==="

--- a/corev_apu/fpga/scripts/pcie_load.c
+++ b/corev_apu/fpga/scripts/pcie_load.c
@@ -1,0 +1,174 @@
+/*
+ * pcie_load — Load a binary file into FPGA DRAM via PCIe BAR0 (mmap).
+ *
+ * Usage: sudo ./pcie_load <resource0_path> <bar_offset> <file>
+ *
+ * <bar_offset> is the offset within the BAR, NOT the final AXI address.
+ * The XDMA IP's pciebar2axibar_0 register adds a fixed base to produce
+ * the AXI address:  AXI_addr = pciebar2axibar_0 + bar_offset.
+ *
+ * If pciebar2axibar_0 = 0x80000000 (DRAM base), use bar_offset = 0x0:
+ *   sudo ./pcie_load /sys/bus/pci/devices/0000:02:00.0/resource0 0x0 boot.bin
+ *
+ * The BAR0 sysfs resource file is accessed via mmap (not read/write/seek).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+int main(int argc, char *argv[])
+{
+    if (argc != 4) {
+        fprintf(stderr, "Usage: %s <resource0> <bar_offset_hex> <payload_file>\n", argv[0]);
+        fprintf(stderr, "  e.g. %s /sys/bus/pci/devices/0000:02:00.0/resource0 0x0 boot.bin\n", argv[0]);
+        return 1;
+    }
+
+    const char *bar_path = argv[1];
+    unsigned long bar_offset = strtoul(argv[2], NULL, 0);
+    const char *payload_path = argv[3];
+
+    /* Open payload file */
+    int payload_fd = open(payload_path, O_RDONLY);
+    if (payload_fd < 0) {
+        perror("open payload");
+        return 1;
+    }
+
+    struct stat st;
+    if (fstat(payload_fd, &st) < 0) {
+        perror("fstat payload");
+        close(payload_fd);
+        return 1;
+    }
+    size_t payload_size = st.st_size;
+
+    /* Read payload into memory */
+    uint8_t *payload = malloc(payload_size);
+    if (!payload) {
+        perror("malloc");
+        close(payload_fd);
+        return 1;
+    }
+    size_t total_read = 0;
+    while (total_read < payload_size) {
+        ssize_t n = read(payload_fd, payload + total_read, payload_size - total_read);
+        if (n <= 0) {
+            perror("read payload");
+            free(payload);
+            close(payload_fd);
+            return 1;
+        }
+        total_read += n;
+    }
+    close(payload_fd);
+
+    /* Open BAR0 resource. We mmap the file below; open flags don't carry
+     * MMIO-ordering semantics on sysfs resource nodes, so plain O_RDWR is
+     * sufficient. */
+    int bar_fd = open(bar_path, O_RDWR);
+    if (bar_fd < 0) {
+        perror("open BAR0 resource");
+        free(payload);
+        return 1;
+    }
+
+    /* Get BAR size from file size */
+    struct stat bar_st;
+    if (fstat(bar_fd, &bar_st) < 0) {
+        perror("fstat BAR0");
+        close(bar_fd);
+        free(payload);
+        return 1;
+    }
+    size_t bar_size = bar_st.st_size;
+
+    if (bar_offset + payload_size > bar_size) {
+        fprintf(stderr, "Error: offset (0x%lx) + payload (%zu) exceeds BAR size (0x%zx)\n",
+                bar_offset, payload_size, bar_size);
+        close(bar_fd);
+        free(payload);
+        return 1;
+    }
+
+    /* mmap the entire BAR (or the needed portion).
+     * We map from the start of the BAR to cover the offset. */
+    size_t map_size = bar_offset + payload_size;
+    /* Round up to page size */
+    long page_size = sysconf(_SC_PAGESIZE);
+    map_size = (map_size + page_size - 1) & ~(page_size - 1);
+
+    void *bar_map = mmap(NULL, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, bar_fd, 0);
+    if (bar_map == MAP_FAILED) {
+        perror("mmap BAR0");
+        close(bar_fd);
+        free(payload);
+        return 1;
+    }
+
+    printf("BAR0 mapped at %p, size 0x%zx\n", bar_map, map_size);
+    printf("Writing %zu bytes to BAR offset 0x%lx ...\n", payload_size, bar_offset);
+
+    /* Stream the payload to DRAM via 64-bit MMIO writes. We deliberately
+     * write dst[0] LAST, with __sync_synchronize() barriers around it.
+     *
+     * The bootrom (corev_apu/fpga/src/bootrom/src/main.c) polls the
+     * first 8 bytes of DRAM for the XDMA_READY_MAGIC sentinel and jumps
+     * to OpenSBI as soon as those 8 bytes change. So dst[0] is effectively
+     * a release-store: when it changes, dst[1..N] must already be visible
+     * on the FPGA side. The volatile dst pointer + the surrounding memory
+     * barriers give us that ordering at the CPU level. PCIe's
+     * posted-write ordering rules then carry it through to DDR4.
+     *
+     * If we wrote dst[0] in sequence with the rest of the payload, the
+     * bootrom could observe the sentinel-replacement before later qwords
+     * have landed in DRAM, and execute partially-loaded firmware. */
+    volatile uint64_t *dst = (volatile uint64_t *)((uint8_t *)bar_map + bar_offset);
+    const uint64_t *src = (const uint64_t *)payload;
+    size_t qwords = payload_size / 8;
+    size_t remainder = payload_size % 8;
+
+    /* 1. Bulk: write qwords 1..N-1 in order */
+    for (size_t i = 1; i < qwords; i++) {
+        dst[i] = src[i];
+    }
+
+    /* 2. Trailing bytes (zero-padded into one extra qword) */
+    if (remainder) {
+        uint64_t last = 0;
+        memcpy(&last, payload + qwords * 8, remainder);
+        dst[qwords] = last;
+    }
+
+    /* 3. Release-store the first qword last (the sentinel-replacement). */
+    __sync_synchronize();
+    dst[0] = src[0];
+    __sync_synchronize();
+
+    /* Read back first 8 bytes as round-trip verification.
+     * If this returns 0xFFFFFFFFFFFFFFFF, the PCIe link or BAR is broken.
+     * If it returns a value different from what was written, the AXI
+     * target may not be responding (DDR4 not calibrated, wrong address). */
+    uint64_t readback = dst[0];
+    uint64_t expected = src[0];
+    printf("Done. Read back at BAR+0x%lx: 0x%016lx (expected 0x%016lx)\n",
+           bar_offset, readback, expected);
+    if (readback == UINT64_C(0xFFFFFFFFFFFFFFFF)) {
+        fprintf(stderr, "WARNING: readback is all-ones — PCIe endpoint not responding!\n");
+    } else if (readback != expected) {
+        fprintf(stderr, "WARNING: readback mismatch — data may not have reached DRAM.\n");
+        fprintf(stderr, "  Check that DDR4 calibration is complete and address translation is correct.\n");
+    }
+
+    munmap(bar_map, map_size);
+    close(bar_fd);
+    free(payload);
+    return 0;
+}

--- a/corev_apu/fpga/scripts/run.tcl
+++ b/corev_apu/fpga/scripts/run.tcl
@@ -24,20 +24,38 @@ if {$::env(BOARD) eq "genesys2"} {
       add_files -fileset constrs_1 -norecurse constraints/vc707.xdc
 } elseif {$::env(BOARD) eq "nexys_video"} {
       add_files -fileset constrs_1 -norecurse constraints/nexys_video.xdc
+} elseif {$::env(BOARD) eq "u200"} {
+      add_files -fileset constrs_1 -norecurse constraints/u200.xdc
 } else {
       exit 1
 }
 
-read_ip { \
-      "xilinx/xlnx_mig_7_ddr3/xlnx_mig_7_ddr3.srcs/sources_1/ip/xlnx_mig_7_ddr3/xlnx_mig_7_ddr3.xci" \
-      "xilinx/xlnx_axi_clock_converter/xlnx_axi_clock_converter.srcs/sources_1/ip/xlnx_axi_clock_converter/xlnx_axi_clock_converter.xci" \
-      "xilinx/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.srcs/sources_1/ip/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.xci" \
-      "xilinx/xlnx_axi_dwidth_converter_dm_slave/xlnx_axi_dwidth_converter_dm_slave.srcs/sources_1/ip/xlnx_axi_dwidth_converter_dm_slave/xlnx_axi_dwidth_converter_dm_slave.xci" \
-      "xilinx/xlnx_axi_dwidth_converter_dm_master/xlnx_axi_dwidth_converter_dm_master.srcs/sources_1/ip/xlnx_axi_dwidth_converter_dm_master/xlnx_axi_dwidth_converter_dm_master.xci" \
-      "xilinx/xlnx_axi_gpio/xlnx_axi_gpio.srcs/sources_1/ip/xlnx_axi_gpio/xlnx_axi_gpio.xci" \
-      "xilinx/xlnx_axi_quad_spi/xlnx_axi_quad_spi.srcs/sources_1/ip/xlnx_axi_quad_spi/xlnx_axi_quad_spi.xci" \
-      "xilinx/xlnx_clk_gen/xlnx_clk_gen.srcs/sources_1/ip/xlnx_clk_gen/xlnx_clk_gen.xci" \
-      "xilinx/xlnx_dpti_clk/xlnx_dpti_clk.srcs/sources_1/ip/xlnx_dpti_clk/xlnx_dpti_clk.xci" \
+if {$::env(BOARD) eq "u200"} {
+      read_ip { \
+            "xilinx/xlnx_ddr4/xlnx_ddr4.srcs/sources_1/ip/xlnx_ddr4/xlnx_ddr4.xci" \
+            "xilinx/xlnx_xdma/xlnx_xdma.srcs/sources_1/ip/xlnx_xdma/xlnx_xdma.xci" \
+            "xilinx/xlnx_axi_clock_converter/xlnx_axi_clock_converter.srcs/sources_1/ip/xlnx_axi_clock_converter/xlnx_axi_clock_converter.xci" \
+            "xilinx/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.srcs/sources_1/ip/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.xci" \
+            "xilinx/xlnx_axi_dwidth_converter_dm_slave/xlnx_axi_dwidth_converter_dm_slave.srcs/sources_1/ip/xlnx_axi_dwidth_converter_dm_slave/xlnx_axi_dwidth_converter_dm_slave.xci" \
+            "xilinx/xlnx_axi_dwidth_converter_dm_master/xlnx_axi_dwidth_converter_dm_master.srcs/sources_1/ip/xlnx_axi_dwidth_converter_dm_master/xlnx_axi_dwidth_converter_dm_master.xci" \
+            "xilinx/xlnx_axi_512_64_dwidth_converter/xlnx_axi_512_64_dwidth_converter.srcs/sources_1/ip/xlnx_axi_512_64_dwidth_converter/xlnx_axi_512_64_dwidth_converter.xci" \
+            "xilinx/xlnx_axi_512_64_dwidth_converter_pcie/xlnx_axi_512_64_dwidth_converter_pcie.srcs/sources_1/ip/xlnx_axi_512_64_dwidth_converter_pcie/xlnx_axi_512_64_dwidth_converter_pcie.xci" \
+            "xilinx/xlnx_axi_gpio/xlnx_axi_gpio.srcs/sources_1/ip/xlnx_axi_gpio/xlnx_axi_gpio.xci" \
+            "xilinx/xlnx_axi_quad_spi/xlnx_axi_quad_spi.srcs/sources_1/ip/xlnx_axi_quad_spi/xlnx_axi_quad_spi.xci" \
+            "xilinx/xlnx_clk_gen/xlnx_clk_gen.srcs/sources_1/ip/xlnx_clk_gen/xlnx_clk_gen.xci" \
+      }
+} else {
+      read_ip { \
+            "xilinx/xlnx_mig_7_ddr3/xlnx_mig_7_ddr3.srcs/sources_1/ip/xlnx_mig_7_ddr3/xlnx_mig_7_ddr3.xci" \
+            "xilinx/xlnx_axi_clock_converter/xlnx_axi_clock_converter.srcs/sources_1/ip/xlnx_axi_clock_converter/xlnx_axi_clock_converter.xci" \
+            "xilinx/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.srcs/sources_1/ip/xlnx_axi_dwidth_converter/xlnx_axi_dwidth_converter.xci" \
+            "xilinx/xlnx_axi_dwidth_converter_dm_slave/xlnx_axi_dwidth_converter_dm_slave.srcs/sources_1/ip/xlnx_axi_dwidth_converter_dm_slave/xlnx_axi_dwidth_converter_dm_slave.xci" \
+            "xilinx/xlnx_axi_dwidth_converter_dm_master/xlnx_axi_dwidth_converter_dm_master.srcs/sources_1/ip/xlnx_axi_dwidth_converter_dm_master/xlnx_axi_dwidth_converter_dm_master.xci" \
+            "xilinx/xlnx_axi_gpio/xlnx_axi_gpio.srcs/sources_1/ip/xlnx_axi_gpio/xlnx_axi_gpio.xci" \
+            "xilinx/xlnx_axi_quad_spi/xlnx_axi_quad_spi.srcs/sources_1/ip/xlnx_axi_quad_spi/xlnx_axi_quad_spi.xci" \
+            "xilinx/xlnx_clk_gen/xlnx_clk_gen.srcs/sources_1/ip/xlnx_clk_gen/xlnx_clk_gen.xci" \
+            "xilinx/xlnx_dpti_clk/xlnx_dpti_clk.srcs/sources_1/ip/xlnx_dpti_clk/xlnx_dpti_clk.xci" \
+      }
 }
 # read_ip xilinx/xlnx_protocol_checker/ip/xlnx_protocol_checker.xci
 
@@ -70,6 +88,10 @@ if {$::env(BOARD) eq "genesys2"} {
 } elseif {$::env(BOARD) eq "nexys_video"} {
       read_verilog -sv {src/nexys_video.svh ../../vendor/pulp-platform/common_cells/include/common_cells/registers.svh}
       set file "src/nexys_video.svh"
+      set registers "../../vendor/pulp-platform/common_cells/include/common_cells/registers.svh"
+} elseif {$::env(BOARD) eq "u200"} {
+      read_verilog -sv {src/u200.svh ../../vendor/pulp-platform/common_cells/include/common_cells/registers.svh}
+      set file "src/u200.svh"
       set registers "../../vendor/pulp-platform/common_cells/include/common_cells/registers.svh"
 } else {
     exit 1

--- a/corev_apu/fpga/scripts/write_cfgmem.tcl
+++ b/corev_apu/fpga/scripts/write_cfgmem.tcl
@@ -28,6 +28,8 @@ lassign $argv mcsfile bitfile
 # https://scholar.princeton.edu/jbalkind/blog/programming-vc707-virtex-7-bpi-flash
 if {$::env(BOARD) eq "genesys2"} {
     write_cfgmem -format mcs -interface SPIx4 -size 256  -loadbit "up 0x0 $bitfile" -file $mcsfile -force
+} elseif {$::env(BOARD) eq "u200"} {
+    write_cfgmem -format mcs -interface SPIx4 -size 1024 -loadbit "up 0x01002000 $bitfile" -file $mcsfile -force
 } elseif {$::env(BOARD) eq "vc707"} {
     write_cfgmem -format mcs -interface bpix16 -size 128 -loadbit "up 0x0 $bitfile" -file $mcsfile -force
 } elseif {$::env(BOARD) eq "kc705"} {

--- a/corev_apu/fpga/src/ariane_xilinx.sv
+++ b/corev_apu/fpga/src/ariane_xilinx.sv
@@ -141,6 +141,33 @@ module ariane_xilinx (
   input  wire [7:0]    pci_exp_rxp     ,
   input  wire [7:0]    pci_exp_rxn     ,
   input  logic         trst_n          ,
+`elsif U200
+  input  wire          c0_sys_clk_p    ,  // 300 MHz SYSCLK0 for DDR4 MIG
+  input  wire          c0_sys_clk_n    ,
+  input  wire          sys_clk_p       ,  // 100 MHz PCIe reference clock
+  input  wire          sys_clk_n       ,
+  input  wire          sys_rst_n       ,  // PCIe PERST# (active-low)
+  input  wire          ref_clk_p       ,  // 300 MHz SYSCLK1 for system PLL
+  input  wire          ref_clk_n       ,
+  input  logic         cpu_resetn      ,  // CPU subsystem reset (active-low)
+  output logic         c0_ddr4_parity  ,
+  output wire [16:0]   c0_ddr4_adr     ,
+  output wire [1:0]    c0_ddr4_ba      ,
+  output wire [0:0]    c0_ddr4_cke     ,
+  output wire [0:0]    c0_ddr4_cs_n    ,
+  inout  wire [71:0]   c0_ddr4_dq      ,
+  inout  wire [17:0]   c0_ddr4_dqs_c   ,
+  inout  wire [17:0]   c0_ddr4_dqs_t   ,
+  output wire [0:0]    c0_ddr4_odt     ,
+  output wire [1:0]    c0_ddr4_bg      ,
+  output wire          c0_ddr4_reset_n ,
+  output wire          c0_ddr4_act_n   ,
+  output wire [0:0]    c0_ddr4_ck_c    ,
+  output wire [0:0]    c0_ddr4_ck_t    ,
+  output wire [15:0]   pci_exp_txp     ,
+  output wire [15:0]   pci_exp_txn     ,
+  input  wire [15:0]   pci_exp_rxp     ,
+  input  wire [15:0]   pci_exp_rxn     ,
 `elsif NEXYS_VIDEO
   input  logic         sys_clk_i   ,
   input  logic         cpu_resetn  ,
@@ -205,6 +232,16 @@ function automatic config_pkg::cva6_cfg_t build_fpga_config(config_pkg::cva6_use
   cfg.NrNonIdempotentRules = unsigned'(1);
   cfg.NonIdempotentAddrBase = 1024'({64'b0});
   cfg.NonIdempotentLength = 1024'({ariane_soc::DRAMBase});
+`ifdef U200
+  // The U200 receives its boot payload via PCIe XDMA, which writes directly
+  // to DDR4 and bypasses the CPU caches. The bootrom uses `fence` to push
+  // dirty lines out and drop stale ones before reading the payload.
+  cfg.DcacheFlushOnFence = bit'(1);
+  cfg.DcacheInvalidateOnFlush = bit'(1);
+  // 16 GB of DDR4 mapped from 0x8000_0000 (vs the default 1 GB on other boards).
+  cfg.ExecuteRegionLength = 1024'({64'h4_00000000, 64'h10000, 64'h1000});
+  cfg.CachedRegionLength = 1024'({64'h4_00000000});
+`endif
   return build_config_pkg::build_config(cfg);
 endfunction
 
@@ -288,6 +325,9 @@ logic rtc;
 `ifdef VCU118
 logic cpu_resetn;
 assign cpu_resetn = ~cpu_reset;
+`elsif U200
+logic cpu_reset;
+assign cpu_reset  = ~cpu_resetn;
 `elsif GENESYSII
 logic cpu_reset;
 assign cpu_reset  = ~cpu_resetn;
@@ -387,6 +427,24 @@ axi_xbar_intf #(
 // ---------------
 // Debug Module
 // ---------------
+`ifdef U200
+// The U200 has no JTAG header. Until a PCIe-routed DMI master is wired in
+// (host → XDMA → AXI-lite → dmi_*), keep the DMI channel idle: no requests
+// driven into dm_top, and any response from dm_top is unconditionally
+// accepted so it cannot stall.
+assign debug_req_valid  = 1'b0;
+assign debug_req        = dm::dmi_req_t'(0);
+assign debug_resp_ready = 1'b1;
+// dmi_jtag and dpti_ctrl are gated out on the U200, so the top-level outputs
+// they would normally drive have no source. Tie them to a known idle value
+// — the matching PACKAGE_PINs in u200.xdc park them on harmless GPIO_MSP /
+// SW_DP test pins.
+assign tdo         = 1'b0;
+assign prog_oen    = 1'b0;
+assign prog_rdn    = 1'b0;
+assign prog_wrn    = 1'b0;
+assign prog_siwun  = 1'b0;
+`else
 dmi_jtag i_dmi_jtag (
     .clk_i                ( clk                  ),
     .rst_ni               ( rst_n                ),
@@ -405,6 +463,7 @@ dmi_jtag i_dmi_jtag (
     .td_o                 ( tdo    ),
     .tdo_oe_o             (        )
 );
+`endif
 
 ariane_axi::req_t    dm_axi_m_req;
 ariane_axi::resp_t   dm_axi_m_resp;
@@ -761,8 +820,14 @@ if (CVA6Cfg.XLEN==32 ) begin
         .m_axi_rready(slave[1].r_ready)
       );
 end else begin
+  `ifdef U200
+    // On U200, slave[1] is driven by the PCIe XDMA section below.
+    // Tie off the debug master's response to prevent X-propagation.
+    assign dm_axi_m_resp = '0;
+  `else
     `AXI_ASSIGN_FROM_REQ(slave[1], dm_axi_m_req)
     `AXI_ASSIGN_TO_RESP(dm_axi_m_resp, slave[1])
+  `endif
 end
 
 
@@ -916,6 +981,14 @@ ariane #(
     logic [DATA_LEN-1:0]            slice;
     logic [$clog2(DATA_LEN)-4:0]    valid_bytes;
 
+`ifdef U200
+    // U200 has no DPTI bridge, so the slicer + dpti_ctrl below are gated out.
+    // Drain the encap FIFO unconditionally so the trace pipeline doesn't
+    // back-pressure into the encoder.
+    assign encap_fifo_pop = !encap_fifo_empty;
+    assign valid_slice    = 1'b0;
+    assign slice          = '0;
+`else
     slicer_DPTI #(
         .SLICE_LEN(DATA_LEN),
         .NO_TIME ('0)
@@ -929,6 +1002,7 @@ ariane #(
         .slice_o           (slice),
         .done_o            (encap_fifo_pop)
     );
+`endif
 // ---------------
 // CLINT
 // ---------------
@@ -1014,6 +1088,7 @@ logic [7:0] r_data;
 logic [11:0] w_count;
 logic [11:0] r_count;
 
+`ifndef U200
 logic prog_rxen_debug;
 logic prog_txen_debug;
 logic prog_spien_debug;
@@ -1062,6 +1137,7 @@ assign FifoEn = !usrFull && !usrEmpty;
           .prog_siwun(prog_siwun),
           .prog_d(prog_d)
 );
+`endif
 // ---------------
 // Peripherals
 // ---------------
@@ -1091,6 +1167,9 @@ ariane_peripherals #(
     `elsif VCU118
     .InclSPI      ( 1'b0         ),
     .InclEthernet ( 1'b0         )
+    `elsif U200
+    .InclSPI      ( 1'b0         ),
+    .InclEthernet ( 1'b0         )
     `elsif NEXYS_VIDEO
     .InclSPI      ( 1'b1         ),
     .InclEthernet ( 1'b0         )
@@ -1109,6 +1188,21 @@ ariane_peripherals #(
     .irq_o        ( irq                          ),
     .rx_i         ( rx                           ),
     .tx_o         ( tx                           ),
+    `ifdef U200
+    // The U200's two QSFP cages are not wired up in this port (out of scope),
+    // and the legacy MII/RGMII Ethernet PHY interface is absent from the card,
+    // so ariane_peripherals is built with InclEthernet=0 for this board and
+    // these RGMII ports are tied off / left open.
+    .eth_txck       (                             ),
+    .eth_rxck       ( 1'b0                        ),
+    .eth_rxctl      ( 1'b0                        ),
+    .eth_rxd        ( 4'b0                        ),
+    .eth_rst_n      (                             ),
+    .eth_txctl      (                             ),
+    .eth_txd        (                             ),
+    .eth_mdio       (                             ),
+    .eth_mdc        (                             ),
+    `else
     .eth_txck,
     .eth_rxck,
     .eth_rxctl,
@@ -1118,6 +1212,7 @@ ariane_peripherals #(
     .eth_txd,
     .eth_mdio,
     .eth_mdc,
+    `endif
     .phy_tx_clk_i   ( phy_tx_clk                  ),
     .sd_clk_i       ( sd_clk_sys                  ),
     .spi_clk_o      ( spi_clk_o                   ),
@@ -1127,6 +1222,9 @@ ariane_peripherals #(
     `ifdef KC705
       .leds_o         ( {led[3:0], unused_led[7:4]}),
       .dip_switches_i ( {sw, unused_switches}     )
+    `elsif U200
+      .leds_o         (                            ),
+      .dip_switches_i ( 8'b0                       )
     `else
       .leds_o         ( led                       ),
       .dip_switches_i ( sw                        )
@@ -1355,6 +1453,19 @@ xlnx_clk_gen i_xlnx_clk_gen (
   .reset    ( cpu_reset       ),
   .locked   ( pll_locked      ),
   .clk_in1  ( ddr_clock_out   )  // 100MHz input clock
+);
+
+`elsif U200
+xlnx_clk_gen i_xlnx_clk_gen (
+  .clk_out1   ( clk            ), // 50 MHz CPU clock
+  .clk_out2   ( phy_tx_clk     ), // 125 MHz (unused on U200, ariane_peripherals tie-off)
+  .clk_out3   ( eth_clk        ), // 125 MHz quadrature (unused on U200)
+  .clk_out4   ( sd_clk_sys     ), // 50 MHz (unused on U200)
+  .clk_out5   ( clk_200MHz_ref ), // 200 MHz reference for ariane_peripherals
+  .reset      ( cpu_reset      ),
+  .locked     ( pll_locked     ),
+  .clk_in1_p  ( ref_clk_p      ), // 300 MHz SYSCLK1 board reference clock (differential)
+  .clk_in1_n  ( ref_clk_n      )
 );
 
 `else
@@ -2117,6 +2228,588 @@ axi_clock_converter_0 pcie_axi_clock_converter (
   .s_axi_rvalid   ( pcie_dwidth_axi_rvalid   ),
   .s_axi_rready   ( pcie_dwidth_axi_rready   )
 );
+`elsif U200
+
+  logic [63:0]  dram_dwidth_axi_awaddr;
+  logic [7:0]   dram_dwidth_axi_awlen;
+  logic [2:0]   dram_dwidth_axi_awsize;
+  logic [1:0]   dram_dwidth_axi_awburst;
+  logic [0:0]   dram_dwidth_axi_awlock;
+  logic [3:0]   dram_dwidth_axi_awcache;
+  logic [2:0]   dram_dwidth_axi_awprot;
+  logic [3:0]   dram_dwidth_axi_awqos;
+  logic         dram_dwidth_axi_awvalid;
+  logic         dram_dwidth_axi_awready;
+  logic [511:0] dram_dwidth_axi_wdata;
+  logic [63:0]  dram_dwidth_axi_wstrb;
+  logic         dram_dwidth_axi_wlast;
+  logic         dram_dwidth_axi_wvalid;
+  logic         dram_dwidth_axi_wready;
+  logic         dram_dwidth_axi_bready;
+  logic [1:0]   dram_dwidth_axi_bresp;
+  logic         dram_dwidth_axi_bvalid;
+  logic [63:0]  dram_dwidth_axi_araddr;
+  logic [7:0]   dram_dwidth_axi_arlen;
+  logic [2:0]   dram_dwidth_axi_arsize;
+  logic [1:0]   dram_dwidth_axi_arburst;
+  logic [0:0]   dram_dwidth_axi_arlock;
+  logic [3:0]   dram_dwidth_axi_arcache;
+  logic [2:0]   dram_dwidth_axi_arprot;
+  logic [3:0]   dram_dwidth_axi_arqos;
+  logic         dram_dwidth_axi_arvalid;
+  logic         dram_dwidth_axi_arready;
+  logic         dram_dwidth_axi_rready;
+  logic         dram_dwidth_axi_rlast;
+  logic         dram_dwidth_axi_rvalid;
+  logic [1:0]   dram_dwidth_axi_rresp;
+  logic [511:0] dram_dwidth_axi_rdata;
+
+xlnx_axi_512_64_dwidth_converter i_axi_dwidth_converter_512_64 (
+  .s_axi_aclk     ( ddr_clock_out            ),
+  .s_axi_aresetn  ( ndmreset_n               ),
+  .s_axi_awid     ( s_axi_awid               ),
+  .s_axi_awaddr   ( s_axi_awaddr             ),
+  .s_axi_awlen    ( s_axi_awlen              ),
+  .s_axi_awsize   ( s_axi_awsize             ),
+  .s_axi_awburst  ( s_axi_awburst            ),
+  .s_axi_awlock   ( s_axi_awlock             ),
+  .s_axi_awcache  ( s_axi_awcache            ),
+  .s_axi_awprot   ( s_axi_awprot             ),
+  .s_axi_awregion ( '0                       ),
+  .s_axi_awqos    ( s_axi_awqos              ),
+  .s_axi_awvalid  ( s_axi_awvalid            ),
+  .s_axi_awready  ( s_axi_awready            ),
+  .s_axi_wdata    ( s_axi_wdata              ),
+  .s_axi_wstrb    ( s_axi_wstrb              ),
+  .s_axi_wlast    ( s_axi_wlast              ),
+  .s_axi_wvalid   ( s_axi_wvalid             ),
+  .s_axi_wready   ( s_axi_wready             ),
+  .s_axi_bid      ( s_axi_bid                ),
+  .s_axi_bresp    ( s_axi_bresp              ),
+  .s_axi_bvalid   ( s_axi_bvalid             ),
+  .s_axi_bready   ( s_axi_bready             ),
+  .s_axi_arid     ( s_axi_arid               ),
+  .s_axi_araddr   ( s_axi_araddr             ),
+  .s_axi_arlen    ( s_axi_arlen              ),
+  .s_axi_arsize   ( s_axi_arsize             ),
+  .s_axi_arburst  ( s_axi_arburst            ),
+  .s_axi_arlock   ( s_axi_arlock             ),
+  .s_axi_arcache  ( s_axi_arcache            ),
+  .s_axi_arprot   ( s_axi_arprot             ),
+  .s_axi_arregion ( '0                       ),
+  .s_axi_arqos    ( s_axi_arqos              ),
+  .s_axi_arvalid  ( s_axi_arvalid            ),
+  .s_axi_arready  ( s_axi_arready            ),
+  .s_axi_rid      ( s_axi_rid                ),
+  .s_axi_rdata    ( s_axi_rdata              ),
+  .s_axi_rresp    ( s_axi_rresp              ),
+  .s_axi_rlast    ( s_axi_rlast              ),
+  .s_axi_rvalid   ( s_axi_rvalid             ),
+  .s_axi_rready   ( s_axi_rready             ),
+  .m_axi_awaddr   ( dram_dwidth_axi_awaddr   ),
+  .m_axi_awlen    ( dram_dwidth_axi_awlen    ),
+  .m_axi_awsize   ( dram_dwidth_axi_awsize   ),
+  .m_axi_awburst  ( dram_dwidth_axi_awburst  ),
+  .m_axi_awlock   ( dram_dwidth_axi_awlock   ),
+  .m_axi_awcache  ( dram_dwidth_axi_awcache  ),
+  .m_axi_awprot   ( dram_dwidth_axi_awprot   ),
+  .m_axi_awregion (                          ),
+  .m_axi_awqos    ( dram_dwidth_axi_awqos    ),
+  .m_axi_awvalid  ( dram_dwidth_axi_awvalid  ),
+  .m_axi_awready  ( dram_dwidth_axi_awready  ),
+  .m_axi_wdata    ( dram_dwidth_axi_wdata    ),
+  .m_axi_wstrb    ( dram_dwidth_axi_wstrb    ),
+  .m_axi_wlast    ( dram_dwidth_axi_wlast    ),
+  .m_axi_wvalid   ( dram_dwidth_axi_wvalid   ),
+  .m_axi_wready   ( dram_dwidth_axi_wready   ),
+  .m_axi_bresp    ( dram_dwidth_axi_bresp    ),
+  .m_axi_bvalid   ( dram_dwidth_axi_bvalid   ),
+  .m_axi_bready   ( dram_dwidth_axi_bready   ),
+  .m_axi_araddr   ( dram_dwidth_axi_araddr   ),
+  .m_axi_arlen    ( dram_dwidth_axi_arlen    ),
+  .m_axi_arsize   ( dram_dwidth_axi_arsize   ),
+  .m_axi_arburst  ( dram_dwidth_axi_arburst  ),
+  .m_axi_arlock   ( dram_dwidth_axi_arlock   ),
+  .m_axi_arcache  ( dram_dwidth_axi_arcache  ),
+  .m_axi_arprot   ( dram_dwidth_axi_arprot   ),
+  .m_axi_arregion (                          ),
+  .m_axi_arqos    ( dram_dwidth_axi_arqos    ),
+  .m_axi_arvalid  ( dram_dwidth_axi_arvalid  ),
+  .m_axi_arready  ( dram_dwidth_axi_arready  ),
+  .m_axi_rdata    ( dram_dwidth_axi_rdata    ),
+  .m_axi_rresp    ( dram_dwidth_axi_rresp    ),
+  .m_axi_rlast    ( dram_dwidth_axi_rlast    ),
+  .m_axi_rvalid   ( dram_dwidth_axi_rvalid   ),
+  .m_axi_rready   ( dram_dwidth_axi_rready   )
+);
+
+  // Subtract DRAMBase so CVA6 address 0x8000_0000 maps to DDR4 address 0x0
+  logic [33:0] ddr4_awaddr_offset;
+  logic [33:0] ddr4_araddr_offset;
+  assign ddr4_awaddr_offset = dram_dwidth_axi_awaddr[33:0] - ariane_soc::DRAMBase[33:0];
+  assign ddr4_araddr_offset = dram_dwidth_axi_araddr[33:0] - ariane_soc::DRAMBase[33:0];
+
+  xlnx_ddr4 i_ddr (
+    .c0_init_calib_complete (                              ),
+    .dbg_clk                (                              ),
+    .c0_sys_clk_p           ( c0_sys_clk_p                 ),
+    .c0_sys_clk_n           ( c0_sys_clk_n                 ),
+    .dbg_bus                (                              ),
+    .c0_ddr4_parity         ( c0_ddr4_parity               ),
+    .addn_ui_clkout1        (                              ),
+    .c0_ddr4_interrupt      (                              ),
+    // ECC AXI control port — RDIMM forces it on; tie inputs low.
+    .c0_ddr4_s_axi_ctrl_awvalid ( 1'b0                    ),
+    .c0_ddr4_s_axi_ctrl_awready (                         ),
+    .c0_ddr4_s_axi_ctrl_awaddr  ( '0                      ),
+    .c0_ddr4_s_axi_ctrl_wvalid  ( 1'b0                    ),
+    .c0_ddr4_s_axi_ctrl_wready  (                         ),
+    .c0_ddr4_s_axi_ctrl_wdata   ( '0                      ),
+    .c0_ddr4_s_axi_ctrl_bvalid  (                         ),
+    .c0_ddr4_s_axi_ctrl_bready  ( 1'b1                    ),
+    .c0_ddr4_s_axi_ctrl_bresp   (                         ),
+    .c0_ddr4_s_axi_ctrl_arvalid ( 1'b0                    ),
+    .c0_ddr4_s_axi_ctrl_arready (                         ),
+    .c0_ddr4_s_axi_ctrl_araddr  ( '0                      ),
+    .c0_ddr4_s_axi_ctrl_rvalid  (                         ),
+    .c0_ddr4_s_axi_ctrl_rready  ( 1'b1                    ),
+    .c0_ddr4_s_axi_ctrl_rdata   (                         ),
+    .c0_ddr4_s_axi_ctrl_rresp   (                         ),
+    .c0_ddr4_adr            ( c0_ddr4_adr                  ),
+    .c0_ddr4_ba             ( c0_ddr4_ba                   ),
+    .c0_ddr4_cke            ( c0_ddr4_cke                  ),
+    .c0_ddr4_cs_n           ( c0_ddr4_cs_n                 ),
+    .c0_ddr4_dq             ( c0_ddr4_dq                   ),
+    .c0_ddr4_dqs_c          ( c0_ddr4_dqs_c                ),
+    .c0_ddr4_dqs_t          ( c0_ddr4_dqs_t                ),
+    .c0_ddr4_odt            ( c0_ddr4_odt                  ),
+    .c0_ddr4_bg             ( c0_ddr4_bg                   ),
+    .c0_ddr4_reset_n        ( c0_ddr4_reset_n              ),
+    .c0_ddr4_act_n          ( c0_ddr4_act_n                ),
+    .c0_ddr4_ck_c           ( c0_ddr4_ck_c                 ),
+    .c0_ddr4_ck_t           ( c0_ddr4_ck_t                 ),
+    .c0_ddr4_ui_clk         ( ddr_clock_out                ),
+    .c0_ddr4_ui_clk_sync_rst( ddr_sync_reset               ),
+    .c0_ddr4_aresetn        ( ndmreset_n                   ),
+    .c0_ddr4_s_axi_awid     ( '0                           ),
+    .c0_ddr4_s_axi_awaddr   ( ddr4_awaddr_offset           ),
+    .c0_ddr4_s_axi_awlen    ( dram_dwidth_axi_awlen        ),
+    .c0_ddr4_s_axi_awsize   ( dram_dwidth_axi_awsize       ),
+    .c0_ddr4_s_axi_awburst  ( dram_dwidth_axi_awburst      ),
+    .c0_ddr4_s_axi_awlock   ( dram_dwidth_axi_awlock       ),
+    .c0_ddr4_s_axi_awcache  ( dram_dwidth_axi_awcache      ),
+    .c0_ddr4_s_axi_awprot   ( dram_dwidth_axi_awprot       ),
+    .c0_ddr4_s_axi_awqos    ( dram_dwidth_axi_awqos        ),
+    .c0_ddr4_s_axi_awvalid  ( dram_dwidth_axi_awvalid      ),
+    .c0_ddr4_s_axi_awready  ( dram_dwidth_axi_awready      ),
+    .c0_ddr4_s_axi_wdata    ( dram_dwidth_axi_wdata        ),
+    .c0_ddr4_s_axi_wstrb    ( dram_dwidth_axi_wstrb        ),
+    .c0_ddr4_s_axi_wlast    ( dram_dwidth_axi_wlast        ),
+    .c0_ddr4_s_axi_wvalid   ( dram_dwidth_axi_wvalid       ),
+    .c0_ddr4_s_axi_wready   ( dram_dwidth_axi_wready       ),
+    .c0_ddr4_s_axi_bready   ( dram_dwidth_axi_bready       ),
+    .c0_ddr4_s_axi_bid      (                              ),
+    .c0_ddr4_s_axi_bresp    ( dram_dwidth_axi_bresp        ),
+    .c0_ddr4_s_axi_bvalid   ( dram_dwidth_axi_bvalid       ),
+    .c0_ddr4_s_axi_arid     ( '0                           ),
+    .c0_ddr4_s_axi_araddr   ( ddr4_araddr_offset           ),
+    .c0_ddr4_s_axi_arlen    ( dram_dwidth_axi_arlen        ),
+    .c0_ddr4_s_axi_arsize   ( dram_dwidth_axi_arsize       ),
+    .c0_ddr4_s_axi_arburst  ( dram_dwidth_axi_arburst      ),
+    .c0_ddr4_s_axi_arlock   ( dram_dwidth_axi_arlock       ),
+    .c0_ddr4_s_axi_arcache  ( dram_dwidth_axi_arcache      ),
+    .c0_ddr4_s_axi_arprot   ( dram_dwidth_axi_arprot       ),
+    .c0_ddr4_s_axi_arqos    ( dram_dwidth_axi_arqos        ),
+    .c0_ddr4_s_axi_arvalid  ( dram_dwidth_axi_arvalid      ),
+    .c0_ddr4_s_axi_arready  ( dram_dwidth_axi_arready      ),
+    .c0_ddr4_s_axi_rready   ( dram_dwidth_axi_rready       ),
+    .c0_ddr4_s_axi_rlast    ( dram_dwidth_axi_rlast        ),
+    .c0_ddr4_s_axi_rvalid   ( dram_dwidth_axi_rvalid       ),
+    .c0_ddr4_s_axi_rresp    ( dram_dwidth_axi_rresp        ),
+    .c0_ddr4_s_axi_rid      (                              ),
+    .c0_ddr4_s_axi_rdata    ( dram_dwidth_axi_rdata        ),
+    .sys_rst                ( cpu_reset                    )
+  );
+
+  logic pcie_ref_clk;
+  logic pcie_ref_clk_gt;
+
+  logic pcie_axi_clk;
+  logic pcie_axi_rstn;
+
+  logic         pcie_axi_awready;
+  logic         pcie_axi_wready;
+  logic [3:0]   pcie_axi_bid;
+  logic [1:0]   pcie_axi_bresp;
+  logic         pcie_axi_bvalid;
+  logic         pcie_axi_arready;
+  logic [3:0]   pcie_axi_rid;
+  logic [511:0] pcie_axi_rdata;
+  logic [1:0]   pcie_axi_rresp;
+  logic         pcie_axi_rlast;
+  logic         pcie_axi_rvalid;
+  logic [3:0]   pcie_axi_awid;
+  logic [63:0]  pcie_axi_awaddr;
+  logic [7:0]   pcie_axi_awlen;
+  logic [2:0]   pcie_axi_awsize;
+  logic [1:0]   pcie_axi_awburst;
+  logic [2:0]   pcie_axi_awprot;
+  logic         pcie_axi_awvalid;
+  logic         pcie_axi_awlock;
+  logic [3:0]   pcie_axi_awcache;
+  logic [511:0] pcie_axi_wdata;
+  logic [63:0]  pcie_axi_wstrb;
+  logic         pcie_axi_wlast;
+  logic         pcie_axi_wvalid;
+  logic         pcie_axi_bready;
+  logic [3:0]   pcie_axi_arid;
+  logic [63:0]  pcie_axi_araddr;
+  logic [7:0]   pcie_axi_arlen;
+  logic [2:0]   pcie_axi_arsize;
+  logic [1:0]   pcie_axi_arburst;
+  logic [2:0]   pcie_axi_arprot;
+  logic         pcie_axi_arvalid;
+  logic         pcie_axi_arlock;
+  logic [3:0]   pcie_axi_arcache;
+  logic         pcie_axi_rready;
+
+  logic [63:0]  pcie_dwidth_axi_awaddr;
+  logic [7:0]   pcie_dwidth_axi_awlen;
+  logic [2:0]   pcie_dwidth_axi_awsize;
+  logic [1:0]   pcie_dwidth_axi_awburst;
+  logic [0:0]   pcie_dwidth_axi_awlock;
+  logic [3:0]   pcie_dwidth_axi_awcache;
+  logic [2:0]   pcie_dwidth_axi_awprot;
+  logic [3:0]   pcie_dwidth_axi_awregion;
+  logic [3:0]   pcie_dwidth_axi_awqos;
+  logic         pcie_dwidth_axi_awvalid;
+  logic         pcie_dwidth_axi_awready;
+  logic [63:0]  pcie_dwidth_axi_wdata;
+  logic [7:0]   pcie_dwidth_axi_wstrb;
+  logic         pcie_dwidth_axi_wlast;
+  logic         pcie_dwidth_axi_wvalid;
+  logic         pcie_dwidth_axi_wready;
+  logic [1:0]   pcie_dwidth_axi_bresp;
+  logic         pcie_dwidth_axi_bvalid;
+  logic         pcie_dwidth_axi_bready;
+  logic [63:0]  pcie_dwidth_axi_araddr;
+  logic [7:0]   pcie_dwidth_axi_arlen;
+  logic [2:0]   pcie_dwidth_axi_arsize;
+  logic [1:0]   pcie_dwidth_axi_arburst;
+  logic [0:0]   pcie_dwidth_axi_arlock;
+  logic [3:0]   pcie_dwidth_axi_arcache;
+  logic [2:0]   pcie_dwidth_axi_arprot;
+  logic [3:0]   pcie_dwidth_axi_arregion;
+  logic [3:0]   pcie_dwidth_axi_arqos;
+  logic         pcie_dwidth_axi_arvalid;
+  logic         pcie_dwidth_axi_arready;
+  logic [63:0]  pcie_dwidth_axi_rdata;
+  logic [1:0]   pcie_dwidth_axi_rresp;
+  logic         pcie_dwidth_axi_rlast;
+  logic         pcie_dwidth_axi_rvalid;
+  logic         pcie_dwidth_axi_rready;
+
+  // PCIe Reset
+  logic sys_rst_n_c;
+  IBUF sys_reset_n_ibuf (.O(sys_rst_n_c), .I(sys_rst_n));
+
+  IBUFDS_GTE4 #(
+    .REFCLK_HROW_CK_SEL ( 2'b00 )
+  ) IBUFDS_GTE4_inst (
+    .O     ( pcie_ref_clk_gt ),
+    .ODIV2 ( pcie_ref_clk    ),
+    .CEB   ( 1'b0            ),
+    .I     ( sys_clk_p       ),
+    .IB    ( sys_clk_n       )
+  );
+
+  // XDMA in AXI Bridge mode (host → FPGA only; DMA + S_AXI tied off)
+  xlnx_xdma i_xdma (
+    .sys_clk                  ( pcie_ref_clk     ),
+    .sys_clk_gt               ( pcie_ref_clk_gt  ),
+    .sys_rst_n                ( sys_rst_n_c      ),
+    .cfg_ltssm_state          (                  ),
+    .user_lnk_up              (                  ),
+    .pci_exp_txp              ( pci_exp_txp      ),
+    .pci_exp_txn              ( pci_exp_txn      ),
+    .pci_exp_rxp              ( pci_exp_rxp      ),
+    .pci_exp_rxn              ( pci_exp_rxn      ),
+    .usr_irq_req              ( 1'b0             ),
+    .usr_irq_ack              (                  ),
+    .msi_enable               (                  ),
+    .msi_vector_width         (                  ),
+    .interrupt_out            (                  ),
+    .axi_aclk                 ( pcie_axi_clk     ),
+    .axi_aresetn              ( pcie_axi_rstn    ),
+    .axi_ctl_aresetn          (                  ),
+    .m_axib_awid              ( pcie_axi_awid    ),
+    .m_axib_awaddr            ( pcie_axi_awaddr  ),
+    .m_axib_awlen             ( pcie_axi_awlen   ),
+    .m_axib_awsize            ( pcie_axi_awsize  ),
+    .m_axib_awburst           ( pcie_axi_awburst ),
+    .m_axib_awprot            ( pcie_axi_awprot  ),
+    .m_axib_awvalid           ( pcie_axi_awvalid ),
+    .m_axib_awready           ( pcie_axi_awready ),
+    .m_axib_awlock            ( pcie_axi_awlock  ),
+    .m_axib_awcache           ( pcie_axi_awcache ),
+    .m_axib_wdata             ( pcie_axi_wdata   ),
+    .m_axib_wstrb             ( pcie_axi_wstrb   ),
+    .m_axib_wlast             ( pcie_axi_wlast   ),
+    .m_axib_wvalid            ( pcie_axi_wvalid  ),
+    .m_axib_wready            ( pcie_axi_wready  ),
+    .m_axib_bid               ( pcie_axi_bid     ),
+    .m_axib_bresp             ( pcie_axi_bresp   ),
+    .m_axib_bvalid            ( pcie_axi_bvalid  ),
+    .m_axib_bready            ( pcie_axi_bready  ),
+    .m_axib_arid              ( pcie_axi_arid    ),
+    .m_axib_araddr            ( pcie_axi_araddr  ),
+    .m_axib_arlen             ( pcie_axi_arlen   ),
+    .m_axib_arsize            ( pcie_axi_arsize  ),
+    .m_axib_arburst           ( pcie_axi_arburst ),
+    .m_axib_arprot            ( pcie_axi_arprot  ),
+    .m_axib_arvalid           ( pcie_axi_arvalid ),
+    .m_axib_arready           ( pcie_axi_arready ),
+    .m_axib_arlock            ( pcie_axi_arlock  ),
+    .m_axib_arcache           ( pcie_axi_arcache ),
+    .m_axib_rid               ( pcie_axi_rid     ),
+    .m_axib_rdata             ( pcie_axi_rdata   ),
+    .m_axib_rresp             ( pcie_axi_rresp   ),
+    .m_axib_rlast             ( pcie_axi_rlast   ),
+    .m_axib_rvalid            ( pcie_axi_rvalid  ),
+    .m_axib_rready            ( pcie_axi_rready  ),
+    // FPGA → host bridge port unused
+    .s_axib_awid              ( '0               ),
+    .s_axib_awaddr            ( '0               ),
+    .s_axib_awregion          ( '0               ),
+    .s_axib_awlen             ( '0               ),
+    .s_axib_awsize            ( '0               ),
+    .s_axib_awburst           ( '0               ),
+    .s_axib_awvalid           ( 1'b0             ),
+    .s_axib_awready           (                  ),
+    .s_axib_wdata             ( '0               ),
+    .s_axib_wstrb             ( '0               ),
+    .s_axib_wlast             ( 1'b0             ),
+    .s_axib_wvalid            ( 1'b0             ),
+    .s_axib_wready            (                  ),
+    .s_axib_bid               (                  ),
+    .s_axib_bresp             (                  ),
+    .s_axib_bvalid            (                  ),
+    .s_axib_bready            ( 1'b0             ),
+    .s_axib_arid              ( '0               ),
+    .s_axib_araddr            ( '0               ),
+    .s_axib_arregion          ( '0               ),
+    .s_axib_arlen             ( '0               ),
+    .s_axib_arsize            ( '0               ),
+    .s_axib_arburst           ( '0               ),
+    .s_axib_arvalid           ( 1'b0             ),
+    .s_axib_arready           (                  ),
+    .s_axib_rid               (                  ),
+    .s_axib_rdata             (                  ),
+    .s_axib_rresp             (                  ),
+    .s_axib_rlast             (                  ),
+    .s_axib_rvalid            (                  ),
+    .s_axib_rready            ( 1'b0             ),
+    // AXI-Lite control unused
+    .s_axil_awaddr            ( '0               ),
+    .s_axil_awprot            ( '0               ),
+    .s_axil_awvalid           ( 1'b0             ),
+    .s_axil_awready           (                  ),
+    .s_axil_wdata             ( '0               ),
+    .s_axil_wstrb             ( '0               ),
+    .s_axil_wvalid            ( 1'b0             ),
+    .s_axil_wready            (                  ),
+    .s_axil_bvalid            (                  ),
+    .s_axil_bresp             (                  ),
+    .s_axil_bready            ( 1'b1             ),
+    .s_axil_araddr            ( '0               ),
+    .s_axil_arprot            ( '0               ),
+    .s_axil_arvalid           ( 1'b0             ),
+    .s_axil_arready           (                  ),
+    .s_axil_rdata             (                  ),
+    .s_axil_rresp             (                  ),
+    .s_axil_rvalid            (                  ),
+    .s_axil_rready            ( 1'b1             )
+  );
+
+  xlnx_axi_512_64_dwidth_converter_pcie i_axi_dwidth_converter_512_64_pcie (
+    .s_axi_aclk     ( pcie_axi_clk             ),
+    .s_axi_aresetn  ( pcie_axi_rstn            ),
+    .s_axi_awid     ( pcie_axi_awid            ),
+    .s_axi_awaddr   ( pcie_axi_awaddr          ),
+    .s_axi_awlen    ( pcie_axi_awlen           ),
+    .s_axi_awsize   ( pcie_axi_awsize          ),
+    .s_axi_awburst  ( pcie_axi_awburst         ),
+    .s_axi_awlock   ( pcie_axi_awlock          ),
+    .s_axi_awcache  ( pcie_axi_awcache         ),
+    .s_axi_awprot   ( pcie_axi_awprot          ),
+    .s_axi_awregion ( '0                       ),
+    .s_axi_awqos    ( '0                       ),
+    .s_axi_awvalid  ( pcie_axi_awvalid         ),
+    .s_axi_awready  ( pcie_axi_awready         ),
+    .s_axi_wdata    ( pcie_axi_wdata           ),
+    .s_axi_wstrb    ( pcie_axi_wstrb           ),
+    .s_axi_wlast    ( pcie_axi_wlast           ),
+    .s_axi_wvalid   ( pcie_axi_wvalid          ),
+    .s_axi_wready   ( pcie_axi_wready          ),
+    .s_axi_bid      ( pcie_axi_bid             ),
+    .s_axi_bresp    ( pcie_axi_bresp           ),
+    .s_axi_bvalid   ( pcie_axi_bvalid          ),
+    .s_axi_bready   ( pcie_axi_bready          ),
+    .s_axi_arid     ( pcie_axi_arid            ),
+    .s_axi_araddr   ( pcie_axi_araddr          ),
+    .s_axi_arlen    ( pcie_axi_arlen           ),
+    .s_axi_arsize   ( pcie_axi_arsize          ),
+    .s_axi_arburst  ( pcie_axi_arburst         ),
+    .s_axi_arlock   ( pcie_axi_arlock          ),
+    .s_axi_arcache  ( pcie_axi_arcache         ),
+    .s_axi_arprot   ( pcie_axi_arprot          ),
+    .s_axi_arregion ( '0                       ),
+    .s_axi_arqos    ( '0                       ),
+    .s_axi_arvalid  ( pcie_axi_arvalid         ),
+    .s_axi_arready  ( pcie_axi_arready         ),
+    .s_axi_rid      ( pcie_axi_rid             ),
+    .s_axi_rdata    ( pcie_axi_rdata           ),
+    .s_axi_rresp    ( pcie_axi_rresp           ),
+    .s_axi_rlast    ( pcie_axi_rlast           ),
+    .s_axi_rvalid   ( pcie_axi_rvalid          ),
+    .s_axi_rready   ( pcie_axi_rready          ),
+    .m_axi_awaddr   ( pcie_dwidth_axi_awaddr   ),
+    .m_axi_awlen    ( pcie_dwidth_axi_awlen    ),
+    .m_axi_awsize   ( pcie_dwidth_axi_awsize   ),
+    .m_axi_awburst  ( pcie_dwidth_axi_awburst  ),
+    .m_axi_awlock   ( pcie_dwidth_axi_awlock   ),
+    .m_axi_awcache  ( pcie_dwidth_axi_awcache  ),
+    .m_axi_awprot   ( pcie_dwidth_axi_awprot   ),
+    .m_axi_awregion ( pcie_dwidth_axi_awregion ),
+    .m_axi_awqos    ( pcie_dwidth_axi_awqos    ),
+    .m_axi_awvalid  ( pcie_dwidth_axi_awvalid  ),
+    .m_axi_awready  ( pcie_dwidth_axi_awready  ),
+    .m_axi_wdata    ( pcie_dwidth_axi_wdata    ),
+    .m_axi_wstrb    ( pcie_dwidth_axi_wstrb    ),
+    .m_axi_wlast    ( pcie_dwidth_axi_wlast    ),
+    .m_axi_wvalid   ( pcie_dwidth_axi_wvalid   ),
+    .m_axi_wready   ( pcie_dwidth_axi_wready   ),
+    .m_axi_bresp    ( pcie_dwidth_axi_bresp    ),
+    .m_axi_bvalid   ( pcie_dwidth_axi_bvalid   ),
+    .m_axi_bready   ( pcie_dwidth_axi_bready   ),
+    .m_axi_araddr   ( pcie_dwidth_axi_araddr   ),
+    .m_axi_arlen    ( pcie_dwidth_axi_arlen    ),
+    .m_axi_arsize   ( pcie_dwidth_axi_arsize   ),
+    .m_axi_arburst  ( pcie_dwidth_axi_arburst  ),
+    .m_axi_arlock   ( pcie_dwidth_axi_arlock   ),
+    .m_axi_arcache  ( pcie_dwidth_axi_arcache  ),
+    .m_axi_arprot   ( pcie_dwidth_axi_arprot   ),
+    .m_axi_arregion ( pcie_dwidth_axi_arregion ),
+    .m_axi_arqos    ( pcie_dwidth_axi_arqos    ),
+    .m_axi_arvalid  ( pcie_dwidth_axi_arvalid  ),
+    .m_axi_arready  ( pcie_dwidth_axi_arready  ),
+    .m_axi_rdata    ( pcie_dwidth_axi_rdata    ),
+    .m_axi_rresp    ( pcie_dwidth_axi_rresp    ),
+    .m_axi_rlast    ( pcie_dwidth_axi_rlast    ),
+    .m_axi_rvalid   ( pcie_dwidth_axi_rvalid   ),
+    .m_axi_rready   ( pcie_dwidth_axi_rready   )
+  );
+
+  assign slave[1].aw_user = '0;
+  assign slave[1].ar_user = '0;
+  assign slave[1].w_user  = '0;
+  assign slave[1].aw_atop = '0; // PCIe does not issue atomic ops
+
+  logic [4:0] slave_b_id;
+  logic [4:0] slave_r_id;
+  assign slave_b_id = slave[1].b_id;
+  assign slave_r_id = slave[1].r_id;
+
+  logic [4:0] arid;
+  logic [4:0] awid;
+  assign slave[1].aw_id = awid[3:0];
+  assign slave[1].ar_id = arid[3:0];
+
+  // PCIe → SoC clock crossing (reuses the existing 5-bit-ID xlnx_axi_clock_converter)
+  xlnx_axi_clock_converter pcie_axi_clock_converter (
+    .m_axi_aclk     ( clk                      ),
+    .m_axi_aresetn  ( ndmreset_n               ),
+    .m_axi_awid     ( awid                     ),
+    .m_axi_awaddr   ( slave[1].aw_addr         ),
+    .m_axi_awlen    ( slave[1].aw_len          ),
+    .m_axi_awsize   ( slave[1].aw_size         ),
+    .m_axi_awburst  ( slave[1].aw_burst        ),
+    .m_axi_awlock   ( slave[1].aw_lock         ),
+    .m_axi_awcache  ( slave[1].aw_cache        ),
+    .m_axi_awprot   ( slave[1].aw_prot         ),
+    .m_axi_awregion ( slave[1].aw_region       ),
+    .m_axi_awqos    ( slave[1].aw_qos          ),
+    .m_axi_awvalid  ( slave[1].aw_valid        ),
+    .m_axi_awready  ( slave[1].aw_ready        ),
+    .m_axi_wdata    ( slave[1].w_data          ),
+    .m_axi_wstrb    ( slave[1].w_strb          ),
+    .m_axi_wlast    ( slave[1].w_last          ),
+    .m_axi_wvalid   ( slave[1].w_valid         ),
+    .m_axi_wready   ( slave[1].w_ready         ),
+    .m_axi_bid      ( slave_b_id               ),
+    .m_axi_bresp    ( slave[1].b_resp          ),
+    .m_axi_bvalid   ( slave[1].b_valid         ),
+    .m_axi_bready   ( slave[1].b_ready         ),
+    .m_axi_arid     ( arid                     ),
+    .m_axi_araddr   ( slave[1].ar_addr         ),
+    .m_axi_arlen    ( slave[1].ar_len          ),
+    .m_axi_arsize   ( slave[1].ar_size         ),
+    .m_axi_arburst  ( slave[1].ar_burst        ),
+    .m_axi_arlock   ( slave[1].ar_lock         ),
+    .m_axi_arcache  ( slave[1].ar_cache        ),
+    .m_axi_arprot   ( slave[1].ar_prot         ),
+    .m_axi_arregion ( slave[1].ar_region       ),
+    .m_axi_arqos    ( slave[1].ar_qos          ),
+    .m_axi_arvalid  ( slave[1].ar_valid        ),
+    .m_axi_arready  ( slave[1].ar_ready        ),
+    .m_axi_rid      ( slave_r_id               ),
+    .m_axi_rdata    ( slave[1].r_data          ),
+    .m_axi_rresp    ( slave[1].r_resp          ),
+    .m_axi_rlast    ( slave[1].r_last          ),
+    .m_axi_rvalid   ( slave[1].r_valid         ),
+    .m_axi_rready   ( slave[1].r_ready         ),
+    .s_axi_aclk     ( pcie_axi_clk             ),
+    .s_axi_aresetn  ( pcie_axi_rstn            ),
+    .s_axi_awid     ( '0                       ),
+    .s_axi_awaddr   ( pcie_dwidth_axi_awaddr   ),
+    .s_axi_awlen    ( pcie_dwidth_axi_awlen    ),
+    .s_axi_awsize   ( pcie_dwidth_axi_awsize   ),
+    .s_axi_awburst  ( pcie_dwidth_axi_awburst  ),
+    .s_axi_awlock   ( pcie_dwidth_axi_awlock   ),
+    .s_axi_awcache  ( pcie_dwidth_axi_awcache  ),
+    .s_axi_awprot   ( pcie_dwidth_axi_awprot   ),
+    .s_axi_awregion ( pcie_dwidth_axi_awregion ),
+    .s_axi_awqos    ( pcie_dwidth_axi_awqos    ),
+    .s_axi_awvalid  ( pcie_dwidth_axi_awvalid  ),
+    .s_axi_awready  ( pcie_dwidth_axi_awready  ),
+    .s_axi_wdata    ( pcie_dwidth_axi_wdata    ),
+    .s_axi_wstrb    ( pcie_dwidth_axi_wstrb    ),
+    .s_axi_wlast    ( pcie_dwidth_axi_wlast    ),
+    .s_axi_wvalid   ( pcie_dwidth_axi_wvalid   ),
+    .s_axi_wready   ( pcie_dwidth_axi_wready   ),
+    .s_axi_bid      (                          ),
+    .s_axi_bresp    ( pcie_dwidth_axi_bresp    ),
+    .s_axi_bvalid   ( pcie_dwidth_axi_bvalid   ),
+    .s_axi_bready   ( pcie_dwidth_axi_bready   ),
+    .s_axi_arid     ( '0                       ),
+    .s_axi_araddr   ( pcie_dwidth_axi_araddr   ),
+    .s_axi_arlen    ( pcie_dwidth_axi_arlen    ),
+    .s_axi_arsize   ( pcie_dwidth_axi_arsize   ),
+    .s_axi_arburst  ( pcie_dwidth_axi_arburst  ),
+    .s_axi_arlock   ( pcie_dwidth_axi_arlock   ),
+    .s_axi_arcache  ( pcie_dwidth_axi_arcache  ),
+    .s_axi_arprot   ( pcie_dwidth_axi_arprot   ),
+    .s_axi_arregion ( pcie_dwidth_axi_arregion ),
+    .s_axi_arqos    ( pcie_dwidth_axi_arqos    ),
+    .s_axi_arvalid  ( pcie_dwidth_axi_arvalid  ),
+    .s_axi_arready  ( pcie_dwidth_axi_arready  ),
+    .s_axi_rid      (                          ),
+    .s_axi_rdata    ( pcie_dwidth_axi_rdata    ),
+    .s_axi_rresp    ( pcie_dwidth_axi_rresp    ),
+    .s_axi_rlast    ( pcie_dwidth_axi_rlast    ),
+    .s_axi_rvalid   ( pcie_dwidth_axi_rvalid   ),
+    .s_axi_rready   ( pcie_dwidth_axi_rready   )
+  );
 `endif
 
 endmodule

--- a/corev_apu/fpga/src/bootrom/Makefile
+++ b/corev_apu/fpga/src/bootrom/Makefile
@@ -15,6 +15,17 @@ CLOCK_FREQUENCY ?= 100000000 #100MHz
 HALF_CLOCK_FREQUENCY ?= 50000000 #50MHz
 UART_BITRATE ?= 115200
 HAS_ETHERNET ?= 1
+else ifeq ($(BOARD), u200)
+# 16 GB DDR4 = 0x4_00000000. The DTS reg cell-pair only takes a 32-bit half each,
+# so the high half goes through DRAM_SIZE_64_HI and the low half through DRAM_SIZE_64.
+DRAM_SIZE_64_HI ?= 0x4
+DRAM_SIZE_64 ?= 0x00000000
+DRAM_SIZE_32 ?= 0x08000000 #128MB
+CLOCK_FREQUENCY ?= 50000000 #50MHz
+HALF_CLOCK_FREQUENCY ?= 25000000 #25MHz
+UART_BITRATE ?= 115200
+HAS_ETHERNET ?= 0
+BOOTS_PCIE ?= BOOT_PCIE
 else
 DRAM_SIZE_64 ?= 0x40000000 #1GB
 DRAM_SIZE_32 ?= 0x08000000 #128MB
@@ -24,12 +35,16 @@ UART_BITRATE ?= 115200
 HAS_ETHERNET ?= 1
 endif
 
+# Other boards default to a single-cell (low-half) DRAM size; high half is zero.
+DRAM_SIZE_64_HI ?= 0x0
+BOOTS_PCIE ?= NO_BOOT_PCIE
+
 ifeq ($(CC),cc)
   CC = $(RISCV)/bin/${CROSSCOMPILE}gcc
   OBJCOPY = $(RISCV)/bin/$(CROSSCOMPILE)objcopy
 endif
 SED = sed
-PLATFORM_DEFINES = -DCLOCK_FREQUENCY=$(CLOCK_FREQUENCY) -DUART_BITRATE=$(UART_BITRATE) -D$(PLATFORM)  -DXLEN=$(XLEN)
+PLATFORM_DEFINES = -DCLOCK_FREQUENCY=$(CLOCK_FREQUENCY) -DUART_BITRATE=$(UART_BITRATE) -D$(PLATFORM)  -DXLEN=$(XLEN) -D$(BOOTS_PCIE)
 
 ifeq ($(XLEN), 64)
 CFLAGS = $(PLATFORM_DEFINES) -Os -ggdb -march=rv64im_zicsr -mabi=lp64 -Wall -mcmodel=medany -mexplicit-relocs -ffreestanding
@@ -86,7 +101,8 @@ $(MAIN): $(DTB) $(OBJS_C) $(OBJS_S) linker.lds
 	@$(CC) $(CFLAGS) $(CCASFLAGS) $(INCLUDES) -c $<  -o $@
 
 %.dts: %.dts.in
-	$(SED) -e "s/DRAM_SIZE_64/$(DRAM_SIZE_64)/g" \
+	$(SED) -e "s/DRAM_SIZE_64_HI/$(DRAM_SIZE_64_HI)/g" \
+	       -e "s/DRAM_SIZE_64/$(DRAM_SIZE_64)/g" \
 	       -e "s/DRAM_SIZE_32/$(DRAM_SIZE_32)/g" \
 	       -e "s/HALF_CLOCK_FREQUENCY/$(HALF_CLOCK_FREQUENCY)/g" \
 	       -e "s/CLOCK_FREQUENCY/$(CLOCK_FREQUENCY)/g" \

--- a/corev_apu/fpga/src/bootrom/cv64a6.dts.in
+++ b/corev_apu/fpga/src/bootrom/cv64a6.dts.in
@@ -31,7 +31,7 @@
   };
   memory@80000000 {
     device_type = "memory";
-    reg = <0x0 0x80000000 0x0 DRAM_SIZE_64>;
+    reg = <0x0 0x80000000 DRAM_SIZE_64_HI DRAM_SIZE_64>;
   };
   leds {
     compatible = "gpio-leds";

--- a/corev_apu/fpga/src/bootrom/src/main.c
+++ b/corev_apu/fpga/src/bootrom/src/main.c
@@ -10,6 +10,12 @@
 #define SECOND_CYCLES   CLOCK_FREQUENCY
 #define WAIT_SECONDS    (10)
 
+#ifdef BOOT_PCIE
+// Sentinel the bootrom writes before polling DRAM. Anything not equal to
+// this marker indicates the host has finished loading the payload via XDMA.
+#define XDMA_READY_MAGIC  0xDEADBEEFCAFEBABEULL
+#endif
+
 static inline uintptr_t get_cycle_count() {
     uintptr_t cycle;
     __asm__ volatile ("csrr %0, cycle" : "=r" (cycle));
@@ -71,10 +77,27 @@ int main()
         print_uart(" updating!\r\n");
         res = update((uint8_t *)0x80000000UL);
     } else {
+#ifdef BOOT_PCIE
+        // No SPI/SD on this platform: the host loads the payload into DRAM
+        // via PCIe XDMA. Seed the first 8 bytes with a sentinel and poll
+        // until the host overwrites it. PCIe writes go straight to DDR4 and
+        // bypass the D-cache, so `fence` (with FlushOnFence/InvalidateOnFlush=1)
+        // is what makes the next read see them.
+        volatile uint64_t *dram_base = (volatile uint64_t *)0x80000000ULL;
+        *dram_base = XDMA_READY_MAGIC;
+        __asm__ volatile ("fence" ::: "memory");
+
+        print_uart(" waiting for PCIe host load...\r\n");
+        while (*dram_base == XDMA_READY_MAGIC) {
+            __asm__ volatile ("fence" ::: "memory");
+        }
+        print_uart(" payload detected, booting!\r\n");
+        res = 0;
+#else
         print_uart(" booting!\r\n");
         #ifndef PLAT_AGILEX
-        res = gpt_find_boot_partition((uint8_t *)0x80000000UL, 2 * 16384); 
-        #else 
+        res = gpt_find_boot_partition((uint8_t *)0x80000000UL, 2 * 16384);
+        #else
             int start_block_fw_payload  = 0x32800; //payload at 100MB
             print_uart("I am Agilex 7! \r\n");
 
@@ -88,7 +111,8 @@ int main()
                     return res;
                 }
 		    }
-        #endif 
+        #endif
+#endif
     }
 
     if (res == 0)

--- a/corev_apu/fpga/src/u200.svh
+++ b/corev_apu/fpga/src/u200.svh
@@ -1,0 +1,13 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Description: Set global FPGA defines for the Alveo U200
+
+`define U200

--- a/corev_apu/fpga/xilinx/ariane_xlnx_ip.yml
+++ b/corev_apu/fpga/xilinx/ariane_xlnx_ip.yml
@@ -6,6 +6,22 @@ xlnx_axi_dwidth_converter:
     si_id_width: 5
     mi_data_width: 32
 
+xlnx_axi_512_64_dwidth_converter:
+  ip: axi_dwidth_converter
+  vendor: xilinx.com
+  config:
+    si_data_width: 64
+    si_id_width: 5
+    mi_data_width: 512
+
+xlnx_axi_512_64_dwidth_converter_pcie:
+  ip: axi_dwidth_converter
+  vendor: xilinx.com
+  config:
+    si_data_width: 512
+    si_id_width: 4
+    mi_data_width: 64
+
 xlnx_axi_clock_converter:
   ip: axi_clock_converter
   vendor: xilinx.com
@@ -79,6 +95,19 @@ xlnx_mig_7_ddr3:
     reset_board_interface: Custom
     mig_dont_touch_param: Custom
     board_mig_param: Custom
+
+xlnx_ddr4:
+  ip: ddr4
+  vendor: xilinx.com
+  config:
+    xml_input_file: ddr4_a.prj
+    reset_board_interface: Custom
+    mig_dont_touch_param: Custom
+    board_mig_param: Custom
+
+xlnx_xdma:
+  ip: xdma
+  vendor: xilinx.com
 
 xlnx_ila:
   ip: xlnx_ila

--- a/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter/Makefile
+++ b/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter/Makefile
@@ -1,0 +1,2 @@
+PROJECT:=xlnx_axi_512_64_dwidth_converter
+include ../common.mk

--- a/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter/tcl/run.tcl
+++ b/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter/tcl/run.tcl
@@ -1,0 +1,22 @@
+set partNumber $::env(XILINX_PART)
+set boardName  $::env(XILINX_BOARD)
+
+set ipName xlnx_axi_512_64_dwidth_converter
+
+create_project $ipName . -force -part $partNumber
+set_property board_part $boardName [current_project]
+
+create_ip -name axi_dwidth_converter -vendor xilinx.com -library ip -module_name $ipName
+
+set_property -dict [list \
+  CONFIG.ADDR_WIDTH {64} \
+  CONFIG.SI_DATA_WIDTH {64} \
+  CONFIG.SI_ID_WIDTH {5} \
+  CONFIG.MI_DATA_WIDTH {512}
+] [get_ips $ipName]
+
+generate_target {instantiation_template} [get_files ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+generate_target all [get_files  ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+create_ip_run [get_files -of_objects [get_fileset sources_1] ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+launch_run -jobs 8 ${ipName}_synth_1
+wait_on_run ${ipName}_synth_1

--- a/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter_pcie/Makefile
+++ b/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter_pcie/Makefile
@@ -1,0 +1,2 @@
+PROJECT:=xlnx_axi_512_64_dwidth_converter_pcie
+include ../common.mk

--- a/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter_pcie/tcl/run.tcl
+++ b/corev_apu/fpga/xilinx/xlnx_axi_512_64_dwidth_converter_pcie/tcl/run.tcl
@@ -1,0 +1,23 @@
+set partNumber $::env(XILINX_PART)
+set boardName  $::env(XILINX_BOARD)
+
+set ipName xlnx_axi_512_64_dwidth_converter_pcie
+
+create_project $ipName . -force -part $partNumber
+set_property board_part $boardName [current_project]
+
+create_ip -name axi_dwidth_converter -vendor xilinx.com -library ip -module_name $ipName
+
+# 4-bit ID matches the XDMA AXI-MM master.
+set_property -dict [list \
+  CONFIG.ADDR_WIDTH {64} \
+  CONFIG.SI_DATA_WIDTH {512} \
+  CONFIG.SI_ID_WIDTH {4} \
+  CONFIG.MI_DATA_WIDTH {64}
+] [get_ips $ipName]
+
+generate_target {instantiation_template} [get_files ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+generate_target all [get_files  ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+create_ip_run [get_files -of_objects [get_fileset sources_1] ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+launch_run -jobs 8 ${ipName}_synth_1
+wait_on_run ${ipName}_synth_1

--- a/corev_apu/fpga/xilinx/xlnx_clk_gen/tcl/run.tcl
+++ b/corev_apu/fpga/xilinx/xlnx_clk_gen/tcl/run.tcl
@@ -23,6 +23,25 @@ if {$::env(BOARD) eq "nexys_video"} {
                         CONFIG.CLKOUT5_REQUESTED_OUT_FREQ {200} \
                         CONFIG.CLKIN1_JITTER_PS {50.0} \
                        ] [get_ips $ipName]
+} elseif {$::env(BOARD) eq "u200"} {
+    # U200: SYSCLK1_300 (Bank 64) drives the system PLL via an external IBUFDS
+    # in the RTL, so the wizard must not insert its own input buffer.
+    # 200 MHz output is needed by ariane_peripherals (clk_200MHz_ref).
+    set_property -dict [list CONFIG.CLK_IN1_BOARD_INTERFACE {default_300mhz_clk1} \
+                        CONFIG.PRIM_SOURCE {Differential_clock_capable_pin} \
+                        CONFIG.NUM_OUT_CLKS {5} \
+                        CONFIG.CLKOUT2_USED {true} \
+                        CONFIG.CLKOUT3_USED {true} \
+                        CONFIG.CLKOUT4_USED {true} \
+                        CONFIG.CLKOUT5_USED {true} \
+                        CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {50} \
+                        CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125} \
+                        CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {125} \
+                        CONFIG.CLKOUT3_REQUESTED_PHASE {90.000} \
+                        CONFIG.CLKOUT4_REQUESTED_OUT_FREQ {50} \
+                        CONFIG.CLKOUT5_REQUESTED_OUT_FREQ {200} \
+                        CONFIG.CLKIN1_JITTER_PS {33.330} \
+                       ] [get_ips $ipName]
 } else {
 set_property -dict [list CONFIG.PRIM_IN_FREQ {200.000} \
                         CONFIG.NUM_OUT_CLKS {4} \

--- a/corev_apu/fpga/xilinx/xlnx_ddr4/Makefile
+++ b/corev_apu/fpga/xilinx/xlnx_ddr4/Makefile
@@ -1,0 +1,2 @@
+PROJECT:=xlnx_ddr4
+include ../common.mk

--- a/corev_apu/fpga/xilinx/xlnx_ddr4/tcl/run.tcl
+++ b/corev_apu/fpga/xilinx/xlnx_ddr4/tcl/run.tcl
@@ -1,0 +1,39 @@
+set partNumber $::env(XILINX_PART)
+set boardName  $::env(XILINX_BOARD)
+
+set ipName xlnx_ddr4
+
+create_project $ipName . -force -part $partNumber
+set_property board_part $boardName [current_project]
+
+create_ip -name ddr4 -vendor xilinx.com -library ip -module_name $ipName
+
+upgrade_ip [get_ips $ipName]
+
+# Alveo U200 has 4× MTA18ASF2G72PZ-2G3 RDIMMs (16 GB / channel, 34-bit AXI addr).
+# AxiSelection=true exposes a 512-bit AXI4 slave; we drive it from a 64→512
+# converter. The IP's input clock is SYSCLK0_300 (default_300mhz_clk0, Bank 42),
+# which keeps the system PLL on SYSCLK1_300 (Bank 64).
+set_property -dict [list \
+  CONFIG.ADDN_UI_CLKOUT1_FREQ_HZ {100} \
+  CONFIG.C0.DDR4_AUTO_AP_COL_A3 {true} \
+  CONFIG.C0.DDR4_AxiAddressWidth {34} \
+  CONFIG.C0.DDR4_AxiDataWidth {512} \
+  CONFIG.C0.DDR4_AxiSelection {true} \
+  CONFIG.C0.DDR4_CasLatency {17} \
+  CONFIG.C0.DDR4_DataMask {NONE} \
+  CONFIG.C0.DDR4_Ecc {false} \
+  CONFIG.C0.DDR4_InputClockPeriod {3332} \
+  CONFIG.C0.DDR4_Mem_Add_Map {ROW_COLUMN_BANK_INTLV} \
+  CONFIG.C0.DDR4_MemoryPart {MTA18ASF2G72PZ-2G3} \
+  CONFIG.C0.DDR4_MemoryType {RDIMMs} \
+  CONFIG.C0.DDR4_TimePeriod {833} \
+  CONFIG.C0_CLOCK_BOARD_INTERFACE {default_300mhz_clk0} \
+  CONFIG.C0_DDR4_BOARD_INTERFACE {ddr4_sdram_c0} \
+] [get_ips xlnx_ddr4]
+
+generate_target {instantiation_template} [get_files ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+generate_target all [get_files  ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+create_ip_run [get_files -of_objects [get_fileset sources_1] ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+launch_run -jobs 8 ${ipName}_synth_1
+wait_on_run ${ipName}_synth_1

--- a/corev_apu/fpga/xilinx/xlnx_xdma/Makefile
+++ b/corev_apu/fpga/xilinx/xlnx_xdma/Makefile
@@ -1,0 +1,2 @@
+PROJECT:=xlnx_xdma
+include ../common.mk

--- a/corev_apu/fpga/xilinx/xlnx_xdma/tcl/run.tcl
+++ b/corev_apu/fpga/xilinx/xlnx_xdma/tcl/run.tcl
@@ -1,0 +1,43 @@
+set partNumber $::env(XILINX_PART)
+set boardName  $::env(XILINX_BOARD)
+
+set ipName xlnx_xdma
+
+create_project $ipName . -force -part $partNumber
+set_property board_part $boardName [current_project]
+
+create_ip -name xdma -vendor xilinx.com -library ip -module_name $ipName
+
+# Alveo U200 — XDMA PCIe Gen3 x16 AXI-MM Bridge (no DMA engine).
+# AXI master: 512-bit data, 64-bit addr, 4-bit ID. PCIe refclk: 100 MHz (AM10/AM11).
+# BAR0 = 256 MB; pciebar2axibar_0 = 0x80000000 → host writes to BAR0 + offset
+# land at AXI address 0x80000000 + offset (DRAM base on the SoC).
+set_property -dict [list \
+    CONFIG.PCIE_BOARD_INTERFACE      {pci_express_x16} \
+    CONFIG.SYS_RST_N_BOARD_INTERFACE {pcie_perstn} \
+    CONFIG.functional_mode           {AXI_Bridge} \
+    CONFIG.mode_selection            {Advanced} \
+    CONFIG.device_port_type          {PCI_Express_Endpoint_device} \
+    CONFIG.pl_link_cap_max_link_width {X16} \
+    CONFIG.pl_link_cap_max_link_speed {8.0_GT/s} \
+    CONFIG.axi_data_width            {512_bit} \
+    CONFIG.axi_addr_width            {64} \
+    CONFIG.axi_id_width              {4} \
+    CONFIG.axilite_master_en         {false} \
+    CONFIG.axist_bypass_en           {false} \
+    CONFIG.ref_clk_freq              {100_MHz} \
+    CONFIG.pf0_device_id             {903F} \
+    CONFIG.pf0_subsystem_vendor_id   {10EE} \
+    CONFIG.en_gt_selection           {true} \
+    CONFIG.pf0_bar0_size             {256}     \
+    CONFIG.pf0_bar0_scale            {Megabytes} \
+    CONFIG.pf0_bar0_64bit            {true}    \
+    CONFIG.pf0_bar0_prefetchable     {true}    \
+    CONFIG.pciebar2axibar_0          {0x0000000080000000} \
+] [get_ips $ipName]
+
+generate_target {instantiation_template} [get_files ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+generate_target all [get_files  ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+create_ip_run [get_files -of_objects [get_fileset sources_1] ./$ipName.srcs/sources_1/ip/$ipName/$ipName.xci]
+launch_run -jobs 8 ${ipName}_synth_1
+wait_on_run ${ipName}_synth_1

--- a/corev_apu/tb/ariane_soc_pkg.sv
+++ b/corev_apu/tb/ariane_soc_pkg.sv
@@ -47,6 +47,8 @@ package ariane_soc;
   localparam logic[63:0] HPSLength      = 64'h800000;
 `ifdef NEXYS_VIDEO
   localparam logic[63:0] DRAMLength     = 64'h20000000; // 512MByte of DDR on Nexys video board
+`elsif U200
+  localparam logic[63:0] DRAMLength     = 64'h4_0000_0000; // 16GByte of DDR4 on Alveo U200
 `else
   localparam logic[63:0] DRAMLength     = 64'h40000000; // 1GByte of DDR (split between two chips on Genesys2)
 `endif

--- a/tutorials/fpga.md
+++ b/tutorials/fpga.md
@@ -1,6 +1,6 @@
 # COREV-APU FPGA Emulation
 
-We currently provide support for the [Genesys 2 board](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual) and the [Agilex 7 Development Kit](https://www.intel.la/content/www/xl/es/products/details/fpga/development-kits/agilex/agf014.html).
+We currently provide support for the [Genesys 2 board](https://reference.digilentinc.com/reference/programmable-logic/genesys-2/reference-manual), the [Agilex 7 Development Kit](https://www.intel.la/content/www/xl/es/products/details/fpga/development-kits/agilex/agf014.html), and the [Xilinx Alveo U200](https://www.xilinx.com/products/boards-and-kits/alveo/u200.html).
 
 - **Genesys 2**
 
@@ -29,6 +29,17 @@ We currently provide support for the [Genesys 2 board](https://reference.digilen
    - GPIOs connected to LEDs
 
 > The ethernet controller and the corresponding network connection, as well as the SD Card connection and the capability to boot linux are still work in progress and not functional at the moment. Expect some updates soon-ish.
+
+- **Alveo U200**
+
+   Tested on Vivado 2022.2. The FPGA currently contains the following peripherals:
+
+   - DDR4 memory controller (16 GB, ECC RDIMM)
+   - PCIe Gen3 x16 endpoint (XDMA in AXI-Bridge mode) used as the boot path
+   - Bootrom containing zero-stage bootloader and device tree
+   - UART (FT4232 USB-UART, microUSB on the front bracket)
+
+> The Alveo U200 has no SD card, ethernet is still work in progress, and on-chip debug is currently stubbed (no `dmi_jtag` instance, see the debugging section). The bootrom waits for the host to load the payload into DDR4 via PCIe (see [Booting Linux on the U200](#booting-linux-on-the-alveo-u200) below)
 
 
 ## Programming the Memory Configuration File or bitstream
@@ -62,7 +73,48 @@ juart-terminal: (Use the IDE stop button or Ctrl-C to terminate)
 Hello World!
 ```
 
+- **Alveo U200**
+
+   The Alveo U200 supports two configuration paths. Both reconfigure the PCIe hard block, so in either case the host must re-enumerate the device after programming via the helper script described at the bottom of this section.
+
+   Common setup, before either path:
+
+   - Connect the U200 to the host via PCIe and connect the microUSB cable for the JTAG/UART FT4232 bridge
+   - Open Vivado 2022.2 (or later)
+   - Open the hardware manager and connect to the U200 (`xcu200_0`)
+
+   **Path A — JTAG bitstream load (volatile, fast for iteration)**
+
+   The bitstream lives in the FPGA fabric until the next power cycle. This method takes a few seconds.
+
+   - Right-click the FPGA device → Program Device
+   - Select `corev_apu/fpga/work-fpga/ariane_xilinx.bit`
+   - Click Program
+
+   **Path B — Quad-SPI flash (persistent, survives power cycles)**
+
+   Use this when you want the bitstream to be persistent across power cycles. This method takes a few minutes.
+
+   - Right-click the FPGA device → Add Configuration Memory Device
+   - Select `mt25qu01g-spi-x1_x2_x4` (the on-board Micron 1 Gb quad-SPI flash)
+   - Add `corev_apu/fpga/work-fpga/ariane_xilinx.mcs` and let Vivado erase/program/verify
+   - Right-click the FPGA device → Boot from Configuration Memory Device (or power-cycle the host)
+
+   **Re-enumerate the PCIe endpoint (both paths)**
+
+   After either Path A or Path B, the FPGA's PCIe hard block resets and the host's stale enumeration is no longer valid. From a host shell:
+
+   ```
+   sudo corev_apu/fpga/scripts/pcie_hot_reset.sh
+   ```
+
+   The script defaults to vendor:device `10ee:903f` (matching the XDMA IP's identifiers). Pass an alternate `vendor:device` on the command line if you have changed the IDs. After it finishes, the device's BAR0 sysfs node is ready for `pcie_load`.
+
 ## Booting Linux
+
+The Linux boot flow depends on the board, because the storage / loader available varies. Pick the subsection that matches your target.
+
+### Booting Linux from an SD card (Genesys 2 / KC705 / VC707 / Nexys Video)
 
 The first stage bootloader will boot from SD Card by default. Get yourself a suitable SD Card (we use [this](https://www.amazon.com/Kingston-Digital-Mobility-MBLY10G2-32GB/dp/B00519BEQO) one). Either grab a pre-built Linux image from [here](https://github.com/pulp-platform/ariane-sdk/releases) or generate the Linux image yourself following the README in the [ariane-sdk repository](https://github.com/pulp-platform/ariane-sdk). Prepare the SD Card by following the "Booting from SD card" section in the ariane-sdk repository.
 
@@ -74,6 +126,42 @@ screen /dev/ttyUSB0 115200
 Default baudrate set by the bootloader and Linux is `115200`.
 
 After you've inserted the SD Card and programmed the FPGA you can connect to the serial port of the FPGA and should see the bootloader and afterwards Linux booting. Default username is `root`, no password required.
+
+### Booting Linux on the Alveo U200
+
+The Alveo U200 has no SD card slot, so its boot flow is different from the other boards. The host loads a single combined payload into DDR4 over PCIe, and the bootrom polls until that payload arrives before jumping to it.
+
+#### Build the payload
+
+Use the [`cva6-sdk`](https://github.com/openhwgroup/cva6-sdk) `BOARD=u200` target. It produces `install64_u200/boot.bin` containing:
+
+| Image |
+| --- |
+| `fw_payload.bin` (OpenSBI + U-Boot) |
+| `fitImage.itb` (kernel + DTB + ramdisk) |
+
+#### Load the payload over PCIe
+
+After the FPGA is programmed and PCIe-enumerated, locate the FPGA's BAR0 sysfs node:
+
+```
+ls -l /sys/bus/pci/devices/<bdf>/resource0
+```
+
+Compile and run the loader (sources in `corev_apu/fpga/scripts/pcie_load.c`):
+
+```
+gcc -O2 -o pcie_load corev_apu/fpga/scripts/pcie_load.c
+sudo ./pcie_load /sys/bus/pci/devices/<bdf>/resource0 0x0 /path/to/cva6-sdk/install64_u200/boot.bin
+```
+
+Connect to the USB-UART (/dev/ttyUSB2 is the typical assignment for FTDI port C; dmesg after plugging the microUSB cable will show the exact node):
+
+```
+screen /dev/ttyUSB2 115200
+```
+
+You should see the bootrom announcement, OpenSBI banner, U-Boot, and the kernel boot to a buildroot login prompt (default username `root`, no password).
 
 ## Booting zephyr RTOS
 
@@ -142,6 +230,16 @@ To clean the project after generating the bitstream, use
 ```
 make clean-altera
 ```
+
+- **Alveo U200**
+
+To generate the FPGA bitstream and configuration-memory file for the Alveo U200, run:
+
+```
+make BOARD=u200 fpga
+```
+
+This produces `corev_apu/fpga/work-fpga/ariane_xilinx.bit` and `ariane_xilinx.mcs`. Flash the `.bit` or `.mcs` to the board using the steps under [Programming the Memory Configuration File or bitstream](#programming-the-memory-configuration-file-or-bitstream) above.
 
 ## Debugging
 
@@ -230,7 +328,11 @@ Info : Listening on port 6666 for tcl connections
 Info : Listening on port 4444 for telnet connections
 ```
 
-- **Common for both boards**
+- **Alveo U200**
+
+The U200 has no JTAG header. The current target stubs `dmi_jtag` out under `` `ifdef U200 `` in `corev_apu/fpga/src/ariane_xilinx.sv`, so on-chip debug is not available. Hart 0 cannot be halted from the host with the present bitstream. A future patch can wire DMI through the existing PCIe XDMA path (host → AXI-Lite → `dmi_*`) — the seam is the `` `ifdef U200 `` block in `ariane_xilinx.sv`.
+
+- **Common for the JTAG-equipped boards**
 
 Then you will be able to either connect through `telnet` or with `gdb`:
 


### PR DESCRIPTION
## Motivation

Add Xilinx Alveo U200 (`xcu200-fsgd2104-2-e`) as a CVA6 FPGA target.

The U200 is the first PCIe datacenter card in the supported board list. Compared to the existing targets (Genesys 2, KC705, VC707, Nexys Video, VCU118) it differs in three ways that drove most of the changes in this PR:

1. **No SD/SPI and no JTAG header.** The card boots its payload over PCIe: the host loads OpenSBI + payload into DDR4 via XDMA, and a sentinel handshake in the bootrom triggers the jump. JTAG debug is not exposed on the board.
2. **16 GB DDR4** vs 1 GB on existing boards — needs a 64-bit DRAM size in the device tree, a wider cached/execute region, and a 64<->512-bit AXI dwidth converter to interface CVA6 (64-bit) to the DDR4 MIG (512-bit at 16 GB).
3. **PCIe XDMA in AXI-Bridge mode.** Instead of an SD/Ethernet bootloader, the host writes BAR0 -> AXI 0x8000_0000 directly, and CVA6's d-cache has to flush/invalidate on `fence` so the bootrom can see the payload.

A companion PR against [`openhwgroup/cva6-sdk`](https://github.com/openhwgroup/cva6-sdk) adds `BOARD=u200` to the SDK and produces `install64_u200/boot.bin` (`fw_payload.bin` truncated to 128 MiB + `fitImage.itb`, loaded at AXI `0x8000_0000`). That image is what the bootrom in this PR waits for. Link: https://github.com/openhwgroup/cva6-sdk/pull/125

## Scope and gating

Everything U200-specific is gated behind one of:

- `BOARD == u200` (top Makefile, `corev_apu/fpga/Makefile`, TCL scripts)
- `` `ifdef U200 `` (in `ariane_xilinx.sv`, `ariane_soc_pkg.sv`, `build_fpga_config()`)
- `` `define U200 `` is set only by the new `corev_apu/fpga/src/u200.svh`, which is added as a global include solely in the U200 Vivado flow.
- `BOOTS_PCIE` makefile knob in the bootrom. Defaults to `NO_BOOT_PCIE` outside the U200 board case.

Other boards see no functional change.

## Commits

The change is split into five commits in the order they should be reviewed:

1. **Bootrom: support 64-bit DRAM and PCIe boot path** Board-agnostic refactor. Splits `DRAM_SIZE_64` into a high/low pair so the DTS can express sizes >= 4 GB, and adds a `BOOTS_PCIE` knob that plumbs `-DBOOT_PCIE` into `main.c`. Default is `NO_BOOT_PCIE`, so the existing bootrom flow is unchanged for every other board.
2. **Add Alveo U200 FPGA build infrastructure** New IP TCL projects (`xlnx_xdma`, `xlnx_ddr4`, `xlnx_axi_512_64_dwidth_converter`, `xlnx_axi_512_64_dwidth_converter_pcie`), the `u200.svh` macro, `u200.xdc`, plus the `BOARD=u200` cases in the top Makefile, the FPGA Makefile, `run.tcl`, `write_cfgmem.tcl`, `xlnx_clk_gen` and `ariane_xlnx_ip.yml`. The PCIe -> SoC clock crossing reuses the existing `xlnx_axi_clock_converter` rather than adding a new IP.
3. **Wire Alveo U200 into ariane_xilinx top** The actual RTL: U200 port section, U200 elsif block (DDR4 + XDMA + width adapter + clock crossing), `ariane_soc_pkg::DRAMLength`, and U200 overrides for `DcacheFlushOnFence`, `DcacheInvalidateOnFlush` and the cached/execute region lengths inside `build_fpga_config()`. `dmi_jtag`, `dpti_ctrl` and `slicer_DPTI` are gated out under the U200 macro, with the resulting stranded outputs tied to idle values so Vivado can place them.
4. **Add Alveo U200 PCIe host-side utilities** `pcie_load.c` (mmaps BAR0 and copies a payload to DRAM) and `pcie_hot_reset.sh` (re-enumerates the device after a JTAG bitstream load). These are NOT invoked by the build flow. They live next to the build scripts so U200 users can find them.
5. **Document Alveo U200 FPGA target** Adds an Alveo U200 section to `tutorials/fpga.md` covering bitstream generation (`make BOARD=u200 fpga`), MCS programming via Vivado, the PCIe boot flow with `pcie_load` and the cva6-sdk `BOARD=u200` `boot.bin` payload, the `pcie_hot_reset.sh` re-enumeration helper, and the on-chip-debug-is-stubbed limitation.

## Some notes

- **`` `ifdef `` over a top-level Board parameter.** CONTRIBUTING.md says conditional compiler directives are strongly discouraged in favor of SystemVerilog parameters. I followed the existing per-board `` `ifdef `` pattern in `ariane_xilinx.sv` (`GENESYSII / KC705 / VC707 / VCU118 / NEXYS_VIDEO`) so the new U200 branch sits next to the others rather than introducing a new style for a single board. Refactoring the file to a `Board` enum parameter would touch every existing target and feels out of scope for a port.
- **Code duplication with the legacy VCU118 path.** The U200 elsif in `ariane_xilinx.sv` is structurally similar to the VCU118 elsif (also DDR4 + XDMA). I deliberately did not touch the VCU118 references --- the upstream VCU118 path references three IP modules that aren't defined in `corev_apu/fpga/xilinx/` (`axi_dwidth_converter_512_64`, `axi_dwidth_converter_256_64`, `axi_clock_converter_0`) and it is not working, so the U200 port adds new IPs under cleaner names rather than changing or fixing the VCU118 path. A later refactor could merge both into one shared elsif body if VCU118 is fixed.
- **Debug is stubbed, not wired.** With DPTI absent and no PCIe-routed DMI master in this PR, `dmi_jtag` is replaced with a constant tie-off (`debug_req_valid = 0`, `debug_resp_ready = 1`). This means hart 0 cannot be halted from the host. The seam is the `` `ifdef U200 `` block right next to where `dmi_jtag` would be instantiated.
- **DPTI tracer is gated.** The U200 has no DPTI (Digilent Parallel Trace Interface) bridge, so `slicer_DPTI` and `dpti_ctrl` are gated out and the encap FIFO is drained unconditionally. RVFI signals are still produced. They just aren't shipped off-chip.
- **Flush/invalidate on `fence`.** The U200 sets `DcacheFlushOnFence` and `DcacheInvalidateOnFlush` to 1 because PCIe
  DMA writes from the host bypass the D-cache. The bootrom's polling loop relies on `fence` to make the host's writes visible. This is set in `build_fpga_config()` (the same hook that already overrides `RVZiCond` and `NonIdempotentRules` upstream), so the shared `cv64a6_imafdc_sv39_config_pkg.sv` is unchanged.
- **`u200.xdc` parks 5 unused-on-U200 outputs on Bank 64 GPIO_MSP / SW_DP test pins.** Vivado cannot trim top-level outputs that have no internal driver, so `tdo`, `prog_oen`, `prog_rdn`, `prog_wrn` and `prog_siwun` are tied to their idle values and given location constraints. Pins were picked from the published Alveo U200 board file XDC.

## What has been tested:

Host loads the cva6-sdk `BOARD=u200` `boot.bin` (OpenSBI + U-Boot + FIT image) via `sudo ./pcie_load /sys/bus/pci/.../resource0 0x0 boot.bin`, bootrom polls, drops the sentinel, and jumps. OpenSBI → U-Boot → kernel boots to a buildroot login prompt.

## Limitations / known issues

- **No on-chip debug:** see "Debug is stubbed, not wired" above.
- **No CI coverage:** see "What this PR does NOT include" above.
- **Only 16 GB out of an available 64 GB:** The U200 carries four independent 16 GB RDIMMs on channels `c0`..`c3`; this PR instantiates only the `c0` MIG and `ariane_soc_pkg::DRAMLength` is set to 16 GB accordingly. Bringing up the other three channels would require either (a) instantiating three more MIGs plus an AXI interconnect / address decoder so CVA6 sees them as one contiguous 64 GB region, or (b) widening `cva6_config_pkg`'s `NrCachedRegionRules`/`NrExecuteRegionRules` so each channel becomes a separate cached/non-idempotent region. Both options are noticeably more invasive than the rest of this PR (new IPs, new interconnect, possibly new arbitration in the d-cache miss handler) and feel out of scope for an initial port.
- **No QSFP / Ethernet support:** The U200 ships with two QSFP28 cages. Bringing them up would require a 10/25/40/100GbE MAC + PCS/PMA IP and a different software stack than CVA6's existing `lowrisc-eth` / RGMII MAC. That felt out of scope for an initial port. `InclEthernet` is set to `1'b0` for U200 and the legacy MII/RGMII top-level ports are tied off. 