### PR TITLE
Add configuration for gcc 16.1 baremetal toolchain and add compatibility fix for RISC-V proxy kernel

### DIFF
--- a/util/toolchain-builder/config/gcc-16.1.0-baremetal.sh
+++ b/util/toolchain-builder/config/gcc-16.1.0-baremetal.sh
@@ -1,0 +1,36 @@
+#############################################################################
+#
+# Copyright 2026 Isaar AHMAD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+#
+# Original Author: Zbigniew CHAMSKI, Thales Silicon Security
+#
+# Adapted by Isaar AHMAD
+#
+#############################################################################
+
+
+# Each *_COMMIT variable can designate any valid 'commit-ish' entity:
+# typically a tag, a commit or the output of "git describe" of a Git tree.
+
+# Binutils
+BINUTILS_COMMIT=binutils-2_46
+
+# GCC
+GCC_COMMIT=releases/gcc-16.1.0
+
+# newlib
+NEWLIB_COMMIT=newlib-4.6.0

--- a/verif/regress/install-pk.sh
+++ b/verif/regress/install-pk.sh
@@ -17,7 +17,7 @@ PK_ARCH=$1
 PK_MABI=$2
 PK_REPO="https://github.com/riscv-software-src/riscv-pk.git"
 PK_BRANCH="master"
-PK_COMMIT_HASH="e5563d1044bd6790325c4602c49f89e1182fa91a"
+PK_COMMIT_HASH="0239d921a2b06c931736e55462ba50233763ee33"
 
 if ! [ -n "$RISCV" ]; then
   echo "Error: RISCV variable undefined"
@@ -27,6 +27,20 @@ fi
 PATH=$RISCV/bin:$PATH
 # Customise this to a fast local disk
 ROOT_PROJECT=$(readlink -f $(dirname "${BASH_SOURCE[0]}")/../../)
+
+# Check if PK_INSTALL_DIR is defined, otherwise set it to <top>/tools/pk
+if [ -z "$PK_INSTALL_DIR" -o "$PK_INSTALL_DIR" = "__local__" ]; then
+  export PK_INSTALL_DIR="$ROOT_PROJECT/tools/pk"
+  echo "Setting PK_INSTALL_DIR to '$PK_INSTALL_DIR'..."
+fi
+# Confirm that RISCV gcc exists
+if [ ! -x "$RISCV/bin/riscv-none-elf-gcc" ]; then
+  echo "Error: '$RISCV/bin/riscv-none-elf-gcc' is not executable."
+  return 1
+fi
+
+# PK_BIN will be the path to access the proxy kernel
+export PK_BIN="$PK_INSTALL_DIR/riscv-none-elf/bin/pk"
 
 if [ -z "$NUM_JOBS" ]; then
     NUM_JOBS=1
@@ -40,17 +54,7 @@ fi
 echo "[install-pk.sh] Entry values:"
 echo "    PK_BUILD_DIR='$PK_BUILD_DIR'"
 echo "    PK_INSTALL_DIR='$PK_INSTALL_DIR'"
-
-# If not set, define the installation location of pk to the local path
-#
-#    <top>/tools/pk
-#
-# Continuous Integration may need to override this particular variable
-# to use a preinstalled build of Verilator.
-if [ -z "$PK_INSTALL_DIR" ]; then
-  export PK_INSTALL_DIR="$ROOT_PROJECT/tools/pk"
-  echo "Setting PK_INSTALL_DIR to '$PK_INSTALL_DIR'..."
-fi
+echo "    PK_BIN='$PK_BIN'"
 
 # Define the default src+build location of pk in case it needs to be (re)built.
 # No need to force this location in Continuous Integration scripts.
@@ -65,7 +69,7 @@ rm -rf "$PK_INSTALL_DIR"
 
 # Build and install pk only if the final binary is not present.
 # Note: The script now always rebuilds due to the rm -rf above.
