### PR TITLE
flows: add yml anchor to dummy compiler targets

### DIFF
--- a/flows/config/compiler.yml
+++ b/flows/config/compiler.yml
@@ -22,7 +22,7 @@
 
 # ===========================================================================================
 
-dummy1:
+dummy1: &dummy1
     TOOLS_PATH: "/tmp/llvm-20"
     CLANG: "riscv32-unknown-elf-clang"
     GCC: None
@@ -30,7 +30,7 @@ dummy1:
     NM: "riscv32-unknown-elf-nm"
     TARGET_TOOLCHAIN: "riscv32-unknown-elf"
 
-dummy2:
+dummy2: &dummy2
     TOOLS_PATH: "/tmp/gcc-15"
     CLANG: None
     GCC: "riscv32-unknown-elf-clang"


### PR DESCRIPTION
Current YAML was invalid due to missing anchor for the compiler targets