### PR TITLE
chore(cvfpu): bump version

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ dependencies:
   axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.31.0 }
   common_cells:
     { git: "https://github.com/pulp-platform/common_cells", version: 1.23.0 }
-  fpnew: { git: "https://github.com/openhwgroup/cvfpu.git", rev: 106251e } # branch: develop
+  fpnew: { git: "https://github.com/openhwgroup/cvfpu.git", rev: 3eb6afe } # branch: develop
   tech_cells_generic:
     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13 }
 


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->
This PR bumps the FPU to the latest version available, including a bug fix to allow synthesis in 32-bit core flavor with FPU enabled. The current version prevents elaboration during synthesis due to a port width mismatch. See: https://github.com/openhwgroup/cvfpu/pull/172. Pinging @IhsaneTahir.

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

