### PR TITLE
cva6_mmu: use live dtlb_is_page for same-cycle DTLB PPN substitution

### DIFF
--- a/core/cva6_mmu/cva6_mmu.sv
+++ b/core/cva6_mmu/cva6_mmu.sv
@@ -554,14 +554,14 @@ module cva6_mmu
         lsu_vaddr_q[11:0]
       };
 
-      if (CVA6Cfg.PtLevels == 3 && dtlb_is_page_q[CVA6Cfg.PtLevels-2]) begin
+      if (CVA6Cfg.PtLevels == 3 && dtlb_is_page[CVA6Cfg.PtLevels-2]) begin
         // Strange 9+PtLevels to avoid CI errors on (purely syntactic) checks on Sv32, where
         // `PPNWMin-(CVA6Cfg.VpnLen/CVA6Cfg.PtLevels)` equals `11` and would lead to `lsu_paddr_o[11:12]`
         lsu_paddr_o[PPNWMin-(CVA6Cfg.VpnLen/CVA6Cfg.PtLevels):9+CVA6Cfg.PtLevels] = lsu_vaddr_q[PPNWMin-(CVA6Cfg.VpnLen/CVA6Cfg.PtLevels):9+CVA6Cfg.PtLevels];
         lsu_dtlb_ppn_o[PPNWMin-(CVA6Cfg.VpnLen/CVA6Cfg.PtLevels):9+CVA6Cfg.PtLevels] = lsu_vaddr_n[PPNWMin-(CVA6Cfg.VpnLen/CVA6Cfg.PtLevels):9+CVA6Cfg.PtLevels];
       end
 
-      if (dtlb_is_page_q[0]) begin
+      if (dtlb_is_page[0]) begin
         lsu_dtlb_ppn_o[PPNWMin:12] = lsu_vaddr_n[PPNWMin:12];
         lsu_paddr_o[PPNWMin:12] = lsu_vaddr_q[PPNWMin:12];
       end


### PR DESCRIPTION
## Summary

Fixes #3322.

`lsu_dtlb_ppn_o` is generated from current-cycle DTLB lookup data (`dtlb_content.ppn`), but the superpage substitution path was gated by the registered page-size state `dtlb_is_page_q`.

This mixes current-cycle PPN information with previous-cycle page-size metadata and can produce an incorrect same-cycle DTLB PPN value when consecutive accesses hit different page sizes.

This change uses the live `dtlb_is_page` signal for the same-cycle `lsu_dtlb_ppn_o` substitution path while leaving the registered `lsu_paddr_o` path unchanged.

## Changes

* Replace `dtlb_is_page_q[CVA6Cfg.PtLevels-2]` with `dtlb_is_page[CVA6Cfg.PtLevels-2]` in the same-cycle DTLB PPN substitution path.
* Replace `dtlb_is_page_q[0]` with `dtlb_is_page[0]` in the same-cycle DTLB PPN substitution path.

## Validation

* RTL inspection against issue #3322.
* Functional simulation and reproducer execution have not yet been performed.
