### PR TITLE
Fix load unit non-idempotence check missing page offset

### DIFF
--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -233,7 +233,7 @@ module load_unit
   logic inflight_stores;
   logic stall_ni;
   assign paddr_ni = config_pkg::is_inside_nonidempotent_regions(
-      CVA6Cfg, {{52 - CVA6Cfg.PPNW{1'b0}}, dtlb_ppn_i, 12'd0}
+      CVA6Cfg, {{52 - CVA6Cfg.PPNW{1'b0}}, dtlb_ppn_i, lsu_ctrl_i.vaddr[11:0]}
   );
   assign not_commit_time = commit_tran_id_i != lsu_ctrl_i.trans_id;
   assign inflight_stores = (!dcache_wbuffer_not_ni_i || !store_buffer_empty_i);


### PR DESCRIPTION
Non-idempotence checks for speculative loads are based on `paddr_ni` which does not include the page offset, this can allow wrong-path speculative loads whose full physical address is inside a sub-page non-idempotent region.
To fix the issue this PR adds the page offset from `vaddr[11:0]` to the `paddr_ni` computation.

* **Fixes** https://github.com/openhwgroup/cva6/issues/3368
