### PR TITLE
ci(format): freeze Verible version

### DIFF
--- a/.github/workflows/verible.yml
+++ b/.github/workflows/verible.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: chipsalliance/verible-formatter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          verible_version: v0.0-4084-gf3e4d98b
           files: '$(find core -regex ".*\.\(v\|sv\)$" | grep -v "^core/include/.*_config_pkg\.sv$")'
           fail_on_formatting_suggestions: true
       - name: CVA6Cfg's XLEN attribute usage verificatory script

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,3 +141,5 @@ To format RTL files checked by GitHub , use the following command:
 ```
 verible-verilog-format --inplace $(git ls-tree -r HEAD --name-only core |grep '\.sv$' |grep -v '^core/include/std_cache_pkg.sv$' |grep -v cvfpu)
 ```
+
+The Verible version currently used in the GitHub CI worflow can be found in [`.github/workflows/verible.yml`](.github/workflows/verible.yml).


### PR DESCRIPTION
Freeze Verible version to the latest release which does not change formatting on CVA6 `master` branch.

Verible version [v0.0-4101-gd8a69151](https://github.com/chipsalliance/verible/releases/tag/v0.0-4101-gd8a69151) changed the formatting of files already in `master`, which makes the worflow fail so I freeze to the previous version.

An alternative would be that all contributors simultaneously update their Verible version.

<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.


<!-- Please indicate why this PR is needed for the project -->

<!-- Is this PR related to existing issues? If so, link to them below -->

<!-- Are there limitations with the current state of this contribution? -->

<!-- If the contribution is not ready to be merged yet, please make this PR a draft: https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests -->

