### PR TITLE
Ahmed hani0 patch 1

### DIFF
--- a/core/include/cv64a60ax_config_pkg.sv
+++ b/core/include/cv64a60ax_config_pkg.sv
@@ -1,4 +1,4 @@
-// Copyright 2022 Thales DIS design services SAS
+// Copyright 2021 Thales DIS design services SAS
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -6,115 +6,145 @@
 // You may obtain a copy of the License at https://solderpad.org/licenses/
 //
 // Original Author: Jean-Roch COULON - Thales
+//
+// Copyright 2023 Commissariat a l'Energie Atomique et aux Energies
+//                Alternatives (CEA)
+//
+// Author: Tanuj Khandelwal - CEA
+// Date: January, 2025
+// Description: CVA6 configuration package using the HPDcache as cache subsystem
+
 
 package cva6_config_pkg;
 
-  localparam CVA6ConfigXlen = 32;
-
+  localparam CVA6ConfigXlen = 64;
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam CVA6ConfigAxiIdWidth = 4;  // axi_pkg.sv
-  localparam CVA6ConfigAxiAddrWidth = 64;  // axi_pkg.sv
-  localparam CVA6ConfigAxiDataWidth = 64;  // axi_pkg.sv
-  localparam CVA6ConfigDataUserWidth = 32;  // axi_pkg.sv
+  localparam CVA6ConfigAxiIdWidth = 4;
+  localparam CVA6ConfigAxiAddrWidth = 39;
+  localparam CVA6ConfigAxiDataWidth = 128;
+  localparam CVA6ConfigDataUserWidth = 12;
 
