### PR TITLE
Fix link between XLEN and hpdcache configuration

### DIFF
--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -189,7 +189,7 @@ module cva6_hpdcache_subsystem
     userCfg.wordWidth = CVA6Cfg.XLEN;
     userCfg.sets = CVA6Cfg.DCACHE_NUM_WORDS;
     userCfg.ways = CVA6Cfg.DCACHE_SET_ASSOC;
-    userCfg.clWords = CVA6Cfg.DCACHE_LINE_WIDTH / CVA6Cfg.XLEN;
+    userCfg.clWords = CVA6Cfg.DCACHE_LINE_WIDTH / userCfg.wordWidth;
     userCfg.reqWords = 1;
     userCfg.reqTransIdWidth = CVA6Cfg.DcacheIdWidth;
     userCfg.reqSrcIdWidth = 3;  // Up to 8 requesters
@@ -197,7 +197,7 @@ module cva6_hpdcache_subsystem
     userCfg.dataWaysPerRamWord = __minu(CVA6Cfg.DCACHE_SET_ASSOC, 128 / CVA6Cfg.XLEN);
     userCfg.dataSetsPerRam = CVA6Cfg.DCACHE_NUM_WORDS;
     userCfg.dataRamByteEnable = 1'b1;
-    userCfg.accessWords = __maxu(CVA6Cfg.AxiDataWidth / CVA6Cfg.XLEN, userCfg.reqWords);
+    userCfg.accessWords = __maxu(CVA6Cfg.AxiDataWidth / userCfg.wordWidth, userCfg.reqWords);
     userCfg.mshrSets = CVA6Cfg.NrLoadBufEntries < 16 ? 1 : CVA6Cfg.NrLoadBufEntries / 2;
     userCfg.mshrWays = CVA6Cfg.NrLoadBufEntries < 16 ? CVA6Cfg.NrLoadBufEntries : 2;
     userCfg.mshrWaysPerRamWord = CVA6Cfg.NrLoadBufEntries < 16 ? CVA6Cfg.NrLoadBufEntries : 2;


### PR DESCRIPTION
Hi,

Currently, in HPDcache configuration, the number of words in a cache line is determined by the cache line width and the XLEN. So to generalize for any word width this commit replaces XLEN by word width.

In addition, the number of accessed words is determined by bus width and word width, XLEN. So with the same idea this PR proposes to XLEN by word width attribute.

Suggested-by: Cesar Fuguet <15080006+cfuguet@users.noreply.github.com>