### PR TITLE
Fix MRET virtualization mode for M-mode

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -2344,8 +2344,8 @@ module csr_regfile
       // set mpie to 1
       mstatus_d.mpie = 1'b1;
       if (CVA6Cfg.RVH) begin
-        // set virtualization mode
-        v_d           = mstatus_q.mpv;
+        // MPV is ignored when returning to M-mode.
+        v_d = (mstatus_q.mpp == riscv::PRIV_LVL_M) ? 1'b0 : mstatus_q.mpv;
         //set mstatus mpv to false
         mstatus_d.mpv = 1'b0;
         if (mstatus_q.mpp != riscv::PRIV_LVL_M) mstatus_d.mprv = 1'b0;

--- a/verif/tests/custom/issues/mret-mpv-rv64.S
+++ b/verif/tests/custom/issues/mret-mpv-rv64.S
@@ -1,0 +1,116 @@
+# Copyright 2026 Keerthivasan
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+# Regression test for CVA6 issue #3313.
+#
+# When MRET returns to M-mode, virtualization mode V must remain zero,
+# regardless of the value previously stored in mstatus.MPV.
+#
+# V is internal architectural state and cannot be read directly.
+# A subsequent trap to M-mode saves V into mstatus.MPV, allowing the
+# post-MRET V state to be checked.
+
+  .section .text
+  .align 2
+
+  .equ MSTATUS_MPP_MASK, 0x0000000000001800
+  .equ MSTATUS_MPP_M,    0x0000000000001800
+  .equ MSTATUS_MPV,      0x0000008000000000
+
+  .equ CAUSE_ECALL_M,    11
+
+  .globl main
+
+main:
+  # Send all exceptions used by this test to M-mode.
+  la      t0, trap_handler
+  csrw    mtvec, t0
+
+  csrw    medeleg, zero
+  csrw    mideleg, zero
+  csrw    hedeleg, zero
+  csrw    hideleg, zero
+
+  # Configure MRET to return to M-mode.
+  li      t0, MSTATUS_MPP_MASK
+  csrc    mstatus, t0
+
+  li      t0, MSTATUS_MPP_M
+  csrs    mstatus, t0
+
+  # Deliberately set MPV before MRET.
+  #
+  # The Hypervisor specification requires MRET to ignore MPV when
+  # MPP=M and to keep virtualization mode V equal to zero.
+  li      t0, MSTATUS_MPV
+  csrc    mstatus, t0
+  csrs    mstatus, t0
+
+  # Confirm that MPV was writable so the test exercises the intended case.
+  csrr    t0, mstatus
+  li      t1, MSTATUS_MPV
+  and     t2, t0, t1
+  beqz    t2, fail_2
+
+  la      t0, m_entry
+  csrw    mepc, t0
+  mret
+
+m_entry:
+  # Trap entry saves the current V state into mstatus.MPV.
+  ecall
+
+  # ECALL must trap.
+  li      a0, 1
+  j       finish
+
+  .align 2
+trap_handler:
+  csrr    t0, mstatus
+
+  # Main regression check.
+  #
+  # On the buggy RTL, MRET copies MPV=1 into V even though MPP=M.
+  # Trap entry then saves that incorrect V=1 value back into MPV.
+  li      t1, MSTATUS_MPV
+  and     t2, t0, t1
+  bnez    t2, fail_8
+
+  # The trap must originate from M-mode.
+  li      t1, MSTATUS_MPP_MASK
+  and     t2, t0, t1
+  li      t3, MSTATUS_MPP_M
+  bne     t2, t3, fail_9
+
+  # ECALL from M-mode must report exception cause 11.
+  csrr    t0, mcause
+  li      t1, CAUSE_ECALL_M
+  bne     t0, t1, fail_3
+
+pass:
+  li      a0, 0
+  j       finish
+
+fail_2:
+  # MPV was unavailable or not writable.
+  li      a0, 2
+  j       finish
+
+fail_3:
+  # Unexpected trap cause.
+  li      a0, 3
+  j       finish
+
+fail_8:
+  # Issue #3313 reproduced: V remained set after MRET to M-mode.
+  li      a0, 8
+  j       finish
+
+fail_9:
+  # Trap did not originate from M-mode.
+  li      a0, 9
+
+finish:
+  jal     exit

--- a/verif/tests/testlist_issues.yaml
+++ b/verif/tests/testlist_issues.yaml
@@ -45,3 +45,7 @@ testlist:
     iterations: 1
     asm_tests: <path_var>/custom/issues/compressed-fpreg-commits-rv32.S
 
+  - test: mret-mpv-rv64
+    <<: *common_test_config
+    iterations: 1
+    asm_tests: <path_var>/custom/issues/mret-mpv-rv64.S


### PR DESCRIPTION
* [x] I have searched for similar pull requests
* [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Why this PR is needed

When the Hypervisor extension is enabled, the current `MRET` path
restores virtualization mode `V` directly from `mstatus.MPV`.

This is incorrect when `mstatus.MPP` contains M-mode. In this case,
`MRET` must keep `V` cleared, regardless of the value stored in `MPV`.
The current implementation can therefore return to M-mode with an
incorrect virtualization state.

## Changes

This PR updates the RVH-enabled `MRET` handling in
`core/csr_regfile.sv` to:

* force `V` to zero when `MPP` is M-mode;
* continue restoring `V` from `MPV` for lower privilege modes;
* preserve the existing `MPV` and `MPRV` update behavior.

It also adds the directed `mret-mpv-rv64` regression test and registers
it in `verif/tests/testlist_issues.yaml`.

## Regression test

The test sets `MPP=M` and `MPV=1`, executes `MRET`, and then triggers an
M-mode `ECALL`.

Because `V` cannot be read directly, the test checks the value saved
into `mstatus.MPV` during trap entry. A nonzero saved value indicates
that `MRET` incorrectly retained `V=1`.

The test also verifies that:

* `MPV` can be written before executing `MRET`;
* the trap originated from M-mode;
* `mcause` reports an M-mode environment call.

## Verification

Test target:

```text
cv64a6_imafdch_sv39
```

The test passes on the Spike reference model:

```text
Spike return code: 0
```

The original CVA6 RTL reproduces the issue:

```text
mret-mpv-rv64.o *** FAILED *** (tohost = 8)
```

After the fix, the CVA6 and Spike executions match:

```text
[PASSED]: 128 matched
1 PASSED, 0 FAILED
Final regression return code: 0
```

`core/csr_regfile.sv` also passes the Verible formatting check.

## Related issue

Fixes #3313.

## Limitations

The directed regression covers the reported `MPP=M, MPV=1` case.

A lower-privilege control test was investigated but encountered an
instruction-access fault before reaching its intended check, so it is
not included in this regression. The RTL expression continues to
restore `V` from `MPV` whenever `MPP` is not M-mode.

This change does not modify the CSR layout, configuration interface, or
behavior outside the RVH-enabled `MRET` path.
