### PR TITLE
fix: tie `debug_mode` to 0 if `DebugEn` is false

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -2744,7 +2744,7 @@ module csr_regfile
 
   // determine if mprv needs to be considered if in debug mode
   assign mprv = (CVA6Cfg.DebugEn && debug_mode_q && !dcsr_q.mprven) ? 1'b0 : mstatus_q.mprv;
-  assign debug_mode_o = debug_mode_q;
+  assign debug_mode_o = CVA6Cfg.DebugEn ? debug_mode_q : 1'b0;
   assign single_step_o = CVA6Cfg.DebugEn ? dcsr_q.step : 1'b0;
   assign mcountinhibit_o = {{29 - MHPMCounterNum{1'b0}}, mcountinhibit_q};
 


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
`DebugEn` set to 0 results in `debug_mode` being at `x`. This is problematic since it is widely used throughout the design and can generate subtle bugs. For example, I noted it since the performance counters did not increase as they rely on `debug_mode` being 0, while it was instead at `x`.

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

