### PR TITLE
update GitHub's actions

### DIFF
--- a/.github/actions/setup-cva6-env/action.yml
+++ b/.github/actions/setup-cva6-env/action.yml
@@ -38,7 +38,7 @@ runs:
     # Step 2: Cache RISC-V Toolchain
     - name: Cache RISC-V Toolchain
       id: cache-toolchain
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: tools/riscv-toolchain/
         key: ${{ runner.os }}-toolchain-${{ hashFiles('ci/install-toolchain.sh') }}
@@ -48,7 +48,7 @@ runs:
     # Step 3: Cache Verilator
     - name: Cache Verilator
       id: cache-verilator
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: tools/verilator/
         key: ${{ runner.os }}-verilator-${{ hashFiles('verif/regress/install-verilator.sh') }}
@@ -58,7 +58,7 @@ runs:
     # Step 4: Cache Spike
     - name: Cache Spike
       id: cache-spike
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: tools/spike/
         key: ${{ runner.os }}-spike-${{ hashFiles('verif/regress/install-spike.sh') }}-${{ steps.submodule-hash.outputs.hash }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       NUM_JOBS: 8
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -25,7 +25,7 @@ jobs:
 
     - name: Cache toolchain
       id: cache-toolchain
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-toolchain
       with:
@@ -34,7 +34,7 @@ jobs:
 
     - name: Cache verilator
       id: cache-verilator
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-verilator
       with:
@@ -43,7 +43,7 @@ jobs:
 
     - name: Cache Spike
       id: cache-spike
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-spike
       with:
@@ -75,7 +75,7 @@ jobs:
     needs:
       build-riscv-tests
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -87,7 +87,7 @@ jobs:
 
     - name: Cache toolchain
       id: cache-toolchain
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-toolchain
       with:
@@ -96,7 +96,7 @@ jobs:
 
     - name: Cache verilator
       id: cache-verilator
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-verilator
       with:
@@ -105,7 +105,7 @@ jobs:
 
     - name: Cache Spike
       id: cache-spike
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-spike
       with:
@@ -141,7 +141,7 @@ jobs:
     needs:
       build-riscv-tests
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -153,7 +153,7 @@ jobs:
 
     - name: Cache toolchain
       id: cache-toolchain
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-toolchain
       with:
@@ -162,7 +162,7 @@ jobs:
 
     - name: Cache verilator
       id: cache-verilator
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-verilator
       with:
@@ -171,7 +171,7 @@ jobs:
 
     - name: Cache Spike
       id: cache-spike
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       env:
           cache-name: cache-spike
       with:

--- a/.github/workflows/openhw-cva6-ci-tier1.yml
+++ b/.github/workflows/openhw-cva6-ci-tier1.yml
@@ -58,7 +58,7 @@ jobs:
     name: Setup Tools
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -105,7 +105,7 @@ jobs:
             linker: ""
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -163,7 +163,7 @@ jobs:
             linker: ""
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/openhw-cva6-ci-tier2.yml
+++ b/.github/workflows/openhw-cva6-ci-tier2.yml
@@ -79,7 +79,7 @@ jobs:
     name: Setup Tools
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -232,7 +232,7 @@ jobs:
             linker: ""
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -335,7 +335,7 @@ jobs:
             linker: ""
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/openhw-cva6-tier-dashboard.yml
+++ b/.github/workflows/openhw-cva6-tier-dashboard.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Restore tier dashboard history from gh-pages-cva6-tier-dashboard-data
         run: |
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Prepare gh-pages-cva6-tier-dashboard-data branch
         run: |

--- a/.github/workflows/verible.yml
+++ b/.github/workflows/verible.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: chipsalliance/verible-formatter-action@main


### PR DESCRIPTION
In #3233 I used a too restrictive command to update actions so it missed the deprecated actions for the Verible workflow, which now fails.

This time I used the following command:

```
ls .github/**/*.yml | get name | each {
  sed -i s=actions/cache@v.=actions/cache@v6= $in
  sed -i s=actions/checkout@v.=actions/checkout@v7= $in
}
```

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