-  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
-      XLEN: unsigned'(CVA6ConfigXlen),
-      VLEN: unsigned'(32),
-      FpgaEn: bit'(0),
-      FpgaAlteraEn: bit'(0),
-      TechnoCut: bit'(1),
-      SuperscalarEn: bit'(0),
-      ALUBypass: bit'(0),
-      NrCommitPorts: unsigned'(1),
-      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
-      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
-      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
-      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
-      MemTidWidth: unsigned'(CVA6ConfigAxiIdWidth),
-      NrLoadBufEntries: unsigned'(2),
-      RVF: bit'(0),
-      RVD: bit'(0),
-      XF16: bit'(0),
-      XF16ALT: bit'(0),
-      XF8: bit'(0),
-      RVA: bit'(0),
-      RVB: bit'(1),
-      ZKN: bit'(0),
-      RVV: bit'(0),
-      RVC: bit'(1),
-      RVH: bit'(1),
-      RVZCMT: bit'(0),
-      RVZCB: bit'(1),
-      RVZCMP: bit'(0),
-      XFVec: bit'(0),
-      CvxifEn: bit'(1),
-      CoproType: config_pkg::COPRO_EXAMPLE,
-      RVZiCond: bit'(0),
-      RVZiCbom: bit'(0),
-      RVZicntr: bit'(0),
-      RVZihpm: bit'(0),
-      NrScoreboardEntries: unsigned'(4),
-      PerfCounterEn: bit'(0),
-      MmuPresent: bit'(0),
-      RVS: bit'(0),
-      RVU: bit'(0),
-      SoftwareInterruptEn: bit'(0),
-      HaltAddress: 64'h800,
-      ExceptionAddress: 64'h808,
-      RASDepth: unsigned'(2),
-      BTBEntries: unsigned'(0),
-      BPType: config_pkg::BHT,
-      BHTEntries: unsigned'(32),
-      BHTHist: unsigned'(3),
-      DmBaseAddress: 64'h0,
-      TvalEn: bit'(0),
-      DirectVecOnly: bit'(1),
-      NrPMPEntries: unsigned'(0),
-      PMPCfgRstVal: {64{64'h0}},
-      PMPAddrRstVal: {64{64'h0}},
-      PMPEntryReadOnly: 64'd0,
-      PMPNapotEn: bit'(0),
-      NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
-      NrNonIdempotentRules: unsigned'(0),
-      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
-      NonIdempotentLength: 1024'({64'b0, 64'b0}),
-      NrExecuteRegionRules: unsigned'(0),
-      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
-      ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
-      NrCachedRegionRules: unsigned'(1),
-      CachedRegionAddrBase: 1024'({64'h8000_0000}),
-      CachedRegionLength: 1024'({64'h40000000}),
-      MaxOutstandingStores: unsigned'(7),
-      DebugEn: bit'(0),
-      SDTRIG: bit'(0),
-      Mcontrol6: bit'(0),
-      Icount: bit'(0),
-      Etrigger: bit'(0),
-      Itrigger: bit'(0),
-      AxiBurstWriteEn: bit'(0),
-      IcacheByteSize: unsigned'(2048),
-      IcacheSetAssoc: unsigned'(2),
-      IcacheLineWidth: unsigned'(128),
-      DCacheType: config_pkg::HPDCACHE_WT,
-      DcacheByteSize: unsigned'(2028),
-      DcacheSetAssoc: unsigned'(2),
-      DcacheLineWidth: unsigned'(128),
-      DcacheFlushOnFence: bit'(0),
-      DcacheFlushOnFenceI: bit'(0),
-      DcacheInvalidateOnFlush: bit'(0),
-      DataUserEn: unsigned'(1),
-      WtDcacheWbufDepth: int'(8),
-      FetchUserWidth: unsigned'(32),
-      FetchUserEn: unsigned'(1),
-      InstrTlbEntries: int'(2),
-      DataTlbEntries: int'(2),
-      UseSharedTlb: bit'(1),
-      SvnapotEn: bit'(0),
-      SharedTlbDepth: int'(64),
-      NrLoadPipeRegs: int'(0),
-      NrStorePipeRegs: int'(0),
-      DcacheIdWidth: int'(1)
-  };
+
+`ifndef __UVMA_AXI_MACROS_SV__
+  `define __UVMA_AXI_MACROS_SV__
+
+  `define IFNDEF_DEFINE(name, value) \
+    `ifndef name \
+      `define name value \
+  `endif
+
+  `define UVMA_AXI_ADDR_MAX_WIDTH 39
+  `define UVMA_AXI_DATA_MAX_WIDTH 128
+  `define UVMA_AXI_USER_MAX_WIDTH 12
+  `define UVMA_AXI_ID_MAX_WIDTH 4
+  // `IFNDEF_DEFINE(UVMA_AXI_STRB_MAX_WIDTH , 8   )
+
+  `define UVMA_AXI_MAX_NB_TXN_BURST 256
+  `define UVMA_AXI_LOOP_MAX_WIDTH 8  
+  `define UVMA_AXI_MMUSID_MAX_WIDTH 32 
+  `define UVMA_AXI_MMUSSID_MAX_WIDTH 20 
+
+`endif  // __UVMA_AXI_MACROS_SV__
+
+
+localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
+   XLEN: unsigned'(CVA6ConfigXlen),
+   VLEN: unsigned'(64),
+   FpgaEn: bit'(0),  // for Xilinx and Altera
+   FpgaAlteraEn: bit'(0),  // for Altera (only)
+   TechnoCut: bit'(0),
+   SuperscalarEn: bit'(0),
+   ALUBypass: bit'(0),
+   NrCommitPorts: unsigned'(2),
+   AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+   AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+   AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+   AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+   MemTidWidth: unsigned'(CVA6ConfigAxiIdWidth),
+   NrLoadBufEntries: unsigned'(8),
+   RVF: bit'(1),
+   RVD: bit'(1),
+   XF16: bit'(0),
+   XF16ALT: bit'(0),
+   XF8: bit'(0),
+   RVA: bit'(1),
+   RVB: bit'(1),
+   ZKN: bit'(0),
+   RVV: bit'(0),
+   RVC: bit'(1),
+   RVH: bit'(1),
+   RVZCMT: bit'(0),
+   RVZCB: bit'(1),
+   RVZCMP: bit'(0),
+   XFVec: bit'(0),
+   CvxifEn: bit'(1),
+   CoproType: config_pkg::COPRO_EXAMPLE,
+   RVZiCond: bit'(1),
+   RVZiCbom: bit'(0),
+   RVZicntr: bit'(1),
+   RVZihpm: bit'(1),
+   NrScoreboardEntries: unsigned'(8),
+   PerfCounterEn: bit'(1),
+   MmuPresent: bit'(1),
+   RVS: bit'(1),
+   RVU: bit'(1),
+   SoftwareInterruptEn: bit'(1),
+   HaltAddress: 64'h800,
+   ExceptionAddress: 64'h808,
+   RASDepth: unsigned'(2),
+   BTBEntries: unsigned'(16),
+   BPType: config_pkg::BHT,
+   BHTEntries: unsigned'(64),
+   BHTHist: unsigned'(3),
+   DmBaseAddress: 64'h300_0000,
+   TvalEn: bit'(1),
+   DirectVecOnly: bit'(0),
+   NrPMPEntries: unsigned'(8),
+   PMPCfgRstVal: {64{64'h0}},
+   PMPAddrRstVal: {64{64'h0}},
+   PMPEntryReadOnly: 64'd0,
+   PMPNapotEn: bit'(1),
+   NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
+   NrNonIdempotentRules: unsigned'(2),
+   NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+   NonIdempotentLength: 1024'({64'b0, 64'b0}),
+   NrExecuteRegionRules: unsigned'(6),
+   ExecuteRegionAddrBase: 1024'({64'h1_0000_0000, 64'h8000_0000, 64'h300_0000, 64'h0, 64'h2000_0000, 64'h8_0000_0000}),
+   ExecuteRegionLength: 1024'({64'h2_0000_0000, 64'h1_0000, 64'h1000, 64'h1_0000, 64'h2000_0000, 64'h7_FFFF_FFFF}),
+   NrCachedRegionRules: unsigned'(2),
+   CachedRegionAddrBase: 1024'({64'h1_0000_0000, 64'h8000_0000}),
+   CachedRegionLength: 1024'({64'h2_0000_0000, 64'h1_0000}),
+   MaxOutstandingStores: unsigned'(7),
+   DebugEn: bit'(1),
+   SDTRIG: bit'(0),
+   Mcontrol6: bit'(0),
+   Icount: bit'(0),
+   Etrigger: bit'(0),
+   Itrigger: bit'(0),
+   AxiBurstWriteEn: bit'(0),
+   IcacheByteSize: unsigned'(32768),
+   IcacheSetAssoc: unsigned'(8),
+   IcacheLineWidth: unsigned'(512),
+   DCacheType: config_pkg::HPDCACHE_WT,
+   DcacheByteSize: unsigned'(32768),
+   DcacheSetAssoc: unsigned'(8),
+   DcacheLineWidth: unsigned'(512),
+   DcacheFlushOnFence: bit'(0),
+   DcacheFlushOnFenceI: bit'(0),
+   DcacheInvalidateOnFlush: bit'(0),
+   DataUserEn: unsigned'(0),
+   WtDcacheWbufDepth: int'(8),
+   FetchUserWidth: unsigned'(32),
+   FetchUserEn: unsigned'(0),
+   InstrTlbEntries: int'(16),
+   DataTlbEntries: int'(16),
+   UseSharedTlb: bit'(0),
+   SvnapotEn: bit'(0),
+   SharedTlbDepth: int'(64),
+   NrLoadPipeRegs: int'(0),
+   NrStorePipeRegs: int'(0),
+   DcacheIdWidth: int'(3)
+};
 
 endpackage

--- a/core/include/cv64a60ax_config_pkg.sv
+++ b/core/include/cv64a60ax_config_pkg.sv
@@ -1,4 +1,4 @@
-// Copyright 2021 Thales DIS design services SAS
+// Copyright 2022 Thales DIS design services SAS
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -6,144 +6,115 @@
 // You may obtain a copy of the License at https://solderpad.org/licenses/
 //
 // Original Author: Jean-Roch COULON - Thales
-//
-// Copyright 2023 Commissariat a l'Energie Atomique et aux Energies
-//                Alternatives (CEA)
-//
-// Author: Tanuj Khandelwal - CEA
-// Date: January, 2025
-// Description: CVA6 configuration package using the HPDcache as cache subsystem
-
 
 package cva6_config_pkg;
 
-  localparam CVA6ConfigXlen = 64;
+  localparam CVA6ConfigXlen = 32;
+
   localparam CVA6ConfigRvfiTrace = 1;
 
-  localparam CVA6ConfigAxiIdWidth = 4;
-  localparam CVA6ConfigAxiAddrWidth = 39;
-  localparam CVA6ConfigAxiDataWidth = 128;
-  localparam CVA6ConfigDataUserWidth = 12;
+  localparam CVA6ConfigAxiIdWidth = 4;  // axi_pkg.sv
+  localparam CVA6ConfigAxiAddrWidth = 64;  // axi_pkg.sv
+  localparam CVA6ConfigAxiDataWidth = 64;  // axi_pkg.sv
+  localparam CVA6ConfigDataUserWidth = 32;  // axi_pkg.sv
 
-
-`ifndef __UVMA_AXI_MACROS_SV__
-  `define __UVMA_AXI_MACROS_SV__
-
-  `define IFNDEF_DEFINE(name, value) \
-    `ifndef name \
-      `define name value \
-  `endif
-
-  `define UVMA_AXI_ADDR_MAX_WIDTH 39
-  `define UVMA_AXI_DATA_MAX_WIDTH 128
-  `define UVMA_AXI_USER_MAX_WIDTH 12
-  `define UVMA_AXI_ID_MAX_WIDTH 4
-  // `IFNDEF_DEFINE(UVMA_AXI_STRB_MAX_WIDTH , 8   )
-
-  `define UVMA_AXI_MAX_NB_TXN_BURST 256
-  `define UVMA_AXI_LOOP_MAX_WIDTH 8  
-  `define UVMA_AXI_MMUSID_MAX_WIDTH 32 
-  `define UVMA_AXI_MMUSSID_MAX_WIDTH 20 
-
-`endif  // __UVMA_AXI_MACROS_SV__
-
-
-localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
-   XLEN: unsigned'(CVA6ConfigXlen),
-   VLEN: unsigned'(64),
-   FpgaEn: bit'(0),  // for Xilinx and Altera
-   FpgaAlteraEn: bit'(0),  // for Altera (only)
-   TechnoCut: bit'(0),
-   SuperscalarEn: bit'(0),
-   ALUBypass: bit'(0),
-   NrCommitPorts: unsigned'(2),
-   AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
-   AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
-   AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
-   AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
-   MemTidWidth: unsigned'(CVA6ConfigAxiIdWidth),
-   NrLoadBufEntries: unsigned'(8),
-   RVF: bit'(1),
-   RVD: bit'(1),
-   XF16: bit'(0),
-   XF16ALT: bit'(0),
-   XF8: bit'(0),
-   RVA: bit'(1),
-   RVB: bit'(1),
-   ZKN: bit'(0),
-   RVV: bit'(0),
-   RVC: bit'(1),
-   RVH: bit'(0),
-   RVZCMT: bit'(0),
-   RVZCB: bit'(1),
-   RVZCMP: bit'(0),
-   XFVec: bit'(0),
-   CvxifEn: bit'(1),
-   CoproType: config_pkg::COPRO_EXAMPLE,
-   RVZiCond: bit'(1),
-   RVZicntr: bit'(1),
-   RVZihpm: bit'(1),
-   NrScoreboardEntries: unsigned'(8),
-   PerfCounterEn: bit'(1),
-   MmuPresent: bit'(1),
-   RVS: bit'(1),
-   RVU: bit'(1),
-   SoftwareInterruptEn: bit'(1),
-   HaltAddress: 64'h800,
-   ExceptionAddress: 64'h808,
-   RASDepth: unsigned'(2),
-   BTBEntries: unsigned'(16),
-   BPType: config_pkg::BHT,
-   BHTEntries: unsigned'(64),
-   BHTHist: unsigned'(3),
-   DmBaseAddress: 64'h300_0000,
-   TvalEn: bit'(1),
-   DirectVecOnly: bit'(0),
-   NrPMPEntries: unsigned'(8),
-   PMPCfgRstVal: {64{64'h0}},
-   PMPAddrRstVal: {64{64'h0}},
-   PMPEntryReadOnly: 64'd0,
-   PMPNapotEn: bit'(1),
-   NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
-   NrNonIdempotentRules: unsigned'(2),
-   NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
-   NonIdempotentLength: 1024'({64'b0, 64'b0}),
-   NrExecuteRegionRules: unsigned'(6),
-   ExecuteRegionAddrBase: 1024'({64'h1_0000_0000, 64'h8000_0000, 64'h300_0000, 64'h0, 64'h2000_0000, 64'h8_0000_0000}),
-   ExecuteRegionLength: 1024'({64'h2_0000_0000, 64'h1_0000, 64'h1000, 64'h1_0000, 64'h2000_0000, 64'h7_FFFF_FFFF}),
-   NrCachedRegionRules: unsigned'(2),
-   CachedRegionAddrBase: 1024'({64'h1_0000_0000, 64'h8000_0000}),
-   CachedRegionLength: 1024'({64'h2_0000_0000, 64'h1_0000}),
-   MaxOutstandingStores: unsigned'(7),
-   DebugEn: bit'(1),
-   SDTRIG: bit'(0),
-   Mcontrol6: bit'(0),
-   Icount: bit'(0),
-   Etrigger: bit'(0),
-   Itrigger: bit'(0),
-   AxiBurstWriteEn: bit'(0),
-   IcacheByteSize: unsigned'(32768),
-   IcacheSetAssoc: unsigned'(8),
-   IcacheLineWidth: unsigned'(512),
-   DCacheType: config_pkg::HPDCACHE_WT,
-   DcacheByteSize: unsigned'(32768),
-   DcacheSetAssoc: unsigned'(8),
-   DcacheLineWidth: unsigned'(512),
-   DcacheFlushOnFence: bit'(0),
-   DcacheFlushOnFenceI: bit'(0),
-   DcacheInvalidateOnFlush: bit'(0),
-   DataUserEn: unsigned'(0),
-   WtDcacheWbufDepth: int'(8),
-   FetchUserWidth: unsigned'(32),
-   FetchUserEn: unsigned'(0),
-   InstrTlbEntries: int'(16),
-   DataTlbEntries: int'(16),
-   UseSharedTlb: bit'(0),
-   SvnapotEn: bit'(0),
-   SharedTlbDepth: int'(64),
-   NrLoadPipeRegs: int'(0),
-   NrStorePipeRegs: int'(0),
-   DcacheIdWidth: int'(3)
-};
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
+      XLEN: unsigned'(CVA6ConfigXlen),
+      VLEN: unsigned'(32),
+      FpgaEn: bit'(0),
+      FpgaAlteraEn: bit'(0),
+      TechnoCut: bit'(1),
+      SuperscalarEn: bit'(0),
+      ALUBypass: bit'(0),
+      NrCommitPorts: unsigned'(1),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      MemTidWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      NrLoadBufEntries: unsigned'(2),
+      RVF: bit'(0),
+      RVD: bit'(0),
+      XF16: bit'(0),
+      XF16ALT: bit'(0),
+      XF8: bit'(0),
+      RVA: bit'(0),
+      RVB: bit'(1),
+      ZKN: bit'(0),
+      RVV: bit'(0),
+      RVC: bit'(1),
+      RVH: bit'(1),
+      RVZCMT: bit'(0),
+      RVZCB: bit'(1),
+      RVZCMP: bit'(0),
+      XFVec: bit'(0),
+      CvxifEn: bit'(1),
+      CoproType: config_pkg::COPRO_EXAMPLE,
+      RVZiCond: bit'(0),
+      RVZiCbom: bit'(0),
+      RVZicntr: bit'(0),
+      RVZihpm: bit'(0),
+      NrScoreboardEntries: unsigned'(4),
+      PerfCounterEn: bit'(0),
+      MmuPresent: bit'(0),
+      RVS: bit'(0),
+      RVU: bit'(0),
+      SoftwareInterruptEn: bit'(0),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth: unsigned'(2),
+      BTBEntries: unsigned'(0),
+      BPType: config_pkg::BHT,
+      BHTEntries: unsigned'(32),
+      BHTHist: unsigned'(3),
+      DmBaseAddress: 64'h0,
+      TvalEn: bit'(0),
+      DirectVecOnly: bit'(1),
+      NrPMPEntries: unsigned'(0),
+      PMPCfgRstVal: {64{64'h0}},
+      PMPAddrRstVal: {64{64'h0}},
+      PMPEntryReadOnly: 64'd0,
+      PMPNapotEn: bit'(0),
+      NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
+      NrNonIdempotentRules: unsigned'(0),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength: 1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules: unsigned'(0),
+      ExecuteRegionAddrBase: 1024'({64'h8000_0000, 64'h1_0000, 64'h0}),
+      ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
+      NrCachedRegionRules: unsigned'(1),
+      CachedRegionAddrBase: 1024'({64'h8000_0000}),
+      CachedRegionLength: 1024'({64'h40000000}),
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(0),
+      SDTRIG: bit'(0),
+      Mcontrol6: bit'(0),
+      Icount: bit'(0),
+      Etrigger: bit'(0),
+      Itrigger: bit'(0),
+      AxiBurstWriteEn: bit'(0),
+      IcacheByteSize: unsigned'(2048),
+      IcacheSetAssoc: unsigned'(2),
+      IcacheLineWidth: unsigned'(128),
+      DCacheType: config_pkg::HPDCACHE_WT,
+      DcacheByteSize: unsigned'(2028),
+      DcacheSetAssoc: unsigned'(2),
+      DcacheLineWidth: unsigned'(128),
+      DcacheFlushOnFence: bit'(0),
+      DcacheFlushOnFenceI: bit'(0),
+      DcacheInvalidateOnFlush: bit'(0),
+      DataUserEn: unsigned'(1),
+      WtDcacheWbufDepth: int'(8),
+      FetchUserWidth: unsigned'(32),
+      FetchUserEn: unsigned'(1),
+      InstrTlbEntries: int'(2),
+      DataTlbEntries: int'(2),
+      UseSharedTlb: bit'(1),
+      SvnapotEn: bit'(0),
+      SharedTlbDepth: int'(64),
+      NrLoadPipeRegs: int'(0),
+      NrStorePipeRegs: int'(0),
+      DcacheIdWidth: int'(1)
+  };
 
 endpackage

--- a/core/include/cv64a60ax_config_pkg.sv
+++ b/core/include/cv64a60ax_config_pkg.sv
@@ -73,7 +73,7 @@ localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
    ZKN: bit'(0),
    RVV: bit'(0),
    RVC: bit'(1),
-   RVH: bit'(1),
+   RVH: bit'(0),
    RVZCMT: bit'(0),
    RVZCB: bit'(1),
    RVZCMP: bit'(0),


### PR DESCRIPTION
CVA6 configuration parameters in cv64a60ax_config_pkg.sv where missing a parameter from the configuration struct elements , it was the: RVZiCbom: bit'(0)

from the cva6_cfg struct.
Now this package can be read and compiled in Formal Tools and in Simulation Programs


- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


## Summary

This PR adds the missing `RVZiCbom` field to the
`cv64a60ax_config_pkg.sv` configuration package.

## Problem

The `cva6_cfg` struct literal in `cv64a60ax_config_pkg.sv` was missing
the `RVZiCbom` field, although `config_pkg::cva6_user_cfg_t` expects this
field.

Some SystemVerilog tools report this as an incomplete structural literal
during elaboration, for example:

```text
IllegalVerilog - cv64a60ax_config_pkg.sv: incomplete structural/array literal<!-- Is this PR related to existing issues? If so, link to them below -->

there are No limitations with the current state of this contribution

