### PR TITLE
Fixed classifications of c.jr and c.jalr instruction in instr_scan

### DIFF
--- a/core/frontend/instr_scan.sv
+++ b/core/frontend/instr_scan.sv
@@ -92,6 +92,7 @@ module instr_scan #(
   // always links to register 0
   logic is_jal_r;
   assign is_jal_r     = (instr_i[15:13] == riscv::OpcodeC2JalrMvAdd)
+                        & (instr_i[11:7] != 5'b00000)
                         & (instr_i[6:2] == 5'b00000)
                         & (instr_i[1:0] == riscv::OpcodeC2);
   assign rvc_jr_o = is_jal_r & ~instr_i[12];


### PR DESCRIPTION
<!-- Contents within these symbols are commented out and will not appear in the PR description -->

<!-- Thanks for your contribution! Before sending us a pull request, please make sure you have read CONTRIBUTING.md -->

- [x] I have searched for similar pull requests
- [x] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

## Description
Fixes incorrect assertion of `rvc_jr_o` and `rvc_jalr_o` in `frontend/instr_scan` for reserved/misclassified compressed instructions.

The `is_jal_r` decode logic only checked `funct3`, `instr_i[6:2]`, and the opcode field, but never checked `rs1` (`instr_i[11:7]`). As a result:
- `c.jr` with `rs1 = x0` (reserved encoding) incorrectly asserted `rvc_jr_o`.
- `c.ebreak` (`funct3 = 100`, bit12=1, rs1=0, rs2=0) was misdecoded as `c.jalr`, incorrectly asserting `rvc_jalr_o`.

Since `rvc_call_o` is derived from `rvc_jalr_o`, it was also incorrectly asserted for `c.ebreak`.

## Fix
Added `instr_i[11:7] != 5'b00000` to the `is_jal_r` condition, per the RISC-V C extension spec:
- C.JR is valid only when `rs1 ≠ x0`.
- C.JALR is valid only when `rs1 ≠ x0`; `rs1 = x0` is C.EBREAK, not C.JALR.

## Related Issue
#3439

## Verification
- Re-ran Jasper formal properties against both repro vectors from the linked issue:
  - `16'h8002` (`c.jr`, `rs1=x0`) → `rvc_jr_o` now low.
  - `16'h9002` (`c.ebreak`) → `rvc_jalr_o` now low.
