### PR TITLE
Fix Spike check

### DIFF
--- a/verif/sim/cva6.py
+++ b/verif/sim/cva6.py
@@ -1097,7 +1097,8 @@ def check_spike_version():
 
   logging.info(f"Spike Version: {user_spike_stderr_string}")
 
-  if user_spike_stderr_string != spike_version:
+  n = min(len(user_spike_stderr_string), len(spike_version))
+  if user_spike_stderr_string[:n] != spike_version[:n]:
     incorrect_version_exit("Spike", user_spike_stderr_string, spike_version)
 
 


### PR DESCRIPTION
Spike version could failed when the compared hash len were not the same. This PR fixes the issue.
