### PR TITLE
fix(decoder): preserve SFENCE.VMA rd legality in RVH VS-mode path

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -301,6 +301,7 @@ module decoder
                     // only if S mode is supported
                     // otherwise decode an illegal instruction
                     if (CVA6Cfg.RVH && v_i) begin
+                      illegal_instr = (instr.itype.rd == '0) ? illegal_instr : 1'b1;
                       virtual_illegal_instr = (priv_lvl_i == riscv::PRIV_LVL_S) ? 1'b0 : 1'b1;
                     end else begin
                       illegal_instr    = (CVA6Cfg.RVS && (priv_lvl_i inside {riscv::PRIV_LVL_M, riscv::PRIV_LVL_S}) && instr.itype.rd == '0) ? 1'b0 : 1'b1;


### PR DESCRIPTION
- [√] I have searched for similar pull requests
- [√] I am a human engaging in an interpersonal interaction. During this interaction, my words are my own and are not generated. If relevant, I provide links to my sources.

This PR fixes a VS-mode `SFENCE.VMA` legality bug under RVH.

When `CVA6Cfg.RVH && v_i`, the decoder correctly clears the temporary virtual-illegal condition for the legal VS-mode case. However, that path can also overwrite an earlier structural-illegal result, such as `rd != x0`, and incorrectly make the instruction legal.

This change keeps `SFENCE.VMA` illegal when `rd != x0` while still preserving the intended RVH / VS-mode behavior for the legal case.

Validated with the test reproducer (`tohost = 0`).

Related issue: #3459