-if [ ! -f "$PK_INSTALL_DIR/riscv-none-elf/bin/pk" ]; then
+if [ ! -f "$PK_BIN" ]; then
     echo "Building pk in '$PK_BUILD_DIR'..."
     echo "pk will be installed in '$PK_INSTALL_DIR'"
     echo "PK_REPO=$PK_REPO"
@@ -91,13 +95,26 @@ if [ ! -f "$PK_INSTALL_DIR/riscv-none-elf/bin/pk" ]; then
     # Proceed with the build
     mkdir -p build
     pushd build
-    ../configure --prefix="$PK_INSTALL_DIR" --host=riscv-none-elf --with-arch="$PK_ARCH"
+    CONFIGURE_ARGS=(
+      "--prefix=$PK_INSTALL_DIR"
+      "--host=riscv-none-elf"
+      "--with-arch=$PK_ARCH"
+    )
+    if [ -n "$PK_MABI" ]; then
+      CONFIGURE_ARGS+=("--with-abi=$PK_MABI")
+    fi
+    ../configure "${CONFIGURE_ARGS[@]}"
     make -j${NUM_JOBS}
     make install
     popd # build
     popd # $PK_BUILD_DIR
 else
     echo "pk already installed in '$PK_INSTALL_DIR'."
+fi
+
+if [ ! -f "$PK_BIN" ]; then
+  echo "Error: PK build completed, but expected binary was not found at '$PK_BIN'."
+  return 1
 fi
 
 # Add pk bin directory to PATH if not already present.

--- a/verif/sim/Makefile
+++ b/verif/sim/Makefile
@@ -398,6 +398,9 @@ xrun_clean_all:
 ###############################################################################
 # testharness specific commands, variables
 ###############################################################################
+PK_INSTALL_DIR ?= $(CVA6_REPO_DIR)/tools/pk
+PK_BIN ?= $(PK_INSTALL_DIR)/riscv-none-elf/bin/pk
+
 vcs-testharness:
 	make -C $(path_var) vcs_build target=$(target) gate=$(gate) top_level=$(th_top_level) flist=$(FLIST_CORE) defines=$(subst +define+,,$(isscomp_opts))$(if $(spike-tandem),SPIKE_TANDEM=1)
 	$(path_var)/work-vcs/simv $(if $(VERDI), -verdi -do $(path_var)/util/$(do_file).do,) +permissive \
@@ -415,10 +418,11 @@ vcs-testharness:
 veri-testharness-pk:
 	rm -rf $(path_var)/work-ver
 	@echo "Trace compact value $(TRACE_COMPACT)"
+	@test -f "$(PK_BIN)" || { echo "Error: PK binary not found at '$(PK_BIN)'. Run verif/regress/install-pk.sh first."; exit 1; }
 	make -C $(path_var) verilate verilator="verilator --no-timing" target=$(target) defines=$(subst +define+,,$(isscomp_opts))
 	$(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) \
-		$(PK_INSTALL_DIR)/riscv-none-elf/bin/pk $(elf) \
-		+tohost_addr=$(shell $$RISCV/bin/$(CV_SW_PREFIX)nm -B $(PK_INSTALL_DIR)/riscv-none-elf/bin/pk | grep -w tohost | cut -d' ' -f1) \
+		$(PK_BIN) $(elf) \
+		+tohost_addr=$$($$RISCV/bin/$(CV_SW_PREFIX)nm -B $(PK_BIN) | grep -w tohost | cut -d' ' -f1) \
 		$(issrun_opts)
 	# If present, move default waveform files to log directory.
 	# Keep track of target in waveform file name.


### PR DESCRIPTION
The PR adds the following features to fix the issue mentioned in #3356 : 
1. Add a new toolchain configuration for building gcc 16.1, compatible with the instructions in util/toolchain-builder.
2. Update the riscv-pk installation script to a recent version compatible with gcc > 15. Without this update, the riscv-pk installation fails due to tighter compiler warnings flagged by gcc versions higher than 15.

The final outcome is that users can now : 
1. Build RISC-V GNU toolchain with gcc 16.1 using the existing toolchain-builder.
2. Run programs compiled with gcc > 15 on veri-testharness-pk simulation target. 

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

