### PR TITLE
fix: secure debug module access from non-debug mode

### DIFF
--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -550,6 +550,7 @@ module ex_stage
       .clk_i,
       .rst_ni,
       .flush_i,
+      .debug_mode_i,
       .stall_st_pending_i,
       .no_st_pending_o,
       .fu_data_i             (lsu_data),

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -160,6 +160,9 @@ module load_store_unit
     // AMO response - CACHE
     input  amo_resp_t           amo_resp_i,
 
+    // Debug mode - CSR_REGFILE
+    input logic debug_mode_i,
+
     // PMP configuration - CSR_REGFILE
     input riscv::pmpcfg_t [avoid_neg(CVA6Cfg.NrPMPEntries-1):0]                   pmpcfg_i,
     // PMP address - CSR_REGFILE
@@ -383,6 +386,7 @@ module load_store_unit
   ) i_pmp_data_if (
       .clk_i               (clk_i),
       .rst_ni              (rst_ni),
+      .debug_mode_i        (debug_mode_i),
       .icache_areq_i       (pmp_icache_areq_i),
       .icache_areq_o       (icache_areq_o),
       .icache_fetch_vaddr_i(icache_areq_i.fetch_vaddr),

--- a/core/pmp/src/pmp_data_if.sv
+++ b/core/pmp/src/pmp_data_if.sv
@@ -15,6 +15,8 @@ module pmp_data_if
 ) (
     input logic clk_i,
     input logic rst_ni,
+    // Debug mode - CSR_REGFILE
+    input logic debug_mode_i,
     // IF interface
     input icache_areq_t icache_areq_i,
     output icache_areq_t icache_areq_o,
@@ -83,7 +85,10 @@ module pmp_data_if
     // exception
     if (icache_areq_i.fetch_valid) begin
       if (icache_areq_o.fetch_exception.cause != riscv::INSTR_PAGE_FAULT) begin
-        if (!match_any_execute_region || !pmp_if_allow) begin
+        if (!match_any_execute_region || !pmp_if_allow
+            || (CVA6Cfg.DebugEn && !debug_mode_i
+                && icache_areq_i.fetch_paddr >= CVA6Cfg.DmBaseAddress[CVA6Cfg.PLEN-1:0]
+                && icache_areq_i.fetch_paddr < (CVA6Cfg.DmBaseAddress[CVA6Cfg.PLEN-1:0] + CVA6Cfg.PLEN'('h1000)))) begin
           icache_areq_o.fetch_exception.cause = riscv::INSTR_ACCESS_FAULT;
           icache_areq_o.fetch_exception.valid = 1'b1;
           // For exception, the virtual address is required for tval, if no MMU is
@@ -126,7 +131,10 @@ module pmp_data_if
     pmp_access_type = lsu_is_store_i ? riscv::ACCESS_WRITE : riscv::ACCESS_READ;
 
     // If translation is not enabled, check the paddr immediately against PMPs
-    if (lsu_valid_i && !data_allow_o) begin
+    if (lsu_valid_i && (!data_allow_o
+        || (CVA6Cfg.DebugEn && !debug_mode_i
+            && lsu_paddr_i >= CVA6Cfg.DmBaseAddress[CVA6Cfg.PLEN-1:0]
+            && lsu_paddr_i < (CVA6Cfg.DmBaseAddress[CVA6Cfg.PLEN-1:0] + CVA6Cfg.PLEN'('h1000))))) begin
       lsu_exception_o.valid = 1'b1;
 
       if (CVA6Cfg.TvalEn) begin


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
### Why this PR is needed
This PR fixes a security vulnerability where Machine Mode code could bypass physical memory protections to access the Debug Module memory if the PMP configuration was set to be overly permissive. 
I've threaded the `debug_mode_i` signal through the Execute Stage and Load-Store Unit down into `pmp_data_if` to enforce a hardcoded range check. Any memory access targeting the debug region (`DmBaseAddress` to `DmBaseAddress + 0xFFF`) while the processor is not in debug mode will now correctly trigger an Instruction, Load, or Store Access Fault.

<!-- Is this PR related to existing issues? If so, link to them below -->
### Related Issues
Fixes #3346 

<!-- Are there limitations with the current state of this contribution? -->
### Limitations
No known limitations. 

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

