### PR TITLE
Fix the Ci to always dump simulation artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,14 @@ jobs:
     - name: Run Tests
       run: |
           set -x
+          mkdir -p "verif/sim/out_$(date +%F)"
           export RISCV=$(pwd)/tools/riscv-toolchain/
           source ci/install-prereq.sh
           source verif/sim/setup-env.sh
           DV_SIMULATORS=${{matrix.simulator}},spike DV_TARGET=${{matrix.config}} bash verif/regress/${{matrix.testcase}}.sh
 
     - name: Upload Lint Report to Github
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.simulator}}.${{matrix.testcase}}.${{matrix.config}}
@@ -181,12 +183,14 @@ jobs:
     - name: Run Tests
       run: |
           set -x
+          mkdir -p "verif/sim/out_$(date +%F)"
           export RISCV=$(pwd)/tools/riscv-toolchain/
           source ci/install-prereq.sh
           source verif/sim/setup-env.sh
           DV_SIMULATORS=${{matrix.simulator}},spike DV_TARGET=${{matrix.config}} bash verif/regress/${{matrix.testcase}}.sh
 
     - name: Upload Lint Report to Github
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.simulator}}.${{matrix.testcase}}.${{matrix.config}}


### PR DESCRIPTION
Add yaml rules to dump CI artifacts in case of failure

The current CI does not dump artifacts when a job fails
so it can be very hard to identify, reproduce and fix a bug that occurs
during CI execution. With this patch, we force dumping
simulation outputs when a CI error occurs.