### PR TITLE
GitHub: add commit hash input to bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -14,6 +14,13 @@ body:
         During this interaction, my words are my own and are not generated.
         If relevant, I provide links to my sources.
       required: true
+- type: input
+  attributes:
+    label: CVA6 commit affected
+    description: The git hash of a commit in the official CVA6 repository that was used to demonstrate the bug.
+    placeholder: "0123abc"
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Bug Description


### PR DESCRIPTION
It would help reproducing the bug, and sometimes find that the issue it about a 5-year-old commit and was fixed a long time ago!

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

