### PR TITLE
fix for 3136 - tie frontend's flush_bp_i to flush_ctrl_bp

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -690,7 +690,8 @@ module cva6
       .rst_ni,
       .boot_addr_i        (boot_addr_i[CVA6Cfg.VLEN-1:0]),
       .flush_bp_i         ((CVA6Cfg.RVU || CVA6Cfg.RVS) ? flush_ctrl_bp : 1'b0),
-      .flush_i            (flush_ctrl_if),                  // not entirely correct
+      // below line is not entirely correct
+      .flush_i            (flush_ctrl_if),
       .halt_i             (halt_ctrl),
       .halt_frontend_i    (halt_frontend),
       .set_pc_commit_i    (set_pc_ctrl_pcgen),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -689,7 +689,7 @@ module cva6
       .clk_i,
       .rst_ni,
       .boot_addr_i        (boot_addr_i[CVA6Cfg.VLEN-1:0]),
-      .flush_bp_i         (1'b0),
+      .flush_bp_i         ((CVA6Cfg.RVU || CVA6Cfg.RVS) ? flush_ctrl_bp : 1'b0),
       .flush_i            (flush_ctrl_if),                  // not entirely correct
       .halt_i             (halt_ctrl),
       .halt_frontend_i    (halt_frontend),


### PR DESCRIPTION
Reopening https://github.com/openhwgroup/cva6/pull/3352 to fix for Eclipse ECA

* [x] I have searched for similar pull requests
* [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

`flush_bp_i` in `i_frontend` (`core/cva6.sv`) has been hardwired to `1'b0` since the first commit, meaning the branch predictor is never flushed on privilege mode transitions (exceptions and `eret`).

The controller already generates `flush_bp_o` on exceptions and `eret`, and this signal is captured as `flush_ctrl_bp` in `cva6.sv`. However, it is currently not connected to the frontend.

As a result, branch predictor state can persist across privilege boundaries (e.g. M↔S, M↔U, S↔U), potentially causing stale predictions to be used after a privilege transition.

In particular, this can lead to:

* Instruction access faults during kernel boot when stale virtual addresses from lower privilege modes remain in the predictor while executing in M-mode.
* Potential timing side-channel leakage across privilege domains through predictor state reuse.

## Change

This PR connects the existing controller-generated flush signal to the frontend branch predictor flush input:

```systemverilog
.flush_bp_i ((CVA6Cfg.RVU || CVA6Cfg.RVS) ? flush_ctrl_bp : 1'b0),
```

Since `CVA6Cfg.RVU` and `CVA6Cfg.RVS` are compile-time configuration constants, synthesis tools will optimize this expression to `1'b0` for M-mode-only configurations, preserving zero-propagation and eliminating unnecessary logic in those variants.

## Related issues

Related to issue #3136.

## Limitations

This change flushes the branch predictor on every exception and `eret`, which may have a small performance impact on systems with frequent privilege transitions.

The existing TODO in `controller.sv` regarding removal of this flush mechanism once PMA checkers are introduced is not addressed by this PR. This change only ensures that the already-generated flush signal is correctly propagated to the frontend.
