### PR TITLE
fix(csr): recompute status sd from next-state fs/xs

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1995,12 +1995,12 @@ module csr_regfile
     end
     // hardwired extension registers
     if (CVA6Cfg.RVS || CVA6Cfg.RVF) begin
-      mstatus_d.sd = (mstatus_q.xs == riscv::Dirty) | (mstatus_q.fs == riscv::Dirty);
+      mstatus_d.sd = (mstatus_d.xs == riscv::Dirty) | (mstatus_d.fs == riscv::Dirty);
     end else begin
       mstatus_d.sd = riscv::Off;
     end
     if (CVA6Cfg.RVH) begin
-      vsstatus_d.sd = (vsstatus_q.xs == riscv::Dirty) | (vsstatus_q.fs == riscv::Dirty);
+      vsstatus_d.sd = (vsstatus_d.xs == riscv::Dirty) | (vsstatus_d.fs == riscv::Dirty);
     end
 
     // reserve PMPCFG bits 5 and 6 (hardwire to 0)


### PR DESCRIPTION
- [√] I have searched for similar pull requests
- [√ ] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

This PR fixes a stale `sd` recomputation issue in the CSR status path.

It recomputes `mstatus.sd` from `mstatus_d.{xs,fs}` and `vsstatus.sd` from `vsstatus_d.{xs,fs}`, instead of using the old registered `_q` state. This keeps `sd` consistent with same-cycle updates that already make `fs` or `xs` dirty.

Related issue: #3460 

Why this change is needed:

`sd` is a summary bit derived from the dirty state of `fs/xs`. In the current implementation, `fs` can already be updated to `Dirty` in the next-state logic, while `sd` is still recomputed from the previous registered state. This creates a one-cycle inconsistency where the visible `fs` state has advanced but `sd` still reflects the old value.

Validation:

- validated with the test reproducer
- the reproducer passes with this patch applied (`tohost = 0`)

Current limitation:

This is a narrow consistency fix for `sd` recomputation and does not otherwise change CSR status semantics.